### PR TITLE
widget: let the home-screen HR and battery line say what it is

### DIFF
--- a/android/app/src/main/java/com/noop/widget/NoopCompactGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/NoopCompactGlanceWidget.kt
@@ -27,6 +27,8 @@ import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
 import androidx.glance.layout.width
+import androidx.glance.semantics.contentDescription
+import androidx.glance.semantics.semantics
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
@@ -128,11 +130,19 @@ private fun CompactWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
             )
         }
         Spacer(modifier = GlanceModifier.height(6.dp))
+        // Same glyph-in-the-text problem as the standard widget: TalkBack gets a bare number with no
+        // name and no unit. The battery Image below has carried a contentDescription all along; this
+        // line never did. (#1799)
+        val hrLabel = uiString(R.string.l10n_noop_compact_glance_widget_heart_rate_410aa15c)
+        val hrDescription = snap.heartRate
+            ?.let { "$hrLabel ${uiString(R.string.l10n_today_screen_value_bpm_8f3a90c3, it)}" }
+            ?: hrLabel
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
                 text = snap.heartRate?.let { "♥ $it" } ?: "♥ - ",
                 // Dim a carried-over reading so a stale HR can't masquerade as a live one.
                 style = TextStyle(color = if (snap.heartRateStale) textSecondary else textPrimary, fontSize = 13.sp),
