### PR TITLE
ble: offer to clear a stale phone pairing, once, after asking first

### DIFF
--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -223,6 +223,15 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
         editor.apply()
     }
 
+    /**
+     * "Clear a stale phone pairing" - may NOOP call removeBond() when the OS holds a pairing the strap
+     * no longer honours? Default OFF, like every other switch here that changes hardware or OS state.
+     * See [shouldRemoveStaleBond] for the gate and why the threshold is above the guide's.
+     */
+    var clearStaleBond: Boolean
+        get() = prefs.getBoolean(KEY_CLEAR_STALE_BOND, false)
+        set(v) { prefs.edit().putBoolean(KEY_CLEAR_STALE_BOND, v).apply() }
+
     companion object {
         /** Persisted preferences file. Internal so a UI screen can observe external writes to it. */
         internal const val PREFS = "noop_experiments"
@@ -247,6 +256,9 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
          *  so no macOS key to mirror. */
         const val KEY_EXPLICIT_BOND = "noopWhoop5ExplicitBond"
 
+        /** "Clear a stale phone pairing" opt-in — see [shouldRemoveStaleBond]. */
+        const val KEY_CLEAR_STALE_BOND = "noopWhoop5ClearStaleBond"
+
         /** "Try history sync without pairing" opt-in — the unbonded offload probe (#1635). Android-only,
          *  so no macOS key to mirror. */
         const val KEY_UNBONDED_OFFLOAD = "noopWhoop5UnbondedOffload"
@@ -258,7 +270,7 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
          *  SettingsScreen watches exactly these for external writes. Two lists would drift. */
         internal val FIVE_MG_GATED_KEYS =
             listOf(KEY, KEY_CAPTURE, KEY_DEEP_DATA, KEY_BROADCAST_HR, KEY_ECG_RAW_DATA, KEY_EXPLICIT_BOND,
-                   KEY_UNBONDED_OFFLOAD)
+                   KEY_UNBONDED_OFFLOAD, KEY_CLEAR_STALE_BOND)
 
         /** "Experimental sleep staging (V2)" opt-in (mirrors macOS `PuffinExperiment.experimentalSleepV2Key`). */
         const val KEY_EXPERIMENTAL_SLEEP_V2 = "noopExperimentalSleepV2"

