### PR TITLE
fix(oura): make the nameless-ring label rule one tested twin, not two

### DIFF
--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -13,6 +13,27 @@ import UIKit
 import AppKit
 #endif
 
+/// The label a discovered ring is listed under: its advertised local name, or `fallback` when it did
+/// not advertise one.
+///
+/// A BONDED ring routinely stops advertising a local name, so the blank case is the NORMAL case for the
+/// ring a user most wants to reconnect to (#1776), not an error path — the scan's service filter is the
+/// only gate and the name is a label. Callers therefore never see an empty `DiscoveredRing.name`, which
+/// is why the wizard renders it unguarded on both platforms (#1783 reads that as a missing guard; the
+/// guard is here, at the single construction site).
+///
+/// BLANK, not empty. The Kotlin twin is `ouraAdvertisedLabel` in `ble/OuraLiveSource.kt`, built on
+/// `ifBlank`, which treats an all-whitespace name as absent. `isEmpty` does not, so a ring advertising
+/// `" "` would have listed blank here and as "Oura" there — the exact silent Swift/Kotlin divergence the
+/// parity contract calls out. Both sides now treat whitespace as absent and return the name UNTRIMMED
+/// when it is present. Pinned by the Kotlin `OuraNamelessRingDiscoveryTest` against this function's own
+/// output. The two agree over ASCII whitespace and ordinary names; they part only on exotic Unicode
+/// spaces (`.whitespacesAndNewlines` includes U+00A0, Java's `Character.isWhitespace` does not), which
+/// no BLE local name carries — stated rather than silently overclaimed.
+func ouraAdvertisedLabel(_ advertisedName: String, fallback: String) -> String {
+    advertisedName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? fallback : advertisedName
+}
+
 /// EXPERIMENTAL, ISOLATED live-BLE source for the Oura ring (gen 3/4/5), driven by the clean-room
 /// `OuraProtocol.OuraDriver`.
 ///
@@ -2212,9 +2233,9 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         let id = peripheral.identifier
         let firstSight = seenPeripherals[id] == nil
         seenPeripherals[id] = peripheral
