### PR TITLE
widgets: give the home-screen vitals footer the app's own HR/HRV icons

### DIFF
--- a/StrandiOSWidgets/NOOPWidget.swift
+++ b/StrandiOSWidgets/NOOPWidget.swift
@@ -273,19 +273,49 @@ struct NOOPWidgetView: View {
         .frame(maxWidth: .infinity)
     }
 
+    /// Home-Screen footer: heart rate, HRV, strap battery, under the score rings.
+    ///
+    /// `heart.fill` is HR and `waveform.path.ecg` is HRV, which is the metric pairing the rest of the app
+    /// uses — `TodayView` renders them as adjacent rows that way, and `DashboardCards`,
+    /// `TodayCustomizationMetadata`, `MetricCatalog` and this extension's own Live Activity all agree.
+    /// The two were inverted here from #1022 until #1795 reported it.
+    ///
+    /// The inversion was an easy one to make and is worth naming so it is not "corrected" back:
+    /// `waveform.path.ecg` IS the right symbol for Live HR as a FEATURE — `RootView`, `RootTabView` and
+    /// `HomeScreenQuickActions` all use it for the Live screen. As a METRIC icon it belongs to HRV, and
+    /// this footer is the one place that renders both metrics side by side, where the collision is the
+    /// entire problem: nothing here carries a text label, so the glyph is the only thing naming a number.
     private func vitalsFooter(compact: Bool) -> some View {
         HStack {
-            Label(snap.bpm.map(String.init) ?? "–", systemImage: "waveform.path.ecg")
+            vital(symbol: "heart.fill", text: snap.bpm.map(String.init),
+                  name: "Heart rate", spoken: snap.bpm.map { "\($0) beats per minute" })
             Spacer()
             if !compact, let hrv = snap.hrv {
-                Label("\(hrv)", systemImage: "heart.fill")
+                vital(symbol: "waveform.path.ecg", text: "\(hrv)",
+                      name: "Heart rate variability", spoken: "\(hrv) milliseconds")
                 Spacer()
             }
-            Label(snap.batteryPct.map { "\($0)%" } ?? "–", systemImage: "battery.50")
+            vital(symbol: "battery.50", text: snap.batteryPct.map { "\($0)%" },
+                  name: "Strap battery", spoken: snap.batteryPct.map { "\($0) percent" })
         }
         .font(.caption2)
         .foregroundStyle(StrandPalette.textSecondary)
         .labelStyle(.titleAndIcon)
+    }
+
+    /// One footer vital. `spoken` is carried separately from the rendered `text` because VoiceOver gets
+    /// neither of the two things a sighted reader uses here: the glyph that names the metric, and the
+    /// unit, which the footer shows for none of them. Without this a reader hears "58", "64", "84 percent"
+    /// — three anonymous numbers. Same reasoning as `accessoryScore`, which #1715 fixed for the lock
+    /// screen; this footer predates it.
+    ///
+    /// Plain literals rather than `String(localized:)`, for the reason spelled out on `accessoryScore`:
+    /// this extension does not carry the app's string catalog, so `String(localized:)` would look
+    /// localized and render English anyway.
+    private func vital(symbol: String, text: String?, name: String, spoken: String?) -> some View {
+        Label(text ?? "–", systemImage: symbol)
+            .accessibilityLabel(Text(name))
+            .accessibilityValue(Text(spoken ?? "No data"))
     }
 
     /// One labelled stat in the large grid — value over a caption, equal-width so the columns align.

--- a/StrandiOSWidgets/NOOPWidget.swift
+++ b/StrandiOSWidgets/NOOPWidget.swift
@@ -209,10 +209,18 @@ struct NOOPWidgetView: View {
             scoreRings(diameter: 88, lineWidth: 8, labelFont: .caption)
             Divider()
             HStack(alignment: .top, spacing: 0) {
-                statCell("HRV", value: snap.hrv.map { "\($0)" }, unit: "ms")
-                statCell("Rest HR", value: snap.restingHr.map { "\($0)" }, unit: "bpm")
-                statCell("HR", value: snap.bpm.map { "\($0)" }, unit: "bpm")
-                statCell("Battery", value: snap.batteryPct.map { "\($0)%" })
+                statCell("HRV", value: snap.hrv.map { "\($0)" }, unit: "ms",
+                         name: "Heart rate variability",
+                         spoken: snap.hrv.map { "\($0) milliseconds" })
+                statCell("Rest HR", value: snap.restingHr.map { "\($0)" }, unit: "bpm",
+                         name: "Resting heart rate",
+                         spoken: snap.restingHr.map { "\($0) beats per minute" })
+                statCell("HR", value: snap.bpm.map { "\($0)" }, unit: "bpm",
+                         name: "Heart rate",
+                         spoken: snap.bpm.map { "\($0) beats per minute" })
+                statCell("Battery", value: snap.batteryPct.map { "\($0)%" },
+                         name: "Strap battery",
+                         spoken: snap.batteryPct.map { "\($0) percent" })
             }
             Spacer(minLength: 0)
         }
@@ -324,8 +332,15 @@ struct NOOPWidgetView: View {
     }
 
     /// One labelled stat in the large grid — value over a caption, equal-width so the columns align.
