### PR TITLE
ble: a timer firing is not the user asking to retry the handshake

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3340,15 +3340,37 @@ class WhoopBleClient(
     // ====================================================================================
 
     /**
-     * Begin scanning for the WHOOP custom service, then connect to the first match.
+     * USER-initiated connect (the Connect button, the scan flow, Add-a-WHOOP). Begin scanning for the
+     * WHOOP custom service, then connect to the first match.
      * Port of `BLEManager.connect()` → `central.scanForPeripherals(withServices:[customService])`.
+     *
+     * The ONLY entry that grants the #1635 one-shot handshake retry. System-initiated paths — the
+     * radio-on rescan, the bond-loop salvage probe, both deferred reconnect timers — MUST use
+     * [connectFromSystem]. Field log 260901-1022: the stale-OS-bond fallback routed a SCAN-driven
+     * reconnect through here, so a suppressed strap wrote a second unanswered hello and paid a second
+     * ~4.8s drop that no user had asked for. Apple has kept these two entries apart since #78 hole-2.
      */
     @SuppressLint("MissingPermission")
-    fun connect(model: WhoopModel = WhoopModel.WHOOP4) {
+    fun connect(model: WhoopModel = WhoopModel.WHOOP4) = connectInternal(model, userInitiated = true)
+
+    /**
+     * SYSTEM-initiated connect: identical to [connect] except it never grants the handshake retry.
+     *
+     * A timer firing is not the user saying "try again". Suppression exists precisely so the automatic
+     * reconnects behind a failed attempt stop writing the hello; handing them the retry re-opens the loop
+     * one link at a time, and does it invisibly, because every line it produces looks exactly like the
+     * user having tapped Connect. Kotlin twin of `BLEManager.connectFromSystem`.
+     */
+    @SuppressLint("MissingPermission")
+    fun connectFromSystem(model: WhoopModel = WhoopModel.WHOOP4) = connectInternal(model, userInitiated = false)
+
+    @SuppressLint("MissingPermission")
+    private fun connectInternal(model: WhoopModel, userInitiated: Boolean) {
         intentionalDisconnect = false
         // #1635: an explicit Connect is the user saying "try the handshake again" — the documented way out
-        // of hello suppression, and the reason suppression is never a permanent verdict.
-        helloRetryRequested = true
+        // of hello suppression, and the reason suppression is never a permanent verdict. Consumed by the
+        // first connect that reaches the hello decision, so it is granted here and nowhere else.
+        if (userInitiated) helloRetryRequested = true
         // PR #588: an explicit user-driven Connect is never an out-of-range retry — clear the involuntary-
         // reconnect streak so this scan (and any reconnects it spawns) starts back at the snappy
         // LOW_LATENCY scan mode + the 3s backoff base, never inheriting a backed-off lower-power scan.
@@ -3589,7 +3611,7 @@ class WhoopBleClient(
                 connectToDevice(dev, autoConnect = true)
             } else {
                 log("Bluetooth radio back on — rescanning for your ${selectedModel.displayName}")
-                connect(selectedModel)
+                connectFromSystem(selectedModel)
             }
         }
     }
@@ -3616,7 +3638,7 @@ class WhoopBleClient(
             intentionalDisconnect = false
             val dev = lastDevice
             if (dev != null && isPreferred(dev)) connectToDevice(dev, autoConnect = true)
-            else connect(selectedModel)
+            else connectFromSystem(selectedModel)
         }
     }
 
@@ -9963,7 +9985,7 @@ class WhoopBleClient(
                 }
                 // #1030 (ryanbr): route through scheduleReconnect so this backoff timer is cancellable
                 // and can't tear down a link that returns before it fires.
-                scheduleReconnect(RECONNECT_DELAY_MS) { connect(selectedModel) }
+                scheduleReconnect(RECONNECT_DELAY_MS) { connectFromSystem(selectedModel) }
                 return
             }
             val dev = lastDevice
