### PR TITLE
push: make an omitted clock a compile error, not a green test

### DIFF
--- a/android/app/src/main/java/com/noop/push/PushCoordinator.kt
+++ b/android/app/src/main/java/com/noop/push/PushCoordinator.kt
@@ -11,8 +11,8 @@ class PushCoordinator(
     private val transport: PushTransport,
     private val progress: PushProgressStore,
     private val sourceId: String,
-    private val today: () -> LocalDate = { LocalDate.now() },
-    private val zoneId: ZoneId = ZoneId.systemDefault(),
+    private val today: () -> LocalDate,
+    private val zoneId: ZoneId,
     private val destinationStillCurrent: () -> Boolean = { true },
 ) {
     suspend fun pushAppend(table: PushAppendTable, deviceId: String): PushResult {

--- a/android/app/src/main/java/com/noop/push/SelfHostedPushWorker.kt
+++ b/android/app/src/main/java/com/noop/push/SelfHostedPushWorker.kt
@@ -8,6 +8,8 @@ import androidx.work.ListenableWorker
 import androidx.work.WorkerParameters
 import com.noop.R
 import com.noop.data.WhoopDatabase
+import java.time.LocalDate
+import java.time.ZoneId
 import kotlinx.coroutines.CancellationException
 
 internal fun persistedDeviceIndex(startDeviceIndex: Int, nextDeviceIndex: Int, retryableFailure: Boolean): Int =
@@ -223,6 +225,10 @@ class SelfHostedPushWorker(
             transport = transport,
             progress = progress,
             sourceId = sourceId,
+            // The real clock and zone live HERE, at the one caller that wants them, rather than as
+            // defaults 35 test constructions could inherit without saying so (#1787).
+            today = { LocalDate.now() },
+            zoneId = ZoneId.systemDefault(),
             destinationStillCurrent = { settings.enabledEndpoint() == endpoint },
         ).pushKnownDevices(startDeviceIndex, MAX_DEVICES_PER_RUN, capabilities)
         settings.recordAcceptedBatches(

--- a/android/app/src/test/java/com/noop/push/PushCoordinatorTest.kt
+++ b/android/app/src/test/java/com/noop/push/PushCoordinatorTest.kt
@@ -52,7 +52,7 @@ class PushCoordinatorTest {
 
         try {
             PushCoordinator(
-                source, transport, MemoryProgress(), SOURCE_A,
+                source, transport, MemoryProgress(), SOURCE_A, pinnedToday, ZoneId.of("UTC"),
                 destinationStillCurrent = { settings.enabledEndpoint() == first },
             ).pushKnownDevices(
                 capabilities = PushCapabilities(
@@ -186,6 +186,8 @@ class PushCoordinatorTest {
             throwing,
             progress,
             SOURCE_A,
+            pinnedToday,
+            ZoneId.of("UTC"),
         ).pushAppend(PushAppendTable.HR_SAMPLE, "a")
         assertTrue(result is PushResult.Rejected && result.retryable)
         assertTrue(progress.cursors.isEmpty())


### PR DESCRIPTION
Addresses #1787. #1786 stopped `main` being red by pinning every construction it could find; this removes the reason one can be written unpinned at all.

```kotlin
-    private val today: () -> LocalDate = { LocalDate.now() },
-    private val zoneId: ZoneId = ZoneId.systemDefault(),
+    private val today: () -> LocalDate,
+    private val zoneId: ZoneId,
```

Both were **silent defaults**: omitting them compiled, read as deliberate, and usually passed — until the calendar moved. `PushWindow` spans `today.minusDays(13)`, the journal fixtures are dated `2026-08-18`, and the row sat inside that window until it didn't.

`zoneId` is the worse of the two. `LocalDate.now()` at least fails everywhere at once; `ZoneId.systemDefault()` makes the answer depend on the **machine**, so a test can pass in CI and fail on a laptop for a reason neither surface shows. That is exactly what happened here — this box runs UTC+12 and went red twelve hours before the runners, which reads as a local quirk at precisely the moment it is a real bug with a deadline.

## It earned itself immediately

Removing the defaults produced compile errors at two sites:

```
PushCoordinatorTest.kt:56   No value passed for parameter 'today'
PushCoordinatorTest.kt:188  No value passed for parameter 'today'
```

**Both survived #1786 and are still wall-clock-dependent on `main`.** They pass only because they don't assert on the day window — the same way the broken one passed for the two weeks before 1 September.

They're multi-line constructions, which is why the greps I verified #1786 with couldn't match them: one ends in a comma rather than `SOURCE_A)`, the other puts every argument on its own line. I stated after that PR that every construction passed an explicit clock, *verified by grep rather than by eye*. It didn't, and grep is the reason. The compiler found in one run what two rounds of manual verification missed — which is the argument for this change, demonstrated on the change itself.

## Cost

One production call site. `SelfHostedPushWorker` now names the real clock and zone:

```kotlin
today = { LocalDate.now() },
zoneId = ZoneId.systemDefault(),
```

That's the point rather than a concession: the two facts that decide the push window live at the one caller that actually wants them, instead of being inherited by 35 constructions that don't.

## Tests

Full `:app:testFullDebugUnitTest` — **5010 tests, 0 failures**. `Tools/doc_comment_lint.py` clean. No behaviour change: the production path resolves to exactly what the defaults produced.
