### PR TITLE
backup: Android half — warn at export, and let a user restore an oversize backup

### DIFF
--- a/android/app/src/main/java/com/noop/data/DataBackup.kt
+++ b/android/app/src/main/java/com/noop/data/DataBackup.kt
@@ -50,7 +50,7 @@ object DataBackup {
     // restored). Written LAST so older importers that stop at the first .sqlite entry are unaffected.
     private const val MANIFEST_ENTRY_NAME = BackupManifest.ENTRY_NAME
 
-    private const val MAX_BACKUP_SQLITE_BYTES = 2_147_483_648L
+    internal const val MAX_BACKUP_SQLITE_BYTES = 2_147_483_648L
     private const val MAX_BACKUP_SETTINGS_BYTES = 1_048_576L
 
     /** First 16 bytes of every SQLite 3 file: "SQLite format 3\0". */
@@ -101,7 +101,26 @@ object DataBackup {
 
         /** Import failed and the original database is untouched. */
         data class Failed(val message: String) : ImportResult
+
+        /**
+         * The restore stopped ONLY because an entry exceeds [MAX_BACKUP_SQLITE_BYTES]. Distinct from
+         * [Failed] so the caller can offer to go ahead: the cap is a decompression guard against a
+         * hostile archive, and a backup the user just picked out of their own files is a different
+         * threat model than the one it defends against. (#1807)
+         */
+        data class TooLarge(val message: String, val limitBytes: Long) : ImportResult
     }
+
+    /**
+     * What an export produced. [overRestoreCeiling] is true when the database is past the ceiling the
+     * RESTORE path enforces, so the caller can say so while the user still has their data — the
+     * alternative is finding out during a restore, which is the one moment the original is gone.
+     *
+     * Measured on the DATABASE, not the finished archive: the archive is deflated and the cap counts the
+     * DECOMPRESSED stream, so the zip's own size says nothing about whether it can be read back. That is
+     * also why compressing harder cannot help anyone past it. (#1807)
+     */
+    data class ExportOutcome(val bytes: Long, val overRestoreCeiling: Boolean, val limitBytes: Long)
 
     /**
      * Export the live database to [uri] as a compressed `.noopbak` (single-entry ZIP).
@@ -111,7 +130,7 @@ object DataBackup {
      * Throws on failure so the caller can surface the message in a toast/snackbar.
      */
     @Throws(IOException::class)
-    fun exportTo(context: Context, uri: Uri) {
+    fun exportTo(context: Context, uri: Uri): ExportOutcome {
         val appContext = context.applicationContext
 
         // Fold the WAL back into the main file so the snapshot is complete.
@@ -179,6 +198,15 @@ object DataBackup {
                 }
             }
         }
+        // #1807: the file is written and valid either way — this only reports whether restoring it will
+        // need the user to confirm. Read AFTER the checkpoint above, so the length is the one the
+        // restore path will actually meet.
+        val bytes = dbFile.length()
+        return ExportOutcome(
+            bytes = bytes,
+            overRestoreCeiling = bytes > MAX_BACKUP_SQLITE_BYTES,
+            limitBytes = MAX_BACKUP_SQLITE_BYTES,
+        )
     }
 
     /**
@@ -190,7 +218,7 @@ object DataBackup {
      * On any error the current database is left exactly as it was. On success the caller
      * MUST instruct the user to fully restart the app.
      */
