### PR TITLE
analytics: do not claim a twin with a Swift stdlib method

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/PreSleepHeartRateFeedback.kt
+++ b/android/app/src/main/java/com/noop/analytics/PreSleepHeartRateFeedback.kt
@@ -236,7 +236,14 @@ object PreSleepHeartRateFeedback {
         )
     }
 
-    /** `a - b`, or null when it would overflow. The Long twin of Swift's `subtractingReportingOverflow`. */
+    /**
+     * `a - b`, or null when it would overflow.
+     *
+     * NOT a twin claim, though it reads like one and originally said so. Apple expresses the same
+     * contract with `subtractingReportingOverflow`, which is Swift STDLIB on `FixedWidthInteger` and
+     * therefore not a declaration in this repository at all — so a reader chasing the reference finds
+     * nothing, and a parity audit resolves it to nothing either.
+     */
     private fun subtractOrNull(a: Long, b: Long): Long? =
         try { Math.subtractExact(a, b) } catch (_: ArithmeticException) { null }
 


### PR DESCRIPTION
Found by the parity ledger in #1534, which reported it as a `dead-twin-reference` within minutes of being run against a merged tree.

I wrote this yesterday in #1785:

```kotlin
/** `a - b`, or null when it would overflow. The Long twin of Swift's `subtractingReportingOverflow`. */
```

`subtractingReportingOverflow` is Swift **stdlib** on `FixedWidthInteger`, not a declaration in this repository — so the reference resolves to nothing. A reader chasing it finds no such function here, and neither does an audit.

#1534 fixes the **identical mistake** in `AICoach.swift`, where *"the twin of Kotlin's `LocalDate.now().toEpochDay()`"* became *"Kotlin computes the same value with…"*. Two of us reached for that phrasing independently, which suggests it's an easy one to make rather than a one-off slip.

Reworded to say what's true: Apple expresses the same contract with that method, and it's stdlib rather than a twin. The file's `PARITY` note a few lines up already had this right — it contrasts `Math.subtractExact` with `subtractingReportingOverflow` without claiming a pairing — so this only brings the one line into line with the rest of the file.

**Fixed rather than baselined, deliberately.** Accepting it as known debt would launder a defect I introduced into the accepted set, which is the opposite of what a ledger is for.

Verified against #1534's ledger that this specific finding is gone: before, two findings on `PreSleepHeartRateFeedback.kt:239`; after, none. Comment-only, so no behaviour change — compile and `doc_comment_lint` clean.
