### PR TITLE
Canonicalize signed zero in effective effort

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
@@ -212,6 +212,7 @@ public enum StrainScorer {
     public static func effectiveEffort(live: Double?, stored: Double?) -> Double? {
         guard let live else { return stored }
         guard let stored else { return live }
+        if live == 0.0 && stored == 0.0 { return 0.0 }
         return Swift.max(live, stored)
     }
 

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/EffectiveEffortTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/EffectiveEffortTests.swift
@@ -47,4 +47,61 @@ final class EffectiveEffortTests: XCTestCase {
     func testEqualSourcesResolveToThatValue() {
         XCTAssertEqual(StrainScorer.effectiveEffort(live: 7.25, stored: 7.25)!, 7.25, accuracy: 1e-9)
     }
+
+    /// #37: when both sources are zero, every sign pairing has the canonical positive-zero bits.
+    func testBothPresentZerosCanonicalizePositiveZero() {
+        let cases: [(label: String, live: Double, stored: Double)] = [
+            ("positive/positive", 0.0, 0.0),
+            ("positive/negative", 0.0, -0.0),
+            ("negative/positive", -0.0, 0.0),
+            ("negative/negative", -0.0, -0.0),
+        ]
+
+        for testCase in cases {
+            let result = StrainScorer.effectiveEffort(live: testCase.live, stored: testCase.stored)!
+            XCTAssertEqual(result.bitPattern, 0.0.bitPattern, testCase.label)
+        }
+    }
+
+    /// A missing source is passthrough, including its exact signed-zero and NaN representation.
+    func testSingleSourcePassesThroughBitForBit() {
+        let values = [
+            0.0,
+            -0.0,
+            7.25,
+            -7.25,
+            Double.infinity,
+            -Double.infinity,
+            Double(bitPattern: 0x7ff8_0000_0000_0042),
+        ]
+
+        for value in values {
+            XCTAssertEqual(StrainScorer.effectiveEffort(live: value, stored: nil)!.bitPattern,
+                           value.bitPattern)
+            XCTAssertEqual(StrainScorer.effectiveEffort(live: nil, stored: value)!.bitPattern,
+                           value.bitPattern)
+        }
+    }
+
+    /// The zero canonicalization must not broaden into a replacement for Swift's MAX semantics.
+    func testBothPresentNonzeroAndNaNBehaviorIsUnchanged() {
+        let nanA = Double(bitPattern: 0x7ff8_0000_0000_0042)
+        let nanB = Double(bitPattern: 0x7ff8_0000_0000_0024)
+        let cases: [(live: Double, stored: Double, expected: Double)] = [
+            (2.3, 0.5, 2.3),
+            (7.25, 7.25, 7.25),
+            (Double.infinity, 12.0, Double.infinity),
+            (12.0, Double.infinity, Double.infinity),
+            (-Double.infinity, -Double.infinity, -Double.infinity),
+            (nanA, 1.0, nanA),
+            (1.0, nanA, 1.0),
+            (nanA, nanB, nanA),
+            (nanB, nanA, nanB),
+        ]
+
+        for testCase in cases {
+            let result = StrainScorer.effectiveEffort(live: testCase.live, stored: testCase.stored)!
+            XCTAssertEqual(result.bitPattern, testCase.expected.bitPattern)
+        }
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
+++ b/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
@@ -250,6 +250,7 @@ object StrainScorer {
     fun effectiveEffort(live: Double?, stored: Double?): Double? {
         if (live == null) return stored
         if (stored == null) return live
+        if (live == 0.0 && stored == 0.0) return 0.0
         return kotlin.math.max(live, stored)
     }
 

--- a/android/app/src/test/java/com/noop/analytics/EffectiveEffortTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/EffectiveEffortTest.kt
@@ -54,4 +54,61 @@ class EffectiveEffortTest {
     @Test fun equalSourcesResolveToThatValue() {
         assertEquals(7.25, StrainScorer.effectiveEffort(live = 7.25, stored = 7.25)!!, 1e-9)
     }
+
+    /** #37: when both sources are zero, every sign pairing has the canonical positive-zero bits. */
+    @Test fun bothPresentZerosCanonicalizePositiveZero() {
+        val cases = listOf(
+            Triple("positive/positive", 0.0, 0.0),
+            Triple("positive/negative", 0.0, -0.0),
+            Triple("negative/positive", -0.0, 0.0),
+            Triple("negative/negative", -0.0, -0.0),
+        )
+
+        for ((label, live, stored) in cases) {
+            val result = StrainScorer.effectiveEffort(live = live, stored = stored)!!
+            assertEquals(label, 0.0.toRawBits(), result.toRawBits())
+        }
+    }
+
+    /** A missing source is passthrough, including its exact signed-zero and NaN representation. */
+    @Test fun singleSourcePassesThroughBitForBit() {
+        val values = listOf(
+            0.0,
+            -0.0,
+            7.25,
+            -7.25,
+            Double.POSITIVE_INFINITY,
+            Double.NEGATIVE_INFINITY,
+            Double.fromBits(0x7ff8_0000_0000_0042L),
+        )
+
+        for (value in values) {
+            assertEquals(value.toRawBits(),
+                StrainScorer.effectiveEffort(live = value, stored = null)!!.toRawBits())
+            assertEquals(value.toRawBits(),
+                StrainScorer.effectiveEffort(live = null, stored = value)!!.toRawBits())
+        }
+    }
+
+    /** The zero canonicalization must not broaden into a replacement for Kotlin's MAX semantics. */
+    @Test fun bothPresentNonzeroAndNaNBehaviorIsUnchanged() {
+        val nanA = Double.fromBits(0x7ff8_0000_0000_0042L)
+        val nanB = Double.fromBits(0x7ff8_0000_0000_0024L)
+        val cases = listOf(
+            Triple(2.3, 0.5, 2.3),
+            Triple(7.25, 7.25, 7.25),
+            Triple(Double.POSITIVE_INFINITY, 12.0, Double.POSITIVE_INFINITY),
+            Triple(12.0, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY),
+            Triple(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY),
+            Triple(nanA, 1.0, nanA),
+            Triple(1.0, nanA, nanA),
+            Triple(nanA, nanB, nanA),
+            Triple(nanB, nanA, nanB),
+        )
+
+        for ((live, stored, expected) in cases) {
+            val result = StrainScorer.effectiveEffort(live = live, stored = stored)!!
+            assertEquals(expected.toRawBits(), result.toRawBits())
+        }
+    }
 }


### PR DESCRIPTION
Canonicalize the both-present signed-zero case to positive zero in the mirrored Swift and Kotlin analytics implementations. This removes the platform-dependent tie behavior of Swift.max and kotlin.math.max while preserving nil passthrough, nonzero ordering/equality, infinities, and NaN operand-order behavior.\n\nAdds mirrored raw-bit regression coverage for all four signed-zero operand combinations plus preservation cases.\n\nRelated issue: https://github.com/bhelm/noop/issues/37\n\nVerification:\n- Swift EffectiveEffortTests: 10 tests, 0 failures\n- Android EffectiveEffortTest: BUILD SUCCESSFUL\n- git diff --check\n- Two independent reviews: no P0/P1 findings