### PR TITLE
ble: keep the hello-suppression latch across a user Connect

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1449,8 +1449,13 @@ public final class BLEManager: NSObject, ObservableObject {
         }
         // #1635: the suppression path pauses NOTHING, so the reset above never fires for it. An explicit
         // Connect is exactly the signal that the user has acted (pairing mode, closed the WHOOP app), so
-        // it must grant a fresh handshake regardless — that is also the only way to clear the latch short
-        // of a genuine bond. Deliberately NOT in connectCore: a system-initiated reconnect must not.
+        // it must grant a fresh handshake regardless. Be exact about what that does and does not do: it
+        // grants ONE connect's worth of hello and leaves the latch standing, so if the strap still will
+        // not answer, the automatic reconnects behind this attempt stay suppressed. The latch is cleared
+        // by the attempt SUCCEEDING (didWriteValueFor's genuine ack) or by forgetDevice, never by the tap
+        // itself — Kotlin `pairingHintClearDropsSuppressionLatch` is the twin of that rule, and it had to
+        // be made one: clearing on the tap there re-paid the whole give-up on every press.
+        // Deliberately NOT in connectCore: a system-initiated reconnect must not.
         helloRetryRequested = true
         bondGiveUp.reset()
         connectCore(model: model)

--- a/Strand/BLE/HelloSuppression.swift
+++ b/Strand/BLE/HelloSuppression.swift
@@ -18,8 +18,11 @@ import WhoopProtocol
 /// the app already models (#69), reached deliberately instead of never at all.
 ///
 /// [userInitiated] always re-attempts: suppression is a fallback for automatic reconnects, never a
