### PR TITLE
test(push): pin the clock, so the suite stops asserting the calendar

### DIFF
--- a/android/app/src/test/java/com/noop/push/PushCoordinatorTest.kt
+++ b/android/app/src/test/java/com/noop/push/PushCoordinatorTest.kt
@@ -74,7 +74,7 @@ class PushCoordinatorTest {
         val progress = MemoryProgress()
         val partial = AckingTransport { batch -> PushAck.fromBatch(batch).copy(acceptedRows = 0) }
 
-        val result = PushCoordinator(source, partial, progress, SOURCE_A).pushAppend(PushAppendTable.HR_SAMPLE, "a")
+        val result = PushCoordinator(source, partial, progress, SOURCE_A, pinnedToday, ZoneId.of("UTC")).pushAppend(PushAppendTable.HR_SAMPLE, "a")
 
         assertTrue(result is PushResult.Rejected)
         assertTrue(progress.cursors.isEmpty())
@@ -87,7 +87,7 @@ class PushCoordinatorTest {
         val progress = MemoryProgress()
         val wrongStatus = AckingTransport { batch -> PushAck.fromBatch(batch).copy(status = "partial") }
 
-        val result = PushCoordinator(source, wrongStatus, progress, SOURCE_A)
+        val result = PushCoordinator(source, wrongStatus, progress, SOURCE_A, pinnedToday, ZoneId.of("UTC"))
             .pushAppend(PushAppendTable.HR_SAMPLE, "a")
 
         assertTrue(result is PushResult.Rejected)
@@ -107,7 +107,7 @@ class PushCoordinatorTest {
                 return PushTransportResponse(200, "{not-json".toByteArray())
             }
         }
-        val coordinator = PushCoordinator(source, malformed, progress, SOURCE_A)
+        val coordinator = PushCoordinator(source, malformed, progress, SOURCE_A, pinnedToday, ZoneId.of("UTC"))
 
         coordinator.pushAppend(PushAppendTable.HR_SAMPLE, "a")
         coordinator.pushAppend(PushAppendTable.HR_SAMPLE, "a")
@@ -129,7 +129,7 @@ class PushCoordinatorTest {
             )
         }
 
-        val result = PushCoordinator(source, transport, progress, SOURCE_A).pushAppend(PushAppendTable.HR_SAMPLE, "a")
+        val result = PushCoordinator(source, transport, progress, SOURCE_A, pinnedToday, ZoneId.of("UTC")).pushAppend(PushAppendTable.HR_SAMPLE, "a")
 
         assertTrue(result is PushResult.Rejected)
         assertTrue(progress.cursors.isEmpty())
@@ -149,7 +149,7 @@ class PushCoordinatorTest {
             }
         }
 
-        val result = PushCoordinator(source, transport, progress, SOURCE_A)
+        val result = PushCoordinator(source, transport, progress, SOURCE_A, pinnedToday, ZoneId.of("UTC"))
             .pushAppend(PushAppendTable.HR_SAMPLE, "a")
 
         assertTrue(result is PushResult.Rejected)
@@ -168,7 +168,7 @@ class PushCoordinatorTest {
                 override suspend fun post(batch: PushBatch) = PushTransportResponse(status, ByteArray(0))
             }
 
-            val result = PushCoordinator(source, transport, progress, SOURCE_A)
+            val result = PushCoordinator(source, transport, progress, SOURCE_A, pinnedToday, ZoneId.of("UTC"))
                 .pushAppend(PushAppendTable.HR_SAMPLE, "a")
 
             assertTrue("HTTP $status", result is PushResult.Rejected && result.retryable == retryable)
@@ -437,7 +437,7 @@ class PushCoordinatorTest {
         )
         val progress = MemoryProgress()
         val firstTransport = AckingTransport()
-        val first = PushCoordinator(source, firstTransport, progress, SOURCE_A)
+        val first = PushCoordinator(source, firstTransport, progress, SOURCE_A, pinnedToday, ZoneId.of("UTC"))
             .pushKnownDevices(startDeviceIndex = 0, maxDevices = 1)
 
         assertTrue(first.hasMoreDevices)