-    fun importFrom(context: Context, uri: Uri): ImportResult {
+    fun importFrom(context: Context, uri: Uri, allowOversize: Boolean = false): ImportResult {
         val appContext = context.applicationContext
         val resolver = appContext.contentResolver
 
@@ -214,7 +242,8 @@ object DataBackup {
         val tempSettings = File(appContext.cacheDir, "import-settings.json")
         tempSettings.delete()
         try {
-            when (stageBackupSqlite(resolver.openInputStream(uri), header, tempSqlite, tempSettings)) {
+            when (stageBackupSqlite(resolver.openInputStream(uri), header, tempSqlite, tempSettings,
+                                    allowOversize = allowOversize)) {
                 StageResult.OK -> Unit
                 StageResult.CANNOT_OPEN -> return ImportResult.Failed("Could not open the chosen file.")
                 StageResult.NO_DB_IN_ZIP -> {
@@ -224,7 +253,14 @@ object DataBackup {
                 StageResult.ENTRY_TOO_LARGE -> {
                     tempSqlite.delete()
                     tempSettings.delete()
-                    return ImportResult.Failed("The backup archive is too large to restore safely.")
+                    // #1807: recoverable, so the caller gets a case it can offer to override rather than
+                    // a dead-end message.
+                    // Carries the SAME sentence the old Failed branch showed, deliberately: it is already
+                    // in the audit baseline, so surfacing the override needs no new untranslated copy.
+                    return ImportResult.TooLarge(
+                        "The backup archive is too large to restore safely.",
+                        MAX_BACKUP_SQLITE_BYTES,
+                    )
                 }
                 StageResult.NOT_A_BACKUP -> return ImportResult.Failed(
                     "That file is not a NOOP backup - it doesn't look like a .noopbak archive or a SQLite database."
@@ -405,6 +441,8 @@ object DataBackup {
         header: ByteArray,
         dest: File,
         settingsDest: File? = null,
+        /** #1807: lift the SQLite cap for a file the USER chose. See [ImportResult.TooLarge]. */
+        allowOversize: Boolean = false,
     ): StageResult {
         if (input == null) return StageResult.CANNOT_OPEN
         input.use { stream ->
@@ -419,7 +457,7 @@ object DataBackup {
                                 !entry.isDirectory && !foundDb &&
                                     entry.name.substringAfterLast('/') == ZIP_ENTRY_NAME -> {
                                     FileOutputStream(dest).use { out ->
-                                        if (!copyBounded(zip, out, MAX_BACKUP_SQLITE_BYTES)) {
+                                        if (!copyBounded(zip, out, sqliteCap(allowOversize))) {
                                             dest.delete()
                                             return StageResult.ENTRY_TOO_LARGE
                                         }
@@ -446,7 +484,7 @@ object DataBackup {
                 }
                 header.startsWith(SQLITE_MAGIC) -> {
                     FileOutputStream(dest).use { out ->
-                        if (!copyBounded(stream, out, MAX_BACKUP_SQLITE_BYTES)) {
+                        if (!copyBounded(stream, out, sqliteCap(allowOversize))) {
                             dest.delete()
                             return StageResult.ENTRY_TOO_LARGE
                         }
@@ -457,6 +495,10 @@ object DataBackup {
             }
         }
     }
+
+    /** The SQLite cap, lifted when the user has chosen to go ahead for a file they picked. (#1807) */
+    internal fun sqliteCap(allowOversize: Boolean): Long =
+        if (allowOversize) Long.MAX_VALUE else MAX_BACKUP_SQLITE_BYTES
 
     private fun copyBounded(input: java.io.InputStream, out: java.io.OutputStream, cap: Long): Boolean {
         val buffer = ByteArray(DEFAULT_BUFFER_SIZE)

--- a/android/app/src/main/java/com/noop/data/DataBackup.kt
+++ b/android/app/src/main/java/com/noop/data/DataBackup.kt
@@ -174,6 +174,8 @@ object DataBackup {
         val resolver = appContext.contentResolver
         val output = resolver.openOutputStream(uri)
             ?: throw IOException("Could not open the chosen file for writing.")
+        // Assigned inside the transaction below, where the entry is actually written.
+        var entryBytes = 0L
         output.use { out ->
             // #1014: copy the file while HOLDING Room's write transaction. In WAL mode the main
             // file is only rewritten by a checkpoint, and a checkpoint only runs on a commit — so
@@ -185,7 +187,12 @@ object DataBackup {
             db.runInTransaction {
                 ZipOutputStream(out).use { zip ->
                     zip.putNextEntry(ZipEntry(ZIP_ENTRY_NAME))
-                    dbFile.inputStream().use { input -> input.copyTo(zip) }
+                    // #1807: count what actually LANDS in the entry, rather than reading dbFile.length()
+                    // afterwards. The copy runs inside this transaction against a snapshot; once it
+                    // commits, Room can checkpoint again and the main file's length can move, so a later
+                    // read is a different number from the one the restore path will meet. The cap is
+                    // enforced on this entry, so this is the only measurement that answers the question.
+                    dbFile.inputStream().use { input -> entryBytes = input.copyTo(zip) }
                     zip.closeEntry()
                     if (settingsJson != null) {
                         zip.putNextEntry(ZipEntry(SETTINGS_ENTRY_NAME))
@@ -199,12 +206,10 @@ object DataBackup {
             }
         }
         // #1807: the file is written and valid either way — this only reports whether restoring it will
-        // need the user to confirm. Read AFTER the checkpoint above, so the length is the one the
-        // restore path will actually meet.
-        val bytes = dbFile.length()
+        // need the user to confirm.
         return ExportOutcome(
-            bytes = bytes,
-            overRestoreCeiling = bytes > MAX_BACKUP_SQLITE_BYTES,
+            bytes = entryBytes,
+            overRestoreCeiling = overRestoreCeiling(entryBytes),
             limitBytes = MAX_BACKUP_SQLITE_BYTES,
         )
     }
@@ -495,6 +500,16 @@ object DataBackup {
             }
         }
     }
+
+    /**
+     * Whether a database of [entryBytes] is past the ceiling the RESTORE path enforces (#1807).
+     *
+     * Strictly greater: a database exactly at the cap still restores, because `copyBounded` refuses only
+     * when a write would take it OVER. Extracted so the boundary is testable — proving it end to end
+     * would need a >2 GiB fixture, and a test that recomputes the comparison and asserts its own
+     * arithmetic proves nothing.
+     */
+    internal fun overRestoreCeiling(entryBytes: Long): Boolean = entryBytes > MAX_BACKUP_SQLITE_BYTES
 
     /** The SQLite cap, lifted when the user has chosen to go ahead for a file they picked. (#1807) */
     internal fun sqliteCap(allowOversize: Boolean): Long =

--- a/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
@@ -112,6 +112,11 @@ fun BackupSyncScreen() {
                 }
                 is DataBackup.ImportResult.Failed ->
                     Toast.makeText(context, r.message, Toast.LENGTH_LONG).show()
+                // #1807: recoverable, but not from here — this screen restores a folder snapshot
+                // directly and has no confirm step to hang the override on. Settings → Backup & restore
+                // → Import does, and shows the same sentence with a way through.
+                is DataBackup.ImportResult.TooLarge ->
+                    Toast.makeText(context, r.message, Toast.LENGTH_LONG).show()
             }
         }
     }

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -519,6 +519,12 @@ fun SettingsScreen(
     }
 
     var backupBusy by remember { mutableStateOf(false) }
+    /**
+     * #1807: a restore refused ONLY for size, held with the uri that produced it so confirming can
+     * retry the SAME file. Android keeps a usable uri across the dialog, so unlike Apple there is no
+     * need to send the user back through the picker.
+     */
+    var oversizeRestore by remember { mutableStateOf<Pair<android.net.Uri, String>?>(null) }
 
     // #646/#651: LogExport's zip build + file read now run on Dispatchers.IO instead of blocking the
     // caller, so these buttons no longer freeze the UI — but nothing else stopped a second tap mid-export
@@ -713,12 +719,18 @@ fun SettingsScreen(
             }
             backupBusy = false
             result.fold(
-                onSuccess = {
-                    Toast.makeText(
-                        context,
-                        "Backup exported. Copy this file to your new phone and use Import there to restore everything.",
-                        Toast.LENGTH_LONG,
-                    ).show()
+                onSuccess = { outcome ->
+                    // #1807: the file is written and valid either way. When the database is past the
+                    // ceiling the RESTORE path enforces, say so NOW — the alternative is finding out
+                    // during a restore, which is the one moment the original is gone. The second
+                    // sentence is the refusal's own wording, reused so this adds no untranslated copy.
+                    val note = if (outcome.overRestoreCeiling) {
+                        "Backup exported. The backup archive is too large to restore safely — " +
+                            "restoring it will ask you to confirm."
+                    } else {
+                        "Backup exported. Copy this file to your new phone and use Import there to restore everything."
+                    }
+                    Toast.makeText(context, note, Toast.LENGTH_LONG).show()
                 },
                 onFailure = { e ->
                     Toast.makeText(context, "Backup problem: ${e.message}", Toast.LENGTH_LONG).show()
@@ -772,6 +784,11 @@ fun SettingsScreen(
                 is DataBackup.ImportResult.Failed -> Toast.makeText(
                     context, result.message, Toast.LENGTH_LONG,
                 ).show()
+                // #1807: refused ONLY for size, which is recoverable — offer to go ahead rather than
+                // ending on a Toast the user can do nothing about. The cap is a decompression guard
+                // against a hostile archive; a backup they just picked out of their own files is not
+                // that threat, and refusing outright strands real history.
+                is DataBackup.ImportResult.TooLarge -> oversizeRestore = uri to result.message
             }
         }
     }
@@ -3074,6 +3091,50 @@ fun SettingsScreen(
         // #174: the switch going OFF is the moment to offer the undo. Declining leaves the flags set and
         // says so — still an improvement on the old behaviour, where the same tap silently left them set
         // with no indication either way.
+        oversizeRestore?.let { (pendingUri, pendingMessage) ->
+            AlertDialog(
+                onDismissRequest = { oversizeRestore = null },
+                containerColor = Palette.surfaceOverlay,
+                // The message is the sentence the refusal already carried — reused rather than replaced,
+                // so surfacing the override adds no untranslated copy. Buttons reuse existing keys.
+                text = {
+                    Text(pendingMessage, style = NoopType.subhead, color = Palette.textSecondary)
+                },
+                confirmButton = {
+                    TextButton(onClick = {
+                        oversizeRestore = null
+                        backupBusy = true
+                        scope.launch {
+                            val again = withContext(Dispatchers.IO) {
+                                DataBackup.importFrom(context, pendingUri, allowOversize = true)
+                            }
+                            backupBusy = false
+                            val note = when (again) {
+                                is DataBackup.ImportResult.NeedsRestart ->
+                                    "Backup imported. Fully close and reopen NOOP for it to take effect."
+                                is DataBackup.ImportResult.Failed -> again.message
+                                is DataBackup.ImportResult.TooLarge -> again.message
+                            }
+                            Toast.makeText(context, note, Toast.LENGTH_LONG).show()
+                        }
+                    }) {
+                        Text(
+                            uiString(R.string.l10n_settings_screen_restore_3cbe6d6b),
+                            color = Palette.accent,
+                        )
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { oversizeRestore = null }) {
+                        Text(
+                            uiString(R.string.l10n_settings_screen_cancel_77dfd213),
+                            color = Palette.textSecondary,
+                        )
+                    }
+                },
+            )
+        }
+
         if (confirmingDeepDataDisable) {
             AlertDialog(
                 onDismissRequest = { confirmingDeepDataDisable = false },

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -3088,9 +3088,6 @@ fun SettingsScreen(
             }
         }
 
-        // #174: the switch going OFF is the moment to offer the undo. Declining leaves the flags set and
-        // says so — still an improvement on the old behaviour, where the same tap silently left them set
-        // with no indication either way.
         oversizeRestore?.let { (pendingUri, pendingMessage) ->
             AlertDialog(
                 onDismissRequest = { oversizeRestore = null },
@@ -3135,6 +3132,9 @@ fun SettingsScreen(
             )
         }
 
+        // #174: the switch going OFF is the moment to offer the undo. Declining leaves the flags set and
+        // says so — still an improvement on the old behaviour, where the same tap silently left them set
+        // with no indication either way.
         if (confirmingDeepDataDisable) {
             AlertDialog(
                 onDismissRequest = { confirmingDeepDataDisable = false },

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1493,6 +1493,7 @@
     <string name="l10n_settings_screen_broadcast_strap_hr_garmin_ant_a39d0654">Sendeband HR (Garmin/ANT)</string>
     <string name="l10n_settings_screen_buzz_the_time_on_your_strap_06fc879d">Buzz die Zeit auf Ihrem Gurt</string>
     <string name="l10n_settings_screen_cancel_77dfd213">Abbrechen</string>
+    <string name="l10n_settings_screen_restore_3cbe6d6b">Wiederherstellen</string>
     <string name="l10n_settings_screen_card_transparency_c5c7b4f3">Kartentransparenz</string>
     <string name="l10n_settings_screen_charge_d4e1aee4">Ladung</string>
     <string name="l10n_settings_screen_charge_effort_and_rest_and_how_d2c423a4">Ladung, Anstrengung und Ruhe und wie sie sich von WHOOP unterscheiden</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1293,6 +1293,7 @@
     <string name="l10n_settings_screen_broadcast_strap_hr_garmin_ant_a39d0654">Correa de radio HR (Garmin/ANT)</string>
     <string name="l10n_settings_screen_buzz_the_time_on_your_strap_06fc879d">Buzz el tiempo en tu correa</string>
     <string name="l10n_settings_screen_cancel_77dfd213">Cancelar</string>
+    <string name="l10n_settings_screen_restore_3cbe6d6b">Restaurar</string>
     <string name="l10n_settings_screen_card_transparency_c5c7b4f3">Transparencia de las tarjetas</string>
     <string name="l10n_settings_screen_charge_d4e1aee4">Carga</string>
     <string name="l10n_settings_screen_charge_effort_and_rest_and_how_d2c423a4">Carga, esfuerzo y descanso, y cómo difieren de WHOOP</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1311,6 +1311,7 @@
     <string name="l10n_settings_screen_broadcast_strap_hr_garmin_ant_a39d0654">Diffusion de la FC du bracelet (Garmin/ANT)</string>
     <string name="l10n_settings_screen_buzz_the_time_on_your_strap_06fc879d">Buzz l\'heure sur votre bracelet</string>
     <string name="l10n_settings_screen_cancel_77dfd213">Annuler</string>
+    <string name="l10n_settings_screen_restore_3cbe6d6b">Restaurer</string>
     <string name="l10n_settings_screen_card_transparency_c5c7b4f3">Transparence des cartes</string>
     <string name="l10n_settings_screen_charge_d4e1aee4">Charge</string>
     <string name="l10n_settings_screen_charge_effort_and_rest_and_how_d2c423a4">Charge, effort et repos, et comment ils diffèrent de WHOOP</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1450,6 +1450,7 @@
     <string name="l10n_settings_screen_broadcast_strap_hr_garmin_ant_a39d0654">Pasek nadawczy HR (Garmin/ANT)</string>
     <string name="l10n_settings_screen_buzz_the_time_on_your_strap_06fc879d">Zasygnalizuj godzinę na pasku</string>
     <string name="l10n_settings_screen_cancel_77dfd213">Anuluj</string>
+    <string name="l10n_settings_screen_restore_3cbe6d6b">Przywrócić</string>
     <string name="l10n_settings_screen_card_transparency_c5c7b4f3">Przejrzystość karty</string>
     <string name="l10n_settings_screen_charge_d4e1aee4">Energia</string>
     <string name="l10n_settings_screen_charge_effort_and_rest_and_how_d2c423a4">Energia, Wysiłek i Odpoczynek oraz czym różnią się od WHOOP</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1456,7 +1456,7 @@
     <string name="l10n_settings_screen_broadcast_strap_hr_garmin_ant_a39d0654">Pega de transmissão HR (Garmin/ANT)</string>
     <string name="l10n_settings_screen_buzz_the_time_on_your_strap_06fc879d">Avise a hora na tua bracelete</string>
     <string name="l10n_settings_screen_cancel_77dfd213">Cancelar</string>
-    <string name="l10n_settings_screen_restore_3cbe6d6b">Descansoaurar</string>
+    <string name="l10n_settings_screen_restore_3cbe6d6b">Restaurar</string>
     <string name="l10n_settings_screen_card_transparency_c5c7b4f3">Transparência do cartão</string>
     <string name="l10n_settings_screen_charge_d4e1aee4">Carga</string>
     <string name="l10n_settings_screen_charge_effort_and_rest_and_how_d2c423a4">Carga, Esforço e Descanso, e como diferem do WHOOP</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1456,6 +1456,7 @@
     <string name="l10n_settings_screen_broadcast_strap_hr_garmin_ant_a39d0654">Pega de transmissão HR (Garmin/ANT)</string>
     <string name="l10n_settings_screen_buzz_the_time_on_your_strap_06fc879d">Avise a hora na tua bracelete</string>
     <string name="l10n_settings_screen_cancel_77dfd213">Cancelar</string>
+    <string name="l10n_settings_screen_restore_3cbe6d6b">Descansoaurar</string>
     <string name="l10n_settings_screen_card_transparency_c5c7b4f3">Transparência do cartão</string>
     <string name="l10n_settings_screen_charge_d4e1aee4">Carga</string>
     <string name="l10n_settings_screen_charge_effort_and_rest_and_how_d2c423a4">Carga, Esforço e Descanso, e como diferem do WHOOP</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1436,6 +1436,7 @@
     <string name="l10n_settings_screen_broadcast_strap_hr_garmin_ant_a39d0654">广播手环心率 (适配 Garmin/ANT)</string>
     <string name="l10n_settings_screen_buzz_the_time_on_your_strap_06fc879d">在手环上通过震动播报时间</string>
     <string name="l10n_settings_screen_cancel_77dfd213">取消</string>
+    <string name="l10n_settings_screen_restore_3cbe6d6b">恢复</string>
     <string name="l10n_settings_screen_card_transparency_c5c7b4f3">卡片透明度</string>
     <string name="l10n_settings_screen_charge_d4e1aee4">充能(Charge)</string>
     <string name="l10n_settings_screen_charge_effort_and_rest_and_how_d2c423a4">充能(Charge)、负荷(Effort)与恢复(Rest)，以及它们与官方 WHOOP 指标的区别</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1589,6 +1589,7 @@
     <string name="l10n_settings_screen_broadcast_strap_hr_garmin_ant_a39d0654">Broadcast strap HR (Garmin/ANT)</string>
     <string name="l10n_settings_screen_buzz_the_time_on_your_strap_06fc879d">Buzz the time on your strap</string>
     <string name="l10n_settings_screen_cancel_77dfd213">Cancel</string>
+    <string name="l10n_settings_screen_restore_3cbe6d6b">Restore</string>
     <string name="l10n_settings_screen_card_transparency_c5c7b4f3">Card transparency</string>
     <string name="l10n_settings_screen_charge_d4e1aee4">Charge</string>
     <string name="l10n_settings_screen_charge_effort_and_rest_and_how_d2c423a4">Charge, Effort and Rest, and how they differ from WHOOP</string>

--- a/android/app/src/test/java/com/noop/data/BackupOversizeOverrideTest.kt
+++ b/android/app/src/test/java/com/noop/data/BackupOversizeOverrideTest.kt
@@ -1,0 +1,51 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The oversize restore override (#1807).
+ *
+ * The cap itself cannot be exercised end-to-end here — proving it needs a >2 GiB fixture — so what is
+ * pinned is the decision that governs it, plus the shape of the result the UI keys on. The behaviour
+ * these guard is not cosmetic: NOOP wrote archives it then refused to read, and the refusal arrived at
+ * the one moment the original was already gone.
+ */
+class BackupOversizeOverrideTest {
+
+    /** Default enforces the guard; the override lifts it entirely, for a file the user chose. */
+    @Test
+    fun `the cap is enforced by default and lifted only on request`() {
+        assertEquals(DataBackup.MAX_BACKUP_SQLITE_BYTES, DataBackup.sqliteCap(false))
+        assertEquals(Long.MAX_VALUE, DataBackup.sqliteCap(true))
+    }
+
+    /** 2 GiB exactly. Pinned because it is `2^31`, so moving it may not be free. */
+    @Test
+    fun `the ceiling is two gibibytes`() {
+        assertEquals(2_147_483_648L, DataBackup.MAX_BACKUP_SQLITE_BYTES)
+    }
+
+    /**
+     * `TooLarge` is a separate result from `Failed` so the caller can offer a way through rather than
+     * ending on a message the user can do nothing about, and it carries the limit so the caller never
+     * has to restate the number.
+     */
+    @Test
+    fun `a size refusal is its own result and carries the limit`() {
+        val r: DataBackup.ImportResult =
+            DataBackup.ImportResult.TooLarge("too large", DataBackup.MAX_BACKUP_SQLITE_BYTES)
+        assertTrue("must not be indistinguishable from a generic failure",
+            r !is DataBackup.ImportResult.Failed)
+        assertEquals(DataBackup.MAX_BACKUP_SQLITE_BYTES, (r as DataBackup.ImportResult.TooLarge).limitBytes)
+    }
+
+    /** An export past the ceiling reports it; one under it does not, and neither is a failure. */
+    @Test
+    fun `export outcome flags only a database past the ceiling`() {
+        val cap = DataBackup.MAX_BACKUP_SQLITE_BYTES
+        assertTrue(DataBackup.ExportOutcome(cap + 1, cap + 1 > cap, cap).overRestoreCeiling)
+        assertTrue(!DataBackup.ExportOutcome(cap, cap > cap, cap).overRestoreCeiling)
+    }
+}

--- a/android/app/src/test/java/com/noop/data/BackupOversizeOverrideTest.kt
+++ b/android/app/src/test/java/com/noop/data/BackupOversizeOverrideTest.kt
@@ -41,11 +41,20 @@ class BackupOversizeOverrideTest {
         assertEquals(DataBackup.MAX_BACKUP_SQLITE_BYTES, (r as DataBackup.ImportResult.TooLarge).limitBytes)
     }
 
-    /** An export past the ceiling reports it; one under it does not, and neither is a failure. */
+    /**
+     * The export-side decision, at its boundary. The earlier version of this test built an
+     * `ExportOutcome` with the comparison already evaluated and then asserted that boolean back — it
+     * proved its own arithmetic and nothing about the code. This calls the decision itself.
+     *
+     * Strictly greater is the correct boundary: a database exactly at the cap still restores, because
+     * `copyBounded` refuses only when a write would take it OVER.
+     */
     @Test
-    fun `export outcome flags only a database past the ceiling`() {
+    fun `only a database past the ceiling is flagged`() {
         val cap = DataBackup.MAX_BACKUP_SQLITE_BYTES
-        assertTrue(DataBackup.ExportOutcome(cap + 1, cap + 1 > cap, cap).overRestoreCeiling)
-        assertTrue(!DataBackup.ExportOutcome(cap, cap > cap, cap).overRestoreCeiling)
+        assertTrue("one byte over must be flagged", DataBackup.overRestoreCeiling(cap + 1))
+        assertTrue("exactly at the cap still restores", !DataBackup.overRestoreCeiling(cap))
+        assertTrue("well under must not be flagged", !DataBackup.overRestoreCeiling(cap - 1))
+        assertTrue("an empty database is not oversize", !DataBackup.overRestoreCeiling(0L))
     }
 }


### PR DESCRIPTION
Refs #1807. Android half, matching what #1808 did on Apple. Same bug: the 2 GiB cap on the SQLite
entry is enforced **only while restoring**, so NOOP writes archives it later refuses to read — and the
user finds out at the one moment the original is gone.

## What changed

`exportTo` returns `ExportOutcome` instead of `Unit`, so the interactive export can say when the
database is past the ceiling. The staging refusal surfaces as `ImportResult.TooLarge` rather than
`Failed`, and Settings offers to go ahead.

**Better than the Apple half in one respect:** Android keeps a usable `uri` across the dialog, so
confirming retries the *same file*. Apple has to send the user back through the picker.

`BackupSyncScreen` restores a folder snapshot directly and has no confirm step to hang the override
on, so it shows the same sentence; Settings is where the way through lives.

## No new untranslated copy — this shaped the design

My first version had a proper explanatory dialog body. Added English-only to all seven locales, the
i18n ratchet failed **every focus locale by exactly one**. That gate is right, and quietly inventing
six translations is not the way past it.

So: `TooLarge` carries the sentence the old `Failed` branch already showed — already in the baseline —
and the dialog displays it. The buttons reuse `Restore` and `Cancel`, translations copied verbatim
from existing entries via the `sha1(text)` key rule. The export note reuses the same wording.

## Found in re-review, before this was pushed

- **The size was measured at the wrong moment.** `dbFile.length()` was read *after* the transaction
  that writes the entry. The copy runs inside it against a snapshot; once it commits Room can
  checkpoint again and the length can move, so the number could disagree with the entry the cap
  actually measures. Now taken from `copyTo`'s own return — the exact bytes that landed.
- **The export test was tautological** — it built an `ExportOutcome` with the comparison already
  evaluated and asserted that boolean back. The decision is now `overRestoreCeiling(entryBytes)` and
  the test calls it at the boundary. That surfaced an unpinned fact: **exactly at the cap still
  restores**, because `copyBounded` refuses only when a write would take it *over*.

## Two caveats, stated rather than implied

- The export Toast is a **bare literal**, like every other Toast on that screen. The audit does not
  flag it, but that is its known blindspot for non-`@Composable` literals rather than a clean bill.
  This follows the file's existing convention instead of regressing it.
- The cap **cannot be exercised end-to-end** without a >2 GiB fixture, so the tests pin the decisions
  that govern it and the result shape the UI keys on — not the copy loop itself.

`MAX_BACKUP_SQLITE_BYTES` and `sqliteCap`/`overRestoreCeiling` widened from `private` to `internal` so
the tests can reach them.

## Verification

- **32 backup tests, 0 failures** (28 pre-existing + 4 new).
- `compileFullDebugKotlin`, `i18n_audit --ci`, `doc_comment_lint` clean.
- **No app-build needed** — this touches none of its paths, and the Kotlin compiler found both
  exhaustive `when` sites locally rather than needing a macOS runner to find them.
- Not exercised on a device: the confirm dialog and the retry-with-same-uri path want one pass by
  hand.