-/// permanent verdict. Someone who puts the strap in pairing mode and presses Connect must get a fresh try,
-/// and that is also how the suppression is cleared.
+/// permanent verdict. Someone who puts the strap in pairing mode and presses Connect must get a fresh try.
+/// That try is ONE connect's worth and nothing more — the latch itself survives the tap, so if the strap
+/// still will not answer, the automatic reconnects behind it stay suppressed instead of re-earning the
+/// give-up over five more refusals. The latch is dropped by a genuine bond (it demonstrably works now) or
+/// by forgetting the strap, which are the two events that are actually evidence about this device.
 ///
 /// Kotlin twin: `com.noop.ble.shouldSendClientHello`.
 func shouldSendClientHello(suppressedForDevice: Bool, userInitiated: Bool) -> Bool {

--- a/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
+++ b/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
@@ -24,8 +24,11 @@ package com.noop.ble
  * never at all.
  *
  * [userInitiated] always re-attempts: suppression is a fallback for automatic reconnects, never a
- * permanent verdict. Someone who puts the strap in pairing mode and presses Connect must get a fresh try,
- * and that is also how the suppression is cleared.
+ * permanent verdict. Someone who puts the strap in pairing mode and presses Connect must get a fresh try.
+ * That try is ONE connect's worth and nothing more — the latch itself survives the tap, so if the strap
+ * still will not answer, the automatic reconnects behind it stay suppressed instead of re-earning the
+ * give-up over five more refusals. The latch is dropped by a genuine bond (it demonstrably works now) or
+ * by forgetting the strap, which are the two events that are actually evidence about this device.
  *
  * Deliberately NOT re-armed by "an OS pairing exists". That looks right — a pairing is new evidence the
  * handshake might work — but the condition never goes away, so a strap that pairs and STILL will not
@@ -111,6 +114,24 @@ internal fun helloOverrideExhaustedLine(attempts: Int): String =
         " The strap answers the write with Insufficient Authentication and refuses SMP pairing, so the" +
         " handshake cannot complete; continuing would only loop the link. Turn the switch off to return to" +
         " the stable live-HR state (#1635)."
+
+/**
+ * May a pairing-hint clear also drop the PERSISTED hello-suppression latch?
+ *
+ * Only a genuine bond. A bond is proof the handshake works on this strap NOW, so the old verdict is stale
+ * and must go. A user Connect is not proof of anything: it already gets its one fresh attempt from the
+ * retry flag ([shouldSendClientHello]'s `userInitiated`), and dropping the latch on top of that un-
+ * suppressed every AUTOMATIC reconnect behind the attempt — so a single tap cost five more refusals and
+ * ~55s of link churn to re-earn a verdict about firmware that had not changed. Field log 260901-0121:
+ * latched 01:02:31, stable for 18 minutes, one tap at 01:21:09, straight back into the loop.
+ *
+ * Forgetting the strap clears it too, but writes the pref directly — the strap is being released, so there
+ * is no hint left to clear and nothing to route through here.
+ *
+ * Apple has only ever cleared the latch on a genuine bond or a forget; this predicate is what makes the
+ * Android side say the same thing.
+ */
+internal fun pairingHintClearDropsSuppressionLatch(genuineBond: Boolean): Boolean = genuineBond
 
 /**
  * Should the give-up latch suppress the hello, rather than pause auto-reconnect?

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5602,8 +5602,14 @@ class WhoopBleClient(
      *  off the involuntary-reconnect path on purpose: the streak must SURVIVE automatic reconnects (like
      *  the #52 pinnedBondRefusals counter) so it can accumulate to the threshold across the strap dropping
      *  and re-bonding. Only an explicit user tap (AppViewModel.connect) starts it over. Public so the
-     *  ViewModel can call it; a thin wrapper over the private [clearPairingHint]. */
-    fun clearPairingHintForUserConnect() = clearPairingHint()
+     *  ViewModel can call it; a thin wrapper over the private [clearPairingHint].
+     *
+     *  #1635: does NOT drop the hello-suppression latch. The fresh handshake attempt a Connect grants is
+     *  carried by [helloRetryRequested], not by clearing the latch, so keeping it costs the user nothing —
+     *  and clearing it un-suppressed every AUTOMATIC reconnect that followed, which is what re-paid the
+     *  full five refusals on every tap. Apple has always cleared it on a genuine bond and on forget only;
+     *  this is the twin of that. */
+    fun clearPairingHintForUserConnect() = clearPairingHint(genuineBond = false)
 
     /** Bonded-handshake watchdog (#50): every other connect phase has a timeout (scan; MTU settle delay;
      *  keep-alive) but the post-discovery bond/CCCD handshake had none — so a WHOOP 4.0 that wedges
@@ -5901,11 +5907,18 @@ class WhoopBleClient(
 
     /** Clear the pairing-hint streak + published hint after a genuine bond or a fresh connect. Also clears
      *  the mirrored [statusNote] only when it still carries the hint, so we never wipe an unrelated note. */
-    private fun clearPairingHint() {
+    private fun clearPairingHint(genuineBond: Boolean = true) {
         bondRefusalStreak = 0
         // #1635: a genuine bond proves the handshake works on this strap — drop the suppression latch so a
         // later transient failure starts from a clean slate rather than inheriting an old verdict.
-        runCatching { com.noop.ui.NoopPrefs.setHelloSuppressed(context, lastDeviceAddress, false) }
+        //
+        // Only a genuine bond. A user Connect passes false: it already gets its fresh attempt from
+        // [helloRetryRequested], and dropping the latch as well left every automatic reconnect after that
+        // attempt un-suppressed, so the give-up had to re-earn itself over five more refusals — ~55s of
+        // link churn per tap, on a strap whose firmware cannot answer the handshake either way.
+        if (pairingHintClearDropsSuppressionLatch(genuineBond)) {
+            runCatching { com.noop.ui.NoopPrefs.setHelloSuppressed(context, lastDeviceAddress, false) }
+        }
         // #1635: the pairing request is asked again from here too, so its one-shot line must be able to
         // report a SECOND retirement. Without this the switch would go quiet for good after one round.
         explicitBondGiveUpLogged = false
@@ -8386,6 +8399,18 @@ class WhoopBleClient(
                         alreadyBondedAtOsLevel = osBonded,
                         appLevelBonded = didBond,
                         alreadyRequestedThisLink = explicitBondRequestedThisLink,
+                        // #1635: deliberately the raw latch, with no `userInitiated` escape hatch beside
+                        // the hello's. A Connect used to re-fire createBond only as a side effect of
+                        // clearing the latch; now that the latch survives the tap, the pairing request
+                        // stays retired and the tap's one fresh attempt is the HELLO. That is the right
+                        // half to keep — the hello is the implicit pairing trigger, so a strap put into
+                        // pairing mode still has a route, while each createBond this strap declines
+                        // raises a system "Pairing rejected" notice the user never asked for.
+                        //
+                        // Do NOT "fix" this by passing `suppressed && !helloRetryRequested`. The deferral
+                        // branch below returns BEFORE the hello consumes that flag, so a re-armed request
+                        // would defer the hello, leave the retry set, and re-arm itself on the next link.
+                        // A full pairing retry is Forget + re-add, which clears the latch outright.
                         bondGivenUpForDevice = suppressed,
                     )
                 ) {
@@ -8417,22 +8442,30 @@ class WhoopBleClient(
                             // once per session. Anything recurring that clears it does not cost one link —
                             // it costs the latch permanently.
                             //
-                            // What replaces it is the explicit Connect, which clears the latch through
-                            // clearPairingHintForUserConnect() — precisely what the epitaph tells the user
-                            // to do, and pinned by HelloSuppressionTest's "suppression is never
-                            // permanent". Be exact about the alternative: the encrypted-bond clear at
-                            // clearPairingHint() lives inside the hello WRITE-COMPLETION callback, so a
-                            // suppressed hello cannot reach it. Claiming it as an automatic route would be
-                            // the same overclaim the give-up line just had to be corrected for.
+                            // What replaces it is the explicit Connect, which grants ONE fresh handshake
+                            // attempt through [helloRetryRequested] — precisely what the epitaph tells the
+                            // user to do, and pinned by HelloSuppressionTest's "suppression is never
+                            // permanent". Note it is the retry flag that carries this, NOT a clear of the
+                            // latch: clearPairingHintForUserConnect() deliberately leaves the latch set so
+                            // the automatic reconnects AFTER that attempt stay suppressed. Be exact about
+                            // the alternative: the encrypted-bond clear at clearPairingHint() lives inside
+                            // the hello WRITE-COMPLETION callback, so a suppressed hello cannot reach it.
+                            // Claiming it as an automatic route would be the same overclaim the give-up
+                            // line just had to be corrected for.
                             //
                             // That costs nothing real. The latch is only set after five consecutive
                             // refusals, so "latched, and pairing now works" needs something to have
                             // CHANGED — new firmware, the strap put into pairing mode (@Zebsi235's MG) —
                             // and a user who has changed something taps Connect. Voiding the verdict on
                             // the mere REQUEST voided it on a hope this strap never fulfils, every eleven
-                            // seconds. The pairing experiment itself is untouched: createBond still runs
-                            // on every link, it just no longer drags the hello back with it, which is what
-                            // [helloDeferredByExplicitBond] says must never share a link.
+                            // seconds. The pairing experiment itself is untouched in the window that
+                            // matters: createBond runs on every link until the latch is set, and it no
+                            // longer drags the hello back with it, which is what
+                            // [helloDeferredByExplicitBond] says must never share a link. Be precise
+                            // about after: `bondGivenUpForDevice = suppressed` retires the request for as
+                            // long as the latch stands, and since the latch now survives a Connect, the
+                            // way back is a genuine bond or Forget + re-add — not a tap. The field log
+                            // read as "createBond on every link" only because every tap wiped the latch.
                             if (initiated) {
                                 // Ask the device directly rather than waiting on our own broadcast
                                 // receiver, which is a suspect in exactly the silence being investigated.

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -27,6 +27,23 @@ class HelloSuppressionTest {
     }
 
     @Test
+    fun `a user Connect spends one attempt and leaves the latch standing`() {
+        // The tap's own connect re-attempts — that is what makes suppression non-permanent...
+        assertTrue(shouldSendClientHello(suppressedForDevice = true, userInitiated = true))
+        // ...but the tap is not evidence about the firmware, so it must not drop the latch.
+        assertFalse(pairingHintClearDropsSuppressionLatch(genuineBond = false))
+        // Which is the whole point: the AUTOMATIC reconnect behind that attempt is still suppressed.
+        // The regression cleared the latch on the tap, so this read false for every reconnect that
+        // followed and the give-up had to re-earn itself over five more refusals (~55s of churn).
+        assertFalse(shouldSendClientHello(suppressedForDevice = true, userInitiated = false))
+    }
+
+    @Test
+    fun `a genuine bond drops the latch - it is the one event that proves the handshake works`() {
+        assertTrue(pairingHintClearDropsSuppressionLatch(genuineBond = true))
+    }
+
+    @Test
     fun `only an unanswered handshake suppresses - an auth refusal still pauses`() {
         // An auth refusal is evidence the strap actively declined and reconnecting cannot help, so the
         // existing pause is right. An unanswered write is not that, and pausing would throw away live HR.


### PR DESCRIPTION
A tap on Connect threw away the #1635 give-up and re-paid its whole cost.

`clearPairingHintForUserConnect()` dropped the persisted hello-suppression latch along with the hint and the streak. The latch was never what granted the retry — `helloRetryRequested` is, and `shouldSendClientHello()` takes `userInitiated` for exactly that. Clearing it only un-suppressed every **automatic** reconnect behind the tap, so the give-up had to re-earn itself over five more refusals before the link settled.

## The field log

`260901-0121`, a WHOOP 5/MG on fw 50.41.1.0:

```
01:01:43  re-add
01:02:31  bond gaveUp refusals=5 (hello suppressed, staying connected)
01:02:38  CLIENT_HELLO suppressed for this strap
          ... 18m 32s, not one disconnect, live HR throughout ...
01:21:09  user taps Connect
01:21:11  asked Android to pair (createBond from BOND_NONE)
01:21:14  connect down after 4.7s
```

~55 s of churn and five dropped links per tap, to re-derive a verdict about firmware that had not changed in between. Reported as "it was down for a good 10mins" — that is this loop, re-entered on each tap.

## Parity

Apple never had this. `BLEManager` drops the latch on a genuine hello ack and in `forgetDevice`, nowhere else. This is the Kotlin side saying the same thing.

## What the tap still does

It keeps its fresh attempt, so *suppression is never permanent* still holds — one connect's worth of hello and nothing more. What it no longer does is re-arm `createBond`, which it only ever did as a side effect of wiping the latch. That is the better half to lose: each request this strap declines raises a system "Pairing rejected" notice the user never asked for, and the hello is itself the implicit pairing trigger, so a strap put into pairing mode still has a route. A full pairing retry stays Forget + re-add.

Worth stating plainly, because it looks like the obvious follow-up and is not: **do not pass `suppressed && !helloRetryRequested` to the bond gate.** The `explicitBondDefersHello` branch returns before the hello consumes that flag, so a re-armed request would defer the hello, leave the retry set, and re-arm itself on the next link. There is a comment at the call site saying so.

## Tests

`:app:testFullDebugUnitTest --tests "com.noop.ble.*"` — 614 tests, 0 failures, including `HelloSuppressionTest` (24) and `ExplicitBondTest` (19). Two new pure tests pin that a Connect spends one attempt and leaves the latch standing, and that a genuine bond drops it. `Tools/doc_comment_lint.py` clean.

Nothing pinned the old wipe, so nothing needed repinning. The user-facing strings ("Tap Connect to try the handshake again") stay accurate and are unchanged, so there is no new i18n debt.

## Doc corrections

Three blocks claimed the tap cleared the latch — `HelloSuppression.kt`, its Swift twin, and the long block in `WhoopBleClient`. That last one also read *"createBond still runs on every link"*, which was only ever true because every tap wiped the latch out from under the gate. All corrected.

## Not in this PR

The give-up threshold is still a flat 5 for both branches, so the genuinely-first-time cost is unchanged at ~55 s. Splitting it (5 for an auth refusal, ~3 for an unanswered handshake, where the user has nothing to act on) is a separate change. The backfill gate — `helloWrittenThisLink=false` means `didBond` can never become true, so history sync cannot start while suppressed — is a real tension and wants its own issue rather than a fix here.
