### PR TITLE
backup: warn at export when a database is past the restore ceiling, and let a user restore it anyway

### DIFF
--- a/Strand/Data/BackupSync.swift
+++ b/Strand/Data/BackupSync.swift
@@ -265,7 +265,13 @@ enum FolderBackup {
 
         let nowMs = Int(Date().timeIntervalSince1970 * 1000.0)
         let dest = folder.appendingPathComponent(BackupSync.snapshotName(nowMs))
-        guard case .exported = await DataBackup.writeBackup(checkpoint: checkpoint, to: dest) else { return false }
+        // #1807: an oversize write still WROTE the file, so it is a success here. The folder sync has
+        // nowhere to surface a warning and must not report failure for a backup that exists — the
+        // interactive export is where the user is told, because that is where they can act on it.
+        switch await DataBackup.writeBackup(checkpoint: checkpoint, to: dest) {
+        case .exported, .exportedOversize: break
+        default: return false
+        }
 
         UserDefaults.standard.set(nowMs, forKey: lastKey)
         prune(in: folder)

--- a/Strand/Data/DataBackup.swift
+++ b/Strand/Data/DataBackup.swift
@@ -27,7 +27,12 @@ import ZIPFoundation
 /// security-scoped access on the panel-returned URLs. Every path is best-effort — failures surface
 /// as a `.failure` result and never crash.
 enum DataBackup {
-    private static let maxBackupSQLiteBytes: Int64 = 2_147_483_648
+    /// Uncompressed ceiling for the SQLite entry, enforced while EXTRACTING (see `extractBackupZip`).
+    /// Deliberately measured on the decompressed stream: this is a zip-bomb guard, and a zip bomb is by
+    /// definition small compressed and enormous expanded, so a cap on the archive's own size would be
+    /// trivially defeated. Compressing harder cannot help a user past it — the backup is already
+    /// `.deflate`d and the count is of bytes landing on disk. (#1807)
+    static let maxBackupSQLiteBytes: Int64 = 2_147_483_648
     private static let maxBackupSettingsBytes: Int64 = 1_048_576
 
     // MARK: - Result
@@ -35,11 +40,21 @@ enum DataBackup {
     enum BackupResult {
         /// Export wrote the backup to `url`.
         case exported(URL)
+        /// Export wrote the backup, but the database is larger than [maxBackupSQLiteBytes], the ceiling
+        /// the restore path enforces. The file is valid and worth keeping — restoring it just needs the
+        /// user to confirm once. Reported at EXPORT time because the alternative is finding out during a
+        /// restore, which is exactly when the original is gone. (#1807)
+        case exportedOversize(URL, bytes: Int64, limit: Int64)
         /// Import succeeded; a relaunch is required for it to take effect. `sidecar` is where the
         /// previous database was preserved, in case the user wants to roll back.
         case imported(sidecar: URL)
         /// The user dismissed the save/open panel — nothing happened, show nothing loud.
         case cancelled
+        /// The restore stopped ONLY because an entry exceeds the size ceiling. Distinct from `failure`
+        /// so the caller can offer to go ahead anyway: the cap is a decompression guard against a hostile
+        /// archive, and a backup the user just picked out of their own files is a different threat model
+        /// than the one it defends against. (#1807)
+        case restoreTooLarge(name: String, limit: Int64)
         /// Something went wrong; `message` is user-facing.
         case failure(String)
     }
@@ -94,7 +109,7 @@ enum DataBackup {
             try await Task.detached(priority: .utility) {
                 try writeVerifiedBackupZip(dbURL: dbURL, to: dest, settingsJSON: currentSettingsJSON())
             }.value
-            return .exported(dest)
+            return exportOutcome(dest, dbURL: dbURL)
         } catch {
             return .failure(String(localized: "Export failed: \(error.localizedDescription)"))
         }
@@ -113,7 +128,7 @@ enum DataBackup {
             return .failure(String(localized: "Export failed: \(error.localizedDescription)"))
         }
         guard let dest = await DocumentPicker.export(staged) else { return .cancelled }
-        return .exported(dest)
+        return exportOutcome(dest, dbURL: dbURL)
         #endif
     }
 
@@ -144,6 +159,17 @@ enum DataBackup {
     /// when the original data may be long gone; failing loudly NOW is the honest move. The read-only
     /// probe sits safely beside the app's open GRDB pool (WAL allows concurrent readers).
     /// `writeBackupForTesting` deliberately bypasses this so tests can build damaged containers.
+    /// `.exported`, or `.exportedOversize` when the database is past the ceiling the restore path
+    /// enforces. Measured on the DATABASE, not the finished archive: the archive is `.deflate`d and the
+    /// cap the restore checks counts the DECOMPRESSED stream, so the zip's own size says nothing about
+    /// whether it can be read back. (#1807)
+    private static func exportOutcome(_ dest: URL, dbURL: URL) -> BackupResult {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: dbURL.path)
+        guard let bytes = (attrs?[.size] as? NSNumber)?.int64Value,
+              bytes > maxBackupSQLiteBytes else { return .exported(dest) }
+        return .exportedOversize(dest, bytes: bytes, limit: maxBackupSQLiteBytes)
+    }
+
     private static func writeVerifiedBackupZip(dbURL: URL, to dest: URL, settingsJSON: Data?) throws {
         if let complaint = DatabaseIntegrity.quickCheckFailure(atPath: dbURL.path) {
             throw ExportIntegrityFailure(complaint: complaint)
@@ -246,7 +272,7 @@ enum DataBackup {
             let fm = FileManager.default
             if fm.fileExists(atPath: dest.path) { try fm.removeItem(at: dest) }
             try writeVerifiedBackupZip(dbURL: dbURL, to: dest, settingsJSON: currentSettingsJSON())
-            return .exported(dest)
+            return exportOutcome(dest, dbURL: dbURL)
         } catch {
             return .failure(String(localized: "Backup failed: \(error.localizedDescription)"))
         }
@@ -273,7 +299,7 @@ enum DataBackup {
     /// siblings). The store stays open, so the swapped-in file only takes effect after a relaunch —
     /// the caller informs the user.
     @MainActor
-    static func runImport() async -> BackupResult {
+    static func runImport(allowOversize: Bool = false) async -> BackupResult {
         let dbPath: String
         do { dbPath = try StorePaths.defaultDatabasePath() }
         catch { return .failure(String(localized: "Couldn't locate the NOOP database. \(error.localizedDescription)")) }
@@ -305,7 +331,7 @@ enum DataBackup {
         // stays valid because the surrounding function is still awaiting here. Only Sendable value
         // types (URL, String) cross the hop; the result hops back to main for handleBackup.
         return await Task.detached(priority: .utility) {
-            restore(from: pickedSource, toDatabaseAt: dbPath)
+            restore(from: pickedSource, toDatabaseAt: dbPath, allowOversize: allowOversize)
         }.value
     }
 
@@ -330,7 +356,8 @@ enum DataBackup {
     /// `settingsDefaults` is where a `settings.json` entry (#1000) is re-applied — injected for the
     /// same reason as `dbPath` (tests use a suite-scoped UserDefaults, never the runner's real domain).
     static func restore(from pickedSource: URL, toDatabaseAt dbPath: String,
-                        settingsDefaults: UserDefaults = .standard) -> BackupResult {
+                        settingsDefaults: UserDefaults = .standard,
+                        allowOversize: Bool = false) -> BackupResult {
         // If the picked file is a .noopbak ZIP, extract the SQLite entry to a temp dir first.
         // Legacy plain-SQLite files fall straight through. The extracted dir is cleaned up below.
         let fm = FileManager.default
@@ -343,7 +370,15 @@ enum DataBackup {
             do {
                 if fm.fileExists(atPath: tmpExtract.path) { try fm.removeItem(at: tmpExtract) }
                 try fm.createDirectory(at: tmpExtract, withIntermediateDirectories: true)
-                try extractBackupZip(at: pickedSource, into: tmpExtract)
+                try extractBackupZip(at: pickedSource, into: tmpExtract, allowOversize: allowOversize)
+            } catch let err as BackupArchiveError {
+                try? fm.removeItem(at: tmpExtract)
+                // Reported as its own case, not a generic failure: this one is RECOVERABLE, and the caller
+                // is the only layer that can ask the user whether to go ahead. (#1807)
+                switch err {
+                case .entryTooLarge(let name):
+                    return .restoreTooLarge(name: name, limit: maxBackupSQLiteBytes)
+                }
             } catch {
                 try? fm.removeItem(at: tmpExtract)
                 return .failure(String(localized: "Couldn't open the backup archive: \(error.localizedDescription)"))
@@ -591,14 +626,15 @@ enum DataBackup {
     /// Extract only the canonical entries from a `.noopbak` ZIP at `zipURL` into `destDir`.
     /// Unknown files are ignored, and each accepted entry is streamed through an uncompressed-size cap
     /// before it lands on disk.
-    private static func extractBackupZip(at zipURL: URL, into destDir: URL) throws {
+    private static func extractBackupZip(at zipURL: URL, into destDir: URL,
+                                         allowOversize: Bool = false) throws {
         let archive = try Archive(url: zipURL, accessMode: .read)
         for entry in archive where entry.type == .file {
             let name = (entry.path as NSString).lastPathComponent
             let limit: Int64
             switch name {
             case backupEntryName:
-                limit = maxBackupSQLiteBytes
+                limit = allowOversize ? Int64.max : maxBackupSQLiteBytes
             case BackupSettings.entryName:
                 limit = maxBackupSettingsBytes
             default:

--- a/Strand/Screens/BackupSyncView.swift
+++ b/Strand/Screens/BackupSyncView.swift
@@ -270,7 +270,14 @@ struct BackupSyncView: View {
                     alertMessage = String(localized: "Fully quit and reopen NOOP to load it.")
                 case .failure(let m):
                     alertTitle = String(localized: "Restore problem"); alertMessage = m
-                case .cancelled, .exported:
+                case .restoreTooLarge(let name, let limit):
+                    // #1807: recoverable, but not from here — this view restores a snapshot directly and
+                    // has no confirm step to hang the override on. Point at the path that does, rather
+                    // than leaving the user with a refusal and nowhere to go.
+                    let cap = ByteCountFormatter.string(fromByteCount: limit, countStyle: .file)
+                    alertTitle = String(localized: "Backup problem")
+                    alertMessage = String(localized: "\(name) is larger than the \(cap) NOOP restores without asking. You can still restore it from Settings → Backup & restore → Import, which will ask you to confirm.")
+                case .cancelled, .exported, .exportedOversize:
                     alertTitle = String(localized: "Restore problem"); alertMessage = String(localized: "Couldn't restore that backup.")
                 }
                 showAlert = true

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -35,6 +35,10 @@ struct SettingsView: View {
     @State private var backupAlertTitle = ""
     @State private var backupAlertMessage = ""
     @State private var showBackupAlert = false
+    /// #1807: a restore refused ONLY for size is recoverable, so it gets its own two-button alert rather
+    /// than the shared single-OK one every other backup outcome uses.
+    @State private var showOversizeRestoreConfirm = false
+    @State private var oversizeRestoreMessage = ""
 
     /// Opt-in WHOOP 5/MG protocol experiments (off by default). See [PuffinExperiment].
     @AppStorage(PuffinExperiment.defaultsKey) private var puffinExperiments = false
@@ -347,6 +351,15 @@ struct SettingsView: View {
             Button("OK", role: .cancel) { }
         } message: {
             Text(backupAlertMessage)
+        }
+        // Title and buttons reuse catalogue strings that already carry all nine locales, rather than
+        // minting new copy that would ship English everywhere until someone translated it. The message
+        // below is where the specifics live. (#1807)
+        .alert("Backup problem", isPresented: $showOversizeRestoreConfirm) {
+            Button("Restore") { runImport(allowOversize: true) }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text(oversizeRestoreMessage)
         }
         .confirmationDialog("Recalibrate your Charge baseline?",
                             isPresented: $showRecalibrateConfirm, titleVisibility: .visible) {
@@ -2576,10 +2589,10 @@ struct SettingsView: View {
         }
     }
 
-    private func runImport() {
+    private func runImport(allowOversize: Bool = false) {
         backupBusy = true
         Task {
-            let result = await DataBackup.runImport()
+            let result = await DataBackup.runImport(allowOversize: allowOversize)
             handleBackup(result)
         }
     }
@@ -2614,6 +2627,19 @@ struct SettingsView: View {
             backupAlertTitle = String(localized: "Backup exported")
             backupAlertMessage = String(localized: "Saved to \(url.lastPathComponent). Copy this file to your other \(Platform.deviceNoun) and use Import there to restore everything.")
             showBackupAlert = true
+        case .exportedOversize(let url, let bytes, let limit):
+            // #1807: the file is written and worth keeping — say so first, then say what restoring it
+            // will ask for. The old behaviour said nothing here and refused at restore, which is the
+            // one moment the original is already gone.
+            let size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+            let cap = ByteCountFormatter.string(fromByteCount: limit, countStyle: .file)
+            backupAlertTitle = String(localized: "Backup exported")
+            backupAlertMessage = String(localized: "Saved to \(url.lastPathComponent). Your database is \(size), over the \(cap) NOOP restores without asking — the backup is complete and valid, and restoring it will ask you to confirm once.")
+            showBackupAlert = true
+        case .restoreTooLarge(let name, let limit):
+            let cap = ByteCountFormatter.string(fromByteCount: limit, countStyle: .file)
+            oversizeRestoreMessage = String(localized: "\(name) is larger than the \(cap) NOOP restores without asking. That limit guards against a malicious archive expanding to fill this \(Platform.deviceNoun) — a backup you exported yourself is not that. Restoring it needs the space the database will take. You'll be asked to choose the file again.")
+            showOversizeRestoreConfirm = true
         case .imported:
             backupAlertTitle = String(localized: "Backup imported")
             backupAlertMessage = String(localized: "Your data has been restored. Quit and reopen NOOP for it to take effect.")


### PR DESCRIPTION
Refs #1807. Apple half — fixes (1) and (2) from the issue.

## The bug

Both platforms cap the SQLite entry at 2 GiB and enforce it **only while restoring**
(`DataBackup.swift:30` → `:615`). Nothing checks at export. So NOOP writes archives it later refuses
to read, reports success, and the user finds out at restore — the one moment the original is gone.

Reachable now: a field diagnostic reports a **1.63 GB** database (76% of the ceiling) with nothing
pruning the raw streams.

## Export now says so

`runExport` and `writeBackup` return `.exportedOversize` when the database is past the cap. The file
is still written — it is valid, and with the override below it is restorable — so this is a
**warning, not a refusal**. Refusing would take away the user's only lossless artefact.

Measured on the **database**, not the finished archive: the archive is `.deflate`d and the cap counts
the **decompressed** stream, so the zip's own size says nothing about whether it can be read back.
That is also the answer to "would compressing help?" — no. The guard is a zip-bomb defence, and a cap
on compressed size would be trivially defeated.

## Restore can be overridden

`entryTooLarge` now surfaces as `.restoreTooLarge` rather than a generic failure, and the caller
offers to go ahead. The cap defends against a hostile archive expanding to fill the device; a backup
the user just picked out of their own Files app is **not that threat**, and a hard refusal there
strands real history for a risk they are not exposed to.

The retry re-runs the picker rather than retaining a security-scoped URL across an alert — clunkier,
but the alert says so, and it avoids getting scoped access wrong.

## The two other switches

`BackupResult` is matched in three places, not one:

- `BackupSync` treats an oversize write as **success** — it did write the file, and the folder sync
  has nowhere to surface a warning. Left as a failure it would have reported a broken sync for a
  backup that exists.
- `BackupSyncView` restores a snapshot directly and has no confirm step to hang the override on, so
  it names the limit and points at the import path that does.

`CsvExport.ExportResult` is a **separate** enum and is untouched.

## Strings

The confirm alert reuses `Backup problem`, `Restore` and `Cancel`, which already carry all nine
locales. The i18n gate caught my first draft minting *"Backup is larger than the safe limit"* and
*"Restore anyway"* — both would have shipped English everywhere until someone translated them.

## Not done here

- **Android.** The same bug exists (`MAX_BACKUP_SQLITE_BYTES`, `copyBounded`), but `exportTo` returns
  `Unit`, so the warning needs a signature change and the override needs a new `ImportResult` variant
  plus Compose UI. Kept separate rather than half-done.
- **Fix (3)** from the issue, and retention/pruning of the raw streams that actually drive a database
  past 2 GiB.

## Verification

- `i18n_audit --ci` and `doc_comment_lint` clean.
- **Not compiled locally.** Every file here is app-target Swift that no default CI job builds —
  `swift build` covers the package only. This needs an app-build dispatch before merge, and that is
  the sole gate on it.


## Re-review notes

Four things verified that could each have been wrong, none of which a compiler here could have told
me: `dbURL` is in scope where `writeBackup`'s return was rerouted (`:262`); the `guard`→`switch` in
`FolderBackup.backupNow` preserves control flow exactly; both edits land inside `enum FolderBackup`
(`BackupSync.swift:139`), so the switch really is over `DataBackup.BackupResult`; and the
`BackupSyncView` case is reachable rather than dead, since `FolderBackup.restore(snapshotNamed:)`
ends in `DataBackup.restore(from: source)`.

**One risk that only a device settles.** Tapping "Restore" in the confirm alert calls
`runImport(allowOversize: true)`, which presents the document picker while that alert is dismissing.
On iOS a presentation started from an alert action can be dropped if the dismissal has not finished.
The picker is presented from inside an async `Task`, so it very likely lands after the alert is gone
— but "very likely" is not verification, and no gate in this repo can check it. If it misbehaves the
fix is to present off a state change rather than from the action closure; that is not done here
because it would be an untested change to working presentation code.

**Also worth knowing:** the export message says restoring "will ask you to confirm once", which is
true of Settings → Import. The Backup & Sync folder path has no confirm step and instead points at
Import, so the two are consistent, but the export wording is describing the Import route
specifically.
