### PR TITLE
ble: record why the stale-pairing clear stays Android-only

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -5603,6 +5603,19 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
             }
             state.append(log: "reconnect n=\(connReconnectCount) failedConnect reason=\(reason)", domain: .connection)
         }
+        // PARITY (#1790): Android can now CLEAR this pairing itself, behind a default-off Test Centre
+        // switch, once, after five of these failures — the step guide-line 2 asks the user to take. This
+        // side deliberately cannot, and the blocker is identity rather than a missing call:
+        //
+        //  - iOS has no route at all; forgetting a pairing is reserved to the user by design.
+        //  - macOS has one in IOBluetooth, but it addresses devices by MAC and CoreBluetooth never
+        //    exposes one — `peripheral.identifier` is a per-app UUID, deliberately not the hardware
+        //    address. The only bridge left is matching `IOBluetoothDevice.pairedDevices()` by NAME, and
+        //    deleting a pairing on a name match removes the wrong device the moment there are two straps
+        //    or one has been renamed.
+        //
+        // So both platforms detect this and both give the same advice; only Android can act on it. Do not
+        // close the gap with a name match. Kotlin twin: `StaleBondRemoval.kt`.
         if let cbErr = error as? CBError, cbErr.code == .peerRemovedPairingInformation {
             state.reconnectGuide = """
             Your strap's Bluetooth pairing was reset - usually by a WHOOP firmware update, or the official WHOOP app reconnecting. NOOP works fine on the new firmware; you just need to re-pair:

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -5607,7 +5607,9 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         // switch, once, after five of these failures — the step guide-line 2 asks the user to take. This
         // side deliberately cannot, and the blocker is identity rather than a missing call:
         //
-        //  - iOS has no route at all; forgetting a pairing is reserved to the user by design.
+        //  - iOS: the same identity problem, with nothing else to reach for. The guide below already
+        //    tells the user to do it themselves, which is the honest answer rather than a claim about
+        //    Apple's intent.
         //  - macOS ships IOBluetooth, a separate classic-Bluetooth framework, and whether its device
         //    removal works on a BLE pairing is a question that never arises for us: it addresses devices
         //    by MAC, and we never have one. `epitaphLine`'s doc already says why — the peripheral UUID is

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -5608,11 +5608,12 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         // side deliberately cannot, and the blocker is identity rather than a missing call:
         //
         //  - iOS has no route at all; forgetting a pairing is reserved to the user by design.
-        //  - macOS has one in IOBluetooth, but it addresses devices by MAC and CoreBluetooth never
-        //    exposes one — `peripheral.identifier` is a per-app UUID, deliberately not the hardware
-        //    address. The only bridge left is matching `IOBluetoothDevice.pairedDevices()` by NAME, and
-        //    deleting a pairing on a name match removes the wrong device the moment there are two straps
-        //    or one has been renamed.
+        //  - macOS ships IOBluetooth, a separate classic-Bluetooth framework, and whether its device
+        //    removal works on a BLE pairing is a question that never arises for us: it addresses devices
+        //    by MAC, and we never have one. `epitaphLine`'s doc already says why — the peripheral UUID is
+        //    "per-install, not the hardware address". The only bridge left is matching
+        //    `IOBluetoothDevice.pairedDevices()` by NAME, and deleting a pairing on a name match removes
+        //    the wrong device the moment there are two straps or one has been renamed.
         //
         // So both platforms detect this and both give the same advice; only Android can act on it. Do not
         // close the gap with a name match. Kotlin twin: `StaleBondRemoval.kt`.

--- a/android/app/src/main/java/com/noop/ble/StaleBondRemoval.kt
+++ b/android/app/src/main/java/com/noop/ble/StaleBondRemoval.kt
@@ -28,15 +28,16 @@ package com.noop.ble
  *
  *  - iOS has no route at all. Removing a pairing is a Settings > Bluetooth > Forget action reserved to
  *    the user, by design.
- *  - macOS does have one, in `IOBluetooth` — a separate, classic-Bluetooth framework — but it addresses
- *    devices by MAC, and CoreBluetooth never exposes one. A peripheral's identity there is
- *    `CBPeripheral.identifier`, a per-app UUID that deliberately is not the hardware address. The only
- *    bridge left is matching `IOBluetoothDevice.pairedDevices()` by NAME, and deleting a pairing on a
- *    name match is precisely the mistake this file's guards exist to prevent: two straps, or a renamed
- *    device, and it removes the wrong one.
+ *  - macOS ships `IOBluetooth`, a separate classic-Bluetooth framework. Whether its device removal
+ *    works on a BLE pairing is a question that never arises: it addresses devices by MAC, and Apple's
+ *    side never has one — `BLEManager.epitaphLine`'s doc already states it, the peripheral UUID being
+ *    "per-install, not the hardware address". The only bridge left is matching
+ *    `IOBluetoothDevice.pairedDevices()` by NAME, and deleting a pairing on a name match is precisely the
+ *    mistake this file's guards exist to prevent: two straps, or a renamed device, and it removes the
+ *    wrong one.
  *
- * So the gap is real and stays: both platforms detect and ask, only this one can act. If a future macOS
- * SDK exposes the hardware address, or CoreBluetooth grows a removal call, revisit it — do not close it
+ * So the gap is real and stays: both platforms detect and ask, only this one can act. If CoreBluetooth
+ * ever exposes the hardware address, or grows a removal call of its own, revisit it — do not close it
  * with a name match.
  */
 

--- a/android/app/src/main/java/com/noop/ble/StaleBondRemoval.kt
+++ b/android/app/src/main/java/com/noop/ble/StaleBondRemoval.kt
@@ -17,6 +17,27 @@ package com.noop.ble
  * Independently arrived at by OpenStrap/edge, whose gen5 bootstrap removes the platform bond once after
  * five consecutive exchange failures and clears the counter only when a connect reaches READY. The
  * threshold and the once-only shape are taken from that behaviour as a fact; none of its code is.
+ *
+ * PARITY: Android-only, and the reason is IDENTITY rather than a missing API — worth stating precisely,
+ * because "CoreBluetooth has no bond-removal call" is true but is not the whole blocker and invites
+ * someone to go looking for a way round it.
+ *
+ * Apple DETECTS the same condition and gives the same advice: `BLEManager`'s `didFailToConnect` handles
+ * `CBError.peerRemovedPairingInformation` and publishes a forget-and-re-pair guide naming the strap. It
+ * simply cannot perform the step.
+ *
+ *  - iOS has no route at all. Removing a pairing is a Settings > Bluetooth > Forget action reserved to
+ *    the user, by design.
+ *  - macOS does have one, in `IOBluetooth` — a separate, classic-Bluetooth framework — but it addresses
+ *    devices by MAC, and CoreBluetooth never exposes one. A peripheral's identity there is
+ *    `CBPeripheral.identifier`, a per-app UUID that deliberately is not the hardware address. The only
+ *    bridge left is matching `IOBluetoothDevice.pairedDevices()` by NAME, and deleting a pairing on a
+ *    name match is precisely the mistake this file's guards exist to prevent: two straps, or a renamed
+ *    device, and it removes the wrong one.
+ *
+ * So the gap is real and stays: both platforms detect and ask, only this one can act. If a future macOS
+ * SDK exposes the hardware address, or CoreBluetooth grows a removal call, revisit it — do not close it
+ * with a name match.
  */
 
 /**

--- a/android/app/src/main/java/com/noop/ble/StaleBondRemoval.kt
+++ b/android/app/src/main/java/com/noop/ble/StaleBondRemoval.kt
@@ -26,8 +26,8 @@ package com.noop.ble
  * `CBError.peerRemovedPairingInformation` and publishes a forget-and-re-pair guide naming the strap. It
  * simply cannot perform the step.
  *
- *  - iOS has no route at all. Removing a pairing is a Settings > Bluetooth > Forget action reserved to
- *    the user, by design.
+ *  - iOS: the same identity problem, with nothing else to reach for. The app's own guide already tells
+ *    the user to do it in Settings, which is the honest answer rather than a claim about Apple's intent.
  *  - macOS ships `IOBluetooth`, a separate classic-Bluetooth framework. Whether its device removal
  *    works on a BLE pairing is a question that never arises: it addresses devices by MAC, and Apple's
  *    side never has one — `BLEManager.epitaphLine`'s doc already states it, the peripheral UUID being


### PR DESCRIPTION
You asked for a mirror of #1790. **A mirror is not safely buildable**, and this PR records why rather than faking one — with a correction to a claim I made in #1790's merge body.

## What I got wrong

#1790 said *"Android-only and permanently so: CoreBluetooth exposes no bond-removal API."* That is true, and it is not the whole blocker. Stated that way it reads as settled, and it invites the next reader to go hunting for a way round.

## The real obstacle is identity, not API

**macOS does have a removal call** — `IOBluetooth`, a separate classic-Bluetooth framework. It addresses devices by **MAC**, and CoreBluetooth never exposes one: a peripheral's identity there is `CBPeripheral.identifier`, a per-app UUID that is deliberately *not* the hardware address. I checked, and nothing in `BLEManager` ever holds a MAC.

That leaves exactly one bridge: enumerate `IOBluetoothDevice.pairedDevices()` and match by **name**. Deleting a pairing on a name match removes the wrong device the moment a user has two straps or has renamed one — which is precisely the mistake `shouldRemoveStaleBond`'s guards exist to prevent. Closing the gap that way would be worse than leaving it open.

**iOS has no route at all.** Forgetting a pairing is a Settings → Bluetooth action reserved to the user by design.

## Why this is worth writing down

Apple is *not* unaware of the condition. `didFailToConnect` already handles `CBError.peerRemovedPairingInformation` and publishes the same forget-and-re-pair guide, naming the strap:

> *Your strap's Bluetooth pairing was reset - usually by a WHOOP firmware update, or the official WHOOP app…*
> *2. Open System Settings → Bluetooth and Forget "WHOOP MG" if it's listed.*

So both platforms detect it, both give the same advice, and only Android can take the step. A future parity audit finding this one-sided should read a **decision**, not an oversight — the same treatment `ExplicitBond` and `BondStateTrace` already get.

Notes only, one on each side, cross-referencing each other. **638 BLE tests green**, doc lint clean, `swiftc -parse` clean.

## One divergence I did NOT change

Apple's stale-bond branch sets the guide and `return`s — it schedules nothing. Android's schedules a reconnect and keeps trying, which is how its failure counter climbs to five at all.

That means on Apple, a user who clears the pairing in System Settings while the app is open is not picked up until they reconnect by hand. It may well be deliberate — not hammering a strap whose bond is known-stale is defensible — and the comment above it cites #1413's standing-connect handoff for the *other* failure paths specifically. I am not changing Apple's reconnect behaviour on my reading of it; flagging it for yours.

---

## Re-review: I made the same mistake inside the correction

The first version of these notes said macOS **"does have"** a bond-removal call in `IOBluetooth`. I cannot verify that from this repository. Asserting an Apple SDK capability from recollection is precisely the move this PR exists to correct — and I did it in the correction.

It was also unnecessary. **The identity blocker makes the API question moot**: even if `IOBluetooth`'s removal works on a BLE pairing, it addresses devices by MAC and Apple's side never has one, so the question never arises. That argument is fully checkable from inside the repo, and it is the stronger one.

The note also had a citation available that I had not used. `BLEManager.epitaphLine`'s own doc already says the peripheral UUID is *"per-install, not the hardware address"* — noop established this before I did, so the note now points at it rather than re-deriving it. I re-grepped `BLEManager` **unfiltered** to be sure nothing MAC-shaped had slipped past my earlier filtered search; the only two hits are that doc line and my own comment.

The closing line lost *"if a future macOS SDK exposes the hardware address"* for the same reason, and now turns on CoreBluetooth — the framework whose behaviour actually governs this.