@@ -447,7 +447,7 @@ class PushCoordinatorTest {
         assertTrue(firstTransport.batches.all { it.deviceId == "a" })
 
         val secondTransport = AckingTransport()
-        val second = PushCoordinator(source, secondTransport, progress, SOURCE_A)
+        val second = PushCoordinator(source, secondTransport, progress, SOURCE_A, pinnedToday, ZoneId.of("UTC"))
             .pushKnownDevices(startDeviceIndex = first.nextDeviceIndex, maxDevices = 1)
 
         assertEquals(0, second.nextDeviceIndex)
@@ -468,12 +468,12 @@ class PushCoordinatorTest {
             ),
         )
         val progress = MemoryProgress()
-        PushCoordinator(source, AckingTransport(), progress, SOURCE_A)
+        PushCoordinator(source, AckingTransport(), progress, SOURCE_A, pinnedToday, ZoneId.of("UTC"))
             .pushKnownDevices()
         source.mutable.remove(key(PushMutableTable.JOURNAL, "noop-journal"))
 
         val afterDelete = AckingTransport()
-        PushCoordinator(source, afterDelete, progress, SOURCE_A)
+        PushCoordinator(source, afterDelete, progress, SOURCE_A, pinnedToday, ZoneId.of("UTC"))
             .pushKnownDevices()
 
         val journal = afterDelete.batches.single {

--- a/android/app/src/test/java/com/noop/push/PushCoordinatorTest.kt
+++ b/android/app/src/test/java/com/noop/push/PushCoordinatorTest.kt
@@ -10,6 +10,18 @@ import java.time.LocalDate
 import java.time.ZoneId
 
 class PushCoordinatorTest {
+    /**
+     * A PINNED "today" for every coordinator built in this file.
+     *
+     * `PushCoordinator` defaults to `LocalDate.now()` and `PushWindow` spans `today.minusDays(13)`, so a
+     * test that omits it silently depends on the wall clock. The journal fixtures here are dated
+     * 2026-08-18, which sat inside that window until 2026-09-01 and then fell out: CI was green at
+     * 23:21Z on 31 Aug and red at 00:13Z on 1 Sep, with `expected:<[journal]> but was:<[]>`. Nothing had
+     * changed but the date. Pin it, and the suite asserts the coordinator's behaviour rather than the
+     * calendar's.
+     */
+    private val pinnedToday = { LocalDate.of(2026, 8, 18) }
+
     @Test
     fun endpointChangeFencesRemainingPostsToCapturedDestination() = runBlocking {
         val settings = SelfHostedPushSettings.forTest(
@@ -360,7 +372,7 @@ class PushCoordinatorTest {
             }
         }
 
-        PushCoordinator(source, transport, MemoryProgress(), SOURCE_A)
+        PushCoordinator(source, transport, MemoryProgress(), SOURCE_A, pinnedToday, ZoneId.of("UTC"))
             .pushAppend(PushAppendTable.HR_SAMPLE, "a")
         Unit
     }
@@ -380,7 +392,7 @@ class PushCoordinatorTest {
         )
         val transport = AckingTransport()
 
-        val result = PushCoordinator(source, transport, MemoryProgress(), SOURCE_A)
+        val result = PushCoordinator(source, transport, MemoryProgress(), SOURCE_A, pinnedToday, ZoneId.of("UTC"))
             .pushMutable(PushMutableTable.JOURNAL, "a")
 
         assertTrue(result is PushResult.Rejected && !result.retryable)
@@ -394,7 +406,7 @@ class PushCoordinatorTest {
         }
         val transport = AckingTransport()
 
-        val result = PushCoordinator(source, transport, MemoryProgress(), SOURCE_A)
+        val result = PushCoordinator(source, transport, MemoryProgress(), SOURCE_A, pinnedToday, ZoneId.of("UTC"))
             .pushAppend(PushAppendTable.EVENT, "a")
 
         assertTrue(result is PushResult.Rejected && !result.retryable)
@@ -408,7 +420,7 @@ class PushCoordinatorTest {
         }
         val transport = AckingTransport()
 
-        val result = PushCoordinator(source, transport, MemoryProgress(), SOURCE_A)
+        val result = PushCoordinator(source, transport, MemoryProgress(), SOURCE_A, pinnedToday, ZoneId.of("UTC"))
             .pushMutable(PushMutableTable.JOURNAL, "a")
 
         assertTrue(result is PushResult.Rejected && !result.retryable)
@@ -490,7 +502,7 @@ class PushCoordinatorTest {
             mutableTables = setOf(PushMutableTable.JOURNAL),
         )
 
-        PushCoordinator(source, transport, MemoryProgress(), SOURCE_A)
+        PushCoordinator(source, transport, MemoryProgress(), SOURCE_A, pinnedToday, ZoneId.of("UTC"))
             .pushKnownDevices(capabilities = capabilities)
 
         assertEquals(emptyList<PushAppendTable>(), source.appendTablesRead)
@@ -503,7 +515,7 @@ class PushCoordinatorTest {
     fun emptyCapabilitiesAvoidEvenDeviceDiscovery() = runBlocking {
         val source = FakePushSource().apply { knownDeviceIdsFailure = AssertionError("Room must stay unopened") }
 
-        val result = PushCoordinator(source, AckingTransport(), MemoryProgress(), SOURCE_A)
+        val result = PushCoordinator(source, AckingTransport(), MemoryProgress(), SOURCE_A, pinnedToday, ZoneId.of("UTC"))
             .pushKnownDevices(capabilities = PushCapabilities(emptySet(), emptySet()))
 
         assertEquals(0, result.acceptedBatches)
@@ -521,7 +533,7 @@ class PushCoordinatorTest {
             }
         }
 
-        val result = PushCoordinator(source, transport, MemoryProgress(), SOURCE_A)
+        val result = PushCoordinator(source, transport, MemoryProgress(), SOURCE_A, pinnedToday, ZoneId.of("UTC"))
             .pushKnownDevices(
                 capabilities = PushCapabilities(setOf(PushAppendTable.HR_SAMPLE), emptySet()),
             )
@@ -543,7 +555,7 @@ class PushCoordinatorTest {
             )
         }
 
-        val result = PushCoordinator(source, transport, MemoryProgress(), SOURCE_A)
+        val result = PushCoordinator(source, transport, MemoryProgress(), SOURCE_A, pinnedToday, ZoneId.of("UTC"))
             .pushKnownDevices(capabilities = PushCapabilities(setOf(PushAppendTable.HR_SAMPLE), emptySet()))
 
         assertEquals("registry_mismatch", result.failure?.receiverCode)

--- a/android/app/src/test/java/com/noop/push/PushCursorTest.kt
+++ b/android/app/src/test/java/com/noop/push/PushCursorTest.kt
@@ -4,9 +4,19 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
+import java.time.LocalDate
+import java.time.ZoneId
 import org.junit.Test
 
 class PushCursorTest {
+    /**
+     * Pinned for the same reason as `PushCoordinatorTest`: `PushCoordinator` defaults to
+     * `LocalDate.now()`, so an omitted clock makes a test depend on the date it runs. These cases
+     * exercise cursor-based append tables rather than the day window, so they were not the ones that
+     * broke on 2026-09-01 — but they are the same latent shape, and pinning costs nothing.
+     */
+    private val pinnedToday = { LocalDate.of(2026, 8, 18) }
+
     @Test
     fun olderTimestampWithHigherRowidIsNotStranded() = runBlocking {
         val old = hr(10, 200)
@@ -19,7 +29,7 @@ class PushCursorTest {
             )
         }
         val transport = AckingTransport()
-        val coordinator = PushCoordinator(source, transport, progress, SOURCE_A)
+        val coordinator = PushCoordinator(source, transport, progress, SOURCE_A, pinnedToday, ZoneId.of("UTC"))
 
         val result = coordinator.pushAppend(PushAppendTable.HR_SAMPLE, "a")
 
@@ -43,7 +53,7 @@ class PushCursorTest {
         }
         val transport = AckingTransport()
 
-        PushCoordinator(source, transport, progress, SOURCE_A).pushAppend(PushAppendTable.HR_SAMPLE, "a")
+        PushCoordinator(source, transport, progress, SOURCE_A, pinnedToday, ZoneId.of("UTC")).pushAppend(PushAppendTable.HR_SAMPLE, "a")
 
         assertEquals(0L, source.afterCursors.single())
         assertTrue(transport.bodies.single().toString(Charsets.UTF_8).contains("\"ts\":50"))
@@ -90,7 +100,7 @@ class PushCursorTest {
         )
         val progress = MemoryProgress()
         val transport = AckingTransport()
-        val coordinator = PushCoordinator(source, transport, progress, SOURCE_A)
+        val coordinator = PushCoordinator(source, transport, progress, SOURCE_A, pinnedToday, ZoneId.of("UTC"))
 
         val first = coordinator.pushAppend(PushAppendTable.RR_INTERVAL, "a")
         val second = coordinator.pushAppend(PushAppendTable.RR_INTERVAL, "a")
@@ -110,7 +120,7 @@ class PushCursorTest {
             ),
         )
         val progress = MemoryProgress()
-        val coordinator = PushCoordinator(source, AckingTransport(), progress, SOURCE_A)
+        val coordinator = PushCoordinator(source, AckingTransport(), progress, SOURCE_A, pinnedToday, ZoneId.of("UTC"))
 
         coordinator.pushAppend(PushAppendTable.HR_SAMPLE, "a")
 


### PR DESCRIPTION
**`main` is red, and nothing in `main` caused it.** This is a time bomb that went off at midnight UTC.

## What happened

`PushCoordinator` defaults to `today = { LocalDate.now() }`, and `PushWindow` spans `today.minusDays(13)` — a 14-day window. Eight coordinators in `PushCoordinatorTest` were constructed without passing a clock, so they asserted against the wall clock. The journal fixtures are dated **2026-08-18**, which sat inside that window while `today ≤ 2026-08-31` and fell out of it on **2026-09-01**.

The CI history on `main` dates it exactly:

| sha | when | result |
|---|---|---|
| `2f32852` | 2026-08-31 **23:21Z** | success |
| `efc98944` | 2026-09-01 **00:13Z** | failure |
| `7b566f5` | after | failure |

Nothing between those runs goes near push — one is a build-number bump, the other an Oura scan fix — and the failure is `expected:<[journal]> but was:<[]>`, which is precisely what a row falling out of the push window looks like.

## Why it looked like an environment quirk first

I hit this locally hours before CI did and set it aside as environment-dependent, because CI was green at the time. This machine runs UTC+12, so it crossed into September twelve hours ahead of the runners. "Fails on my machine, passes in CI" was the symptom of a real bug with a deadline, not of a flaky local setup — worth recording, because that is exactly the shape that gets waved through.

## The fix

Every other coordinator in the file already pins `today` and `ZoneId.of("UTC")`. These eight now do the same, through one shared `pinnedToday` so the next one added inherits it rather than re-introducing the bug. **No production code changes** — the coordinator's behaviour is untouched; the test simply stops depending on what day it is run.

## Tests

Full `:app:testFullDebugUnitTest` — **4999 tests, 0 failures** (`PushCoordinatorTest` 23/23, previously 22/23).

## Note

This is why #1785 shows a red `build-and-test`: it inherits the breakage from `main`. Merging this first should turn it green without a rebase.

---

## Re-review of my own fix

**The first pass was incomplete.** It matched only the constructions written `MemoryProgress(), SOURCE_A)` and missed **ten** more that pass a local `progress` variable — including the `replace_window` journal case at `:476`, which is exactly the day-windowed shape that broke. I had claimed every construction now pinned a clock; it did not.

Also pinned `PushCursorTest`'s four. Those exercise cursor-based append tables rather than the day window, so they were never going to break on 1 Sep — but they are the same latent shape and pinning costs nothing.

There is now **no construction of `PushCoordinator` anywhere in the test sources that does not pass an explicit clock**, verified by grep rather than by eye.

## Swept for the same bug class elsewhere

`PushCoordinator` is the only production class with an injectable clock defaulting to `now()`. Four other test files read the real clock directly (`HistoricalStreamsUnhandledTypeTest`, `RawTimelineRepositoryDaoTest`, `DecoderOracleTest`, `ScheduledReportPolicyTest`), but none pairs that with a hardcoded `2026-08`/`2026-09` fixture, so none has the fixed-fixture-versus-moving-window pattern that detonated here. This was the only instance.

## The durable fix, deliberately not in this PR

Pinning tests fixes today's failure; it does not stop the next one being written. The actual hazard is that `today` has a **silent default** — `= { LocalDate.now() }` — so omitting it is invisible at the call site.

Removing that default would make omission a compile error. It is viable: there is exactly one production caller (`SelfHostedPushWorker.kt:221`), which currently relies on the default and would pass `{ LocalDate.now() }` explicitly.

I have kept it out of this PR on purpose — `main` is red, and a production signature change is the wrong thing to attach to an urgent test-only fix. Worth a follow-up.