### PR TITLE
android: twin standardHRHostReceivedLine and be honest about take(200)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/LivePersistTrace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/LivePersistTrace.swift
@@ -27,11 +27,13 @@ public enum StandardHRLifecycleFlush {
 /// log full of `rr emit … offered=N` and no indication that none of it landed. That is the worst shape a
 /// diagnostic gap can take: the instrumentation that exists reads like success.
 ///
-/// Byte-identical twin of the Kotlin `liveInsertFailedLine` in `com.noop.ble.StalledLinkDiagnostics`, so
-/// an Android and an Apple log of the same failure compare directly. The Kotlin side lives beside its
-/// caller in the BLE package; this one lives here because `Collector` is app-target Swift with no default
-/// CI, and the package is where the other emitted-line builders (`Spo2ReTrace`, `SleepStager+Trace`,
-/// `ConnectionReadout`) already sit and get tested.
+/// Twin of the Kotlin `liveInsertFailedLine` in `com.noop.ble.StalledLinkDiagnostics`, so an Android and
+/// an Apple log of the same failure compare directly. Rendered strings match for ASCII (store errors).
+/// The 200-character bound is not a Unicode-identical truncation: Kotlin `take(200)` counts UTF-16 code
+/// units and Swift `prefix(200)` counts grapheme clusters. Store error descriptions are ASCII, which is
+/// the load-bearing case. The Kotlin side lives beside its caller in the BLE package; this one lives here
+/// because `Collector` is app-target Swift with no default CI, and the package is where the other
+/// emitted-line builders (`Spo2ReTrace`, `SleepStager+Trace`, `ConnectionReadout`) already sit and get tested.
 public enum LivePersistTrace {
 
     public enum StandardHRFlushReason: String {
@@ -103,6 +105,7 @@ public enum LivePersistTrace {
     ) -> String {
         // Bounded like the Kotlin `take(200)`: a full error description can be enormous, and the useful
         // cases (a full disk, a corrupted database, a schema mismatch) are distinguished well inside it.
+        // ASCII-only twin: `take` is UTF-16 code units, `prefix` is grapheme clusters.
         let detail = message.flatMap { m -> String? in
             let trimmed = m.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? nil : ": " + String(m.prefix(200))

--- a/android/app/src/main/java/com/noop/ble/StalledLinkDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/ble/StalledLinkDiagnostics.kt
@@ -130,6 +130,17 @@ internal fun backfillDeferredLine(
  * the store and [standardHrFlushSucceededLine] what the store actually took, because a batch that is
  * offered in full and inserted as zero is precisely the failure that otherwise reads like success.
  */
+internal fun standardHrHostReceivedLine(
+    hostUnixSeconds: Int,
+    acceptedHrRows: Int, acceptedRrRows: Int,
+    rejectedHrRows: Int, rejectedRrRows: Int,
+    pendingHrRows: Int, pendingRrRows: Int,
+): String =
+    "standard-hr transport host-received hostUnixSec=$hostUnixSeconds" +
+        " acceptedHRRows=$acceptedHrRows acceptedRRRows=$acceptedRrRows" +
+        " rejectedHRRows=$rejectedHrRows rejectedRRRows=$rejectedRrRows" +
+        " pendingHRRows=$pendingHrRows pendingRRRows=$pendingRrRows"
+
 internal fun standardHrFlushAttemptLine(
     reason: String,
     offeredHrRows: Int,
@@ -204,6 +215,8 @@ internal fun liveInsertFailedLine(
     rrFrames: Int,
     consecutiveFailures: Int,
 ): String {
+    // Bound is ASCII-only (store errors). Kotlin `take(200)` is UTF-16 code units; Swift `prefix(200)`
+    // is grapheme clusters. They agree on ASCII, which is the load-bearing case — not a Unicode twin.
     val detail = message?.takeIf { it.isNotBlank() }?.let { ": ${it.take(200)}" } ?: ""
     val run = if (consecutiveFailures >= 2) {
         " $consecutiveFailures consecutive failures — these rows are not landing and the re-buffer is" +

--- a/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
+++ b/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
@@ -280,13 +280,29 @@ class StandardHrSource(
     private var lastEnqueuedContact: StandardHrContact? = null
 
     private fun enqueue(hr: Int, rr: List<Int>, contact: StandardHrContact) {
-        val shouldFlush = synchronized(bufferLock) {
+        val ts = System.currentTimeMillis() / 1000L
+        val shouldFlush: Boolean
+        val hostLine: String
+        synchronized(bufferLock) {
             val record = StandardHrMapping.shouldRecordContact(lastEnqueuedContact, contact)
             if (record) lastEnqueuedContact = contact
-            buffer.add(Sample(hr, rr, if (record) contact else null, System.currentTimeMillis() / 1000L))
-            buffer.size >= flushCount ||
+            buffer.add(Sample(hr, rr, if (record) contact else null, ts))
+            // Twin of Collector.ingestStandardHR's host-received line. Gates on THIS sample match
+            // rowsOf / Swift ingest; pending is the gated contents of the raw buffer. Cadence still
+            // trips on buffer.size so we do not move the filter (#1770).
+            val acceptedHr = if (hr in 30..220) 1 else 0
+            val acceptedRr = rr.count { it in 250..3000 }
+            val (pendingHr, pendingRr) = rowsOf(buffer)
+            hostLine = standardHrHostReceivedLine(
+                hostUnixSeconds = ts.toInt(),
+                acceptedHrRows = acceptedHr, acceptedRrRows = acceptedRr,
+                rejectedHrRows = 1 - acceptedHr, rejectedRrRows = rr.size - acceptedRr,
+                pendingHrRows = pendingHr.size, pendingRrRows = pendingRr.size,
+            )
+            shouldFlush = buffer.size >= flushCount ||
                 System.currentTimeMillis() - lastFlushMs >= flushIntervalMs
         }
+        log(hostLine)
         if (shouldFlush) flush()
     }
 

--- a/android/app/src/test/java/com/noop/ble/StalledLinkDiagnosticsTest.kt
+++ b/android/app/src/test/java/com/noop/ble/StalledLinkDiagnosticsTest.kt
@@ -183,6 +183,9 @@ class StalledLinkDiagnosticsTest {
      * The two platforms emit this line into logs meant to be read beside each other, and every
      * `contains` check above would still pass with a stray space or a moved clause. This is the
      * assertion that actually holds them together.
+     *
+     * ASCII only: the 200-char bound is Kotlin `take` (UTF-16) vs Swift `prefix` (graphemes). Store
+     * errors are ASCII, which is what this oracle covers. It is not a Unicode truncation twin.
      */
     @Test
     fun `the whole line matches the Swift rendering byte for byte`() {
@@ -343,6 +346,21 @@ class StalledLinkDiagnosticsTest {
      * same stall compare directly.
      */
     @Test
+    fun `host receipt separates accepted and rejected rows`() {
+        assertEquals(
+            "standard-hr transport host-received hostUnixSec=1750000000" +
+                " acceptedHRRows=1 acceptedRRRows=2 rejectedHRRows=0 rejectedRRRows=1" +
+                " pendingHRRows=4 pendingRRRows=5",
+            standardHrHostReceivedLine(
+                hostUnixSeconds = 1_750_000_000,
+                acceptedHrRows = 1, acceptedRrRows = 2,
+                rejectedHrRows = 0, rejectedRrRows = 1,
+                pendingHrRows = 4, pendingRrRows = 5,
+            ),
+        )
+    }
+
+    @Test
     fun `flush success separates offered from actually inserted rows`() {
         assertEquals(
             "standard-hr transport flush-attempt reason=cadence offeredHRRows=4 offeredRRRows=5",
@@ -378,6 +396,28 @@ class StalledLinkDiagnosticsTest {
             listOf("cadence", "disconnect", "background", "termination", "explicit"),
             StandardHrFlushReason.entries.map { it.raw },
         )
+    }
+
+    /**
+     * [standardHrHostReceivedLine] is dead unless enqueue calls it. Apple emits at ingest; Android
+     * buffers raw samples and range-gates at flush, so the line is computed from this sample's gates
+     * plus [rowsOf] pending, WITHOUT moving the 30-sample trigger onto accepted-only rows (#1770).
+     */
+    @Test
+    fun `enqueue emits host-received without moving the flush trigger onto accepted rows`() {
+        var root = java.io.File(System.getProperty("user.dir") ?: ".").canonicalFile
+        val src = run {
+            repeat(4) {
+                val f = java.io.File(root, "android/app/src/main/java/com/noop/ble/StandardHrSource.kt")
+                if (f.isFile) return@run f.readText()
+                root = root.parentFile ?: root
+            }
+            error("StandardHrSource.kt not found — this test must not pass by default")
+        }
+        val enqueue = src.substringAfter("private fun enqueue(").substringBefore("private fun rowsOf(")
+        assertTrue("enqueue must emit the host-received twin", enqueue.contains("standardHrHostReceivedLine("))
+        assertTrue("pending counts must use the gated rowsOf helper", enqueue.contains("rowsOf(buffer)"))
+        assertTrue("cadence must stay on raw buffer size", enqueue.contains("buffer.size >= flushCount"))
     }
 
 }


### PR DESCRIPTION
## Summary
- Leftover from #1770 / #1767: Kotlin twin of `standardHRHostReceivedLine`, called from `StandardHrSource.enqueue` (Apple emits at ingest). Flush-attempt / succeeded / rebuffered were already on main; this adds the missing fourth line without moving the 30-sample cadence onto accepted-only rows.
- Item 2: `liveInsertFailedLine` no longer claims an absolute byte-identical 200-char bound. KDoc + Swift comment state the twin is ASCII-only (store errors): Kotlin `take(200)` is UTF-16, Swift `prefix(200)` is graphemes.
- JVM tests pin the host-received line to the Swift format string and assert enqueue emits it without changing the flush trigger.

## Test plan
- [ ] `:app:testFullDebugUnitTest --tests com.noop.ble.StalledLinkDiagnosticsTest`
- [ ] Confirm Android CI path filters cover the touched files

Refs #1770 #1767.