-        if firstSight { log("Oura: found \(name.isEmpty ? "Oura ring" : name) (\(id)) rssi \(RSSI.intValue)") }
+        if firstSight { log("Oura: found \(ouraAdvertisedLabel(name, fallback: "Oura ring")) (\(id)) rssi \(RSSI.intValue)") }
         let ring = DiscoveredRing(id: id,
-                                  name: name.isEmpty ? "Oura" : name,
+                                  name: ouraAdvertisedLabel(name, fallback: "Oura"),
                                   rssi: RSSI.intValue,
                                   detectedGen: detectedGen)
         if let idx = discovered.firstIndex(where: { $0.id == id }) {

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -52,6 +52,29 @@ import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 
 /**
+ * The label a discovered ring is listed under: its advertised local name, or [fallback] when it did not
+ * advertise one.
+ *
+ * A BONDED ring routinely stops advertising a local name, so the blank case is the NORMAL case for the
+ * ring a user most wants to reconnect to (#1776), not an error path - the scan's ScanFilter is the only
+ * gate and the name is a label. Callers therefore never see a blank `DiscoveredRing.name`, which is why
+ * the wizard renders it unguarded on both platforms (#1783 reads that as a missing guard; the guard is
+ * here, at the single construction site).
+ *
+ * BLANK, not empty. `isBlank` treats an all-whitespace name as absent; the Swift twin
+ * `ouraAdvertisedLabel` in `Strand/BLE/OuraLiveSource.swift` used `isEmpty`, which does not, so a ring
+ * advertising `" "` listed as "Oura" here and blank there - the exact silent Kotlin/Swift divergence the
+ * parity contract calls out. Both sides now treat whitespace as absent and return the name UNTRIMMED
+ * when it is present, and `OuraNamelessRingDiscoveryTest` pins this function against the Swift twin's
+ * own output. The two agree over ASCII whitespace and ordinary names; they part only on exotic Unicode
+ * spaces (Java's `Character.isWhitespace` excludes U+00A0, Swift's `.whitespacesAndNewlines` includes
+ * it), which no BLE local name carries - stated rather than silently overclaimed.
+ */
+internal fun ouraAdvertisedLabel(advertisedName: String, fallback: String): String =
+    advertisedName.ifBlank { fallback }
+
+
+/**
  * EXPERIMENTAL, ISOLATED live-BLE source for the Oura ring (gen3 / gen4 / gen5).
  *
  * Faithful Kotlin twin of Strand/BLE/OuraLiveSource.swift. This replaced an earlier honest dead-end
@@ -1101,7 +1124,7 @@ class OuraLiveSource(
             val address = device.address ?: return
             val name = result.scanRecord?.deviceName ?: runCatching { device.name }.getOrNull() ?: ""
             val firstSight = seen.put(address, device) == null   // null → not seen before this scan
-            if (firstSight) log("Oura: found ${name.ifBlank { "Oura ring" }} ($address) rssi ${result.rssi}")
+            if (firstSight) log("Oura: found ${ouraAdvertisedLabel(name, "Oura ring")} ($address) rssi ${result.rssi}")
             // Best-effort generation guess from the advertised name — a LABEL only (the wizard falls back
             // to GEN3 when it is null). Nothing is dropped here: startScan's ScanFilter pins SERVICE_UUID in
             // the BT stack, so that is the gate, and a ring is listed even when it advertises no local name
@@ -1114,7 +1137,7 @@ class OuraLiveSource(
             val detectedGen = OuraRingGen.recognise(name)
             val ring = DiscoveredRing(
                 address = address,
-                name = name.ifBlank { "Oura" },
+                name = ouraAdvertisedLabel(name, "Oura"),
                 rssi = result.rssi,
                 detectedGen = detectedGen,
             )

--- a/android/app/src/main/java/com/noop/ui/AddDeviceWizard.kt
+++ b/android/app/src/main/java/com/noop/ui/AddDeviceWizard.kt
@@ -1338,7 +1338,10 @@ private fun OuraPickStep(
                     DiscoveredRow(
                         name = ring.name,
                         // Subtitle = the detected generation (best-effort); "Oura ring" when undetected.
-                        subtitle = ring.detectedGen?.displayName ?: "Oura ring",
+                        // Localised: a ring that advertises no local name has no detectable generation
+                        // either, so this fallback is exactly what the #1776 bonded-ring case renders.
+                        subtitle = ring.detectedGen?.displayName
+                            ?: uiString(R.string.l10n_add_device_wizard_oura_ring_e3431536),
                         rssi = ring.rssi,
                         onTap = { onPick(ring) },
                     )

--- a/android/app/src/test/java/com/noop/ble/OuraNamelessRingDiscoveryTest.kt
+++ b/android/app/src/test/java/com/noop/ble/OuraNamelessRingDiscoveryTest.kt
@@ -20,6 +20,11 @@ import org.junit.Test
  * (no name gate in the callback; the ScanFilter is the only gate) is a live BLE discovery behaviour and
  * cannot be asserted here — it is validated on hardware. Apple has always behaved this way
  * (Strand/BLE/OuraLiveSource.swift), so this also closes a cross-platform divergence.
+ *
+ * What CAN be asserted headlessly is how the nameless ring is then LABELLED, which is the last test here.
+ * #1783 reports that label arriving blank in the wizard on both platforms; it does not, because
+ * `ouraAdvertisedLabel` substitutes a fallback at the single `DiscoveredRing` construction site on each
+ * platform. That test pins the rule so the guard cannot be dropped as redundant later.
  */
 class OuraNamelessRingDiscoveryTest {
 
@@ -35,6 +40,37 @@ class OuraNamelessRingDiscoveryTest {
     fun `a named ring recognises fine, so the bug was specific to the nameless case`() {
         assertEquals(ExperimentalBrand.OURA, ExperimentalBrand.recognise("Oura Ring 4"))
         assertEquals(ExperimentalBrand.OURA, ExperimentalBrand.recognise("oura 2h3b2405003655"))
+    }
+
+    /**
+     * The label rule itself, pinned against the Swift twin's OWN output.
+     *
+     * Every expected value below is stdout from `ouraAdvertisedLabel` in
+     * `Strand/BLE/OuraLiveSource.swift`, compiled standalone (`swiftc -O twin.swift main.swift`) over this
+     * exact case list and pasted verbatim - not read off the Kotlin implementation, and not eyeballed.
+     * That is what caught the divergence this test exists for: the first draft of the Kotlin helper was
+     * `advertisedName.trim().ifEmpty { fallback }`, which returns the TRIMMED name, while Swift returns
+     * the original. The `" Oura Ring 4 "` case is the one that separates them.
+     *
+     * Whitespace, not emptiness, is the boundary - a ring advertising `" "` used to list as "Oura" here
+     * and blank on Apple. This guards only the ASCII whitespace a BLE local name can realistically carry;
+     * the two stdlib definitions part on exotic Unicode spaces (U+00A0), which is documented at the
+     * helper rather than asserted here.
+     */
+    @Test
+    fun `the label rule matches the Swift twin byte for byte`() {
+        assertEquals("Oura", ouraAdvertisedLabel("", "Oura"))
+        assertEquals("Oura ring", ouraAdvertisedLabel("", "Oura ring"))
+        assertEquals("Oura", ouraAdvertisedLabel(" ", "Oura"))
+        assertEquals("Oura", ouraAdvertisedLabel("   ", "Oura"))
+        assertEquals("Oura", ouraAdvertisedLabel("\t", "Oura"))
+        assertEquals("Oura", ouraAdvertisedLabel("\n", "Oura"))
+        assertEquals("Oura", ouraAdvertisedLabel(" \t\n ", "Oura"))
+        assertEquals("Oura Ring 4", ouraAdvertisedLabel("Oura Ring 4", "Oura"))
+        assertEquals("oura 2h3b2405003655", ouraAdvertisedLabel("oura 2h3b2405003655", "Oura"))
+        assertEquals(" Oura Ring 4 ", ouraAdvertisedLabel(" Oura Ring 4 ", "Oura"))
+        assertEquals("O", ouraAdvertisedLabel("O", "Oura"))
+        assertEquals("Oura ring", ouraAdvertisedLabel("Oura ring", "Oura"))
     }
 
     @Test


### PR DESCRIPTION
## Diff shape

| file | change |
|---|---|
| `Strand/BLE/OuraLiveSource.swift` | new top-level `ouraAdvertisedLabel`; both call sites routed through it; `.isEmpty` → whitespace-aware |
| `android/…/ble/OuraLiveSource.kt` | Kotlin twin `ouraAdvertisedLabel`; both call sites routed through it |
| `android/…/ui/AddDeviceWizard.kt` | subtitle fallback uses the existing `l10n_…_oura_ring_e3431536` key |
| `android/…/ble/OuraNamelessRingDiscoveryTest.kt` | +1 oracle test, 12 cases from the Swift twin's stdout |

88 insertions, 5 deletions. No new strings, so nothing owed in any locale.

## Verification actually run

- Android `testFullDebugUnitTest -Duser.language=en`: 5040 tests, 4/4 in
  `OuraNamelessRingDiscoveryTest`. The 2 `RecoveryDriversTest` float-rounding failures
  (`expected:<-0.5> but was:<-0.4999999999999929>`) are pre-existing on `upstream/main`.
- macOS `xcodebuild -project Strand.xcodeproj -scheme Strand -destination platform=macOS
  CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**. Required: this touches app-target Swift,
  which `swift-packages.yml` does not compile and `app-build.yml` is disabled.
- `Tools/doc_comment_lint.py` exit 0, `Tools/i18n_audit.py --ci upstream/main` exit 0.
- **No hardware.** Not owed: this changes a label, not the BLE path. Discovery is untouched.

## The oracle, for the PR body if asked

Swift twin compiled standalone (`swiftc -O twin.swift main.swift`) over the 12-case list; its stdout
is pasted verbatim as the Kotlin expectations. It immediately caught my own first Kotlin draft,
`advertisedName.trim().ifEmpty { fallback }` — returns the trimmed name where Swift returns the
original. `" Oura Ring 4 "` is the separating case. Note the oracle guards only the
Kotlin→Swift direction; the Swift side has no equivalent test, because `Strand/BLE` tests run only
under `xcodebuild … test` and `app-build.yml` is off by default.

## Known boundary, stated not hidden

Kotlin `isBlank` (Java `Character.isWhitespace`) and Swift `.whitespacesAndNewlines` disagree on
exotic Unicode spaces — U+00A0 is whitespace to Swift, not to Java. Documented at the helper on both
sides rather than asserted, since no BLE local name carries one.