### PR TITLE
analytics: give the pre-sleep HR feedback its Kotlin twin

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/PreSleepHeartRateFeedback.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/PreSleepHeartRateFeedback.swift
@@ -242,11 +242,14 @@ public enum PreSleepHeartRateFeedback {
                         journalContext: context)
     }
 
-    private static var gregorianUTC: Calendar {
+    /// Stored, not computed (#1784). `canonicalDay` reads this once per history row, so a computed
+    /// property built a fresh `Calendar` for every prior night. `Calendar` is a `Sendable` value type,
+    /// so one shared instance is safe and the construction happens once.
+    private static let gregorianUTC: Calendar = {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!
         return calendar
-    }
+    }()
 
     private static func canonicalDay(_ day: String) -> Date? {
         let bytes = Array(day.utf8)
@@ -268,6 +271,13 @@ public enum PreSleepHeartRateFeedback {
         return date
     }
 
+    /// One sample per timestamp, FIRST occurrence wins.
+    ///
+    /// First-wins is the caller's precedence order, not an arbitrary pick: `evaluate`'s contract is an
+    /// already-coalesced timeline where measured data outranks PPG-derived, so the first element for a
+    /// timestamp is the one the repository chose. Stated here as well as on `evaluate` because the rule
+    /// is invisible at this call site, and a later reader changing it to last-wins would silently invert
+    /// that precedence (#1784).
     private static func deduplicated(_ hr: [HRSample]) -> [HRSample] {
         var seen = Set<Int>()
         return hr.filter { seen.insert($0.ts).inserted }

--- a/android/app/src/main/java/com/noop/analytics/PreSleepHeartRateFeedback.kt
+++ b/android/app/src/main/java/com/noop/analytics/PreSleepHeartRateFeedback.kt
@@ -1,0 +1,268 @@
+package com.noop.analytics
+
+import com.noop.data.JournalEntry
+import com.noop.protocol.HrSample
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+/**
+ * An opt-in, descriptive pre-sleep heart-rate reading for the following morning.
+ *
+ * Kotlin twin of `StrandAnalytics.PreSleepHeartRateFeedback` (#1784). The caller supplies a
+ * timestamp-coalesced HR timeline: the repository's existing HR reads already coalesce measured and
+ * PPG-derived samples, with measured data taking precedence. This object selects the longest supplied
+ * sleep session, reads the declared half-open window immediately before it, and compares that
+ * observation with a personal rolling baseline. It neither diagnoses nor recommends an action. Journal
+ * answers are returned only as facts from the same day; one night cannot establish an association, so
+ * they never alter the reading or become an insight.
+ *
+ * PARITY, and the two places this deliberately differs from the Swift original:
+ *
+ *  - Apple's `SleepSession` is this side's [DetectedSleep] — same shape, the naming divergence that
+ *    already exists between the two analytics layers.
+ *  - Apple carries session timestamps as `Int`; [DetectedSleep] carries `Long`, so the window
+ *    arithmetic here is `Long` and sample timestamps widen at the comparison. The overflow guard is
+ *    therefore `Math.subtractExact` rather than `subtractingReportingOverflow`, which is the same
+ *    contract — fail closed, never trap — expressed in the idiom each language actually has.
+ *
+ * Everything that produces a NUMBER is byte-identical by construction: the same [MetricCfg], the same
+ * [Baselines.rollingMeanSD], the same [Baselines.computeStatus], and the same HR plausibility range.
+ */
+object PreSleepHeartRateFeedback {
+
+    /**
+     * Baseline configuration deliberately shares the existing HR plausibility range while keeping a
+     * small floor spread for transparent personal comparison. `rollingMeanSD` is the existing auditable
+     * baseline primitive; this is not a new scoring model.
+     */
+    val baselineCfg = MetricCfg(
+        minVal = SleepHeartRateContrast.VALID_MIN_BPM,
+        maxVal = SleepHeartRateContrast.VALID_MAX_BPM,
+        floorSpread = 2.0,
+        halfLifeB = 14.0,
+        halfLifeS = 21.0,
+    )
+    const val DEFAULT_PRE_SLEEP_WINDOW_SECONDS: Int = 30 * 60
+    const val DEFAULT_MINIMUM_VALID_SAMPLES: Int = 10
+    val minimumBaselineNights: Int = Baselines.minNightsSeed
+
+    /**
+     * A prior eligible pre-sleep observation. Callers persist/assemble history; this pure slice does
+     * not write, schedule a prompt, or penalize a missing night.
+     */
+    data class HistoricalReading(val day: String, val meanBpm: Double)
+
+    /**
+     * Why a morning reading is or is not available. Every non-eligible state is recoverable on a
+     * later, sufficiently covered night; none creates a streak, goal, or obligation.
+     */
+    sealed class Eligibility {
+        object Disabled : Eligibility()
+        object InvalidDay : Eligibility()
+        object InvalidWindow : Eligibility()
+        object MissingPrimarySleep : Eligibility()
+        data class InsufficientPreSleepSamples(val valid: Int, val required: Int) : Eligibility()
+        data class InsufficientBaseline(val validNights: Int, val required: Int) : Eligibility()
+        data class StaleBaseline(val daysSinceUpdate: Int) : Eligibility()
+        object Eligible : Eligibility()
+    }
+
+    /**
+     * The observed, un-imputed pre-sleep data. Completeness is stated as a sample count because raw
+     * HR cadence can vary; this slice does not pretend a count is a percentage of time covered.
+     */
+    data class Observation(
+        val primarySleepStartTs: Long,
+        val primarySleepEndTs: Long,
+        val windowStartTs: Long,
+        val windowEndTs: Long,
+        val meanBpm: Double,
+        val validSamples: Int,
+        val totalTimestampSamples: Int,
+    )
+
+    /** A personal comparison only, never a population norm or a health classification. */
+    data class Comparison(
+        val baselineBpm: Double,
+        val deltaBpm: Double,
+        val baselineNights: Int,
+        val baselineStatus: BaselineStatus,
+    )
+
+    /** Explicit limits that a presentation layer must keep visible rather than turning into certainty. */
+    sealed class Uncertainty {
+        /** The first eligible personal baseline is usable but not yet trusted by [Baselines]. */
+        object ProvisionalBaseline : Uncertainty()
+        /** There are not yet enough valid historical nights to make any personal comparison. */
+        object NoPersonalComparison : Uncertainty()
+        /** A mature personal baseline has not received a plausible value recently enough to compare. */
+        data class StaleBaseline(val daysSinceUpdate: Int) : Uncertainty()
+    }
+
+    /** This slice intentionally makes no causal inference from a single observation or its journal facts. */
+    enum class Inference { NOT_ESTABLISHED }
+
+    /** This slice intentionally cannot support a behavior, treatment, or other recommendation. */
+    enum class Recommendation { UNSUPPORTED }
+
+    /**
+     * A projection of a same-day [JournalEntry]. It preserves what was logged without exposing notes or
+     * claiming that the entry explains this reading.
+     */
+    data class JournalFact(
+        val day: String,
+        val question: String,
+        val answeredYes: Boolean,
+        val numericValue: Double?,
+    )
+
+    data class Feedback(
+        val eligibility: Eligibility,
+        val observation: Observation?,
+        val comparison: Comparison?,
+        val uncertainty: List<Uncertainty>,
+        val inference: Inference,
+        val recommendation: Recommendation,
+        /** Same-day journal facts only. They are deliberately not treated as a causal insight. */
+        val journalContext: List<JournalFact>,
+    )
+
+    /**
+     * Produce the next-morning reading from existing timestamped HR and sleep primitives.
+     *
+     * [hr] is expected to be the repository's measured/PPG-coalesced timeline. To remain safe for other
+     * callers, duplicate timestamps are also ignored after the first element, preserving the caller's
+     * precedence order. Both window bounds are transparent and half-open:
+     * `[sleep.start - window, sleep.start)`.
+     */
+    fun evaluate(
+        enabled: Boolean,
+        sessions: List<DetectedSleep>,
+        hr: List<HrSample>,
+        history: List<HistoricalReading>,
+        journalEntries: List<JournalEntry>,
+        day: String,
+        minimumValidSamples: Int = DEFAULT_MINIMUM_VALID_SAMPLES,
+        preSleepWindowSeconds: Int = DEFAULT_PRE_SLEEP_WINDOW_SECONDS,
+    ): Feedback {
+        fun closed(e: Eligibility, obs: Observation? = null, unc: List<Uncertainty> = emptyList(),
+                   ctx: List<JournalFact> = emptyList()) =
+            Feedback(e, obs, null, unc, Inference.NOT_ESTABLISHED, Recommendation.UNSUPPORTED, ctx)
+
+        if (!enabled) return closed(Eligibility.Disabled)
+        val evaluationDate = canonicalDay(day) ?: return closed(Eligibility.InvalidDay)
+        if (minimumValidSamples <= 0 || preSleepWindowSeconds <= 0) return closed(Eligibility.InvalidWindow)
+
+        val sessionsWithDuration = sessions.mapNotNull { session ->
+            val duration = subtractOrNull(session.end, session.start)
+            if (duration != null && duration > 0L) session to duration else null
+        }
+        val primary = sessionsWithDuration.maxByOrNull { it.second }?.first
+            ?: return closed(Eligibility.MissingPrimarySleep)
+
+        val start = subtractOrNull(primary.start, preSleepWindowSeconds.toLong())
+            ?: return closed(Eligibility.InvalidWindow)
+        val inWindow = deduplicated(hr).filter { it.ts.toLong() >= start && it.ts.toLong() < primary.start }
+        val valid = inWindow.filter {
+            baselineCfg.minVal <= it.bpm.toDouble() && it.bpm.toDouble() <= baselineCfg.maxVal
+        }
+        if (valid.size < minimumValidSamples) {
+            return closed(Eligibility.InsufficientPreSleepSamples(valid.size, minimumValidSamples))
+        }
+        val mean = valid.sumOf { it.bpm }.toDouble() / valid.size.toDouble()
+        val observation = Observation(
+            primarySleepStartTs = primary.start, primarySleepEndTs = primary.end,
+            windowStartTs = start, windowEndTs = primary.start, meanBpm = mean,
+            validSamples = valid.size, totalTimestampSamples = inWindow.size,
+        )
+        // Baselines use prior nights only and `rollingMeanSD` requires oldest-to-newest input. Retain the
+        // first caller-supplied reading for a repeated canonical day; one day contributes at most one
+        // night and no synthetic average is invented.
+        val seenDays = mutableSetOf<String>()
+        val priorHistory = history
+            .mapNotNull { reading ->
+                val date = canonicalDay(reading.day)
+                if (date != null && date.isBefore(evaluationDate) && seenDays.add(reading.day)) {
+                    reading to date
+                } else {
+                    null
+                }
+            }
+            .sortedBy { it.second }
+        val rollingBaseline = Baselines.rollingMeanSD(priorHistory.map { it.first.meanBpm }, baselineCfg)
+        val latestContributingDate = priorHistory.lastOrNull {
+            baselineCfg.minVal <= it.first.meanBpm && it.first.meanBpm <= baselineCfg.maxVal
+        }?.second
+        val nightsSinceUpdate = latestContributingDate
+            ?.let { maxOf(0L, ChronoUnit.DAYS.between(it, evaluationDate)).toInt() } ?: 0
+        val baseline = BaselineState(
+            baseline = rollingBaseline.baseline,
+            spread = rollingBaseline.spread,
+            nValid = rollingBaseline.nValid,
+            nightsSinceUpdate = nightsSinceUpdate,
+            status = Baselines.computeStatus(rollingBaseline.nValid, nightsSinceUpdate),
+        )
+        val context = journalEntries.filter { it.day == day }.map {
+            JournalFact(it.day, it.question, it.answeredYes, it.numericValue)
+        }
+        if (baseline.nValid < minimumBaselineNights) {
+            return closed(
+                Eligibility.InsufficientBaseline(baseline.nValid, minimumBaselineNights),
+                obs = observation, unc = listOf(Uncertainty.NoPersonalComparison), ctx = context,
+            )
+        }
+        if (!baseline.usable) {
+            return closed(
+                Eligibility.StaleBaseline(baseline.nightsSinceUpdate), obs = observation,
+                unc = listOf(Uncertainty.StaleBaseline(baseline.nightsSinceUpdate)), ctx = context,
+            )
+        }
+        val comparison = Comparison(
+            baselineBpm = baseline.baseline, deltaBpm = mean - baseline.baseline,
+            baselineNights = baseline.nValid, baselineStatus = baseline.status,
+        )
+        val uncertainty =
+            if (baseline.status == BaselineStatus.TRUSTED) emptyList()
+            else listOf(Uncertainty.ProvisionalBaseline)
+        return Feedback(
+            eligibility = Eligibility.Eligible, observation = observation, comparison = comparison,
+            uncertainty = uncertainty, inference = Inference.NOT_ESTABLISHED,
+            recommendation = Recommendation.UNSUPPORTED, journalContext = context,
+        )
+    }
+
+    /** `a - b`, or null when it would overflow. The Long twin of Swift's `subtractingReportingOverflow`. */
+    private fun subtractOrNull(a: Long, b: Long): Long? =
+        try { Math.subtractExact(a, b) } catch (_: ArithmeticException) { null }
+
+    /**
+     * A calendar day, or null when the string is not a canonical `YYYY-MM-DD`.
+     *
+     * The shape check alone is not enough: it accepts `2026-02-31`. [LocalDate.of] rejects an impossible
+     * day, which is what the Swift twin's round-trip through `Calendar` is doing.
+     */
+    private fun canonicalDay(day: String): LocalDate? {
+        val bytes = day.toByteArray(Charsets.UTF_8)
+        if (bytes.size != 10 || bytes[4] != '-'.code.toByte() || bytes[7] != '-'.code.toByte()) return null
+        val digitPositions = intArrayOf(0, 1, 2, 3, 5, 6, 8, 9)
+        if (!digitPositions.all { bytes[it] in 48..57 }) return null
+        val year = (bytes[0] - 48) * 1_000 + (bytes[1] - 48) * 100 + (bytes[2] - 48) * 10 + (bytes[3] - 48)
+        val month = (bytes[5] - 48) * 10 + (bytes[6] - 48)
+        val dayOfMonth = (bytes[8] - 48) * 10 + (bytes[9] - 48)
+        return try { LocalDate.of(year, month, dayOfMonth) } catch (_: java.time.DateTimeException) { null }
+    }
+
+    /**
+     * One sample per timestamp, FIRST occurrence wins.
+     *
+     * First-wins is the caller's precedence order, not an arbitrary pick: [evaluate]'s contract is an
+     * already-coalesced timeline where measured data outranks PPG-derived, so the first element for a
+     * timestamp is the one the repository chose. Stated here as well as on [evaluate] because the rule
+     * is invisible at this call site, and a later reader changing it to last-wins would silently invert
+     * that precedence (#1784).
+     */
+    private fun deduplicated(hr: List<HrSample>): List<HrSample> {
+        val seen = mutableSetOf<Int>()
+        return hr.filter { seen.add(it.ts) }
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/PreSleepHeartRateFeedback.kt
+++ b/android/app/src/main/java/com/noop/analytics/PreSleepHeartRateFeedback.kt
@@ -169,7 +169,12 @@ object PreSleepHeartRateFeedback {
         if (valid.size < minimumValidSamples) {
             return closed(Eligibility.InsufficientPreSleepSamples(valid.size, minimumValidSamples))
         }
-        val mean = valid.sumOf { it.bpm }.toDouble() / valid.size.toDouble()
+        // `toLong()` before summing, not after: `sumOf { it.bpm }` accumulates in Int and would WRAP
+        // silently, where Apple's `reduce` accumulates in 64-bit and cannot. Unreachable with a real
+        // window — 220 bpm needs ~9.7M samples to overflow — but a wrapped sum produces a plausible
+        // wrong mean rather than a failure, and this file guards its other arithmetic explicitly
+        // (`subtractOrNull`). Exact integer sum then divide, which is Apple's order too.
+        val mean = valid.sumOf { it.bpm.toLong() }.toDouble() / valid.size.toDouble()
         val observation = Observation(
             primarySleepStartTs = primary.start, primarySleepEndTs = primary.end,
             windowStartTs = start, windowEndTs = primary.start, meanBpm = mean,

--- a/android/app/src/test/java/com/noop/analytics/PreSleepHeartRateFeedbackTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/PreSleepHeartRateFeedbackTest.kt
@@ -1,0 +1,216 @@
+package com.noop.analytics
+
+import com.noop.data.JournalEntry
+import com.noop.protocol.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Kotlin twin of `PreSleepHeartRateFeedbackTests` (#1784), assertion for assertion.
+ *
+ * The numbers are the point: every expected value here was taken from the Swift suite unchanged, so a
+ * divergence in [Baselines.rollingMeanSD], [Baselines.computeStatus] or the day arithmetic shows up as a
+ * failure rather than as two platforms quietly disagreeing about the same night.
+ */
+class PreSleepHeartRateFeedbackTest {
+
+    private fun samples(start: Int, bpm: Int, count: Int): List<HrSample> =
+        (0 until count).map { HrSample(ts = start + it * 60, bpm = bpm) }
+
+    private fun sleep(start: Long = 10_000, end: Long = 36_000) =
+        DetectedSleep(start = start, end = end, efficiency = 0.9, stages = emptyList(),
+                      restingHR = null, avgHRV = null)
+
+    private fun reading(day: String, bpm: Double) =
+        PreSleepHeartRateFeedback.HistoricalReading(day = day, meanBpm = bpm)
+
+    @Test
+    fun `eligible feedback separates observation, comparison, uncertainty and unsupported recommendation`() {
+        val history = listOf(60.0, 61.0, 62.0, 63.0).mapIndexed { i, bpm ->
+            reading("2026-08-0${i + 1}", bpm)
+        }
+        val journal = JournalEntry(deviceId = "d", day = "2026-08-05", question = "Late meal",
+                                   answeredYes = true)
+        val feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled = true, sessions = listOf(sleep()),
+            hr = samples(8_800, 70, 12) + samples(10_000, 55, 12),
+            history = history, journalEntries = listOf(journal), day = "2026-08-05",
+            minimumValidSamples = 10, preSleepWindowSeconds = 1_800,
+        )
+
+        assertEquals(PreSleepHeartRateFeedback.Eligibility.Eligible, feedback.eligibility)
+        assertEquals(8_200L, feedback.observation?.windowStartTs)
+        assertEquals(10_000L, feedback.observation?.windowEndTs)
+        assertEquals(70.0, feedback.observation!!.meanBpm, 1e-9)
+        assertEquals(12, feedback.observation?.validSamples)
+        assertEquals(61.5, feedback.comparison!!.baselineBpm, 1e-9)
+        assertEquals(8.5, feedback.comparison!!.deltaBpm, 1e-9)
+        assertEquals(BaselineStatus.PROVISIONAL, feedback.comparison?.baselineStatus)
+        assertEquals(listOf(PreSleepHeartRateFeedback.Uncertainty.ProvisionalBaseline), feedback.uncertainty)
+        assertEquals(PreSleepHeartRateFeedback.Inference.NOT_ESTABLISHED, feedback.inference)
+        assertEquals(PreSleepHeartRateFeedback.Recommendation.UNSUPPORTED, feedback.recommendation)
+        assertEquals(
+            listOf(PreSleepHeartRateFeedback.JournalFact("2026-08-05", "Late meal", true, null)),
+            feedback.journalContext,
+        )
+    }
+
+    @Test
+    fun `the baseline uses only sorted prior nights`() {
+        val history = listOf(
+            reading("2026-08-01", 60.0), reading("2026-08-04", 63.0), reading("2026-08-02", 61.0),
+            reading("2026-08-03", 62.0), reading("2026-08-05", 90.0), reading("2026-08-06", 100.0),
+        )
+        val feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled = true, sessions = listOf(sleep()), hr = samples(8_800, 70, 12),
+            history = history, journalEntries = emptyList(), day = "2026-08-05",
+            minimumValidSamples = 10, preSleepWindowSeconds = 1_800,
+        )
+        // Current and future days must not leak in, and unsorted input must not change the answer.
+        assertEquals(61.5, feedback.comparison!!.baselineBpm, 1e-9)
+        assertEquals(4, feedback.comparison?.baselineNights)
+    }
+
+    @Test
+    fun `a repeated prior day cannot satisfy the minimum baseline nights`() {
+        val history = List(4) { reading("2026-08-01", 60.0) }
+        val feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled = true, sessions = listOf(sleep()), hr = samples(8_800, 70, 12),
+            history = history, journalEntries = emptyList(), day = "2026-08-05",
+            minimumValidSamples = 10, preSleepWindowSeconds = 1_800,
+        )
+        assertEquals(
+            PreSleepHeartRateFeedback.Eligibility.InsufficientBaseline(
+                1, PreSleepHeartRateFeedback.minimumBaselineNights),
+            feedback.eligibility,
+        )
+        assertNull(feedback.comparison)
+        assertEquals(listOf(PreSleepHeartRateFeedback.Uncertainty.NoPersonalComparison), feedback.uncertainty)
+    }
+
+    @Test
+    fun `noncanonical and impossible days cannot satisfy the minimum baseline nights`() {
+        // "2026-08-04Z" is the wrong length; 2026-02-31 passes a shape check and fails a real calendar.
+        val history = listOf(
+            reading("2026-08-01", 60.0), reading("2026-08-04Z", 61.0),
+            reading("2026-02-31", 62.0), reading("2026-08-03", 63.0),
+        )
+        val feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled = true, sessions = listOf(sleep()), hr = samples(8_800, 70, 12),
+            history = history, journalEntries = emptyList(), day = "2026-08-05",
+            minimumValidSamples = 10, preSleepWindowSeconds = 1_800,
+        )
+        assertEquals(
+            PreSleepHeartRateFeedback.Eligibility.InsufficientBaseline(
+                2, PreSleepHeartRateFeedback.minimumBaselineNights),
+            feedback.eligibility,
+        )
+    }
+
+    @Test
+    fun `invalid evaluation days cannot produce feedback`() {
+        for (day in listOf("2026-8-05", "2026-02-31", "not-a-day", "", "2026-08-05Z")) {
+            val feedback = PreSleepHeartRateFeedback.evaluate(
+                enabled = true, sessions = listOf(sleep()), hr = samples(8_800, 70, 12),
+                history = emptyList(), journalEntries = emptyList(), day = day,
+                minimumValidSamples = 10, preSleepWindowSeconds = 1_800,
+            )
+            assertEquals("day=$day", PreSleepHeartRateFeedback.Eligibility.InvalidDay, feedback.eligibility)
+            assertNull(feedback.observation)
+        }
+    }
+
+    @Test
+    fun `a baseline at the exact stale boundary stays trusted across a year boundary`() {
+        val history = (1..13).map { reading(String.format("2023-01-%02d", it), 60.0) } +
+            reading("2023-12-18", 60.0)
+        val feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled = true, sessions = listOf(sleep()), hr = samples(8_800, 70, 12),
+            history = history, journalEntries = emptyList(), day = "2024-01-01",
+            minimumValidSamples = 10, preSleepWindowSeconds = 1_800,
+        )
+        assertEquals(PreSleepHeartRateFeedback.Eligibility.Eligible, feedback.eligibility)
+        assertEquals(BaselineStatus.TRUSTED, feedback.comparison?.baselineStatus)
+        assertTrue(feedback.uncertainty.isEmpty())
+    }
+
+    @Test
+    fun `one day past the stale boundary is explicitly stale across a leap day`() {
+        val history = (1..13).map { reading(String.format("2024-01-%02d", it), 60.0) } +
+            reading("2024-02-15", 60.0)
+        val feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled = true, sessions = listOf(sleep()), hr = samples(8_800, 70, 12),
+            history = history, journalEntries = emptyList(), day = "2024-03-01",
+            minimumValidSamples = 10, preSleepWindowSeconds = 1_800,
+        )
+        // 15 only if 2024-02-29 is counted: the leap day is the assertion.
+        assertEquals(PreSleepHeartRateFeedback.Eligibility.StaleBaseline(15), feedback.eligibility)
+        assertNotNull(feedback.observation)
+        assertNull(feedback.comparison)
+        assertEquals(listOf(PreSleepHeartRateFeedback.Uncertainty.StaleBaseline(15)), feedback.uncertainty)
+    }
+
+    @Test
+    fun `an extreme sleep session duration fails closed without trapping`() {
+        val feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled = true, sessions = listOf(sleep(start = Long.MIN_VALUE, end = Long.MAX_VALUE)),
+            hr = samples(8_800, 70, 12), history = emptyList(), journalEntries = emptyList(),
+            day = "2026-08-05", minimumValidSamples = 10, preSleepWindowSeconds = 1_800,
+        )
+        assertEquals(PreSleepHeartRateFeedback.Eligibility.MissingPrimarySleep, feedback.eligibility)
+    }
+
+    @Test
+    fun `an extreme pre-sleep window fails closed without trapping`() {
+        val feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled = true, sessions = listOf(sleep(start = Long.MIN_VALUE + 1, end = Long.MIN_VALUE + 2)),
+            hr = samples(8_800, 70, 12), history = emptyList(), journalEntries = emptyList(),
+            day = "2026-08-05", minimumValidSamples = 10, preSleepWindowSeconds = 1_800,
+        )
+        assertEquals(PreSleepHeartRateFeedback.Eligibility.InvalidWindow, feedback.eligibility)
+    }
+
+    @Test
+    fun `opting out and lapsing fail closed without creating feedback or punishment`() {
+        val off = PreSleepHeartRateFeedback.evaluate(
+            enabled = false, sessions = listOf(sleep()), hr = samples(8_800, 70, 12),
+            history = emptyList(), journalEntries = emptyList(), day = "2026-08-05",
+        )
+        assertEquals(PreSleepHeartRateFeedback.Eligibility.Disabled, off.eligibility)
+        assertNull(off.observation)
+        assertTrue(off.journalContext.isEmpty())
+
+        val noSleep = PreSleepHeartRateFeedback.evaluate(
+            enabled = true, sessions = emptyList(), hr = samples(8_800, 70, 12),
+            history = emptyList(), journalEntries = emptyList(), day = "2026-08-05",
+        )
+        assertEquals(PreSleepHeartRateFeedback.Eligibility.MissingPrimarySleep, noSleep.eligibility)
+
+        val thin = PreSleepHeartRateFeedback.evaluate(
+            enabled = true, sessions = listOf(sleep()), hr = samples(8_800, 70, 3),
+            history = emptyList(), journalEntries = emptyList(), day = "2026-08-05",
+            minimumValidSamples = 10, preSleepWindowSeconds = 1_800,
+        )
+        assertEquals(
+            PreSleepHeartRateFeedback.Eligibility.InsufficientPreSleepSamples(3, 10), thin.eligibility)
+        // Every one of these is recoverable on a later night: no streak, no goal, no obligation.
+        assertEquals(PreSleepHeartRateFeedback.Recommendation.UNSUPPORTED, thin.recommendation)
+    }
+
+    @Test
+    fun `duplicate timestamps keep the caller's first sample, which is its precedence order`() {
+        // The repository coalesces measured over PPG before this runs, so first-wins preserves that
+        // choice. Last-wins would silently invert it.
+        val hr = samples(8_800, 70, 12) + samples(8_800, 200, 12)
+        val feedback = PreSleepHeartRateFeedback.evaluate(
+            enabled = true, sessions = listOf(sleep()), hr = hr, history = emptyList(),
+            journalEntries = emptyList(), day = "2026-08-05",
+            minimumValidSamples = 10, preSleepWindowSeconds = 1_800,
+        )
+        assertEquals(70.0, feedback.observation!!.meanBpm, 1e-9)
+        assertEquals(12, feedback.observation?.totalTimestampSamples)
+    }
+}


