### PR TITLE
ble: spend fewer links learning what the strap already told us

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -148,9 +148,13 @@ struct PostBondTimeoutLoopDetector {
 /// The streak accumulates across the reconnect loop (a disconnect does NOT reset it) and is cleared only by
 /// a genuine bond or an explicit user reconnect, exactly like BLEManager's existing `bondRefusalStreak`.
 struct BondRefusalGiveUp {
-    /// Consecutive bond refusals before we pause auto-reconnect + write the epitaph. 5 (not 2, where the
+    /// Consecutive bond refusals before we PAUSE auto-reconnect + write the epitaph. 5 (not 2, where the
     /// pairing HINT already shows): the hint asks the user to act; we give them several reconnect cycles to
     /// do it before we stop hammering. A genuinely held/stale strap reaches 5 within a couple of minutes.
+    ///
+    /// This is the AUTH-REFUSAL number specifically, and `recordRefusal` takes a per-refusal override for
+    /// that reason: an unanswered handshake asks the user for nothing, so waiting five cycles for a decision
+    /// they cannot make just buys ~4.8s link drops. See `giveUpThresholdFor`.
     let giveUpThreshold: Int
 
     private(set) var refusals = 0
@@ -162,9 +166,9 @@ struct BondRefusalGiveUp {
 
     /// Record one bond refusal. Returns true if THIS refusal freshly crossed the give-up threshold (so the
     /// caller pauses the reconnect + writes the epitaph exactly once).
-    mutating func recordRefusal() -> Bool {
+    mutating func recordRefusal(threshold: Int? = nil) -> Bool {
         refusals += 1
-        if !gaveUp && refusals >= giveUpThreshold {
+        if !gaveUp && refusals >= (threshold ?? giveUpThreshold) {
             gaveUp = true
             return true
         }
@@ -5300,7 +5304,12 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
     /// Shared by both call sites so the split cannot drift: the auth path (a write error) and the
     /// unanswered path (a disconnect with a hello still outstanding) reach the same decision.
     private func recordWhoop5BondRefusal(authRefusal: Bool, peripheralUUID: String) {
-        guard bondGiveUp.recordRefusal() else { return }
+        // #1635: the two causes want different patience, for the same reason they want different
+        // outcomes - see `giveUpThresholdFor`. Keyed on the same authRefusal as the branch below, so the
+        // threshold and the treatment can never disagree about which kind of refusal this is.
+        guard bondGiveUp.recordRefusal(
+            threshold: giveUpThresholdFor(authRefusal: authRefusal, pauseThreshold: bondGiveUp.giveUpThreshold)
+        ) else { return }
         let opaque = BondRefusalGiveUp.opaqueId(fromLocalUUID: peripheralUUID)
         let suppress = giveUpSuppressesHello(authRefusal: authRefusal)
         if suppress {

--- a/Strand/BLE/HelloSuppression.swift
+++ b/Strand/BLE/HelloSuppression.swift
@@ -29,6 +29,33 @@ func shouldSendClientHello(suppressedForDevice: Bool, userInitiated: Bool) -> Bo
     !suppressedForDevice || userInitiated
 }
 
+/// How many consecutive refusals this cause needs before the give-up latches.
+///
+/// The flat 5 was argued for the AUTH-REFUSAL branch and only makes sense there: the pairing hint shows at
+/// 2, the hint asks the user to do something (close the official app, free a stale phone pairing), and the
+/// extra cycles are the time to do it before NOOP stops hammering.
+///
+/// An unanswered handshake gives the user nothing to act on. The write vanishes, the strap is not refusing
+/// anything it could be talked out of, and the outcome — suppress the hello and keep streaming live HR —
+/// needs no permission and costs no capability that was reachable anyway. Every cycle spent waiting is a
+/// ~4.8s link drop bought for nothing, so this branch stops at 3.
+///
+/// Not 2, which is exactly where the pairing hint fires: a strap whose hello is unanswered twice by some
+/// transient would latch a PERSISTED verdict with no margin at all. 3 keeps one cycle of margin and still
+/// takes roughly 40% off the churn.
+///
+/// Kotlin twin: `com.noop.ble.UNANSWERED_GIVE_UP_THRESHOLD`.
+let unansweredGiveUpThreshold = 3
+
+/// The give-up threshold for the refusal in hand. Keyed on the same `authRefusal` that decides whether the
+/// give-up suppresses or pauses (`giveUpSuppressesHello`), so the two can never disagree about which branch
+/// a refusal belongs to.
+///
+/// Kotlin twin: `com.noop.ble.giveUpThresholdFor`.
+func giveUpThresholdFor(authRefusal: Bool, pauseThreshold: Int) -> Int {
+    authRefusal ? pauseThreshold : unansweredGiveUpThreshold
+}
+
 /// Should the give-up latch suppress the hello, rather than pause auto-reconnect?
 ///
 /// The two give-up causes want opposite treatment, which is why they are split here rather than sharing

--- a/StrandTests/BondRefusalGiveUpTests.swift
+++ b/StrandTests/BondRefusalGiveUpTests.swift
@@ -68,4 +68,25 @@ final class BondRefusalGiveUpTests: XCTestCase {
         XCTAssertTrue(hint.contains("Forget This Device"))
         XCTAssertFalse(hint.contains("\u{2014}"))
     }
+
+    /// A per-refusal threshold moves the crossing without duplicating it. Kotlin twin:
+    /// `BondRefusalGiveUpTest."a lower threshold latches sooner, and the latch still reports once"`.
+    func testPerRefusalThresholdLatchesSoonerAndStillReportsOnce() {
+        var g = BondRefusalGiveUp()          // pause threshold 5
+        XCTAssertFalse(g.recordRefusal(threshold: 3))
+        XCTAssertFalse(g.recordRefusal(threshold: 3))
+        XCTAssertTrue(g.recordRefusal(threshold: 3), "crossed at 3, not 5")
+        XCTAssertTrue(g.gaveUp)
+        XCTAssertFalse(g.recordRefusal(threshold: 3), "the latch reports exactly once")
+        XCTAssertEqual(4, g.refusals)
+    }
+
+    /// Omitting it keeps the constructed threshold, so every existing caller is unchanged.
+    func testOmittingTheThresholdKeepsTheConstructedOne() {
+        var g = BondRefusalGiveUp()
+        XCTAssertEqual(5, g.giveUpThreshold)
+        for _ in 1...4 { XCTAssertFalse(g.recordRefusal()) }
+        XCTAssertTrue(g.recordRefusal())
+    }
+
 }

--- a/StrandTests/HelloSuppressionTests.swift
+++ b/StrandTests/HelloSuppressionTests.swift
@@ -170,5 +170,27 @@ final class HelloSuppressionTests: XCTestCase {
             XCTAssertFalse(keepAliveMayRun(connected: false, didBond: true, bonded: true, family: family))
         }
     }
-}
 
+    // MARK: - giveUpThresholdFor
+
+    /// The Kotlin twin is `HelloSuppressionTest."an unanswered handshake gives up sooner than an auth
+    /// refusal"`. Both numbers matter: 5 keeps the auth branch's patience, 3 is the unanswered branch.
+    func testUnansweredHandshakeGivesUpSoonerThanAuthRefusal() {
+        XCTAssertEqual(5, giveUpThresholdFor(authRefusal: true, pauseThreshold: 5))
+        XCTAssertEqual(3, giveUpThresholdFor(authRefusal: false, pauseThreshold: 5))
+        // Above the hint threshold, so a PERSISTED verdict still keeps a cycle of margin.
+        XCTAssertGreaterThan(unansweredGiveUpThreshold, 2)
+    }
+
+    /// Patience and treatment read the SAME refusal. Keyed apart they could disagree — pausing on a branch
+    /// that waited the suppression count, or vice versa. Kotlin twin: "the threshold and the treatment
+    /// read the same refusal".
+    func testThresholdAndTreatmentReadTheSameRefusal() {
+        for auth in [true, false] {
+            let suppresses = giveUpSuppressesHello(authRefusal: auth)
+            let threshold = giveUpThresholdFor(authRefusal: auth, pauseThreshold: 5)
+            XCTAssertEqual(suppresses, threshold == unansweredGiveUpThreshold)
+        }
+    }
+
+}

--- a/android/app/src/main/java/com/noop/ble/BondRefusalGiveUp.kt
+++ b/android/app/src/main/java/com/noop/ble/BondRefusalGiveUp.kt
@@ -20,11 +20,15 @@ package com.noop.ble
  */
 class BondRefusalGiveUp(
     /**
-     * Consecutive bond refusals before we pause auto-reconnect + write the epitaph. 5 (not 2, where the
+     * Consecutive bond refusals before we PAUSE auto-reconnect + write the epitaph. 5 (not 2, where the
      * pairing HINT already shows): the hint asks the user to act; we give them several reconnect cycles to
      * do it before we stop hammering. A genuinely held/stale strap reaches 5 within a couple of minutes.
+     *
+     * This is the AUTH-REFUSAL number specifically, and [recordRefusal] takes a per-refusal override for
+     * that reason: an unanswered handshake asks the user for nothing, so waiting five cycles for a decision
+     * they cannot make just buys ~4.8s link drops. See [giveUpThresholdFor].
      */
-    private val giveUpThreshold: Int = 5,
+    val giveUpThreshold: Int = 5,
 ) {
     var refusals = 0
         private set
@@ -39,10 +43,14 @@ class BondRefusalGiveUp(
     /**
      * Record one bond refusal. Returns true if THIS refusal freshly crossed the give-up threshold (so the
      * caller pauses the reconnect + writes the epitaph exactly once).
+     *
+     * [threshold] defaults to the constructed [giveUpThreshold]; callers that can tell the two give-up
+     * CAUSES apart pass the one for the refusal in hand ([giveUpThresholdFor]). The latch is still reported
+     * exactly once whatever the threshold, so a lower one moves the crossing without duplicating it.
      */
-    fun recordRefusal(): Boolean {
+    fun recordRefusal(threshold: Int = giveUpThreshold): Boolean {
         refusals += 1
-        if (!gaveUp && refusals >= giveUpThreshold) {
+        if (!gaveUp && refusals >= threshold) {
             gaveUp = true
             return true
         }

--- a/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
+++ b/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
@@ -116,6 +116,32 @@ internal fun helloOverrideExhaustedLine(attempts: Int): String =
         " the stable live-HR state (#1635)."
 
 /**
+ * How many consecutive refusals this cause needs before the give-up latches.
+ *
+ * The flat 5 was argued for the AUTH-REFUSAL branch and only makes sense there: the pairing hint shows at
+ * 2, the hint asks the user to do something (close the official app, free a stale phone pairing), and the
+ * extra cycles are the time to do it before NOOP stops hammering.
+ *
+ * An unanswered handshake gives the user nothing to act on. The write vanishes, the strap is not refusing
+ * anything it could be talked out of, and the outcome — suppress the hello and keep streaming live HR —
+ * needs no permission and costs no capability that was reachable anyway. Every cycle spent waiting is a
+ * ~4.8s link drop bought for nothing, so this branch stops at 3.
+ *
+ * Not 2, which is exactly where the pairing hint fires: a strap whose hello is unanswered twice by some
+ * transient would latch a PERSISTED verdict with no margin at all. 3 keeps one cycle of margin and still
+ * takes roughly 40% off the churn.
+ */
+internal const val UNANSWERED_GIVE_UP_THRESHOLD = 3
+
+/**
+ * The give-up threshold for the refusal in hand. Keyed on the same [authRefusal] that decides whether the
+ * give-up suppresses or pauses ([giveUpSuppressesHello]), so the two can never disagree about which branch
+ * a refusal belongs to.
+ */
+internal fun giveUpThresholdFor(authRefusal: Boolean, pauseThreshold: Int): Int =
+    if (authRefusal) pauseThreshold else UNANSWERED_GIVE_UP_THRESHOLD
+
+/**
  * May a pairing-hint clear also drop the PERSISTED hello-suppression latch?
  *
  * Only a genuine bond. A bond is proof the handshake works on this strap NOW, so the old verdict is stale

--- a/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
+++ b/android/app/src/main/java/com/noop/ble/HelloSuppression.kt
@@ -116,6 +116,31 @@ internal fun helloOverrideExhaustedLine(attempts: Int): String =
         " the stable live-HR state (#1635)."
 
 /**
+ * Should an explicit Connect keep the link it already holds, instead of rebuilding it?
+ *
+ * `getConnectedWhoopDevice()` answers "the OS has this device connected", which is true of our own live
+ * GATT too — so the Easy-connect path re-attached over a link that was already working. Field log
+ * 260901-0121: a link up 18m 32s and streaming was replaced on a tap.
+ *
+ * Every clause is load-bearing:
+ *  - [genuinelyBonded]: the ONLY state where a reconnect can achieve nothing. A suppressed strap is
+ *    deliberately excluded — there the tap IS the handshake retry, and the hello can only be written on a
+ *    new link's discovery, so it has to reconnect.
+ *  - [sameDevice]: a tap meant for a different strap must not be swallowed by the one in hand.
+ *  - [silentMs] < [stallFuseMs]: `connected` alone is not evidence the link WORKS. A silently dead GATT
+ *    reports connected until the watchdog bounces it, and that is exactly when someone taps Connect —
+ *    keeping the link there would make the button inert in the one state it exists for. The fuse is the
+ *    watchdog's own, so the two can never disagree about whether this link is alive.
+ */
+internal fun connectKeepsExistingLink(
+    genuinelyBonded: Boolean,
+    connected: Boolean,
+    sameDevice: Boolean,
+    silentMs: Long,
+    stallFuseMs: Long,
+): Boolean = genuinelyBonded && connected && sameDevice && silentMs < stallFuseMs
+
+/**
  * How many consecutive refusals this cause needs before the give-up latches.
  *
  * The flat 5 was argued for the AUTH-REFUSAL branch and only makes sense there: the pairing hint shows at

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3391,6 +3391,23 @@ class WhoopBleClient(
         // pipeline consistent. A stale connection or bond falls back to a scan via handleDisconnect.
         val direct = getConnectedWhoopDevice() ?: bondedWhoopDevice()
         if (direct != null) {
+            // #1635: we may already HOLD this link. getConnectedWhoopDevice() answers "the OS has this
+            // device connected", which is true of our own live GATT too — so without this, a Connect tap
+            // tore down a working link and rebuilt it. Field log 260901-0121: gen=6 had been up 18m 32s
+            // streaming HR when a tap replaced it with gen=7.
+            //
+            // Only when a reconnect could achieve NOTHING, which is exactly the genuinely-bonded case:
+            // the handshake is done, so there is no retry to spend and no state a fresh link would fix.
+            // A suppressed strap is deliberately NOT covered — there the tap IS the handshake retry, and
+            // the hello can only be written on a new link's discovery, so it must still reconnect.
+            if (didBond && _state.value.connected && gatt?.device?.address == direct.address) {
+                // Consume it. The retry belongs to the tap that asked, and leaving it set would hand a
+                // stale one to a later AUTOMATIC reconnect - the same leak the deferral branch warns of.
+                helloRetryRequested = false
+                log("Connect: already connected and bonded to ${direct.name ?: "WHOOP"} — keeping the link" +
+                    " rather than rebuilding it (#1635).")
+                return
+            }
             selectedModel = WhoopModel.WHOOP5_MG
             log("Easy-connect: attaching directly to ${direct.name ?: "WHOOP"} (no scan needed)")
             _state.update { it.copy(
@@ -5871,7 +5888,10 @@ class WhoopBleClient(
         // (the pairing hint has had several cycles to be acted on), pause auto-reconnect so we stop hammering
         // a strap that can't bond, write the one-line epitaph (opaque hashed id only, no PII), and surface
         // the honest paused hint. A genuine bond or a manual reconnect re-arms it.
-        if (bondGiveUp.recordRefusal()) {
+        // #1635: the two causes want different patience, for the same reason they want different
+        // outcomes — see [giveUpThresholdFor]. Keyed on the same authRefusal as the branch below, so the
+        // threshold and the treatment can never disagree about which kind of refusal this is.
+        if (bondGiveUp.recordRefusal(giveUpThresholdFor(authRefusal, bondGiveUp.giveUpThreshold))) {
             // #1635: an unanswered handshake and an auth refusal want opposite treatment — see
             // [giveUpSuppressesHello]. Suppressing keeps a link that is streaming live HR; pausing is for a
             // strap that actively declined and cannot be helped by reconnecting.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3400,15 +3400,31 @@ class WhoopBleClient(
             // the handshake is done, so there is no retry to spend and no state a fresh link would fix.
             // A suppressed strap is deliberately NOT covered — there the tap IS the handshake retry, and
             // the hello can only be written on a new link's discovery, so it must still reconnect.
-            if (didBond && _state.value.connected && gatt?.device?.address == direct.address) {
+            //
+            // AFTER the selectedModel pin, not before: both helpers match only a 5/MG, so this branch is
+            // also where a stale selection gets corrected. Returning above it would leave the picker and
+            // any later rescan on the wrong family.
+            selectedModel = WhoopModel.WHOOP5_MG
+            // `connected` alone is not evidence the link WORKS — a silently dead GATT reports connected
+            // until the watchdog bounces it, and that is precisely when someone taps Connect. Declining
+            // to act there would turn the button inert in the one state it exists for, so require the
+            // link to be live by the watchdog's own measure.
+            val silentMs = System.currentTimeMillis() - lastDataAtMs
+            if (connectKeepsExistingLink(
+                    genuinelyBonded = didBond,
+                    connected = _state.value.connected,
+                    sameDevice = gatt?.device?.address == direct.address,
+                    silentMs = silentMs,
+                    stallFuseMs = liveLinkStallFuseMs(),
+                )
+            ) {
                 // Consume it. The retry belongs to the tap that asked, and leaving it set would hand a
                 // stale one to a later AUTOMATIC reconnect - the same leak the deferral branch warns of.
                 helloRetryRequested = false
-                log("Connect: already connected and bonded to ${direct.name ?: "WHOOP"} — keeping the link" +
-                    " rather than rebuilding it (#1635).")
+                log("Connect: already connected and bonded to ${direct.name ?: "WHOOP"}, last data" +
+                    " ${silentMs / 1000}s ago — keeping the link rather than rebuilding it (#1635).")
                 return
             }
-            selectedModel = WhoopModel.WHOOP5_MG
             log("Easy-connect: attaching directly to ${direct.name ?: "WHOOP"} (no scan needed)")
             _state.update { it.copy(
                 scanning = false, whoop5Detected = false,
@@ -7499,6 +7515,17 @@ class WhoopBleClient(
     // MARK: Live-stream keep-alive  (port of BLEManager.startKeepAlive / keepAliveFire)
     // ====================================================================================
 
+    /**
+     * How long this family's live link may go silent before the app stops calling it healthy.
+     *
+     * Shared by the keep-alive's bounce decision and the Connect no-op below, deliberately: the no-op
+     * says "a reconnect would achieve nothing", and the only honest measure of that is the same one the
+     * watchdog uses to decide a reconnect IS needed. Two numbers here could disagree, and the way they
+     * would fail is a Connect button that declines to act on a link the watchdog has already given up on.
+     */
+    private fun liveLinkStallFuseMs(): Long =
+        if (connectedFamily == DeviceFamily.WHOOP5) KEEPALIVE_STALL_5MG_EMPTY_MS else KEEPALIVE_STALL_MS
+
     /** (Re)start the 30s keep-alive. Called from the connect handshake; cancelled in [reset]. */
     private fun startKeepAlive() {
         handler.removeCallbacks(keepAliveRunnable)
@@ -7537,8 +7564,7 @@ class WhoopBleClient(
             // data — #580 mistakenly gated the wide fuse on `historyEmpty`, so a 5/MG that DID serve history
             // still thrashed on the 120s fuse (#1414). Widen to the whole 5/MG family; WHOOP 4 keeps 120s.
             // (`historyEmpty` still gates the battery-backfill interval — a separate concern, left as-is.)
-            val bounceFuse = if (connectedFamily == DeviceFamily.WHOOP5)
-                KEEPALIVE_STALL_5MG_EMPTY_MS else KEEPALIVE_STALL_MS
+            val bounceFuse = liveLinkStallFuseMs()
             if (silentMs > bounceFuse) {
                 // Nothing for the fuse window — the live stream/link stalled. Bounce it: the auto-rescan on
                 // disconnect re-bonds and resumes streaming (the automatic version of the manual fix).

--- a/android/app/src/test/java/com/noop/ble/BondRefusalGiveUpTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BondRefusalGiveUpTest.kt
@@ -81,4 +81,24 @@ class BondRefusalGiveUpTest {
         assertTrue(hint.contains("Forget This Device"))
         assertFalse(hint.contains("\u2014"))
     }
+
+    @Test
+    fun `a lower threshold latches sooner, and the latch still reports once`() {
+        var g = BondRefusalGiveUp()          // pause threshold 5
+        assertFalse(g.recordRefusal(threshold = 3))
+        assertFalse(g.recordRefusal(threshold = 3))
+        assertTrue(g.recordRefusal(threshold = 3))   // crossed at 3, not 5
+        assertTrue(g.gaveUp)
+        // Still exactly one crossing: the epitaph and the latch write are once-per-give-up.
+        assertFalse(g.recordRefusal(threshold = 3))
+        assertEquals(4, g.refusals)
+    }
+
+    @Test
+    fun `omitting the threshold keeps the constructed one`() {
+        val g = BondRefusalGiveUp()
+        assertEquals(5, g.giveUpThreshold)
+        repeat(4) { assertFalse(g.recordRefusal()) }
+        assertTrue(g.recordRefusal())
+    }
 }

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -44,6 +44,27 @@ class HelloSuppressionTest {
     }
 
     @Test
+    fun `an unanswered handshake gives up sooner than an auth refusal`() {
+        // The auth refusal keeps the full patience: the hint asks the user to act, and 5 is the time
+        // to act in. An unanswered handshake asks nothing of them, so waiting only buys link drops.
+        assertEquals(5, giveUpThresholdFor(authRefusal = true, pauseThreshold = 5))
+        assertEquals(3, giveUpThresholdFor(authRefusal = false, pauseThreshold = 5))
+        // Above the hint threshold, so a latched PERSISTED verdict still needs a cycle of margin.
+        assertTrue(UNANSWERED_GIVE_UP_THRESHOLD > 2)
+    }
+
+    @Test
+    fun `the threshold and the treatment read the same refusal`() {
+        // These two decide patience and outcome for one refusal. Keyed apart they could disagree -
+        // pausing on a branch that waited the suppression count, or vice versa.
+        for (auth in listOf(true, false)) {
+            val suppresses = giveUpSuppressesHello(authRefusal = auth)
+            val threshold = giveUpThresholdFor(authRefusal = auth, pauseThreshold = 5)
+            assertEquals(suppresses, threshold == UNANSWERED_GIVE_UP_THRESHOLD)
+        }
+    }
+
+    @Test
     fun `only an unanswered handshake suppresses - an auth refusal still pauses`() {
         // An auth refusal is evidence the strap actively declined and reconnecting cannot help, so the
         // existing pause is right. An unanswered write is not that, and pausing would throw away live HR.

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -44,6 +44,34 @@ class HelloSuppressionTest {
     }
 
     @Test
+    fun `a Connect keeps a live bonded link it already holds`() {
+        assertTrue(connectKeepsExistingLink(genuinelyBonded = true, connected = true, sameDevice = true,
+                                            silentMs = 5_000, stallFuseMs = 600_000))
+    }
+
+    @Test
+    fun `a Connect rebuilds when a reconnect could still achieve something`() {
+        // Suppressed / never bonded: the tap IS the handshake retry, and that needs a new link.
+        assertFalse(connectKeepsExistingLink(genuinelyBonded = false, connected = true, sameDevice = true,
+                                             silentMs = 5_000, stallFuseMs = 600_000))
+        // A tap aimed at a different strap must not be swallowed by the one in hand.
+        assertFalse(connectKeepsExistingLink(genuinelyBonded = true, connected = true, sameDevice = false,
+                                             silentMs = 5_000, stallFuseMs = 600_000))
+        assertFalse(connectKeepsExistingLink(genuinelyBonded = true, connected = false, sameDevice = true,
+                                             silentMs = 5_000, stallFuseMs = 600_000))
+    }
+
+    @Test
+    fun `a silently dead link does NOT keep the button inert`() {
+        // The regression this clause exists for: GATT still says connected, nothing has arrived, and the
+        // watchdog is about to bounce it. That is exactly when Connect is tapped, so it must act.
+        assertFalse(connectKeepsExistingLink(genuinelyBonded = true, connected = true, sameDevice = true,
+                                             silentMs = 600_000, stallFuseMs = 600_000))
+        assertFalse(connectKeepsExistingLink(genuinelyBonded = true, connected = true, sameDevice = true,
+                                             silentMs = 900_000, stallFuseMs = 600_000))
+    }
+
+    @Test
     fun `an unanswered handshake gives up sooner than an auth refusal`() {
         // The auth refusal keeps the full patience: the hint asks the user to act, and 5 is the time
         // to act in. An unanswered handshake asks nothing of them, so waiting only buys link drops.


### PR DESCRIPTION
Two changes against the same complaint — manual reconnects cost too much. Follows #1778, which stopped a tap wiping the suppression latch; this is the rest of what a tap pays for.

## 1. The give-up threshold now follows the cause

The flat 5 was argued for the **auth-refusal** branch and only holds there: the pairing hint shows at 2, it asks the user to close the official app or free a stale pairing, and the extra cycles are the time to do it.

An unanswered handshake asks the user for nothing. The write vanishes, the strap is not refusing something it could be talked out of, and the outcome — suppress the hello, keep streaming live HR — needs no permission and costs no capability that was reachable anyway. Every cycle spent waiting is a ~4.8 s link drop bought for nothing, so that branch stops at **3**.

Not 2, which is exactly where the pairing hint fires: a strap whose hello goes unanswered twice by some transient would latch a **persisted** verdict with no margin at all. 3 keeps a cycle of margin and still takes ~40% off the first latch.

`giveUpThresholdFor` keys on the same `authRefusal` as `giveUpSuppressesHello`, so patience and treatment can never disagree about which kind of refusal is in hand. A test pins that pairing across both branches rather than trusting the two to be edited together.

## 2. A Connect tap no longer rebuilds a link it already holds

`getConnectedWhoopDevice()` answers *"the OS has this device connected"* — which is true of our own live GATT too. So Easy-connect re-attached over the top of a link we were already holding.

Field log `260901-0121`: `gen=6` had been up **18m 32s** streaming HR (`sinceConnect=1109s`) when a tap replaced it with `gen=7`.

Deliberately narrow: the guard fires only when a reconnect could achieve **nothing**, which is the genuinely-bonded case. A **suppressed** strap still reconnects, because there the tap *is* the handshake retry and the hello can only be written on a new link's discovery. Making that a no-op would strand suppression with no in-app way back.

Two things worth flagging for review:

- It is a **new `didBond` reader**. On an unbonded-by-design 5/MG it never fires — that is the intended reading, not an oversight.
- The no-op **consumes `helloRetryRequested`**. Leaving it set would hand a stale retry to a later automatic reconnect, which is the same leak the deferral branch already warns about.

## Tests

`:app:testFullDebugUnitTest --tests "com.noop.ble.*"` — **618 tests, 0 failures**. Four new: the two thresholds and their margin, the threshold/treatment pairing, that a lower threshold moves the crossing without duplicating the latch, and that omitting it keeps the constructed 5. `Tools/doc_comment_lint.py` clean.

## Parity

Swift carries both twins — `unansweredGiveUpThreshold` / `giveUpThresholdFor` and the `recordRefusal(threshold:)` override. The connect guard is Android-only: `connect()`'s Easy-connect re-attach is the Android path, and Apple already separates `connect()` from `connectFromSystem()`.

Threshold docs on both platforms said "before we pause auto-reconnect" as though it were one number; corrected to name it as the auth-refusal figure.

## What this does not change

No user-facing copy, so no i18n. And it does not help the case that actually needs a decision: a tap on a **connected, streaming, suppressed** strap still costs one ~11 s cycle. Making that a no-op would mean moving the retry off the Connect button onto its own affordance and rewording the hint that currently says "Tap Connect to try the handshake again" — a product call plus 8 iOS / 4 Android locales, so it wants its own change.

---

## Re-review notes

Two bugs in the connect guard were found after the first push and are fixed in `dd2983b`:

- It returned **above** the `selectedModel` pin. Both Easy-connect helpers match only a 5/MG, so that assignment is where a stale family selection gets corrected; returning first left the picker and any later rescan on the wrong family.
- `connected` is not evidence the link **works**. A silently dead GATT reports connected until the watchdog bounces it — exactly the state someone taps Connect in — so the guard would have made the button inert in the one situation it exists for. It now also requires the link to be live by the watchdog's own fuse, extracted to `liveLinkStallFuseMs()` and shared with `keepAliveFire()` so the two cannot disagree. `lastDataAtMs` is fed by `onInbound`, i.e. the same signal the watchdog reads.

### One consequence a reviewer should weigh, not fixed here

`DevicesScreen`'s WHOOP row shows a `"Reconnecting…"` toast and then calls `viewModel.connect()`, with the comment *"A short toast confirms the tap, since the link state only changes a few seconds later."* On the new no-op path the link state does not change at all, so on a bonded, live strap that toast is inaccurate — it still confirms the tap, but it names something that no longer happens.

The button is offered whenever the device is a WHOOP, with no `!live.connected` gate. Options are to gate it on not-connected, or to reword the toast; both are UI/string changes on a raw English literal, so they want their own change rather than riding in on a BLE fix. Flagging rather than folding it in.

### Checked and clear

- `didBond` and `lastDataAtMs` are both `@Volatile`. `gatt` is not, which is pre-existing and used widely — but every way a stale read can go here resolves to "guard is false, reconnect as before", so it falls safe.
- `AppViewModel.connect()`'s tail only promotes the foreground service, which is harmless (and arguably right) on a no-op.
- The no-op consumes `helloRetryRequested`; on a genuinely bonded strap there is no suppression for it to spend anyway.