### PR TITLE
sleep: let the HR band widen the sparse bridge's active bound, not be vetoed by it

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -245,6 +245,23 @@ public enum SleepStager {
     /// not. `mergeMin` (15) already absorbs shorter active runs upstream in `mergePeriods`.
     public static let sparseBridgeActiveMaxMin: Int = 30
 
+    /// The same bound when HR across the whole span stays in the sleep band.
+    ///
+    /// `sparseBridgeActiveMaxMin`'s own doc calls the minute bound "the cheap half of the guard" and the
+    /// HR band "the real one" — but the check order meant the cheap half vetoed first, so the real one
+    /// never got to speak for a run over 30 minutes. A 42-minute active run with sleep-band HR was
+    /// rejected identically to one with a wearer plainly up and about.
+    ///
+    /// That is the wrong way round on a strap whose "active" verdict comes from MOTION, which is the
+    /// sparse and unreliable signal on the hardware this fires for (field log 260901-1022: 20,647 gravity
+    /// samples across a 54-hour window, against 109,868 HR). HR is the better witness there, and it is
+    /// already computed. 60 rather than something larger because it is `minSleepMin`: an interruption
+    /// long enough to be a session in its own right is a genuine awakening whatever HR says.
+    ///
+    /// Applied as a MAXIMUM against `sparseBridgeActiveMaxMin`, never a replacement, so the in-band path
+    /// can only ever be more permissive — an out-of-band span keeps the 30-minute bound exactly.
+    public static let sparseBridgeActiveMaxInBandMin: Int = 60
+
     // MARK: - Stage 1–3 constants (sleep_features.py)
 
     public static let epochS: Double = 30.0
@@ -502,6 +519,8 @@ public enum SleepStager {
         let gapMin: Int
         /// Minutes of intervening ACTIVE run, or 0 when the pair was only separated by a gap (#1657).
         let activeMin: Int
+        /// The bound this pair was actually judged against — 30, or 60 when HR stayed in the sleep band.
+        let activeCapMin: Int
         /// Whether the intervening HR stayed in the sleep band (the bridge's second condition).
         let hrInSleepBand: Bool
         /// Whether this pair was merged.
@@ -535,6 +554,7 @@ public enum SleepStager {
         if !sparse || periods.isEmpty { return (periods, []) }
         let bridgeGapS = sparseBridgeGapMin * 60
         let activeMaxS = sparseBridgeActiveMaxMin * 60
+        let activeMaxInBandS = sparseBridgeActiveMaxInBandMin * 60
         var out: [Period] = []
         var attempts: [SparseBridgeAttempt] = []
 
@@ -543,18 +563,27 @@ public enum SleepStager {
         /// The order of the checks fixes which reason a failing pair reports, and it is deliberate:
         /// overlap and gap are properties of the pair, activeTooLong is a property of what sits between
         /// them, and hrOutOfBand is last because it is the only one that needed the HR series to decide.
+        /// `activeMaxInBandS` is a PARAMETER rather than a capture, mirroring the Kotlin default of 0.
+        /// Captured, case 1 (adjacent sleep runs, no intervening active run) would report activeCapMin=60
+        /// on Apple and 0 on Android for the identical decision — same behaviour, divergent trace, which
+        /// is exactly the byte-for-byte comparison these lines exist to allow.
         func consider(_ left: Period, _ right: Period, activeS: Int,
-                      dropTrailing: Bool, activeMaxS: Int) -> Bool {
+                      dropTrailing: Bool, activeMaxS: Int, activeMaxInBandS: Int = 0) -> Bool {
             let gap = right.start - left.end
             let inBand = hrSleepBandAcross(left.end, right.start, hr: hr, baseline: baseline)
+            // The HR band is the real guard, so let it widen the minute bound rather than be vetoed by
+            // it. max, not a swap: in-band can only ever be MORE permissive, and case 1 (activeMaxS = 0,
+            // no intervening run) is untouched because activeS is 0 there too.
+            let activeCapS = inBand ? max(activeMaxS, activeMaxInBandS) : activeMaxS
             let reason: String
             if gap < 0 { reason = "overlap" }
             else if gap > bridgeGapS { reason = "gapTooLong" }
-            else if activeS > activeMaxS { reason = "activeTooLong" }
+            else if activeS > activeCapS { reason = "activeTooLong" }
             else if !inBand { reason = "hrOutOfBand" }
             else { reason = "bridged" }
             let bridged = reason == "bridged"
             attempts.append(SparseBridgeAttempt(gapMin: gap / 60, activeMin: activeS / 60,
+                                                activeCapMin: activeCapS / 60,
                                                 hrInSleepBand: inBand, bridged: bridged, reason: reason))
             guard bridged else { return false }
             if dropTrailing { out.removeLast() }
@@ -574,7 +603,8 @@ public enum SleepStager {
                    out[out.count - 2].stage == "sleep" {
                     let prev = out[out.count - 2]
                     if consider(prev, p, activeS: last.end - last.start,
-                                dropTrailing: true, activeMaxS: activeMaxS) { continue }
+                                dropTrailing: true, activeMaxS: activeMaxS,
+                                activeMaxInBandS: activeMaxInBandS) { continue }
                 }
             }
             out.append(p)
@@ -1138,7 +1168,7 @@ public enum SleepStager {
             for (i, a) in bridgeAttempts.enumerated() {
                 traceSink(GateTrace.runLine(index: -1, startTs: 0, endTs: 0,
                     verdict: a.bridged ? .kept : .dropped, gate: "sparseBridgePair",
-                    detail: "pair=\(i) gapMin=\(a.gapMin) activeMin=\(a.activeMin) "
+                    detail: "pair=\(i) gapMin=\(a.gapMin) activeMin=\(a.activeMin) activeCapMin=\(a.activeCapMin) "
                         + "hrInSleepBand=\(a.hrInSleepBand) reason=\(a.reason)"))
             }
         }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerActiveBridgeTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerActiveBridgeTests.swift
@@ -38,7 +38,8 @@ final class SleepStagerActiveBridgeTests: XCTestCase {
     /// absorbing it would score wakefulness as sleep — wrong in a new direction and harder to notice than
     /// the truncation being fixed.
     func testAnActiveRunLongerThanTheBoundIsLeftAlone() {
-        let tooLong = SleepStager.sparseBridgeActiveMaxMin * 60 + 60
+        // Repinned past the IN-BAND bound: this HR is calm, so that is the bound in force.
+        let tooLong = SleepStager.sparseBridgeActiveMaxInBandMin * 60 + 60
         let out = SleepStager.bridgeSparseSleep(
             [sleep(0, 3000), active(3000, 3000 + tooLong), sleep(3000 + tooLong, 9000)],
             sparse: true, hr: calmHr(0, 9000), baseline: baseline)
@@ -87,14 +88,17 @@ final class SleepStagerActiveBridgeTests: XCTestCase {
     /// The trace has to say WHY, and the blocking length is the number a reader needs. The old trace could
     /// only report runsBefore == runsAfter, which says the bridge did nothing and not what stopped it.
     func testABlockedPairReportsTheBoundThatBlockedItWithTheActiveLength() {
-        let tooLong = SleepStager.sparseBridgeActiveMaxMin * 60 + 60
+        // Repinned past the IN-BAND bound: this HR is calm, so that is the bound in force.
+        let tooLong = SleepStager.sparseBridgeActiveMaxInBandMin * 60 + 60
         let (_, attempts) = SleepStager.bridgeSparseSleepTraced(
             [sleep(0, 3000), active(3000, 3000 + tooLong), sleep(3000 + tooLong, 9000)],
             sparse: true, hr: calmHr(0, 9000), baseline: baseline)
         XCTAssertEqual(attempts.count, 1)
         XCTAssertEqual(attempts.first?.reason, "activeTooLong")
         XCTAssertEqual(attempts.first?.bridged, false)
-        XCTAssertEqual(attempts.first?.activeMin, SleepStager.sparseBridgeActiveMaxMin + 1)
+        XCTAssertEqual(attempts.first?.activeMin, SleepStager.sparseBridgeActiveMaxInBandMin + 1)
+        // And it names WHICH bound, or the same activeMin reads blocked in one log, merged in another.
+        XCTAssertEqual(attempts.first?.activeCapMin, SleepStager.sparseBridgeActiveMaxInBandMin)
     }
 
     /// The tracer and the merge are ONE pass now. This file used to keep a shadow copy of the loop purely
@@ -199,5 +203,54 @@ final class SleepStagerActiveBridgeTests: XCTestCase {
             line,
             "gate run=-1 spanS=0 DROPPED gate=sparseBridgePair "
                 + "pair=0 gapMin=23 activeMin=21 hrInSleepBand=true reason=activeTooLong")
+    }
+
+    /// The change this constant exists for. A 45-minute interruption sits between the two bounds: over
+    /// the 30-minute default, under the 60-minute in-band one. With HR in the sleep band the whole way it
+    /// is now absorbed, where before the minute bound vetoed before HR was ever consulted.
+    ///
+    /// Field shape, not invented: log 260901-1022 had a 42-minute active run with hrInSleepBand=true
+    /// dropped as activeTooLong, and the 52-minute sleep run it would have joined then died on the
+    /// 60-minute minimum. Kotlin twin: "an active run past the default bound is absorbed when HR stays
+    /// in the sleep band".
+    func testActiveRunPastTheDefaultBoundIsAbsorbedWhenHRStaysInTheSleepBand() {
+        let mid = SleepStager.sparseBridgeActiveMaxMin * 60 + 15 * 60   // 45 min
+        let periods = [sleep(0, 3000), active(3000, 3000 + mid), sleep(3000 + mid, 9000)]
+        let out = SleepStager.bridgeSparseSleep(periods, sparse: true, hr: calmHr(0, 9000), baseline: baseline)
+        XCTAssertEqual(out.count, 1)
+        XCTAssertEqual(out.first?.stage, "sleep")
+        XCTAssertEqual(out.first?.start, 0)
+        XCTAssertEqual(out.first?.end, 9000)
+    }
+
+    /// ...and the widened bound is not a licence. The same 45 minutes with the wearer plainly up still
+    /// fails, because in-band is the CONDITION for the wider bound, not a separate escape from it.
+    func testTheWiderBoundDoesNotApplyWhenHRIsElevated() {
+        let mid = SleepStager.sparseBridgeActiveMaxMin * 60 + 15 * 60
+        let periods = [sleep(0, 3000), active(3000, 3000 + mid), sleep(3000 + mid, 9000)]
+        let hot = calmHr(0, 3000) + calmHr(3001, 3000 + mid, bpm: 110) + calmHr(3001 + mid, 9000)
+        let out = SleepStager.bridgeSparseSleep(periods, sparse: true, hr: hot, baseline: baseline)
+        XCTAssertEqual(out.count, 3)
+    }
+
+    /// The in-band bound may only ever widen, and it stops at `minSleepMin`.
+    func testTheInBandBoundIsAMaximumNeverAReplacement() {
+        XCTAssertGreaterThanOrEqual(SleepStager.sparseBridgeActiveMaxInBandMin,
+                                    SleepStager.sparseBridgeActiveMaxMin)
+        XCTAssertEqual(SleepStager.sparseBridgeActiveMaxInBandMin, SleepStager.minSleepMin)
+    }
+
+    /// Case 1 (two adjacent sleep runs, nothing between) has NO active run, so the bound it reports must
+    /// be 0 on both platforms — not the in-band 60. Computing the cap from a captured local rather than a
+    /// parameter made this report 60 for the identical decision: same behaviour, divergent trace.
+    /// Kotlin twin: "an adjacent-pair merge reports no active bound".
+    func testAnAdjacentPairMergeReportsNoActiveBound() {
+        let (_, attempts) = SleepStager.bridgeSparseSleepTraced(
+            [sleep(0, 3000), sleep(3600, 9000)],
+            sparse: true, hr: calmHr(0, 9000), baseline: baseline)
+        XCTAssertEqual(attempts.count, 1)
+        XCTAssertEqual(attempts.first?.reason, "bridged")
+        XCTAssertEqual(attempts.first?.activeMin, 0)
+        XCTAssertEqual(attempts.first?.activeCapMin, 0)
     }
 }

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -343,6 +343,25 @@ object SleepStager {
      */
     const val sparseBridgeActiveMaxMin: Int = 30
 
+    /**
+     * The same bound when HR across the whole span stays in the sleep band.
+     *
+     * [sparseBridgeActiveMaxMin]'s own doc calls the minute bound "the cheap half of the guard" and the HR
+     * band "the real one" — but the check order meant the cheap half vetoed first, so the real one never
+     * got to speak for a run over 30 minutes. A 42-minute active run with sleep-band HR was rejected
+     * identically to one with a wearer plainly up and about.
+     *
+     * That is the wrong way round on a strap whose "active" verdict comes from MOTION, which is the sparse
+     * and unreliable signal on the hardware this fires for (field log 260901-1022: 20,647 gravity samples
+     * across a 54-hour window, against 109,868 HR). HR is the better witness there, and it is already
+     * computed. 60 rather than something larger because it is [minSleepMin]: an interruption long enough
+     * to be a session in its own right is a genuine awakening whatever HR says, and must still split.
+     *
+     * Applied as a MAXIMUM against [sparseBridgeActiveMaxMin], never a replacement, so the in-band path
+     * can only ever be more permissive — an out-of-band span keeps the 30-minute bound exactly.
+     */
+    const val sparseBridgeActiveMaxInBandMin: Int = 60
+
     // ── Stage 1–3 constants (sleep_features.py) ──────────────────────────────
 
     const val epochS: Double = 30.0
@@ -654,6 +673,8 @@ object SleepStager {
         val gapMin: Long,
         /** Minutes of intervening ACTIVE run, or 0 when the pair was only separated by a gap. */
         val activeMin: Long,
+        /** The bound this pair was actually judged against — 30, or 60 when HR stayed in the sleep band. */
+        val activeCapMin: Long,
         /** Whether the intervening HR stayed in the sleep band. */
         val hrInSleepBand: Boolean,
         /** Whether this pair was merged. */
@@ -681,6 +702,7 @@ object SleepStager {
         if (!sparse || periods.isEmpty()) return periods to emptyList()
         val bridgeGapS = (sparseBridgeGapMin * 60).toLong()
         val activeMaxS = (sparseBridgeActiveMaxMin * 60).toLong()
+        val activeMaxInBandS = (sparseBridgeActiveMaxInBandMin * 60).toLong()
         val out = ArrayList<Period>()
         val attempts = ArrayList<SparseBridgeAttempt>()
         for (p in periods) {
@@ -696,7 +718,8 @@ object SleepStager {
                 if (last != null && last.stage == "active" && prev != null && prev.stage == "sleep") {
                     val activeS = last.end - last.start
                     if (considerBridge(out, attempts, prev, p, activeS, bridgeGapS, hr, baseline,
-                                       dropTrailing = true, activeMaxS = activeMaxS)) continue
+                                       dropTrailing = true, activeMaxS = activeMaxS,
+                                       activeMaxInBandS = activeMaxInBandS)) continue
                 }
             }
             out.add(p)
@@ -716,19 +739,24 @@ object SleepStager {
         out: ArrayList<Period>, attempts: ArrayList<SparseBridgeAttempt>,
         left: Period, right: Period, activeS: Long, bridgeGapS: Long,
         hr: List<HrSample>, baseline: Double?,
-        dropTrailing: Boolean = false, activeMaxS: Long = 0L,
+        dropTrailing: Boolean = false, activeMaxS: Long = 0L, activeMaxInBandS: Long = 0L,
     ): Boolean {
         val gap = right.start - left.end
         val inBand = hrSleepBandAcross(left.end, right.start, hr, baseline)
+        // The HR band is the real guard, so let it widen the minute bound rather than be vetoed by it.
+        // maxOf, not a swap: in-band can only ever be MORE permissive, and case 1 (activeMaxS = 0, no
+        // intervening run) is untouched because activeS is 0 there too.
+        val activeCapS = if (inBand) maxOf(activeMaxS, activeMaxInBandS) else activeMaxS
         val reason = when {
             gap < 0 -> "overlap"
             gap > bridgeGapS -> "gapTooLong"
-            activeS > activeMaxS -> "activeTooLong"
+            activeS > activeCapS -> "activeTooLong"
             !inBand -> "hrOutOfBand"
             else -> "bridged"
         }
         val bridged = reason == "bridged"
         attempts.add(SparseBridgeAttempt(gapMin = gap / 60, activeMin = activeS / 60,
+                                         activeCapMin = activeCapS / 60,
                                          hrInSleepBand = inBand, bridged = bridged, reason = reason))
         if (!bridged) return false
         if (dropTrailing) out.removeAt(out.size - 1)
@@ -1287,7 +1315,7 @@ object SleepStager {
                 traceSink(SleepStagerTrace.runLine(-1, 0, 0,
                     if (a.bridged) SleepStagerTrace.Verdict.KEPT else SleepStagerTrace.Verdict.DROPPED,
                     "sparseBridgePair",
-                    "pair=$i gapMin=${a.gapMin} activeMin=${a.activeMin} " +
+                    "pair=$i gapMin=${a.gapMin} activeMin=${a.activeMin} activeCapMin=${a.activeCapMin} " +
                         "hrInSleepBand=${a.hrInSleepBand} reason=${a.reason}"))
             }
         }

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerActiveBridgeTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerActiveBridgeTest.kt
@@ -46,7 +46,10 @@ class SleepStagerActiveBridgeTest {
      */
     @Test
     fun `an active run longer than the bound is left alone`() {
-        val tooLong = (SleepStager.sparseBridgeActiveMaxMin * 60L) + 60L
+        // Repinned, same shape: with calm HR the applicable bound is the IN-BAND one, so "longer than
+        // the bound" has to be measured against that. Using the 30-minute figure here would now be
+        // asserting the old behaviour rather than the invariant, which is still "past the bound, no merge".
+        val tooLong = (SleepStager.sparseBridgeActiveMaxInBandMin * 60L) + 60L
         val periods = listOf(sleep(0, 3000), active(3000, 3000 + tooLong), sleep(3000 + tooLong, 9000))
         val out = SleepStager.bridgeSparseSleep(periods, sparse = true, hr = calmHr(0, 9000), baseline = baseline)
         assertEquals(3, out.size)
@@ -100,7 +103,10 @@ class SleepStagerActiveBridgeTest {
      */
     @Test
     fun `a blocked pair reports the bound that blocked it, with the active length`() {
-        val tooLong = (SleepStager.sparseBridgeActiveMaxMin * 60L) + 60L
+        // Repinned past the IN-BAND bound: this HR is calm, so that is the bound in force. Same
+        // invariant — a pair blocked on length says so and reports the length — measured against the
+        // rule that actually applied rather than the one that used to.
+        val tooLong = (SleepStager.sparseBridgeActiveMaxInBandMin * 60L) + 60L
         val periods = listOf(sleep(0, 3000), active(3000, 3000 + tooLong), sleep(3000 + tooLong, 9000))
         val (_, attempts) = SleepStager.bridgeSparseSleepTraced(
             periods, sparse = true, hr = calmHr(0, 9000), baseline = baseline,
@@ -108,7 +114,9 @@ class SleepStagerActiveBridgeTest {
         assertEquals(1, attempts.size)
         assertEquals("activeTooLong", attempts[0].reason)
         assertFalse(attempts[0].bridged)
-        assertEquals(SleepStager.sparseBridgeActiveMaxMin + 1L, attempts[0].activeMin)
+        assertEquals(SleepStager.sparseBridgeActiveMaxInBandMin + 1L, attempts[0].activeMin)
+        // And it names WHICH bound, or the same activeMin looks blocked in one log and merged in another.
+        assertEquals(SleepStager.sparseBridgeActiveMaxInBandMin.toLong(), attempts[0].activeCapMin)
     }
 
     /**
@@ -226,5 +234,64 @@ class SleepStagerActiveBridgeTest {
                 "pair=0 gapMin=23 activeMin=21 hrInSleepBand=true reason=activeTooLong",
             line,
         )
+    }
+
+    /**
+     * The change this constant exists for. A 45-minute interruption sits between the two bounds: over the
+     * 30-minute default, under the 60-minute in-band one. With HR in the sleep band the whole way it is
+     * now absorbed, where before the minute bound vetoed before HR was ever consulted.
+     *
+     * Field shape, not invented: log 260901-1022 had a 42-minute active run with hrInSleepBand=true
+     * dropped as activeTooLong, and the 52-minute sleep run it would have joined then died on the
+     * 60-minute minimum. One threshold stood between a staged night and No Data.
+     */
+    @Test
+    fun `an active run past the default bound is absorbed when HR stays in the sleep band`() {
+        val mid = (SleepStager.sparseBridgeActiveMaxMin * 60L) + (15 * 60L)   // 45 min
+        val periods = listOf(sleep(0, 3000), active(3000, 3000 + mid), sleep(3000 + mid, 9000))
+        val out = SleepStager.bridgeSparseSleep(periods, sparse = true, hr = calmHr(0, 9000), baseline = baseline)
+        assertEquals(1, out.size)
+        assertEquals("sleep", out[0].stage)
+        assertEquals(0L, out[0].start)
+        assertEquals(9000L, out[0].end)
+    }
+
+    /**
+     * ...and the widened bound is not a licence. The same 45 minutes with the wearer plainly up still
+     * fails, because in-band is the CONDITION for the wider bound, not a separate escape from it.
+     */
+    @Test
+    fun `the wider bound does not apply when HR is elevated`() {
+        val mid = (SleepStager.sparseBridgeActiveMaxMin * 60L) + (15 * 60L)
+        val periods = listOf(sleep(0, 3000), active(3000, 3000 + mid), sleep(3000 + mid, 9000))
+        val hot = calmHr(0, 3000) + calmHr(3001, 3000 + mid, bpm = 110) + calmHr(3001 + mid, 9000)
+        val out = SleepStager.bridgeSparseSleep(periods, sparse = true, hr = hot, baseline = baseline)
+        assertEquals(3, out.size)
+    }
+
+    /** The in-band bound may only ever widen: an out-of-band span keeps the 30-minute one exactly. */
+    @Test
+    fun `the in-band bound is a maximum, never a replacement`() {
+        assertTrue(SleepStager.sparseBridgeActiveMaxInBandMin >= SleepStager.sparseBridgeActiveMaxMin)
+        // And it stops at minSleepMin: past that an interruption is a session of its own, whatever HR says.
+        assertEquals(SleepStager.minSleepMin, SleepStager.sparseBridgeActiveMaxInBandMin)
+    }
+
+    /**
+     * Case 1 (two adjacent sleep runs, nothing between) has NO active run, so the bound it reports must
+     * be 0 on both platforms — not the in-band 60. Swift computed the cap from a captured local rather
+     * than a parameter, which made it report 60 here for the identical decision: same behaviour, divergent
+     * trace, defeating the byte-for-byte comparison these lines exist to allow.
+     */
+    @Test
+    fun `an adjacent-pair merge reports no active bound`() {
+        val (_, attempts) = SleepStager.bridgeSparseSleepTraced(
+            listOf(sleep(0, 3000), sleep(3600, 9000)),
+            sparse = true, hr = calmHr(0, 9000), baseline = baseline,
+        )
+        assertEquals(1, attempts.size)
+        assertEquals("bridged", attempts[0].reason)
+        assertEquals(0L, attempts[0].activeMin)
+        assertEquals(0L, attempts[0].activeCapMin)
     }
 }


### PR DESCRIPTION
`sparseBridgeActiveMaxMin`'s own doc calls the 30-minute bound *"the cheap half of the guard"* and the HR band *"the real one"*. The check order meant the cheap half vetoed first, so the real one never got to speak for a run over 30 minutes — a 42-minute active run with `hrInSleepBand=true` was rejected exactly like one with the wearer plainly up.

That is the wrong way round on a strap whose "active" verdict comes from **motion**, which is the sparse and unreliable signal on the hardware this fires for.

## The night that showed it

Field log `260901-1022`, night of 2026-08-27 — 20,647 gravity samples across 54 hours against 109,868 HR:

```
pair=0  gap=17m   active=17m   inBand=true   bridged
pair=1  gap=42m   active=42m   inBand=true   activeTooLong   ← 12 minutes over
pair=2  gap=28m   active=28m   inBand=true   bridged
pair=3  gap=102m  active=102m  inBand=false  gapTooLong

run=0   52 min → DROPPED minSleepMin (60)
run=1   74 min → DROPPED daytimeGuard
run=2   27 min → DROPPED minSleepMin (60)
```

Had `pair=1` bridged, the 52-minute run would have cleared the 60-minute floor and the night would have staged. One threshold, twelve minutes, stood between a staged night and `Rest: No Data`.

## The change

`sparseBridgeActiveMaxInBandMin = 60`, applied as a **maximum** against the existing bound — so the in-band path can only ever be more permissive, and an out-of-band span keeps 30 exactly. 60 because it is `minSleepMin`: an interruption long enough to be a session in its own right is a genuine awakening whatever HR says, and must still split the night.

The trace now carries `activeCapMin`. Without it the same `activeMin=42` reads blocked in one log and merged in another with nothing saying why.

## Tests

Two existing tests pinned the old bound using calm HR, so they now describe the wrong rule. **Repinned to the same shape** — "past the bound, no merge" — measured against the bound that actually applies, rather than deleted.

New coverage: a 45-minute run (between the two bounds) is absorbed with in-band HR and still rejected with elevated HR; and the in-band bound is asserted to be a maximum that stops at `minSleepMin`.

## A parity bug re-review caught in my own first cut

Swift computed the cap from a **captured local** rather than a parameter, so case 1 — two adjacent sleep runs with nothing between — reported `activeCapMin=60` on Apple where Kotlin reported `0`. Identical behaviour, divergent trace line, which defeats exactly the byte-for-byte comparison these lines exist to allow. Swift now takes it as a parameter mirroring the Kotlin default, and both platforms pin that case.

## Verification

- Android: **1792 analytics tests, 0 failures** (full `:app:testFullDebugUnitTest` is 4995 with 1 failure — `PushCoordinatorTest.capabilitiesPreventEveryUnsupportedStreamSnapshotAndPost`, which I confirmed fails identically on clean `main` with my changes stashed, so it is pre-existing and unrelated).
- Swift: **1686 tests, 0 failures** (`StrandAnalytics`, via the Linux snapshot-SQLite harness).
- `Tools/doc_comment_lint.py` clean.

## Scope

This helps nights that **have** motion — imported history, and straps that report it. It does not help a WHOOP 5/MG on the live path, where `grav=0` and `reason=no-motion` is the binding constraint; no bridge tuning reaches that. Worth being explicit so this is not mistaken for a fix to the reporter's own Rest.

---

## Re-review: the size of the exposure, stated precisely

The bridge does not merely span the interruption — `dropTrailing` **removes** the intervening active run and replaces the pair with one sleep period covering `left.start … right.end`:

```kotlin
if (dropTrailing) out.removeAt(out.size - 1)
out[out.size - 1] = Period(stage = "sleep", start = left.start, end = right.end)
```

So those minutes are **converted from active to sleep**, not just bridged across. That was already true; what this PR changes is the ceiling, from 30 minutes per bridge to 60.

And bridges are not one-per-night. The same field log shows `runsBefore=5 runsAfter=3` — two bridges in a single night — and a merged run can bridge again with the next pair, so they chain. The worst-case sleep inflation per night therefore roughly doubles.

That is the designed mechanism rather than a defect, and the in-band condition still has to hold for every one of them. But it is the honest magnitude of the accuracy exposure, and it is the reason I would rather this were measured with `SleepBench` on a real database before it lands than argued from the one night that motivated it.

## Parity, verified rather than eyeballed

| | Kotlin | Swift |
|---|---|---|
| constant | `sparseBridgeActiveMaxInBandMin: Int = 60` | `sparseBridgeActiveMaxInBandMin: Int = 60` |
| cap | `if (inBand) maxOf(activeMaxS, activeMaxInBandS) else activeMaxS` | `inBand ? max(activeMaxS, activeMaxInBandS) : activeMaxS` |
| reason order | overlap → gapTooLong → activeTooLong → hrOutOfBand → bridged | identical |
| trace | `pair=… gapMin=… activeMin=… activeCapMin=… hrInSleepBand=… reason=…` | byte-identical |
| tests | 16 | 16 |

The one divergence that existed — Swift computing the cap from a captured local, so case 1 reported `activeCapMin=60` against Kotlin's `0` — was found in this review pass and is fixed and pinned on both sides.