+    ///
+    /// `name` and `spoken` exist because the on-screen caption is abbreviated for width and the unit is a
+    /// separate view: read as-is, VoiceOver produces "64", "ms", "HRV" — three fragments, value before
+    /// label, with "ms" and "bpm" spelled out letter by letter. Collapsing to one element lets the cell
+    /// speak "Heart rate variability, 64 milliseconds". `spoken` falls back to the rendered value rather
+    /// than to "No data", so a caller that omits it degrades to the old reading instead of lying.
     private func statCell(_ label: String, value: String?, unit: String? = nil,
-                          tint: Color = StrandPalette.textPrimary) -> some View {
+                          tint: Color = StrandPalette.textPrimary,
+                          name: String? = nil, spoken: String? = nil) -> some View {
         VStack(alignment: .leading, spacing: 2) {
             HStack(alignment: .firstTextBaseline, spacing: 2) {
                 Text(value ?? "–")
@@ -338,6 +353,9 @@ struct NOOPWidgetView: View {
             Text(label).font(.caption2).foregroundStyle(StrandPalette.textTertiary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(name ?? label))
+        .accessibilityValue(Text(spoken ?? value ?? "No data"))
     }
 }
 

--- a/StrandiOSWidgets/NOOPWidget.swift
+++ b/StrandiOSWidgets/NOOPWidget.swift
@@ -314,6 +314,11 @@ struct NOOPWidgetView: View {
     /// localized and render English anyway.
     private func vital(symbol: String, text: String?, name: String, spoken: String?) -> some View {
         Label(text ?? "–", systemImage: symbol)
+            // Collapse first, like `accessoryScore` and `WidgetScoreRing` already do. A `Label` under
+            // `.titleAndIcon` renders an image beside a text, so without this the bare number stays its
+            // own element and whether the label below wins is SwiftUI container semantics rather than
+            // something this file decides. Every other labelled graphic here ignores its children.
+            .accessibilityElement(children: .ignore)
             .accessibilityLabel(Text(name))
             .accessibilityValue(Text(spoken ?? "No data"))
     }


### PR DESCRIPTION
Reported in #1795 by @Sneheth, who is right: in the home-screen widget footer the HR and HRV
values read backwards against their icons.

## The bug

`vitalsFooter` paired `snap.bpm` with `waveform.path.ecg` and `snap.hrv` with `heart.fill` —
the inverse of the pairing used everywhere else in the app:

| surface | HRV | HR / resting HR |
|---|---|---|
| `TodayView:2816-2820` (adjacent rows) | `waveform.path.ecg` | `heart.fill` |
| `TodayCustomizationMetadata:44-45` | `waveform.path.ecg` | `heart.fill` |
| `DashboardCards:88-89` | `waveform.path.ecg` | `heart.fill` |
| `MetricCatalog:134` | `waveform.path.ecg` | — |
| `NOOPLiveActivity:39` (same extension) | — | `heart.fill` |
| **`NOOPWidget:278-281` (this footer)** | **`heart.fill`** | **`waveform.path.ecg`** |

It matters more than a mismatched glyph normally would: the footer renders no text labels, so
the icon is the only thing naming each number.

Not a regression — the footer has been this way since #1022, and it is untouched by the 11.0.0
diff. Unrelated to the other widget report going around.

## Why it happened, recorded so it is not "corrected" back

`waveform.path.ecg` IS the right symbol for **Live HR as a feature** — `RootView:126`,
`RootTabView:640` and `HomeScreenQuickActions:32` all use it for the Live screen. As a **metric**
icon it belongs to HRV, and this footer is the single place that draws both metrics side by
side, which is where the collision becomes the whole problem. The doc comment says this.

## Second defect, same four lines

The three vitals were bare numbers with no unit and no name, so VoiceOver read "58", "64",
"84 percent" — three anonymous figures. Added `accessibilityLabel` / `accessibilityValue`,
carrying `spoken` separately from the rendered text so the unit reaches a reader who cannot
see the glyph.

This is exactly the gap #1715 fixed for the lock-screen accessory ("an icon says nothing to
VoiceOver"). The footer predates that change and never got the treatment. Literals stay plain
rather than `String(localized:)`, for the reason already documented on `accessoryScore`: this
extension does not carry the app's string catalog, so `String(localized:)` would look localised
and render English regardless.

## Verification

- `swiftc -parse` clean; brace balance checked on the touched region.
- `Tools/doc_comment_lint.py` exit 0, `Tools/i18n_audit.py --ci` exit 0.
- Rendering is otherwise unchanged: `.labelStyle(.titleAndIcon)` still propagates through the
  helper, the `–` placeholder and the `!compact` gate on HRV are preserved, and the diff
  contains nothing beyond the icon swap and the accessibility modifiers.
- **Not compile-verified.** This is app-target Swift in `StrandiOSWidgets`, which
  `swift-packages.yml` does not build and `app-build.yml` is disabled by default. Needs an
  app-build dispatch before merge.
- **No test added, deliberately.** The natural home is `StrandTests`, which no default CI runs,
  so a pin on the icon pairing would rot silently. The doc comment carries the reasoning
  instead. Happy to add one if you would rather have it.
- On-device check still owed: the footer appears in `systemSmall` and `systemMedium` only.