### PR TITLE
docs: describe the CI that actually runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,13 +60,30 @@ cd android
 
 ## What CI checks
 
-Two GitHub Actions workflows run on every PR and push to `main`. They compile and
-run unit tests only — no code signing, no secrets, no release.
+**Five** GitHub Actions workflows can run on a PR. Three run on *every* PR; two are
+path-filtered and only run when you touch what they cover. All of them compile and run
+unit tests only — no code signing, no secrets, no release.
 
-| Workflow | Trigger | What it does |
+The check names GitHub shows you are **job** names, which do not resemble the workflow
+names. That column is why this table exists:
+
+| Check you see | Workflow | Runs when |
 |---|---|---|
-| **Swift Packages CI** (`.github/workflows/swift-packages.yml`) | changes under `Packages/**` | `swift build` + `swift test` for each package |
-| **Android CI** (`.github/workflows/android.yml`) | changes under `android/**` | `assembleFullDebug` + `testFullDebugUnitTest` (JDK 17) |
+| `check` | **i18n Coverage** (`i18n-coverage.yml`) | every PR |
+| `doc-comments` | **Source Hygiene** (`source-hygiene.yml`) | every PR |
+| `linux-capture` | **Tools Python CI** (`tools-python.yml`) | every PR |
+| `build-and-test` | **Android CI** (`android.yml`) | `android/**`, the protocol/store test resources, `Strand/Resources/Localizable.xcstrings` |
+| `test (…)`, `tools (…)` | **Swift Packages CI** (`swift-packages.yml`) | `Packages/**`, the `Tools/SleepBench`, `Tools/SleepPSG` and `Tools/Backfill` packages, `android/app/src/test/resources/**`, `Strand/Liquid/LiquidCore.swift` |
+
+So an Android-only PR shows **four** checks, not one: Android CI plus the three that always
+run. Seeing a short list does not mean little was checked.
+
+**App build** (`app-build.yml`, app-target compile + the `StrandTests` macOS suite) is
+`disabled_manually` and is **not** in that list. App-target code — SwiftUI views,
+`BLEManager`, `Repository`, Compose screens — is compiled by **nothing** on a normal PR, so
+build it locally before you push, or ask a maintainer to dispatch `app-build.yml`. See
+[docs/CONTRIBUTING.md](docs/CONTRIBUTING.md#what-ci-gates--and-what-it-deliberately-doesnt)
+for why the lean setup is deliberate and what else is gated at release time instead.
 
 If CI fails on your PR, fix the cause rather than working around it. Never commit
 generated output (`Strand.xcodeproj/`) or any secrets, keystores, or `local.properties`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,11 @@ cd android
 
 ## What CI checks
 
-**Five** GitHub Actions workflows can run on a PR. Three run on *every* PR; two are
-path-filtered and only run when you touch what they cover. All of them compile and run
-unit tests only — no code signing, no secrets, no release.
+Some GitHub Actions workflows run on *every* PR; others are path-filtered and only run when
+you touch what they cover. All of them compile and run unit tests only — no code signing, no
+secrets, no release. The table is the source of truth, deliberately — the section this
+replaced led with a count, and a count in prose is what goes stale while the list below it
+looks fine.
 
 The check names GitHub shows you are **job** names, which do not resemble the workflow
 names. That column is why this table exists:
@@ -75,8 +77,8 @@ names. That column is why this table exists:
 | `build-and-test` | **Android CI** (`android.yml`) | `android/**`, the protocol/store test resources, `Strand/Resources/Localizable.xcstrings` |
 | `test (…)`, `tools (…)` | **Swift Packages CI** (`swift-packages.yml`) | `Packages/**`, the `Tools/SleepBench`, `Tools/SleepPSG` and `Tools/Backfill` packages, `android/app/src/test/resources/**`, `Strand/Liquid/LiquidCore.swift` |
 
-So an Android-only PR shows **four** checks, not one: Android CI plus the three that always
-run. Seeing a short list does not mean little was checked.
+Read that as a worked example: an Android-only PR runs Android CI plus the three that always
+run, so a short list of checks does not mean little was checked.
 
 **App build** (`app-build.yml`, app-target compile + the `StrandTests` macOS suite) is
 `disabled_manually` and is **not** in that list. App-target code — SwiftUI views,

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -254,14 +254,19 @@ NOOP runs a **deliberately lean CI**: fast, no-hardware checks guard the point o
 and hardware-dependent verification runs at release time or on demand. This is a choice for an
 anonymous, offline, sideloaded project — not a gap to fill with more gates.
 
-- **On every PR (required):** `swift-packages` runs `swift test` for `Packages/**`; `i18n-coverage`
-  runs the string audit. These catch the regressions that matter most (protocol/analytics math,
-  storage, i18n) without a device or an Xcode/Gradle app build.
+- **On every PR (required):** `source-hygiene`, `tools-python` and `i18n-coverage` have no path
+  filter, so all three run on everything. `swift-packages` (`swift test` for `Packages/**`) and
+  `android` (`assembleFullDebug` + `testFullDebugUnitTest`) are **path-filtered** — they run when you
+  touch what they cover, which is most substantive PRs. Between them these catch the regressions that
+  matter most (protocol/analytics math, storage, i18n) without a device or an app build. The check
+  names you see are JOB names and do not resemble the workflow names; the table in the root
+  [CONTRIBUTING.md](../CONTRIBUTING.md#what-ci-checks) maps them.
 - **Disabled by design — you build the app yourself:** `app-build.yml` (app-target compile, iOS needs
-  `macos-26`) and `android.yml` (Android app build) are **off**. So a compile error in **app-target**
-  code (SwiftUI Views, `BLEManager`, `Repository`, a Compose screen) passes every default check.
-  Before you push app-layer changes, compile locally — `xcodebuild … build` /
-  `./gradlew compileFullDebugKotlin` — or dispatch `app-build.yml` on demand.
+  `macos-26`) is **off**. So a compile error in **app-target** code (SwiftUI Views, `BLEManager`,
+  `Repository`, a Compose screen) passes every default check — `android.yml` builds and unit-tests the
+  Android app but nothing compiles the Apple app target. Before you push app-layer changes, compile
+  locally — `xcodebuild … build` / `./gradlew compileFullDebugKotlin` — or dispatch `app-build.yml`
+  on demand.
 - **Gated at release, not per PR:** Android release lint (`lintVitalFullRelease`) runs inside
   `assembleFullRelease` in the staging/release builds, so lint-fatal issues (e.g. an
   `ExtraTranslation` in a `values-<lang>` file) surface there. Run `./gradlew lintVitalFullRelease`


### PR DESCRIPTION
Reported in #1789 by @kvnloo. Verifying it turned up a second, worse error in the other file.

## What was wrong

**Root `CONTRIBUTING.md`** said *"Two GitHub Actions workflows run on every PR"* and named Swift Packages CI and Android CI. Those are the only two that **are** path-filtered. The three with no `paths:` filter — Source Hygiene, Tools Python CI, i18n Coverage — were missing entirely.

**`docs/CONTRIBUTING.md`** said `app-build.yml` *"and `android.yml` (Android app build) are **off**"*. `android.yml` is **active** — `gh workflow list` reports it, and its `build-and-test` job ran on every Android PR merged today. Only `app-build` is `disabled_manually`.

That second one is worse than an undercount. Telling someone the check most likely to catch their mistake doesn't run invites them to skip testing locally and be surprised by a red PR they were told to expect green. The same section also listed `swift-packages` under "on every PR" when it's path-filtered.

## The thing neither file had

The checks GitHub shows are **job** names, and they don't resemble the workflow names:

| Check you see | Workflow |
|---|---|
| `check` | i18n Coverage |
| `doc-comments` | Source Hygiene |
| `linux-capture` | Tools Python CI |
| `build-and-test` | Android CI |
| `test (…)`, `tools (…)` | Swift Packages CI |

Nothing on the PR page connects them, so an Android-only PR shows four checks and reads as though almost nothing ran — when all three always-on workflows did. **I misread it that way myself, repeatedly, before mapping it**, which is what convinced me it belongs in the table rather than being obvious-once-stated.

## How they're split now

The two files disagreed with each other as well as with reality, which is how this drifted. So each owns a different thing:

- **Root** owns the enumeration and the job-name mapping — what a first-time contributor needs to read their own PR.
- **`docs/`** owns the rationale and what's deliberately gated at release instead, and points at the root table rather than restating it.

Cross-links both ways, anchors following the file's existing TOC convention.

## Verification

Every trigger, path filter and workflow state in the new text was read from `.github/workflows/` and `gh workflow list` — not from the old prose. Table pipe-escaping checked (the `Tools/Sleep*` cell originally contained `|` characters that would have broken the table). `doc_comment_lint` and `i18n_audit` clean.

Worth noting: this PR is docs-only, so it should show exactly the **three** always-on checks and neither path-filtered one — a live demonstration of the table it adds.

## Not changed

The `(#1770)` citation @kvnloo mentions is in the issue text, not in either file, so there's nothing to correct here.