### PR DESCRIPTION
Addresses all three items in #1784. #1772 landed the Swift slice; this gives it the Android half and clears the two review nits.

## The twin

`PreSleepHeartRateFeedback` was the only analytics type in the repo without an Android counterpart — 82 of 97 non-extension `StrandAnalytics` sources have a same-named `.kt`, and the two that don't still carry their Kotlin symbols elsewhere. Unlike `ExplicitBond` or `BondStateTrace`, which are Android-only and say so with a `PARITY:` note giving a CoreBluetooth reason, there was no platform barrier here: Android already had `Baselines`, `MetricCfg`, `BaselineState`, `computeStatus` and journal entries.

**Everything that produces a number is shared, not re-derived** — the same `MetricCfg`, the same `Baselines.rollingMeanSD`, the same `Baselines.computeStatus`, the same HR plausibility range (`VALID_MIN_BPM`/`VALID_MAX_BPM`, the naming-convention twin of `validMinBpm`/`validMaxBpm`).

The test suite is the real parity check: it asserts the Swift suite's expected values **unchanged** — baseline `61.5`, delta `8.5`, `12` valid samples, window `[8_200, 10_000)`, and the stale case that equals `15` only if `2024-02-29` is counted. A divergence in the rolling mean, the status thresholds or the day arithmetic fails a test rather than leaving two platforms quietly disagreeing about the same night.