@@ -9999,7 +10021,7 @@ class WhoopBleClient(
                 val rescanDelay = nextReconnectDelayMs()
                 log("Disconnected (status=$status); rescanning in ${rescanDelay / 1000}s (attempt $failedReconnectAttempts$heldSuffix)")
                 // #1030 (ryanbr): cancellable backoff timer (see scheduleReconnect).
-                scheduleReconnect(rescanDelay) { connect(selectedModel) }
+                scheduleReconnect(rescanDelay) { connectFromSystem(selectedModel) }
             }
         } else {
             log("Disconnected (intentional)")

--- a/android/app/src/test/java/com/noop/ble/SystemInitiatedConnectTest.kt
+++ b/android/app/src/test/java/com/noop/ble/SystemInitiatedConnectTest.kt
@@ -21,13 +21,27 @@ import java.io.File
  */
 class SystemInitiatedConnectTest {
 
+    /**
+     * Deliberately FAILS rather than skipping when the source cannot be found.
+     *
+     * The nearby [com.noop.protocol.CommandCatalogueTest] uses `Assume` for its schema, and that is right
+     * there: it reads a file from a SIBLING Swift package that a stripped checkout may genuinely not have.
+     * This one reads the file its own module is compiled from, so "not found" means the search is wrong,
+     * not that the environment is thin — and a regression gate that quietly declines to run is worse than
+     * no gate, because the green tick then means nothing. Walk the parents so any working directory
+     * resolves, and if none does, say so loudly.
+     */
     private fun clientSource(): String {
         val rel = "android/app/src/main/java/com/noop/ble/WhoopBleClient.kt"
-        val userDir = File(System.getProperty("user.dir") ?: ".")
-        val f = listOf(File(userDir, rel), File(userDir, "../../$rel"), File(userDir, "../$rel"))
-            .firstOrNull { it.exists() }
-        org.junit.Assume.assumeTrue(
-            "WhoopBleClient.kt not found from user.dir=$userDir — skipping the entry-point check", f != null)
+        val start = File(System.getProperty("user.dir") ?: ".").absoluteFile
+        val f = generateSequence(start) { it.parentFile }
+            .map { File(it, rel) }
+            .firstOrNull { it.isFile }
+        assertTrue(
+            "WhoopBleClient.kt not found walking up from user.dir=$start — this gate cannot run, and a " +
+                "gate that silently skips is worse than none. Fix the path, do not re-add an Assume.",
+            f != null,
+        )
         return f!!.readText()
     }
 

--- a/android/app/src/test/java/com/noop/ble/SystemInitiatedConnectTest.kt
+++ b/android/app/src/test/java/com/noop/ble/SystemInitiatedConnectTest.kt
@@ -42,14 +42,24 @@ class SystemInitiatedConnectTest {
         )
     }
 
+    /**
+     * Deliberately "no internal caller uses the user entry" rather than "the system entry is used N
+     * times". A count would fail the day someone adds a FIFTH system path correctly, which trains people
+     * to edit the number instead of thinking; this phrasing passes for any correct addition and fails for
+     * any incorrect one. The client never needs to call its own public user entry — every internal path
+     * is by definition system-initiated.
+     */
     @Test
-    fun `the system entry point exists and is actually used`() {
+    fun `no internal path calls the user-facing connect`() {
         val src = clientSource()
         assertTrue("connectFromSystem must exist as the system-initiated entry",
                    src.contains("fun connectFromSystem("))
-        // Radio-on rescan, salvage probe, and both deferred reconnect timers.
-        val uses = Regex("""connectFromSystem\(selectedModel\)""").findAll(src).count()
-        assertEquals("every system-initiated connect should route here", 4, uses)
+        val offenders = Regex("""(?<![A-Za-z])connect\((selectedModel|model|persistedWhoopModel\(\))\)""")
+            .findAll(src).map { it.value }.toList()
+        assertEquals(
+            "an internal caller is by definition not the user — use connectFromSystem(...): $offenders",
+            0, offenders.size,
+        )
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/ble/SystemInitiatedConnectTest.kt
+++ b/android/app/src/test/java/com/noop/ble/SystemInitiatedConnectTest.kt
@@ -1,0 +1,63 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * #1635: only a USER gesture may grant the one-shot CLIENT_HELLO retry.
+ *
+ * This reads the source rather than calling the client, because the rule is about which ENTRY POINT a
+ * caller picks — there is no return value to assert on, and the client needs a radio. The regression it
+ * exists for already happened once: the stale-OS-bond fallback scheduled its reconnect through the
+ * user-facing `connect()`, so on a suppressed strap a scan-driven retry wrote a second unanswered hello
+ * and paid a second ~4.8s drop nobody asked for (field log 260901-1022, gen=3).
+ *
+ * Nothing else would have caught it. Every line that path produces is identical to a real user tap, the
+ * BLE path has no CI, and a unit test of the client cannot reach it. Apple has kept the two entries apart
+ * since #78 hole-2 and says so in `BLEManager.connect`'s doc; this is Android's version of that rule
+ * being enforced rather than remembered.
+ */
+class SystemInitiatedConnectTest {
+
+    private fun clientSource(): String {
+        val rel = "android/app/src/main/java/com/noop/ble/WhoopBleClient.kt"
+        val userDir = File(System.getProperty("user.dir") ?: ".")
+        val f = listOf(File(userDir, rel), File(userDir, "../../$rel"), File(userDir, "../$rel"))
+            .firstOrNull { it.exists() }
+        org.junit.Assume.assumeTrue(
+            "WhoopBleClient.kt not found from user.dir=$userDir — skipping the entry-point check", f != null)
+        return f!!.readText()
+    }
+
+    @Test
+    fun `a deferred reconnect never routes through the user-facing connect`() {
+        val offenders = Regex("""scheduleReconnect\([^)]*\)\s*\{\s*connect\(""")
+            .findAll(clientSource()).map { it.value }.toList()
+        assertEquals(
+            "a timer firing is not the user asking to retry the handshake — use connectFromSystem(...): " +
+                offenders,
+            0, offenders.size,
+        )
+    }
+
+    @Test
+    fun `the system entry point exists and is actually used`() {
+        val src = clientSource()
+        assertTrue("connectFromSystem must exist as the system-initiated entry",
+                   src.contains("fun connectFromSystem("))
+        // Radio-on rescan, salvage probe, and both deferred reconnect timers.
+        val uses = Regex("""connectFromSystem\(selectedModel\)""").findAll(src).count()
+        assertEquals("every system-initiated connect should route here", 4, uses)
+    }
+
+    @Test
+    fun `only the user entry grants the hello retry`() {
+        val src = clientSource()
+        val grants = Regex("""helloRetryRequested\s*=\s*true""").findAll(src).count()
+        assertEquals("the retry is granted in exactly one place, behind the userInitiated flag", 1, grants)
+        assertTrue("that one place must be gated on userInitiated",
+                   src.contains("if (userInitiated) helloRetryRequested = true"))
+    }
+}


### PR DESCRIPTION
Android had one connect entry point. Four system-initiated paths used it — the radio-on rescan, the bond-loop salvage probe, and both deferred reconnect timers — so each was handed the #1635 one-shot CLIENT_HELLO retry that only a user gesture should get.

## The field evidence

Log `260901-1022`, build 403. The link held **7h 29m** suppressed and silent, then:

```
10:21:50  Easy-connect  gen=2          ← the user's tap
10:21:51  writing CLIENT_HELLO                  correct: the tap's one retry
10:21:54  connect down after 4.7s
10:21:54  stale OS bond (attempt 1); falling back to a scan
10:22:00  Discovered … connecting  gen=3        ← AUTOMATIC, no user involved
10:22:02  writing CLIENT_HELLO                  ← should have been suppressed
10:22:05  connect down after 4.8s
10:22:11  gen=4
10:22:13  CLIENT_HELLO suppressed  → stable
```

The fallback scheduled its rescan through `connect()`, which re-granted the retry, so the automatic reconnect wrote a second unanswered hello and paid a second drop. Two drops per manual reconnect where the design says one.

## The change

`connectFromSystem()` is now the entry for those four sites — identical to `connect()` except that it never grants the retry. Both delegate to a private `connectInternal(model, userInitiated:)`.

Apple has had exactly this split since #78 hole-2, and `BLEManager.connect`'s doc already states the rule Android was missing:

> *System-initiated paths (Bluetooth poweredOn, the deferred reconnect timers, the salvage probe) **MUST** use `connectFromSystem()` instead — the old single entry point let every poweredOn event silently un-pause the give-up and re-run the full refusal hammer.*

Left as user-initiated deliberately: `SourceCoordinator`'s `startWhoop` (both call sites are a user switching the active strap) and `reconnectToAddress` (the launch path, which never granted the retry in the first place).

## Why the test reads source

The rule is about which entry point a caller picks. There is no return value to assert on, the client needs a radio, and every log line the wrong path produces is **identical to a real user tap** — which is why this survived until a field log turned up. `CommandCatalogueTest` sets the precedent for reading source from `user.dir`.

Three assertions: no `scheduleReconnect(…) { connect(` remains, `connectFromSystem` exists and is used at all four sites, and `helloRetryRequested = true` appears exactly once, behind the `userInitiated` flag.

I verified the gate can actually fail by reintroducing the exact regression — two of the three assertions failed — then restored it. It reports `skipped=0`, so it is genuinely finding the source rather than quietly assuming past itself.

## Parity note, not fixed here

Apple has one internal self-call to its user entry: `readoptWorkingStrap` (#52 multi-WHOOP pin handoff) calls `connect(model:)`. By Apple's own rule that should be `connectFromSystem()`, but it is **not** a safe one-word change — Apple's `connect()` also resets the bond-loop give-up when paused, and a pin handoff that fires after repeated refusals plausibly depends on that un-pause. Worth its own look with a multi-strap install; flagging rather than guessing.

## Tests

`:app:testFullDebugUnitTest --tests "com.noop.ble.*"` — **624 tests, 0 failures, 0 skipped**. `Tools/doc_comment_lint.py` clean. Android-only change, so no Swift compile risk.