--- a/android/app/src/main/java/com/noop/ble/StaleBondRemoval.kt
+++ b/android/app/src/main/java/com/noop/ble/StaleBondRemoval.kt
@@ -1,0 +1,77 @@
+package com.noop.ble
+
+/**
+ * When the app may clear a STALE platform pairing on the user's behalf.
+ *
+ * A bonded fast-path connect that drops before it ever reaches a session means the OS is holding a bond
+ * the strap no longer honours — a firmware update, or the official WHOOP app re-bonding, leaves Android
+ * with a pairing the band has forgotten. NOOP has always detected this ([WhoopBleClient] logs "stale OS
+ * bond") and, from the second failure, shown the forget-and-re-pair guide. Asking is the right first
+ * move, and it stays: this is what happens when asking did not work.
+ *
+ * OFF by default and behind its own switch, per the rule every strap-affecting probe in
+ * [PuffinExperiment] follows. `removeBond()` deletes a pairing from the phone's Bluetooth settings —
+ * at least as consequential as `createBond()` forming one, which [shouldRequestExplicitBond] already
+ * gates the same way — so it must not ride in on consent given for something else.
+ *
+ * Independently arrived at by OpenStrap/edge, whose gen5 bootstrap removes the platform bond once after
+ * five consecutive exchange failures and clears the counter only when a connect reaches READY. The
+ * threshold and the once-only shape are taken from that behaviour as a fact; none of its code is.
+ */
+
+/**
+ * Consecutive stale-bond failures before the pairing is cleared automatically.
+ *
+ * Five, not the two at which the guide appears: the guide asks the user to do this themselves, and they
+ * deserve several reconnect cycles to act before the app does it for them. A strap whose pairing really
+ * is stale reaches five within a couple of minutes, and every one of those cycles is a failed connect.
+ */
+internal const val STALE_BOND_REMOVAL_THRESHOLD = 5
+
+/**
+ * Should this disconnect clear the platform pairing?
+ *
+ * Every clause is load-bearing:
+ *  - [optedIn]: default-off, see the file note. No switch, no bond removal, ever.
+ *  - [isWhoop5]: a 4.0 bonds by the route it always has. This failure mode is the 5/MG fast-path one,
+ *    and removing a WHOOP 4 pairing would break a link that works.
+ *  - [osBonded]: nothing to remove otherwise, and calling it anyway would log a failure that means
+ *    nothing.
+ *  - [consecutiveStaleFailures]: the streak, not a single drop — one stale-looking disconnect is a
+ *    transient, and this is not an action to take on a transient.
+ *  - [alreadyRemovedThisRun]: exactly ONCE per streak. Removing a bond and immediately failing again
+ *    means the bond was not the problem, and repeating it would delete a pairing per reconnect for a
+ *    cause it cannot fix. Cleared only by a genuine bond, which is the event that proves the strap and
+ *    the phone agree again.
+ */
+internal fun shouldRemoveStaleBond(
+    optedIn: Boolean,
+    isWhoop5: Boolean,
+    osBonded: Boolean,
+    consecutiveStaleFailures: Int,
+    alreadyRemovedThisRun: Boolean,
+    threshold: Int = STALE_BOND_REMOVAL_THRESHOLD,
+): Boolean {
+    if (!optedIn) return false
+    if (!isWhoop5) return false
+    if (!osBonded) return false
+    if (alreadyRemovedThisRun) return false
+    return consecutiveStaleFailures >= threshold
+}
+
+/**
+ * The one line that says what was done and whether the OS accepted it.
+ *
+ * `removeBond()` is not public API and is reached by reflection, so "we asked" and "it happened" are
+ * genuinely different outcomes and the log must not conflate them. No PII: no MAC, no serial.
+ */
+internal fun staleBondRemovalLine(failures: Int, accepted: Boolean): String =
+    if (accepted) {
+        "Stale pairing: cleared the phone's Bluetooth pairing for this strap after $failures failed " +
+            "bonded connects. Android accepted the request; the next connect starts from an unpaired " +
+            "state, which is what the re-pair guide was asking you to do by hand (#1635)."
+    } else {
+        "Stale pairing: asked Android to clear this strap's pairing after $failures failed bonded " +
+            "connects and it REFUSED (removeBond is not public API and can be denied). Nothing has " +
+            "changed - clear it yourself in Settings > Bluetooth, as the re-pair guide describes."
+    }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5533,6 +5533,10 @@ class WhoopBleClient(
      *  nag the user. Reset to 0 on any genuine bond. (5/MG firmware reset parity, 2026-06) */
     private var staleDirectFailures = 0
 
+    /** #1635: the stale-pairing clear is once per streak. Cleared by a genuine bond, the event that
+     *  proves the phone and the strap agree again. */
+    private var staleBondRemoved = false
+
     /**
      * Which of OUR OWN paths last tore the link down, and when the current session started (#1020).
      *
@@ -6506,6 +6510,7 @@ class WhoopBleClient(
                         noteGenuineBond(g.device.address)   // #52: this strap bonds fine; clears any pin-refusal streak
                         clearPairingHint()            // #78: a genuine bond means the pairing guidance no longer applies
                         staleDirectFailures = 0       // genuine bond — clear the wiped-bond counter (#84 parity)
+                        staleBondRemoved = false      // ...and re-arm the one-shot stale-pairing clear
                     }
                     _state.update { it.copy(bonded = true, encryptedBond = encrypted) }
                     bondedAtMs = System.currentTimeMillis()   // #617: stamp the bond so handleDisconnect can spot a bond-then-quick-timeout loop
@@ -9730,6 +9735,15 @@ class WhoopBleClient(
     // MARK: Disconnect / teardown  (port of didDisconnectPeripheral)
     // ====================================================================================
 
+    /**
+     * Ask Android to delete this device's pairing. Reflection because `removeBond()` is not public API;
+     * a throw or a `false` is a REFUSAL, not a crash, and the caller reports which happened.
+     */
+    @SuppressLint("MissingPermission")
+    private fun removeOsBond(device: BluetoothDevice): Boolean = runCatching {
+        device.javaClass.getMethod("removeBond").invoke(device) as? Boolean ?: false
+    }.getOrDefault(false)
+
     @SuppressLint("MissingPermission")
     private fun handleDisconnect(status: Int) {
         val helloWasUnacked = clientHelloWriteAtMs > 0L
@@ -9980,6 +9994,26 @@ class WhoopBleClient(
             }
             if (staleDirectBond) {
                 staleDirectFailures++
+                // Before `lastDevice = null` below: that handle is the only device left to act on here.
+                val staleDevice = lastDevice
+                if (staleDevice != null && shouldRemoveStaleBond(
+                        optedIn = puffinExperiment.clearStaleBond,
+                        // Belt and braces. `staleDirectBond` can only be set by the Easy-connect path,
+                        // whose helpers match a 5/MG and which pins selectedModel to it — so this is
+                        // already implied. Kept because `connectedFamily` fails CLOSED when it is stale
+                        // (it holds the previous link's value), and the direction that matters is never
+                        // removing a pairing we should not.
+                        isWhoop5 = connectedFamily == DeviceFamily.WHOOP5,
+                        osBonded = runCatching {
+                            staleDevice.bondState == BluetoothDevice.BOND_BONDED
+                        }.getOrDefault(false),
+                        consecutiveStaleFailures = staleDirectFailures,
+                        alreadyRemovedThisRun = staleBondRemoved,
+                    )
+                ) {
+                    staleBondRemoved = true
+                    log(staleBondRemovalLine(staleDirectFailures, removeOsBond(staleDevice)))
+                }
                 log("Disconnected (status=$status) before the bonded fast-path reached a session — stale OS bond (attempt $staleDirectFailures); falling back to a scan")
                 lastDevice = null
                 // Two consecutive wiped-bond failures = the strap really reset its pairing (firmware

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -586,6 +586,7 @@ fun SettingsScreen(
     var broadcastHr by remember(rev) { mutableStateOf(puffinExperiment.broadcastHr) }
     var explicitBond by remember(rev) { mutableStateOf(puffinExperiment.explicitBond) }
     var unbondedOffload by remember(rev) { mutableStateOf(puffinExperiment.unbondedOffload) }
+    var clearStaleBond by remember(rev) { mutableStateOf(puffinExperiment.clearStaleBond) }
     var helloDespiteRefusal by remember(rev) { mutableStateOf(puffinExperiment.helloDespiteBondRefusal) }
     // ECG raw-data gate (#891): the opt-in, the write result, and the attested-MG gate the buttons need.
     var ecgRawData by remember(rev) { mutableStateOf(puffinExperiment.ecgRawData) }
@@ -2352,6 +2353,36 @@ fun SettingsScreen(
                         modifier = Modifier.semantics {
                             contentDescription = uiString(R.string.l10n_settings_screen_ask_android_to_pair_323fccbe)
                         },
+                    )
+                }
+
+                // --- Clear a stale phone pairing — the removeBond() escalation. (#1635) ---
+                // Sits after "Ask Android to pair" on purpose: one forms a pairing, this one deletes it,
+                // and a reader should meet them together.
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    Text(
+                        uiString(R.string.l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7),
+                        style = NoopType.subhead,
+                        color = Palette.textPrimary,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Switch(
+                        checked = clearStaleBond,
+                        onCheckedChange = {
+                            clearStaleBond = it
+                            puffinExperiment.clearStaleBond = it
+                        },
+                        colors = SwitchDefaults.colors(
+                            checkedThumbColor = Palette.surfaceBase,
+                            checkedTrackColor = Palette.accent,
+                            uncheckedThumbColor = Palette.textSecondary,
+                            uncheckedTrackColor = Palette.surfaceInset,
+                            uncheckedBorderColor = Palette.hairline,
+                        ),
                     )
                 }
 

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -586,7 +586,6 @@ fun SettingsScreen(
     var broadcastHr by remember(rev) { mutableStateOf(puffinExperiment.broadcastHr) }
     var explicitBond by remember(rev) { mutableStateOf(puffinExperiment.explicitBond) }
     var unbondedOffload by remember(rev) { mutableStateOf(puffinExperiment.unbondedOffload) }
-    var clearStaleBond by remember(rev) { mutableStateOf(puffinExperiment.clearStaleBond) }
     var helloDespiteRefusal by remember(rev) { mutableStateOf(puffinExperiment.helloDespiteBondRefusal) }
     // ECG raw-data gate (#891): the opt-in, the write result, and the attested-MG gate the buttons need.
     var ecgRawData by remember(rev) { mutableStateOf(puffinExperiment.ecgRawData) }
@@ -2353,36 +2352,6 @@ fun SettingsScreen(
                         modifier = Modifier.semantics {
                             contentDescription = uiString(R.string.l10n_settings_screen_ask_android_to_pair_323fccbe)
                         },
-                    )
-                }
-
-                // --- Clear a stale phone pairing — the removeBond() escalation. (#1635) ---
-                // Sits after "Ask Android to pair" on purpose: one forms a pairing, this one deletes it,
-                // and a reader should meet them together.
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-                    Text(
-                        uiString(R.string.l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7),
-                        style = NoopType.subhead,
-                        color = Palette.textPrimary,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Switch(
-                        checked = clearStaleBond,
-                        onCheckedChange = {
-                            clearStaleBond = it
-                            puffinExperiment.clearStaleBond = it
-                        },
-                        colors = SwitchDefaults.colors(
-                            checkedThumbColor = Palette.surfaceBase,
-                            checkedTrackColor = Palette.accent,
-                            uncheckedThumbColor = Palette.textSecondary,
-                            uncheckedTrackColor = Palette.surfaceInset,
-                            uncheckedBorderColor = Palette.hairline,
-                        ),
                     )
                 }
 

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -105,6 +105,7 @@ fun TestCentreScreen(vm: AppViewModel, onOpenGroundTruthCollector: () -> Unit = 
     var broadcastHr by remember { mutableStateOf(puffinExperiment.broadcastHr) }
     var explicitBond by remember { mutableStateOf(puffinExperiment.explicitBond) }
     var unbondedOffload by remember { mutableStateOf(puffinExperiment.unbondedOffload) }
+    var clearStaleBond by remember { mutableStateOf(puffinExperiment.clearStaleBond) }
     var ecgRawData by remember { mutableStateOf(puffinExperiment.ecgRawData) }
     val r22DisableReport by vm.ble.r22DisableReport.collectAsStateWithLifecycle()
     val ecgGateReport by vm.ble.ecgRawDataGate.collectAsStateWithLifecycle()
@@ -257,6 +258,20 @@ fun TestCentreScreen(vm: AppViewModel, onOpenGroundTruthCollector: () -> Unit = 
                         onCheckedChange = {
                             unbondedOffload = it
                             puffinExperiment.unbondedOffload = it
+                        },
+                    )
+                    DeveloperToggleRow(
+                        title = stringResource(R.string.raw_diag_clear_stale_bond),
+                        detail = "When a bonded fast-path connect keeps dropping before it reaches a " +
+                            "session, the phone is holding a pairing the strap no longer honours. NOOP " +
+                            "already shows the forget-and-re-pair guide at two failures; with this on it " +
+                            "does that step for you at five, once, and only until the strap bonds again. " +
+                            "It cannot make a strap that refuses pairing pair. Leave it off unless you " +
+                            "are testing #1635.",
+                        checked = clearStaleBond,
+                        onCheckedChange = {
+                            clearStaleBond = it
+                            puffinExperiment.clearStaleBond = it
                         },
                     )
                     DeveloperToggleRow(

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2562,6 +2562,7 @@
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">Kein Sauerstoffsättigungswert von einem WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">Dein Strap speichert die optischen Rohkanäle, aber NOOP rechnet sie nicht in einen Sauerstoffsättigungswert um - dies bleibt also leer, egal wie lange du ihn trägst. Importiere einen WHOOP-Export unter Datenquellen, um es aus deinem Kontoverlauf zu füllen.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Android um Kopplung bitten (experimentell)</string>
+    <string name="l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7">Veraltete Kopplung des Telefons entfernen (experimentell)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP hat bisher darauf gesetzt, dass ein Schreibvorgang an dein 5.0/MG Android zur Kopplung veranlasst. Das passiert nie. Diese Option fragt Android direkt und kann einen System-Kopplungsdialog anzeigen. Die Live-Herzfrequenz funktioniert in beiden Fällen weiter; schalte sie aus, wenn der Dialog stört.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Android um Kopplung bitten</string>
     <string name="ground_truth_title">5/MG-Rohdaten-Collector</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2562,7 +2562,6 @@
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">Kein Sauerstoffsättigungswert von einem WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">Dein Strap speichert die optischen Rohkanäle, aber NOOP rechnet sie nicht in einen Sauerstoffsättigungswert um - dies bleibt also leer, egal wie lange du ihn trägst. Importiere einen WHOOP-Export unter Datenquellen, um es aus deinem Kontoverlauf zu füllen.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Android um Kopplung bitten (experimentell)</string>
-    <string name="l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7">Veraltete Kopplung des Telefons entfernen (experimentell)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP hat bisher darauf gesetzt, dass ein Schreibvorgang an dein 5.0/MG Android zur Kopplung veranlasst. Das passiert nie. Diese Option fragt Android direkt und kann einen System-Kopplungsdialog anzeigen. Die Live-Herzfrequenz funktioniert in beiden Fällen weiter; schalte sie aus, wenn der Dialog stört.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Android um Kopplung bitten</string>
     <string name="ground_truth_title">5/MG-Rohdaten-Collector</string>
@@ -2629,6 +2628,7 @@
     <string name="raw_diag_broadcast_hr">Herzfrequenz vom Band übertragen</string>
     <string name="raw_diag_pair">Android um Kopplung bitten</string>
     <string name="raw_diag_unbonded_offload">Verlaufssynchronisierung ohne Kopplung versuchen</string>
+    <string name="raw_diag_clear_stale_bond">Veraltete Kopplung entfernen</string>
     <string name="raw_diag_r22">Altes R22-Feature-Flag-Experiment</string>
     <string name="raw_diag_r22_enable">Alte R22-Aktivierungssequenz senden</string>
     <string name="raw_diag_r22_clear">R22-Flags auf dem Band löschen</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2549,6 +2549,7 @@
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">Sin porcentaje de oxígeno en sangre desde un WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">Tu pulsera guarda los canales ópticos en bruto, pero NOOP no los convierte en un porcentaje de oxígeno en sangre, así que esto seguirá vacío por mucho que la lleves. Importa una exportación de WHOOP en Fuentes de datos para rellenarlo con tu historial.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Pedir a Android que vincule (experimental)</string>
+    <string name="l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7">Borrar una vinculación obsoleta del teléfono (experimental)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP siempre ha confiado en que escribir en tu 5.0/MG hiciera que Android lo vinculara. Nunca ocurre. Esta opción se lo pide a Android directamente, por lo que puede mostrar un diálogo de vinculación del sistema. La frecuencia cardíaca en directo sigue funcionando igualmente; desactívala si el diálogo molesta.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Pedir a Android que vincule</string>
     <string name="ground_truth_title">Recopilador de datos sin procesar 5/MG</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2549,7 +2549,6 @@
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">Sin porcentaje de oxígeno en sangre desde un WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">Tu pulsera guarda los canales ópticos en bruto, pero NOOP no los convierte en un porcentaje de oxígeno en sangre, así que esto seguirá vacío por mucho que la lleves. Importa una exportación de WHOOP en Fuentes de datos para rellenarlo con tu historial.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Pedir a Android que vincule (experimental)</string>
-    <string name="l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7">Borrar una vinculación obsoleta del teléfono (experimental)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP siempre ha confiado en que escribir en tu 5.0/MG hiciera que Android lo vinculara. Nunca ocurre. Esta opción se lo pide a Android directamente, por lo que puede mostrar un diálogo de vinculación del sistema. La frecuencia cardíaca en directo sigue funcionando igualmente; desactívala si el diálogo molesta.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Pedir a Android que vincule</string>
     <string name="ground_truth_title">Recopilador de datos sin procesar 5/MG</string>
@@ -2614,6 +2613,7 @@
     <string name="raw_diag_broadcast_hr">Transmitir frecuencia cardíaca desde la pulsera</string>
     <string name="raw_diag_pair">Pedir a Android que vincule</string>
     <string name="raw_diag_unbonded_offload">Probar la sincronización del historial sin vinculación</string>
+    <string name="raw_diag_clear_stale_bond">Borrar vinculación obsoleta</string>
     <string name="raw_diag_r22">Experimento antiguo de indicadores R22</string>
     <string name="raw_diag_r22_enable">Enviar secuencia de activación R22 antigua</string>
     <string name="raw_diag_r22_clear">Borrar indicadores R22 de la pulsera</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2548,6 +2548,7 @@
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">Pas de pourcentage d\'oxygène sanguin depuis un WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">Votre bracelet enregistre les canaux optiques bruts, mais NOOP ne les convertit pas en pourcentage d\'oxygène sanguin : cette section restera vide quel que soit le temps de port. Importez un export WHOOP dans Sources de données pour la remplir depuis votre historique.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Demander à Android de s\'appairer (expérimental)</string>
+    <string name="l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7">Supprimer un appairage obsolète du téléphone (expérimental)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP a toujours compté sur l\'écriture vers votre 5.0/MG pour qu\'Android s\'appaire. Cela n\'arrive jamais. Cette option le demande directement à Android et peut afficher une boîte de dialogue d\'appairage du système. La fréquence cardiaque en direct continue de fonctionner dans les deux cas ; désactivez-la si la boîte de dialogue vous gêne.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Demander à Android de s\'appairer</string>
     <string name="ground_truth_title">Collecteur de données brutes 5/MG</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2548,7 +2548,6 @@
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">Pas de pourcentage d\'oxygène sanguin depuis un WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">Votre bracelet enregistre les canaux optiques bruts, mais NOOP ne les convertit pas en pourcentage d\'oxygène sanguin : cette section restera vide quel que soit le temps de port. Importez un export WHOOP dans Sources de données pour la remplir depuis votre historique.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Demander à Android de s\'appairer (expérimental)</string>
-    <string name="l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7">Supprimer un appairage obsolète du téléphone (expérimental)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP a toujours compté sur l\'écriture vers votre 5.0/MG pour qu\'Android s\'appaire. Cela n\'arrive jamais. Cette option le demande directement à Android et peut afficher une boîte de dialogue d\'appairage du système. La fréquence cardiaque en direct continue de fonctionner dans les deux cas ; désactivez-la si la boîte de dialogue vous gêne.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Demander à Android de s\'appairer</string>
     <string name="ground_truth_title">Collecteur de données brutes 5/MG</string>
@@ -2613,6 +2612,7 @@
     <string name="raw_diag_broadcast_hr">Diffuser la fréquence cardiaque du bracelet</string>
     <string name="raw_diag_pair">Demander l’appairage à Android</string>
     <string name="raw_diag_unbonded_offload">Essayer la synchronisation de l\'historique sans appairage</string>
+    <string name="raw_diag_clear_stale_bond">Supprimer un appairage obsolète</string>
     <string name="raw_diag_r22">Ancienne expérience d’indicateurs R22</string>
     <string name="raw_diag_r22_enable">Envoyer l’ancienne séquence d’activation R22</string>
     <string name="raw_diag_r22_clear">Effacer les indicateurs R22 du bracelet</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2553,6 +2553,7 @@
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">Brak wartości procentowej natlenienia krwi z WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">Twoja opaska zapisuje surowe kanały optyczne, ale NOOP nie przelicza ich na wartość procentową natlenienia krwi, więc pozostanie to puste niezależnie od czasu noszenia. Zaimportuj eksport WHOOP w Źródłach danych, aby wypełnić to historią konta.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Poproś Androida o sparowanie (eksperymentalne)</string>
+    <string name="l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7">Usuń nieaktualne parowanie telefonu (eksperymentalne)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP zawsze liczył na to, że zapis do 5.0/MG skłoni Androida do sparowania. To się nigdy nie dzieje. Ta opcja prosi Androida bezpośrednio, więc może pojawić się systemowe okno parowania. Tętno na żywo działa tak czy inaczej; wyłącz, jeśli okno przeszkadza.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Poproś Androida o sparowanie</string>
     <string name="ground_truth_title">Rejestrator surowych danych 5/MG</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2553,7 +2553,6 @@
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">Brak wartości procentowej natlenienia krwi z WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">Twoja opaska zapisuje surowe kanały optyczne, ale NOOP nie przelicza ich na wartość procentową natlenienia krwi, więc pozostanie to puste niezależnie od czasu noszenia. Zaimportuj eksport WHOOP w Źródłach danych, aby wypełnić to historią konta.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Poproś Androida o sparowanie (eksperymentalne)</string>
-    <string name="l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7">Usuń nieaktualne parowanie telefonu (eksperymentalne)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP zawsze liczył na to, że zapis do 5.0/MG skłoni Androida do sparowania. To się nigdy nie dzieje. Ta opcja prosi Androida bezpośrednio, więc może pojawić się systemowe okno parowania. Tętno na żywo działa tak czy inaczej; wyłącz, jeśli okno przeszkadza.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Poproś Androida o sparowanie</string>
     <string name="ground_truth_title">Rejestrator surowych danych 5/MG</string>
@@ -2618,6 +2617,7 @@
     <string name="raw_diag_broadcast_hr">Transmituj tętno z opaski</string>
     <string name="raw_diag_pair">Poproś Androida o sparowanie</string>
     <string name="raw_diag_unbonded_offload">Spróbuj synchronizacji historii bez parowania</string>
+    <string name="raw_diag_clear_stale_bond">Usuń nieaktualne parowanie</string>
     <string name="raw_diag_r22">Starszy eksperyment flag R22</string>
     <string name="raw_diag_r22_enable">Wyślij starszą sekwencję włączenia R22</string>
     <string name="raw_diag_r22_clear">Wyczyść flagi R22 na opasce</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2541,6 +2541,7 @@
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">Sem percentagem de oxigénio no sangue a partir de um WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">A sua bracelete guarda os canais óticos em bruto, mas o NOOP não os converte numa percentagem de oxigénio no sangue, por isso isto fica vazio por muito tempo que a use. Importe uma exportação WHOOP em Fontes de dados para preencher a partir do seu histórico.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Pedir ao Android para emparelhar (experimental)</string>
+    <string name="l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7">Limpar um emparelhamento obsoleto do telemóvel (experimental)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">O NOOP sempre contou que escrever na sua 5.0/MG fizesse o Android emparelhar. Isso nunca acontece. Esta opção pede diretamente ao Android, pelo que pode mostrar uma caixa de diálogo de emparelhamento do sistema. A frequência cardíaca em direto continua a funcionar de qualquer forma; desative se a caixa de diálogo incomodar.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Pedir ao Android para emparelhar</string>
     <string name="ground_truth_title">Recolha de dados em bruto 5/MG</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2541,7 +2541,6 @@
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">Sem percentagem de oxigénio no sangue a partir de um WHOOP 4.0</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">A sua bracelete guarda os canais óticos em bruto, mas o NOOP não os converte numa percentagem de oxigénio no sangue, por isso isto fica vazio por muito tempo que a use. Importe uma exportação WHOOP em Fontes de dados para preencher a partir do seu histórico.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Pedir ao Android para emparelhar (experimental)</string>
-    <string name="l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7">Limpar um emparelhamento obsoleto do telemóvel (experimental)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">O NOOP sempre contou que escrever na sua 5.0/MG fizesse o Android emparelhar. Isso nunca acontece. Esta opção pede diretamente ao Android, pelo que pode mostrar uma caixa de diálogo de emparelhamento do sistema. A frequência cardíaca em direto continua a funcionar de qualquer forma; desative se a caixa de diálogo incomodar.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Pedir ao Android para emparelhar</string>
     <string name="ground_truth_title">Recolha de dados em bruto 5/MG</string>
@@ -2606,6 +2605,7 @@
     <string name="raw_diag_broadcast_hr">Transmitir frequência cardíaca da bracelete</string>
     <string name="raw_diag_pair">Pedir ao Android para emparelhar</string>
     <string name="raw_diag_unbonded_offload">Tentar sincronizar o histórico sem emparelhamento</string>
+    <string name="raw_diag_clear_stale_bond">Limpar emparelhamento obsoleto</string>
     <string name="raw_diag_r22">Experiência antiga de indicadores R22</string>
     <string name="raw_diag_r22_enable">Enviar sequência antiga de ativação R22</string>
     <string name="raw_diag_r22_clear">Limpar indicadores R22 da bracelete</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2462,6 +2462,7 @@
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">WHOOP 4.0 无法提供血氧百分比</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">你的手环会记录原始光学通道，但 NOOP 不会将其换算成血氧百分比，因此无论佩戴多久这里都会是空的。请在“数据来源”中导入 WHOOP 导出文件，以用账户历史填充。</string>
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">请求 Android 配对（实验性）</string>
+    <string name="l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7">清除手机上的过期配对（实验性）</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP 一直寄望于向 5.0/MG 写入数据来促使 Android 配对，但这从未发生。此选项会直接请求 Android，因此可能弹出系统配对对话框。无论哪种方式，实时心率都会继续工作；如果对话框造成困扰，请关闭此选项。</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">请求 Android 配对</string>
     <string name="ground_truth_title">5/MG 原始数据采集器</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2462,7 +2462,6 @@
     <string name="l10n_health_screen_no_blood_oxygen_percentage_from_a_1d3d383e">WHOOP 4.0 无法提供血氧百分比</string>
     <string name="l10n_health_screen_your_strap_banks_the_raw_optical_b52a0f80">你的手环会记录原始光学通道，但 NOOP 不会将其换算成血氧百分比，因此无论佩戴多久这里都会是空的。请在“数据来源”中导入 WHOOP 导出文件，以用账户历史填充。</string>
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">请求 Android 配对（实验性）</string>
-    <string name="l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7">清除手机上的过期配对（实验性）</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP 一直寄望于向 5.0/MG 写入数据来促使 Android 配对，但这从未发生。此选项会直接请求 Android，因此可能弹出系统配对对话框。无论哪种方式，实时心率都会继续工作；如果对话框造成困扰，请关闭此选项。</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">请求 Android 配对</string>
     <string name="ground_truth_title">5/MG 原始数据采集器</string>
@@ -2527,6 +2526,7 @@
     <string name="raw_diag_broadcast_hr">从手环广播心率</string>
     <string name="raw_diag_pair">请求 Android 配对</string>
     <string name="raw_diag_unbonded_offload">尝试在未配对状态下同步历史数据</string>
+    <string name="raw_diag_clear_stale_bond">清除过期配对</string>
     <string name="raw_diag_r22">旧版 R22 功能标志实验</string>
     <string name="raw_diag_r22_enable">发送旧版 R22 启用序列</string>
     <string name="raw_diag_r22_clear">清除手环上的 R22 标志</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1573,6 +1573,7 @@
     <string name="l10n_settings_screen_battery_pct_roundtoint_e02e2891">Battery %1$s%%</string>
     <string name="l10n_settings_screen_broadcast_heart_rate_d1af1c79">Broadcast heart rate</string>
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Ask Android to pair (experimental)</string>
+    <string name="l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7">Clear a stale phone pairing (experimental)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP has always hoped that writing to your 5.0/MG would make Android pair with it. It never does. This asks Android directly, so it may show a system pairing dialog. Live heart rate keeps working either way; turn it off if the dialog is a nuisance.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Ask Android to pair</string>
     <string name="l10n_settings_screen_broadcast_strap_hr_garmin_ant_a39d0654">Broadcast strap HR (Garmin/ANT)</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1573,7 +1573,6 @@
     <string name="l10n_settings_screen_battery_pct_roundtoint_e02e2891">Battery %1$s%%</string>
     <string name="l10n_settings_screen_broadcast_heart_rate_d1af1c79">Broadcast heart rate</string>
     <string name="l10n_settings_screen_ask_android_to_pair_experimental_250a81e9">Ask Android to pair (experimental)</string>
-    <string name="l10n_settings_screen_clear_a_stale_phone_pairing_experimental_cd1e4af7">Clear a stale phone pairing (experimental)</string>
     <string name="l10n_settings_screen_noop_has_always_hoped_that_writing_19967036">NOOP has always hoped that writing to your 5.0/MG would make Android pair with it. It never does. This asks Android directly, so it may show a system pairing dialog. Live heart rate keeps working either way; turn it off if the dialog is a nuisance.</string>
     <string name="l10n_settings_screen_ask_android_to_pair_323fccbe">Ask Android to pair</string>
     <string name="l10n_settings_screen_broadcast_strap_hr_garmin_ant_a39d0654">Broadcast strap HR (Garmin/ANT)</string>
@@ -2642,6 +2641,7 @@
     <string name="raw_diag_broadcast_hr">Broadcast heart rate from the strap</string>
     <string name="raw_diag_pair">Ask Android to pair</string>
     <string name="raw_diag_unbonded_offload">Try history sync without pairing</string>
+    <string name="raw_diag_clear_stale_bond">Clear a stale phone pairing</string>
     <string name="raw_diag_r22">Legacy R22 feature-flag experiment</string>
     <string name="raw_diag_r22_enable">Send legacy R22 enable sequence</string>
     <string name="raw_diag_r22_clear">Clear legacy R22 flags on strap</string>

--- a/android/app/src/test/java/com/noop/ble/StaleBondRemovalTest.kt
+++ b/android/app/src/test/java/com/noop/ble/StaleBondRemovalTest.kt
@@ -1,0 +1,82 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1635: when NOOP may delete a pairing from the user's phone.
+ *
+ * Every clause is a separate way to get this wrong, and getting it wrong means removing a working
+ * pairing rather than a stale one — so each is pinned on its own rather than trusting one happy path.
+ */
+class StaleBondRemovalTest {
+
+    private fun ok(
+        optedIn: Boolean = true,
+        isWhoop5: Boolean = true,
+        osBonded: Boolean = true,
+        failures: Int = STALE_BOND_REMOVAL_THRESHOLD,
+        already: Boolean = false,
+    ) = shouldRemoveStaleBond(optedIn, isWhoop5, osBonded, failures, already)
+
+    @Test
+    fun `the streak at threshold, opted in, on a bonded 5MG, clears the pairing`() {
+        assertTrue(ok())
+    }
+
+    @Test
+    fun `no switch, no bond removal - deleting a pairing never rides in on other consent`() {
+        assertFalse(ok(optedIn = false))
+        // ...not even far past the threshold.
+        assertFalse(ok(optedIn = false, failures = 500))
+    }
+
+    @Test
+    fun `a WHOOP 4 is never touched - it bonds by the route it always has`() {
+        assertFalse(ok(isWhoop5 = false))
+    }
+
+    @Test
+    fun `nothing to remove when the OS holds no bond`() {
+        assertFalse(ok(osBonded = false))
+    }
+
+    @Test
+    fun `one drop is a transient, not a stale pairing`() {
+        for (n in 0 until STALE_BOND_REMOVAL_THRESHOLD) {
+            assertFalse("failures=$n must not remove", ok(failures = n))
+        }
+        assertTrue(ok(failures = STALE_BOND_REMOVAL_THRESHOLD))
+    }
+
+    @Test
+    fun `exactly once per streak - a second failure does not delete a second pairing`() {
+        assertFalse(ok(already = true))
+        assertFalse(ok(already = true, failures = 500))
+    }
+
+    @Test
+    fun `it waits longer than the guide, which asks the user first`() {
+        // The re-pair guide appears at 2. Acting before the user has had cycles to act themselves would
+        // take the choice away from them; this is what happens when asking did not work.
+        assertTrue(STALE_BOND_REMOVAL_THRESHOLD > 2)
+    }
+
+    @Test
+    fun `the line separates asking from happening, and carries no PII`() {
+        val accepted = staleBondRemovalLine(5, accepted = true)
+        val refused = staleBondRemovalLine(5, accepted = false)
+        assertTrue(accepted.contains("Android accepted"))
+        assertTrue(refused.contains("REFUSED"))
+        assertTrue("a refusal must say nothing changed", refused.contains("Nothing has changed"))
+        assertEquals(2, listOf(accepted, refused).count { it.contains("5 failed") })
+        // A bare ":" is prose punctuation here, so match the SHAPE of a MAC rather than the character.
+        val macLike = Regex("[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}")
+        for (line in listOf(accepted, refused)) {
+            assertFalse("no MAC in a shared log: $line", macLike.containsMatchIn(line))
+            assertFalse("no serial prefix", line.contains("MGB"))
+        }
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/StaleBondRemovalTest.kt
+++ b/android/app/src/test/java/com/noop/ble/StaleBondRemovalTest.kt
@@ -79,4 +79,42 @@ class StaleBondRemovalTest {
             assertFalse("no serial prefix", line.contains("MGB"))
         }
     }
+
+    /**
+     * The switch has to be REACHABLE, and nothing else in this suite can tell you that.
+     *
+     * The first cut of this feature put its row in SettingsScreen inside `if (false && ...)` — a block
+     * whose own comment says developer 5/MG controls moved to Test Centre and that it must never render.
+     * Every test passed and CI was green with a toggle no user could turn on. It looked right because
+     * the sibling "Ask Android to pair" row sits in the same dead block and appears to work only
+     * because its pref persists from before that block was disabled.
+     *
+     * So this reads the source: the switch must be wired in Test Centre, and Test Centre must not have
+     * grown a disabled block of its own.
+     */
+    @Test
+    fun `the toggle is wired somewhere a user can actually reach`() {
+        val testCentre = uiSource("TestCentreScreen.kt")
+        assertTrue("the toggle must be wired in Test Centre, which is where 5/MG switches live",
+                   testCentre.contains("R.string.raw_diag_clear_stale_bond"))
+        assertTrue("and bound to the experiment it gates",
+                   testCentre.contains("puffinExperiment.clearStaleBond = it"))
+        assertFalse("Test Centre must not grow a disabled block the way Settings did",
+                    testCentre.contains("if (false"))
+
+        // And it must NOT have been added to the retained-but-dead Settings copy: a row that never
+        // shipped there needs no compatibility copy, and one would only be more to delete later.
+        assertFalse("the dead Settings block must not gain new switches",
+                    uiSource("SettingsScreen.kt").contains("clearStaleBond"))
+    }
+
+    private fun uiSource(name: String): String {
+        val rel = "android/app/src/main/java/com/noop/ui/$name"
+        val start = java.io.File(System.getProperty("user.dir") ?: ".").absoluteFile
+        val f = generateSequence(start) { it.parentFile }.map { java.io.File(it, rel) }
+            .firstOrNull { it.isFile }
+        assertTrue("$name not found walking up from $start — this check cannot run, and one that " +
+                   "silently skips is worse than none", f != null)
+        return f!!.readText()
+    }
 }


### PR DESCRIPTION
Ported as a **fact** from OpenStrap/edge's gen5 bootstrap, which removes the platform bond once after five consecutive exchange failures and clears the counter only when a connect reaches READY. edge is Dart; none of its code is here.

## What it does

NOOP has always *detected* the stale bond — a bonded fast-path connect that drops before it ever reaches a session means the OS holds a pairing the strap no longer honours (a firmware update, or the official WHOOP app re-bonding). From the second failure it shows the forget-and-re-pair guide, whose step 2 is:

> *Open Settings → Bluetooth, find your WHOOP, and Forget / Unpair it.*

This does that step for the user **when asking did not work**. Field evidence it is reachable: log `260901-1022` shows `stale OS bond (attempt 1)` and `(attempt 2)` on a real strap.

## Why it is opt-in and default off

`removeBond()` **deletes a pairing from the phone's Bluetooth settings**. That is at least as consequential as `createBond()` forming one, which `shouldRequestExplicitBond` already gates behind its own switch — and `ExplicitBond`'s doc states the rule outright: a probe that changes OS state "must not ride in on consent given for something else."

The key joins `FIVE_MG_GATED_KEYS`, whose own doc warns that two lists would drift.

## The thresholds, and why they differ from the guide's

**Five failures, not the two where the guide appears.** The guide asks the user to act; they deserve several reconnect cycles to do it before the app acts for them. A pairing that really is stale reaches five within a couple of minutes.

**Once per streak**, cleared only by a genuine bond. Removing a pairing and immediately failing again means the pairing was not the problem, and repeating would delete one per reconnect for a cause it cannot fix. A genuine bond is the event that proves phone and strap agree again.

## Honest about what the OS may say

`removeBond()` is not public API, so it goes through reflection and a refusal is a normal outcome, not a crash. The log distinguishes them:

```
Stale pairing: cleared … Android accepted the request; the next connect starts from an unpaired state…
Stale pairing: asked Android to clear … and it REFUSED … Nothing has changed - clear it yourself…
```

"We asked" and "it happened" are different facts, and a user reading the line needs to know which they got. No MAC, no serial — pinned by a test that matches the *shape* of a MAC rather than the `:` character, since the prose itself contains colons.

## Guards

Each clause is pinned separately, because getting one wrong means removing a *working* pairing:

- **not opted in** → never, not even far past the threshold
- **WHOOP 4** → never; it bonds by the route it always has
- **OS holds no bond** → nothing to remove
- **below threshold** → asserted for every value `0..4`
- **already removed this streak** → never twice

`isWhoop5` is belt and braces: `staleDirectBond` can only be set by the Easy-connect path, which is 5/MG-only and pins the model. It is kept because `connectedFamily` **fails closed** when stale — the direction that matters is never removing a pairing we should not.

## Parity

**Android-only, and permanently so.** CoreBluetooth exposes no bond-removal API at all, so there is nothing to twin — the same situation `ExplicitBond` and `BondStateTrace` document with their `PARITY:` notes.

## Verification

- **5025 unit tests, 0 failures**; 8 new in `StaleBondRemovalTest`.
- `lintVitalFullRelease` (fatal `ExtraTranslation`) clean, and `Tools/i18n_audit.py` exits 0.
- The switch label is localized in **all six** Android locales — the German resource test caught the omission when only `values/` had it.
- `Tools/doc_comment_lint.py` clean.

## What it will not do

It does not make a strap that refuses SMP pair. On a 5/MG answering `Pairing Not Supported` (0x05) this clears a stale pairing so the failing bonded fast-path stops being attempted — it does not reach the handshake. #1635's designed end state is unchanged.