### Two places it deliberately reads differently

Both recorded in the file's own `PARITY` note, so a future audit finds a decision rather than a discrepancy:

- **Apple's `SleepSession` is this side's `DetectedSleep`** — same shape (`start`, `end`, `efficiency`, `stages`, `restingHR`, `avgHRV`), the naming divergence the two analytics layers already had.
- **`DetectedSleep` carries `Long` timestamps where Apple carries `Int`**, so the window arithmetic is `Long` and sample timestamps widen at the comparison. The overflow guard is therefore `Math.subtractExact` rather than `subtractingReportingOverflow` — the same contract, *fail closed, never trap*, in the idiom each language actually has. Both extreme-value tests port directly and still pass.

## Nit 1 — `gregorianUTC` built a `Calendar` per history row

It was a computed property, and `canonicalDay` reads it once per prior night. Now stored. `Calendar` is a `Sendable` value type, so one shared instance is safe under this package's concurrency checking — no `nonisolated(unsafe)` needed.

## Nit 2 — the dedup tie-break

`deduplicated` keeps the **first** sample for a repeated timestamp. That isn't arbitrary: `evaluate`'s contract is an already-coalesced timeline where measured data outranks PPG-derived, so first-wins preserves the repository's precedence. The rule was stated on `evaluate` but not at the helper, where it's invisible and a later reader could invert it by switching to last-wins.

Documented on both platforms, and the Kotlin suite now pins it with a duplicate-timestamp case that would fail under last-wins.

## Tests

- Android: **11 new tests, 0 failures, 0 skipped**; full `com.noop.analytics.*` — **1803 tests, 0 failures**.
- Swift: full `StrandAnalytics` — **1697 tests, 0 failures** (1 pre-existing skip), via the Linux snapshot-SQLite harness.
- `Tools/doc_comment_lint.py` clean.

## Still not wired

Both halves remain uncalled by design; the integration is #1760. This PR does not change that — it means Android won't silently lack the feature when that integration lands, and that the Kotlin numbers were derived *alongside* the Swift ones rather than having to reproduce them afterwards.