+                modifier = GlanceModifier.semantics { contentDescription = hrDescription },
             )
             Spacer(modifier = GlanceModifier.width(10.dp))
             Image(

--- a/android/app/src/main/java/com/noop/widget/NoopCompactGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/NoopCompactGlanceWidget.kt
@@ -134,8 +134,12 @@ private fun CompactWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
         // name and no unit. The battery Image below has carried a contentDescription all along; this
         // line never did. (#1799)
         val hrLabel = uiString(R.string.l10n_noop_compact_glance_widget_heart_rate_410aa15c)
+        // Live-marked, not stale-marked, for the reason spelled out on the standard widget: the dimming
+        // below is colour-only, and "live" already exists in every locale so this needs no new copy.
+        val liveSuffix =
+            if (snap.heartRateStale) "" else " " + uiString(R.string.l10n_today_screen_sync_chip_live_98aadb37)
         val hrDescription = snap.heartRate
-            ?.let { "$hrLabel ${uiString(R.string.l10n_today_screen_value_bpm_8f3a90c3, it)}" }
+            ?.let { "$hrLabel ${uiString(R.string.l10n_today_screen_value_bpm_8f3a90c3, it)}$liveSuffix" }
             ?: hrLabel
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(

--- a/android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt
@@ -164,8 +164,15 @@ private fun WidgetContent(snap: WidgetSnapshot, dark: Boolean) {
         // audit can see it.
         val hrLabel = uiString(R.string.l10n_noop_glance_widget_heart_rate_410aa15c)
         val batteryLabel = uiString(R.string.l10n_noop_glance_widget_strap_battery_a6c7f09c)
+        // The stale/live distinction is drawn ONLY by dimming the text below, which is a colour-only
+        // channel: TalkBack, and anyone who cannot perceive the dim, was told a carried-over reading was
+        // current. Marked on the LIVE side rather than the stale one, so a stale value simply carries no
+        // claim instead of needing a word for it - and because "live" already exists in all seven
+        // locales as the Today sync chip, so this adds no new copy to translate.
+        val liveSuffix =
+            if (snap.heartRateStale) "" else " " + uiString(R.string.l10n_today_screen_sync_chip_live_98aadb37)
         val hrDescription = snap.heartRate
-            ?.let { "$hrLabel ${uiString(R.string.l10n_today_screen_value_bpm_8f3a90c3, it)}" }
+            ?.let { "$hrLabel ${uiString(R.string.l10n_today_screen_value_bpm_8f3a90c3, it)}$liveSuffix" }
             ?: hrLabel
         val batteryDescription = snap.batteryPct
             ?.let { "$batteryLabel ${uiString(R.string.l10n_today_screen_pct_ee63e247, it)}" }

--- a/android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt
@@ -23,6 +23,8 @@ import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
+import androidx.glance.semantics.contentDescription
+import androidx.glance.semantics.semantics
 import androidx.glance.layout.width
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
@@ -150,16 +152,36 @@ private fun WidgetContent(snap: WidgetSnapshot, dark: Boolean) {
             )
         }
         Spacer(modifier = GlanceModifier.height(8.dp))
+        // The ♥ and ⚡ are characters inside the text, not labelled images, so TalkBack reads whatever
+        // the glyph happens to be called - or skips it - and the metric arrives as a bare number with no
+        // name and no unit. The compact widget already labels the same two values (its battery Image
+        // carries a contentDescription); this one never did. (#1799)
+        //
+        // Built here rather than inside the semantics lambda. uiString would resolve there too - it is a
+        // plain function over the Application resources, not a composable - but #571 recorded that the
+        // i18n audit cannot see copy assigned inside a semantics {} lambda, so a literal written there
+        // would pass CI and ship English to every locale. Keeping the lookup outside puts it where the
+        // audit can see it.
+        val hrLabel = uiString(R.string.l10n_noop_glance_widget_heart_rate_410aa15c)
+        val batteryLabel = uiString(R.string.l10n_noop_glance_widget_strap_battery_a6c7f09c)
+        val hrDescription = snap.heartRate
+            ?.let { "$hrLabel ${uiString(R.string.l10n_today_screen_value_bpm_8f3a90c3, it)}" }
+            ?: hrLabel
+        val batteryDescription = snap.batteryPct
+            ?.let { "$batteryLabel ${uiString(R.string.l10n_today_screen_pct_ee63e247, it)}" }
+            ?: batteryLabel
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(
                 text = snap.heartRate?.let { "♥ $it" } ?: "♥ - ",
                 // Dim a carried-over reading so a stale HR can't masquerade as a live one.
                 style = TextStyle(color = if (snap.heartRateStale) textSecondary else textPrimary, fontSize = 13.sp),
+                modifier = GlanceModifier.semantics { contentDescription = hrDescription },
             )
             Spacer(modifier = GlanceModifier.width(10.dp))
             Text(
                 text = snap.batteryPct?.let { "⚡ $it%" } ?: "⚡ - ",
                 style = TextStyle(color = textPrimary, fontSize = 13.sp),
+                modifier = GlanceModifier.semantics { contentDescription = batteryDescription },
             )
         }
         Spacer(modifier = GlanceModifier.height(2.dp))

--- a/android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt
@@ -23,9 +23,9 @@ import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
 import androidx.glance.layout.padding
+import androidx.glance.layout.width
 import androidx.glance.semantics.contentDescription
 import androidx.glance.semantics.semantics
-import androidx.glance.layout.width
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
@@ -154,8 +154,9 @@ private fun WidgetContent(snap: WidgetSnapshot, dark: Boolean) {
         Spacer(modifier = GlanceModifier.height(8.dp))
         // The ♥ and ⚡ are characters inside the text, not labelled images, so TalkBack reads whatever
         // the glyph happens to be called - or skips it - and the metric arrives as a bare number with no
-        // name and no unit. The compact widget already labels the same two values (its battery Image
-        // carries a contentDescription); this one never did. (#1799)
+        // name and no unit. The compact widget is not the accessible counterexample it looks like: only
+        // its battery IMAGE ever carried a contentDescription, and its heart-rate line is the same
+        // unlabelled text as this one, fixed alongside it here. (#1799)
         //
         // Built here rather than inside the semantics lambda. uiString would resolve there too - it is a
         // plain function over the Application resources, not a composable - but #571 recorded that the

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -708,6 +708,7 @@
     <string name="l10n_mind_section_reading_your_check_ins_71a100a9">Lesen Sie Ihre Check-ins...</string>
     <string name="l10n_noop_compact_glance_widget_charge_49a8cb83">GEBÜHR</string>
     <string name="l10n_noop_compact_glance_widget_effort_660752e7">ANSTRENGUNG</string>
+    <string name="l10n_noop_compact_glance_widget_heart_rate_410aa15c">Herzfrequenz</string>
     <string name="l10n_noop_compact_glance_widget_rest_cbaaa181">RUHE</string>
     <string name="l10n_noop_compact_glance_widget_strap_battery_a6c7f09c">Strap-Akku</string>
     <string name="l10n_noop_glance_widget_charge_49a8cb83">GEBÜHR</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -712,7 +712,9 @@
     <string name="l10n_noop_compact_glance_widget_strap_battery_a6c7f09c">Strap-Akku</string>
     <string name="l10n_noop_glance_widget_charge_49a8cb83">GEBÜHR</string>
     <string name="l10n_noop_glance_widget_effort_660752e7">ANSTRENGUNG</string>
+    <string name="l10n_noop_glance_widget_heart_rate_410aa15c">Herzfrequenz</string>
     <string name="l10n_noop_glance_widget_rest_cbaaa181">RUHE</string>
+    <string name="l10n_noop_glance_widget_strap_battery_a6c7f09c">Strap-Akku</string>
     <string name="l10n_notifications_settings_screen_02d_02d_ce23a78c">%1$02d:%2$02d</string>
     <string name="l10n_notifications_settings_screen_all_other_apps_51a8af2c">Alle anderen Apps</string>
     <string name="l10n_notifications_settings_screen_app_name_wrist_alerts_dd3540fa">%1$s-Handgelenkwarnungen</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -512,7 +512,9 @@
     <string name="l10n_noop_compact_glance_widget_strap_battery_a6c7f09c">Batería de la pulsera</string>
     <string name="l10n_noop_glance_widget_charge_49a8cb83">CHARGE</string>
     <string name="l10n_noop_glance_widget_effort_660752e7">ESFUERZO</string>
+    <string name="l10n_noop_glance_widget_heart_rate_410aa15c">Frecuencia cardíaca</string>
     <string name="l10n_noop_glance_widget_rest_cbaaa181">DESCANSO</string>
+    <string name="l10n_noop_glance_widget_strap_battery_a6c7f09c">Batería de la pulsera</string>
     <string name="l10n_notifications_settings_screen_02d_02d_ce23a78c">%1$02d:%2$02d</string>
     <string name="l10n_notifications_settings_screen_all_other_apps_51a8af2c">Todas las demás aplicaciones</string>
     <string name="l10n_notifications_settings_screen_app_name_wrist_alerts_dd3540fa">Alertas de muñeca %1$s</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -508,6 +508,7 @@
     <string name="l10n_mind_section_reading_your_check_ins_71a100a9">Leyendo tus cheques...</string>
     <string name="l10n_noop_compact_glance_widget_charge_49a8cb83">CHARGE</string>
     <string name="l10n_noop_compact_glance_widget_effort_660752e7">ESFUERZO</string>
+    <string name="l10n_noop_compact_glance_widget_heart_rate_410aa15c">Frecuencia cardíaca</string>
     <string name="l10n_noop_compact_glance_widget_rest_cbaaa181">DESCANSO</string>
     <string name="l10n_noop_compact_glance_widget_strap_battery_a6c7f09c">Batería de la pulsera</string>
     <string name="l10n_noop_glance_widget_charge_49a8cb83">CHARGE</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -530,7 +530,9 @@
     <string name="l10n_noop_compact_glance_widget_strap_battery_a6c7f09c">Batterie du bracelet</string>
     <string name="l10n_noop_glance_widget_charge_49a8cb83">CHARGE</string>
     <string name="l10n_noop_glance_widget_effort_660752e7">EFFORT</string>
+    <string name="l10n_noop_glance_widget_heart_rate_410aa15c">Fréquence cardiaque</string>
     <string name="l10n_noop_glance_widget_rest_cbaaa181">REPOS</string>
+    <string name="l10n_noop_glance_widget_strap_battery_a6c7f09c">Batterie du bracelet</string>
     <string name="l10n_notifications_settings_screen_02d_02d_ce23a78c">%1$02d:%2$02d</string>
     <string name="l10n_notifications_settings_screen_all_other_apps_51a8af2c">Toutes les autres applications</string>
     <string name="l10n_notifications_settings_screen_app_name_wrist_alerts_dd3540fa">Alertes aux poignets %1$s</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -526,6 +526,7 @@
     <string name="l10n_mind_section_reading_your_check_ins_71a100a9">Lire vos check-ins...</string>
     <string name="l10n_noop_compact_glance_widget_charge_49a8cb83">CHARGE</string>
     <string name="l10n_noop_compact_glance_widget_effort_660752e7">EFFORT</string>
+    <string name="l10n_noop_compact_glance_widget_heart_rate_410aa15c">Fréquence cardiaque</string>
     <string name="l10n_noop_compact_glance_widget_rest_cbaaa181">REPOS</string>
     <string name="l10n_noop_compact_glance_widget_strap_battery_a6c7f09c">Batterie du bracelet</string>
     <string name="l10n_noop_glance_widget_charge_49a8cb83">CHARGE</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -665,6 +665,7 @@
     <string name="l10n_mind_section_reading_your_check_ins_71a100a9">Czytanie Twoich meldowań…</string>
     <string name="l10n_noop_compact_glance_widget_charge_49a8cb83">OPŁATA</string>
     <string name="l10n_noop_compact_glance_widget_effort_660752e7">WYSIŁEK</string>
+    <string name="l10n_noop_compact_glance_widget_heart_rate_410aa15c">Tętno</string>
     <string name="l10n_noop_compact_glance_widget_rest_cbaaa181">ODPOCZYNEK</string>
     <string name="l10n_noop_compact_glance_widget_strap_battery_a6c7f09c">Bateria na pasek</string>
     <string name="l10n_noop_glance_widget_charge_49a8cb83">OPŁATA</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -669,7 +669,9 @@
     <string name="l10n_noop_compact_glance_widget_strap_battery_a6c7f09c">Bateria na pasek</string>
     <string name="l10n_noop_glance_widget_charge_49a8cb83">OPŁATA</string>
     <string name="l10n_noop_glance_widget_effort_660752e7">WYSIŁEK</string>
+    <string name="l10n_noop_glance_widget_heart_rate_410aa15c">Tętno</string>
     <string name="l10n_noop_glance_widget_rest_cbaaa181">ODPOCZYNEK</string>
+    <string name="l10n_noop_glance_widget_strap_battery_a6c7f09c">Bateria na pasek</string>
     <string name="l10n_notifications_settings_screen_02d_02d_ce23a78c">%1$02d:%2$02d</string>
     <string name="l10n_notifications_settings_screen_all_other_apps_51a8af2c">Wszystkie inne aplikacje</string>
     <string name="l10n_notifications_settings_screen_app_name_wrist_alerts_dd3540fa">Alerty na nadgarstku %1$s</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -677,7 +677,9 @@
     <string name="l10n_noop_compact_glance_widget_strap_battery_a6c7f09c">Bateria de pega</string>
     <string name="l10n_noop_glance_widget_charge_49a8cb83">COBRAR</string>
     <string name="l10n_noop_glance_widget_effort_660752e7">EFFORT</string>
+    <string name="l10n_noop_glance_widget_heart_rate_410aa15c">Frequência cardíaca</string>
     <string name="l10n_noop_glance_widget_rest_cbaaa181">DESCANSO</string>
+    <string name="l10n_noop_glance_widget_strap_battery_a6c7f09c">Bateria de pega</string>
     <string name="l10n_notifications_settings_screen_02d_02d_ce23a78c">%1$02d:%2$02d</string>
     <string name="l10n_notifications_settings_screen_all_other_apps_51a8af2c">Todos os outros aplicativos</string>
     <string name="l10n_notifications_settings_screen_app_name_wrist_alerts_dd3540fa">%1$s alertas de pulso</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -673,6 +673,7 @@
     <string name="l10n_mind_section_reading_your_check_ins_71a100a9">A ler os teus check-ins…</string>
     <string name="l10n_noop_compact_glance_widget_charge_49a8cb83">COBRAR</string>
     <string name="l10n_noop_compact_glance_widget_effort_660752e7">EFFORT</string>
+    <string name="l10n_noop_compact_glance_widget_heart_rate_410aa15c">Frequência cardíaca</string>
     <string name="l10n_noop_compact_glance_widget_rest_cbaaa181">DESCANSO</string>
     <string name="l10n_noop_compact_glance_widget_strap_battery_a6c7f09c">Bateria de pega</string>
     <string name="l10n_noop_glance_widget_charge_49a8cb83">COBRAR</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -660,7 +660,9 @@
     <string name="l10n_noop_compact_glance_widget_strap_battery_a6c7f09c">手环电量</string>
     <string name="l10n_noop_glance_widget_charge_49a8cb83">充能</string>
     <string name="l10n_noop_glance_widget_effort_660752e7">负荷</string>
+    <string name="l10n_noop_glance_widget_heart_rate_410aa15c">心率</string>
     <string name="l10n_noop_glance_widget_rest_cbaaa181">恢复</string>
+    <string name="l10n_noop_glance_widget_strap_battery_a6c7f09c">手环电量</string>
     <string name="l10n_notifications_settings_screen_02d_02d_ce23a78c">%1$02d:%2$02d</string>
     <string name="l10n_notifications_settings_screen_all_other_apps_51a8af2c">所有其他 App</string>
     <string name="l10n_notifications_settings_screen_app_name_wrist_alerts_dd3540fa">%1$s 手腕震动提醒</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -656,6 +656,7 @@
     <string name="l10n_mind_section_reading_your_check_ins_71a100a9">正在读取您的打卡记录…</string>
     <string name="l10n_noop_compact_glance_widget_charge_49a8cb83">充能</string>
     <string name="l10n_noop_compact_glance_widget_effort_660752e7">负荷</string>
+    <string name="l10n_noop_compact_glance_widget_heart_rate_410aa15c">心率</string>
     <string name="l10n_noop_compact_glance_widget_rest_cbaaa181">恢复</string>
     <string name="l10n_noop_compact_glance_widget_strap_battery_a6c7f09c">手环电量</string>
     <string name="l10n_noop_glance_widget_charge_49a8cb83">充能</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -797,7 +797,9 @@
     <string name="l10n_noop_compact_glance_widget_strap_battery_a6c7f09c">Strap battery</string>
     <string name="l10n_noop_glance_widget_charge_49a8cb83">CHARGE</string>
     <string name="l10n_noop_glance_widget_effort_660752e7">EFFORT</string>
+    <string name="l10n_noop_glance_widget_heart_rate_410aa15c">Heart rate</string>
     <string name="l10n_noop_glance_widget_rest_cbaaa181">REST</string>
+    <string name="l10n_noop_glance_widget_strap_battery_a6c7f09c">Strap battery</string>
     <string name="l10n_notifications_settings_screen_02d_02d_ce23a78c">%1$02d:%2$02d</string>
     <string name="l10n_notifications_settings_screen_all_other_apps_51a8af2c">All other apps</string>
     <string name="l10n_notifications_settings_screen_app_name_wrist_alerts_dd3540fa">%1$s wrist alerts</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -793,6 +793,7 @@
     <string name="l10n_mind_section_reading_your_check_ins_71a100a9">Reading your check-ins…</string>
     <string name="l10n_noop_compact_glance_widget_charge_49a8cb83">CHARGE</string>
     <string name="l10n_noop_compact_glance_widget_effort_660752e7">EFFORT</string>
+    <string name="l10n_noop_compact_glance_widget_heart_rate_410aa15c">Heart rate</string>
     <string name="l10n_noop_compact_glance_widget_rest_cbaaa181">REST</string>
     <string name="l10n_noop_compact_glance_widget_strap_battery_a6c7f09c">Strap battery</string>
     <string name="l10n_noop_glance_widget_charge_49a8cb83">CHARGE</string>


### PR DESCRIPTION
Refs #1799.

## The problem

`NoopGlanceWidget.kt:153-164` draws live HR and strap battery as `"♥ $it"` and `"⚡ $it%"`. The
glyphs are **characters inside the text**, not labelled images, and the file set no `semantics` at
all — only layout modifiers. TalkBack reads whatever the glyph happens to be called, or skips it,
so both metrics arrive as bare numbers with no name and no unit.

`NoopCompactGlanceWidget` has the **same unlabelled heart-rate line**, byte for byte, so this is
fixed in both widgets. My first pass described the compact widget as "the accessible one" and that
was overstated — only its battery *Image* carries a `contentDescription`; its HR text never did.
The real asymmetry is narrower: the compact widget labels its battery icon, the standard one
labels nothing.

The three score cells in the standard widget are fine; they pass real localised word labels through
`ScoreCell`. It was only the HR/battery row.

## The fix, and the one I did not take

`GlanceModifier.semantics { contentDescription = … }` on both, giving "Heart rate 58 bpm" and
"Strap battery 84%". **No visual change.**

#1799 floated a second option — split the glyphs into `Image`s the way the compact widget does.
That would match the sibling more closely, but it changes what ships to users' home screens, and
it is a consistency refactor riding on an accessibility fix. Kept separate.

`androidx.glance.semantics` is available at the pinned Glance 1.1.1 (verified in the resolved
`.aar`; nothing in the repo used it before, and every existing `.semantics` is
`androidx.compose.ui.semantics` from the regular Compose UI, so it was worth confirming rather
than assuming).

## Strings

Two new keys in all **seven** locale files:

- `l10n_noop_glance_widget_heart_rate_410aa15c`
- `l10n_noop_glance_widget_strap_battery_a6c7f09c`

The key suffix is `sha1(text)[:8]` — verified against three known keys, all exact — so identical
English text yields the identical suffix, and the translations are **copied verbatim** from the
existing entries that already carry that exact text (`l10n_breathe_screen_heart_rate_410aa15c`,
`l10n_noop_compact_glance_widget_strap_battery_a6c7f09c`) rather than invented. Value formats reuse
existing bare format strings (`%1$s bpm`, `%1$s%%`) for the same reason — no machine-translated copy
enters the catalogue.

Descriptions are built above the `Row`, not inside the `semantics` lambda. `uiString` would resolve
there too — it reads Application resources and is not a composable — but #571 recorded that the i18n
audit cannot see copy assigned inside a `semantics {}` lambda, so a literal written there would pass
CI and ship English everywhere.

## Verification

- `compileFullDebugKotlin --no-build-cache` clean.
- `testFullDebugUnitTest --tests "com.noop.widget.*"` green.
- `Tools/i18n_audit.py --ci` exit 0 — it **caught a real defect mid-work**: my first battery
  description was `"$batteryLabel $it%"`, an embedded literal `%`. Now a format string.
- `lintVitalFullRelease -PstagingRelease` clean — the `ExtraTranslation` gate that a compile and the
  i18n audit both miss after a `strings.xml` change.
- `Tools/doc_comment_lint.py` exit 0.
- **Not TalkBack-tested.** Nothing here can verify the announcement without a device; the change is
  a `contentDescription` on two existing nodes, and the visual output is unchanged.

## Note on the audit baseline

The audit reports `2 baseline entries no longer found` for this file. Those are the two visible-text
literals (`"♥ $it"`, `"⚡ $it%"`), which are unchanged — the entries drifted because my insertion moved
their line numbers. Not touched here, since `--update-baseline` would sweep unrelated entries into
this PR.


## Stale readings no longer read as current

`heartRateStale` is drawn **only by dimming the text** — a colour-only channel — in both widgets.
The first pass here described a stale reading as "Heart rate 58 bpm" regardless, which is *worse*
than the bare `"♥ 58"` it replaced: the old text claimed nothing, the description actively asserted
a carried-over value was current.

Fixed by marking the **live** side rather than the stale one. A stale value then carries no claim
instead of needing a word for it, and the positive case reuses `l10n_today_screen_sync_chip_live_98aadb37`
("live"), which already exists in all seven locales — `Live` / `en vivo` / `en direct` / `na żywo` /
`em direto` / `实时`. So the fix adds **no new copy to translate**, and every string in this branch
is still copied from an existing vetted entry rather than invented.

The suffix is built outside the string template because the i18n audit rejects a template whose
interpolations contain no `uiString` call — which is exactly what an intermediate `value` local
produced. The audit caught that too.
