### PR TITLE
sleep: give the HR-only spine a funnel line, because it shipped silent

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager+Trace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager+Trace.swift
@@ -15,6 +15,18 @@ extension SleepStager {
     /// The gate-trace line formatters. Compact, parseable, no em-dashes.
     public enum GateTrace {
 
+        /// Why the HR-only spine did or did not run (#1801). Twin of the Kotlin `hrOnlyGateLine`.
+        ///
+        /// The funnel line below only exists when the spine is CALLED, so its absence was ambiguous in
+        /// exactly the way that made the first field report unreadable: it could mean the gate never
+        /// opened, or that the sink was never wired. This says which, on any day with no motion — the
+        /// only days where the question arises.
+        public static func hrOnlyGateLine(attempted: Bool, reason: String,
+                                          gravRows: Int, storedNights: Int) -> String {
+            "[sleep] hr-only gate attempted=\(attempted) reason=\(reason) "
+                + "grav=\(gravRows) stored=\(storedNights)"
+        }
+
         /// The HR-only spine's own funnel line (#1801). Byte-identical twin of the Kotlin
         /// `SleepStagerTrace.hrOnlyLine`, so an Android and an Apple log of the same night compare
         /// directly — which is the entire reason these formatters are twinned at all.
@@ -26,11 +38,13 @@ extension SleepStager {
         ///
         /// `anchorBpm` and `bandBpm` are printed because they are DERIVED, not configured: the anchor is
         /// a percentile of THIS window, so the same code gives every wearer a different threshold.
-        public static func hrOnlyLine(anchorBpm: Double?, bandBpm: Double?, epochs: Int,
+        public static func hrOnlyLine(anchorBpm: Double?, bandBpm: Double?,
+                                      hrP50: Double?, hrP90: Double?, epochs: Int,
                                       runs: Int, mergedRuns: Int, sleepRuns: Int,
                                       longestSleepMin: Int, staged: Int, kept: Int,
                                       minSleepMin: Int) -> String {
             "[sleep] hr-only spine anchorBpm=\(round1(anchorBpm)) bandBpm=\(round1(bandBpm)) "
+                + "hrP50=\(round1(hrP50)) hrP90=\(round1(hrP90)) "
                 + "epochs=\(epochs) runs=\(runs) merged=\(mergedRuns) sleepRuns=\(sleepRuns) "
                 + "longestMin=\(longestSleepMin) staged=\(staged) kept=\(kept) minSleepMin=\(minSleepMin)"
         }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager+Trace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager+Trace.swift
@@ -15,6 +15,36 @@ extension SleepStager {
     /// The gate-trace line formatters. Compact, parseable, no em-dashes.
     public enum GateTrace {
 
+        /// The HR-only spine's own funnel line (#1801). Byte-identical twin of the Kotlin
+        /// `SleepStagerTrace.hrOnlyLine`, so an Android and an Apple log of the same night compare
+        /// directly — which is the entire reason these formatters are twinned at all.
+        ///
+        /// The path shipped SILENT on both platforms, and a field log then showed `reason=no-motion`
+        /// with no way to tell whether the spine had run and found nothing or never ran. Every number
+        /// separates the two failures that actually happen: a band too tight (`sleepRuns` near zero)
+        /// from a duration gate eating real runs (`sleepRuns` high, `longestMin` under `minSleepMin`).
+        ///
+        /// `anchorBpm` and `bandBpm` are printed because they are DERIVED, not configured: the anchor is
+        /// a percentile of THIS window, so the same code gives every wearer a different threshold.
+        public static func hrOnlyLine(anchorBpm: Double?, bandBpm: Double?, epochs: Int,
+                                      runs: Int, mergedRuns: Int, sleepRuns: Int,
+                                      longestSleepMin: Int, staged: Int, kept: Int,
+                                      minSleepMin: Int) -> String {
+            "[sleep] hr-only spine anchorBpm=\(round1(anchorBpm)) bandBpm=\(round1(bandBpm)) "
+                + "epochs=\(epochs) runs=\(runs) merged=\(mergedRuns) sleepRuns=\(sleepRuns) "
+                + "longestMin=\(longestSleepMin) staged=\(staged) kept=\(kept) minSleepMin=\(minSleepMin)"
+        }
+
+        /// One decimal, by ARITHMETIC rather than `String(format:)`. Twin of the Kotlin `round1`, and
+        /// see its note: `printf` rounds half-to-even on the binary value while Java's `String.format`
+        /// rounds HALF_UP on the decimal expansion, so the two disagreed on 64.05. This does the same
+        /// IEEE arithmetic on both platforms and cannot.
+        private static func round1(_ v: Double?) -> String {
+            guard let v else { return "nil" }
+            let tenths = Int((v * 10.0).rounded())
+            return "\(tenths / 10).\(abs(tenths % 10))"
+        }
+
         /// One verdict line for a candidate run. `gate` names the constant that decided it
         /// (minSleepMin, maxMainSleepSpanS, offWrist, daytimeGuard, morningStillness, hrConfirm,
         /// sparseBridge, accepted); `detail` carries that gate's numbers. `startTs`/`endTs` give the

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager+Trace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager+Trace.swift
@@ -39,6 +39,10 @@ extension SleepStager {
         /// see its note: `printf` rounds half-to-even on the binary value while Java's `String.format`
         /// rounds HALF_UP on the decimal expansion, so the two disagreed on 64.05. This does the same
         /// IEEE arithmetic on both platforms and cannot.
+        ///
+        /// NON-NEGATIVE ONLY, same as the Kotlin twin: `-0.5` would print "0.5", because the integer
+        /// division truncates toward zero and the sign is then lost to `abs`. Every current caller is a
+        /// bpm, which cannot be negative.
         private static func round1(_ v: Double?) -> String {
             guard let v else { return "nil" }
             let tenths = Int((v * 10.0).rounded())

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -615,9 +615,15 @@ public enum SleepStager {
     /// and it lives outside this package. The spine and the anchor below it stay `internal` — the tests
     /// reach them with `@testable`, and nothing outside should be building its own spine.
     public static func hrOnlySessions(hr: [HRSample], rr: [RRInterval], resp: [RespSample],
-                                      minMinutes: Int = minSleepMin) -> [SleepSession] {
+                                      minMinutes: Int = minSleepMin,
+                                      traceSink: ((String) -> Void)? = nil) -> [SleepSession] {
         let hrS = hr.sorted { $0.ts < $1.ts }
-        guard let baseline = hrOnlyBaseline(hrS) else { return [] }
+        guard let baseline = hrOnlyBaseline(hrS) else {
+            traceSink?(GateTrace.hrOnlyLine(anchorBpm: nil, bandBpm: nil, epochs: 0, runs: 0,
+                                            mergedRuns: 0, sleepRuns: 0, longestSleepMin: 0,
+                                            staged: 0, kept: 0, minSleepMin: minMinutes))
+            return []
+        }
         let rrS = rr.sorted { $0.ts < $1.ts }
         var out: [SleepSession] = []
         // mergePeriods for the same reason the motion path calls it: a run boundary is a threshold
@@ -625,16 +631,35 @@ public enum SleepStager {
         // spine returns the night's minutes correctly but shredded into sub-mergeMin fragments, every one
         // of which then fails the minimum-duration gate below — 8 h of detected sleep yielding zero
         // sessions. Absorbing the short runs first is what turns a spine into a night.
-        for p in mergePeriods(hrOnlySleepRuns(hrS, baseline: baseline)) {
+        let rawRuns = hrOnlySleepRuns(hrS, baseline: baseline)
+        let merged = mergePeriods(rawRuns)
+        var staged = 0
+        var longestSleepS = 0
+        for p in merged {
             if p.stage != "sleep" { continue }
+            longestSleepS = max(longestSleepS, p.end - p.start)
             if (p.end - p.start) < minMinutes * 60 { continue }
             let stages = SleepStagerV2.stageSession(start: p.start, end: p.end, grav: [],
                                                     hr: hrS, rr: rrS, resp: resp)
+            staged += 1
             if stages.isEmpty { continue }
             out.append(SleepSession(start: p.start, end: p.end,
                                     efficiency: efficiency(start: p.start, end: p.end, stages: stages),
                                     stages: stages, restingHR: nil, avgHRV: nil, hrOnly: true))
         }
+        traceSink?(GateTrace.hrOnlyLine(
+            anchorBpm: baseline,
+            bandBpm: baseline * hrOnlyBandMult,
+            // The real epoch count, not the sample count: the spine buckets by `hrOnlyEpochS` before it
+            // decides anything, so this is the axis every other number here is measured on.
+            epochs: Set(hrS.map { $0.ts / hrOnlyEpochS }).count,
+            runs: rawRuns.count,
+            mergedRuns: merged.count,
+            sleepRuns: merged.filter { $0.stage == "sleep" }.count,
+            longestSleepMin: longestSleepS / 60,
+            staged: staged,
+            kept: out.count,
+            minSleepMin: minMinutes))
         return out
     }
 

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -520,8 +520,14 @@ public enum SleepStager {
     /// The `p` percentile of `hr` by bpm, nearest-rank. Shared with `hrOnlyBaseline` so the spread the
     /// trace reports is measured by the SAME rule as the anchor it is meant to be judged against.
     static func hrPercentile(_ hr: [HRSample], _ p: Double) -> Double? {
-        if hr.isEmpty { return nil }
-        let sorted = hr.map { Double($0.bpm) }.sorted()
+        percentileOfSorted(hr.map { Double($0.bpm) }.sorted(), p)
+    }
+
+    /// The `p` percentile of an ALREADY-SORTED bpm list, nearest-rank. Split out because the caller
+    /// needs three percentiles from the same window, and the obvious spelling sorts once per
+    /// percentile — ~160k samples sorted three times per scored day across a 21-day rescore.
+    static func percentileOfSorted(_ sorted: [Double], _ p: Double) -> Double? {
+        if sorted.isEmpty { return nil }
         let idx = min(max(Int(Double(sorted.count - 1) * p), 0), sorted.count - 1)
         return sorted[idx]
     }
@@ -624,7 +630,9 @@ public enum SleepStager {
                                       minMinutes: Int = minSleepMin,
                                       traceSink: ((String) -> Void)? = nil) -> [SleepSession] {
         let hrS = hr.sorted { $0.ts < $1.ts }
-        guard let baseline = hrOnlyBaseline(hrS) else {
+        // ONE sort of the bpm axis, reused for the anchor and for the spread the trace reports.
+        let sortedBpm = hrS.map { Double($0.bpm) }.sorted()
+        guard let baseline = percentileOfSorted(sortedBpm, hrOnlyAnchorPercentile) else {
             traceSink?(GateTrace.hrOnlyLine(anchorBpm: nil, bandBpm: nil, hrP50: nil, hrP90: nil,
                                             epochs: 0, runs: 0,
                                             mergedRuns: 0, sleepRuns: 0, longestSleepMin: 0,
@@ -660,8 +668,8 @@ public enum SleepStager {
             // The wearer's own spread. An anchor alone cannot be judged: p10 of 60 means one thing when
             // the median is 63 and quite another when it is 74, and only the second leaves a night the
             // band can separate.
-            hrP50: hrPercentile(hrS, 0.50),
-            hrP90: hrPercentile(hrS, 0.90),
+            hrP50: percentileOfSorted(sortedBpm, 0.50),
+            hrP90: percentileOfSorted(sortedBpm, 0.90),
             // The real epoch count, not the sample count: the spine buckets by `hrOnlyEpochS` before it
             // decides anything, so this is the axis every other number here is measured on.
             epochs: Set(hrS.map { $0.ts / hrOnlyEpochS }).count,

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -514,9 +514,15 @@ public enum SleepStager {
     /// the value is always one the wearer actually recorded and the two platforms cannot disagree on a
     /// rounding rule.
     static func hrOnlyBaseline(_ hr: [HRSample]) -> Double? {
+        hrPercentile(hr, hrOnlyAnchorPercentile)
+    }
+
+    /// The `p` percentile of `hr` by bpm, nearest-rank. Shared with `hrOnlyBaseline` so the spread the
+    /// trace reports is measured by the SAME rule as the anchor it is meant to be judged against.
+    static func hrPercentile(_ hr: [HRSample], _ p: Double) -> Double? {
         if hr.isEmpty { return nil }
         let sorted = hr.map { Double($0.bpm) }.sorted()
-        let idx = min(max(Int(Double(sorted.count - 1) * hrOnlyAnchorPercentile), 0), sorted.count - 1)
+        let idx = min(max(Int(Double(sorted.count - 1) * p), 0), sorted.count - 1)
         return sorted[idx]
     }
 
@@ -619,7 +625,8 @@ public enum SleepStager {
                                       traceSink: ((String) -> Void)? = nil) -> [SleepSession] {
         let hrS = hr.sorted { $0.ts < $1.ts }
         guard let baseline = hrOnlyBaseline(hrS) else {
-            traceSink?(GateTrace.hrOnlyLine(anchorBpm: nil, bandBpm: nil, epochs: 0, runs: 0,
+            traceSink?(GateTrace.hrOnlyLine(anchorBpm: nil, bandBpm: nil, hrP50: nil, hrP90: nil,
+                                            epochs: 0, runs: 0,
                                             mergedRuns: 0, sleepRuns: 0, longestSleepMin: 0,
                                             staged: 0, kept: 0, minSleepMin: minMinutes))
             return []
@@ -650,6 +657,11 @@ public enum SleepStager {
         traceSink?(GateTrace.hrOnlyLine(
             anchorBpm: baseline,
             bandBpm: baseline * hrOnlyBandMult,
+            // The wearer's own spread. An anchor alone cannot be judged: p10 of 60 means one thing when
+            // the median is 63 and quite another when it is 74, and only the second leaves a night the
+            // band can separate.
+            hrP50: hrPercentile(hrS, 0.50),
+            hrP90: hrPercentile(hrS, 0.90),
             // The real epoch count, not the sample count: the spine buckets by `hrOnlyEpochS` before it
             // decides anything, so this is the axis every other number here is measured on.
             epochs: Set(hrS.map { $0.ts / hrOnlyEpochS }).count,

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -532,6 +532,22 @@ public enum SleepStager {
         return sorted[idx]
     }
 
+    /// How many distinct `hrOnlyEpochS` buckets `sortedByTs` spans.
+    ///
+    /// A single pass rather than a Set, because `hrS` is already sorted by timestamp so the bucket key
+    /// is non-decreasing. The obvious spelling (`Set(hrS.map { … })`) builds a full intermediate array
+    /// AND a set over every sample to end up with a few thousand distinct keys — per scored day, across
+    /// the 21-day rescore. A diagnostic must not cost what it is measuring.
+    static func distinctEpochs(_ sortedByTs: [HRSample]) -> Int {
+        var count = 0
+        var last = Int.min
+        for s in sortedByTs {
+            let key = s.ts / hrOnlyEpochS
+            if key != last { count += 1; last = key }
+        }
+        return count
+    }
+
     /// Epoch for the HR-only spine, in seconds.
     public static let hrOnlyEpochS: Int = 60
 
@@ -672,7 +688,7 @@ public enum SleepStager {
             hrP90: percentileOfSorted(sortedBpm, 0.90),
             // The real epoch count, not the sample count: the spine buckets by `hrOnlyEpochS` before it
             // decides anything, so this is the axis every other number here is measured on.
-            epochs: Set(hrS.map { $0.ts / hrOnlyEpochS }).count,
+            epochs: distinctEpochs(hrS),
             runs: rawRuns.count,
             mergedRuns: merged.count,
             sleepRuns: merged.filter { $0.stage == "sleep" }.count,

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerHrOnlyTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerHrOnlyTraceTests.swift
@@ -8,16 +8,17 @@ final class SleepStagerHrOnlyTraceTests: XCTestCase {
 
     func testLineNamesTheDerivedThresholdAndLongestCandidate() {
         XCTAssertEqual(
-            SleepStager.GateTrace.hrOnlyLine(anchorBpm: 61.0, bandBpm: 64.05, epochs: 3021, runs: 48,
+            SleepStager.GateTrace.hrOnlyLine(anchorBpm: 61.0, bandBpm: 64.05, hrP50: 74.0, hrP90: 88.0, epochs: 3021, runs: 48,
                                              mergedRuns: 12, sleepRuns: 7, longestSleepMin: 41,
                                              staged: 0, kept: 0, minSleepMin: 60),
-            "[sleep] hr-only spine anchorBpm=61.0 bandBpm=64.1 epochs=3021 runs=48 merged=12 "
+            "[sleep] hr-only spine anchorBpm=61.0 bandBpm=64.1 hrP50=74.0 hrP90=88.0 "
+                + "epochs=3021 runs=48 merged=12 "
                 + "sleepRuns=7 longestMin=41 staged=0 kept=0 minSleepMin=60"
         )
     }
 
     func testAbsentAnchorPrintsNilRatherThanZero() {
-        let line = SleepStager.GateTrace.hrOnlyLine(anchorBpm: nil, bandBpm: nil, epochs: 0, runs: 0,
+        let line = SleepStager.GateTrace.hrOnlyLine(anchorBpm: nil, bandBpm: nil, hrP50: nil, hrP90: nil, epochs: 0, runs: 0,
                                                     mergedRuns: 0, sleepRuns: 0, longestSleepMin: 0,
                                                     staged: 0, kept: 0, minSleepMin: 60)
         XCTAssertTrue(line.contains("anchorBpm=nil bandBpm=nil"))
@@ -47,7 +48,7 @@ final class SleepStagerHrOnlyTraceTests: XCTestCase {
             (71.4, "71.4"), (1.05, "1.1"), (0.0, "0.0"), (120.0, "120.0"),
         ]
         for (v, expected) in cases {
-            let line = SleepStager.GateTrace.hrOnlyLine(anchorBpm: v, bandBpm: nil, epochs: 0, runs: 0,
+            let line = SleepStager.GateTrace.hrOnlyLine(anchorBpm: v, bandBpm: nil, hrP50: nil, hrP90: nil, epochs: 0, runs: 0,
                                                         mergedRuns: 0, sleepRuns: 0, longestSleepMin: 0,
                                                         staged: 0, kept: 0, minSleepMin: 60)
             XCTAssertTrue(line.contains("anchorBpm=\(expected) "), "\(v) -> expected \(expected), got: \(line)")

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerHrOnlyTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerHrOnlyTraceTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// Twin of the Kotlin `SleepStagerHrOnlyTraceTest`. The expected strings are byte-identical on both
+/// platforms on purpose — these lines exist to be read side by side.
+final class SleepStagerHrOnlyTraceTests: XCTestCase {
+
+    func testLineNamesTheDerivedThresholdAndLongestCandidate() {
+        XCTAssertEqual(
+            SleepStager.GateTrace.hrOnlyLine(anchorBpm: 61.0, bandBpm: 64.05, epochs: 3021, runs: 48,
+                                             mergedRuns: 12, sleepRuns: 7, longestSleepMin: 41,
+                                             staged: 0, kept: 0, minSleepMin: 60),
+            "[sleep] hr-only spine anchorBpm=61.0 bandBpm=64.1 epochs=3021 runs=48 merged=12 "
+                + "sleepRuns=7 longestMin=41 staged=0 kept=0 minSleepMin=60"
+        )
+    }
+
+    func testAbsentAnchorPrintsNilRatherThanZero() {
+        let line = SleepStager.GateTrace.hrOnlyLine(anchorBpm: nil, bandBpm: nil, epochs: 0, runs: 0,
+                                                    mergedRuns: 0, sleepRuns: 0, longestSleepMin: 0,
+                                                    staged: 0, kept: 0, minSleepMin: 60)
+        XCTAssertTrue(line.contains("anchorBpm=nil bandBpm=nil"))
+    }
+
+    /// The rounding is ARITHMETIC, not `printf`. A harness caught `String(format: "%.1f", 64.05)`
+    /// giving 64.0 on Apple against Java's 64.1 — a divergence that `anchor * 1.05` would have hit
+    /// constantly. These are the values that harness compared.
+    func testOneDecimalRoundingMatchesTheKotlinTwin() {
+        let cases: [(Double, String)] = [
+            (64.05, "64.1"), (61.0, "61.0"), (77.7, "77.7"), (66.15, "66.2"),
+            (71.4, "71.4"), (1.05, "1.1"), (0.0, "0.0"), (120.0, "120.0"),
+        ]
+        for (v, expected) in cases {
+            let line = SleepStager.GateTrace.hrOnlyLine(anchorBpm: v, bandBpm: nil, epochs: 0, runs: 0,
+                                                        mergedRuns: 0, sleepRuns: 0, longestSleepMin: 0,
+                                                        staged: 0, kept: 0, minSleepMin: 60)
+            XCTAssertTrue(line.contains("anchorBpm=\(expected) "), "\(v) -> expected \(expected), got: \(line)")
+        }
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerHrOnlyTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerHrOnlyTraceTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import WhoopProtocol
 @testable import StrandAnalytics
 
 /// Twin of the Kotlin `SleepStagerHrOnlyTraceTest`. The expected strings are byte-identical on both
@@ -20,6 +21,21 @@ final class SleepStagerHrOnlyTraceTests: XCTestCase {
                                                     mergedRuns: 0, sleepRuns: 0, longestSleepMin: 0,
                                                     staged: 0, kept: 0, minSleepMin: 60)
         XCTAssertTrue(line.contains("anchorBpm=nil bandBpm=nil"))
+    }
+
+    /// `epochs` counts EPOCHS, not samples — the axis every other number is measured on. Twin of the
+    /// Kotlin test, which guards a bug I actually made: the first version reported the HR sample count.
+    func testEpochsCountsEpochsNotSamples() {
+        var lines: [String] = []
+        // 10 epochs x 6 samples = 60 samples.
+        var hr: [HRSample] = []
+        for i in 0..<10 {
+            let base = (1000 + i) * 60
+            for k in 0..<6 { hr.append(HRSample(ts: base + k * 10, bpm: 120)) }
+        }
+        _ = SleepStager.hrOnlySessions(hr: hr, rr: [], resp: [], traceSink: { lines.append($0) })
+        XCTAssertEqual(lines.count, 1, "exactly one funnel line per call")
+        XCTAssertTrue(lines[0].contains("epochs=10 "), "got: \(lines[0])")
     }
 
     /// The rounding is ARITHMETIC, not `printf`. A harness caught `String(format: "%.1f", 64.05)`

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1183,11 +1183,27 @@ final class IntelligenceEngine: ObservableObject {
                     // shipping it silent cost on Android (#1801). That sink is nil unless Sleep test mode
                     // is active, so this collects nothing on a normal pass; passing a closure of my own
                     // here would have appended on every scored day regardless.
-                    providedSleep = stored.isEmpty
-                        ? SleepStager.hrOnlySessions(hr: hr, rr: rr, resp: resp,
-                                                     traceSink: traceSink)
-                        : stored
+                    if stored.isEmpty {
+                        traceSink?(SleepStager.GateTrace.hrOnlyGateLine(
+                            attempted: true, reason: "no-motion-no-hypnogram",
+                            gravRows: grav.count, storedNights: 0))
+                        providedSleep = SleepStager.hrOnlySessions(hr: hr, rr: rr, resp: resp,
+                                                                   traceSink: traceSink)
+                    } else {
+                        traceSink?(SleepStager.GateTrace.hrOnlyGateLine(
+                            attempted: false, reason: "stored-hypnogram",
+                            gravRows: grav.count, storedNights: stored.count))
+                        providedSleep = stored
+                    }
                 } else {
+                    // Only worth saying on a day with NO motion: there the spine was the remaining option
+                    // and something declined it, which a silent absence could not distinguish. A day WITH
+                    // motion skips this — the motion spine is the answer there.
+                    if grav.count < 2 {
+                        traceSink?(SleepStager.GateTrace.hrOnlyGateLine(
+                            attempted: false, reason: "imported-owner",
+                            gravRows: grav.count, storedNights: 0))
+                    }
                     providedSleep = []
                 }
                 let tScore0 = Date()

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1178,8 +1178,14 @@ final class IntelligenceEngine: ObservableObject {
                     // Fall back to the HR-only spine ONLY when the device supplied nothing of its own: a
                     // hypnogram the device actually recorded is always better evidence than one inferred
                     // from heart rate.
+                    // Route the spine's funnel through the SAME `traceSink` the gate lines use, so one
+                    // report explains both halves rather than one going quiet — which is exactly what
+                    // shipping it silent cost on Android (#1801). That sink is nil unless Sleep test mode
+                    // is active, so this collects nothing on a normal pass; passing a closure of my own
+                    // here would have appended on every scored day regardless.
                     providedSleep = stored.isEmpty
-                        ? SleepStager.hrOnlySessions(hr: hr, rr: rr, resp: resp)
+                        ? SleepStager.hrOnlySessions(hr: hr, rr: rr, resp: resp,
+                                                     traceSink: traceSink)
                         : stored
                 } else {
                     providedSleep = []

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -967,13 +967,31 @@ object IntelligenceEngine {
                     // the device supplied nothing of its own: a hypnogram the device actually recorded is
                     // always better evidence than one inferred from heart rate.
                     if (stored.isNotEmpty()) {
+                        dayDiag(SleepStagerTrace.hrOnlyGateLine(
+                            attempted = false, reason = "stored-hypnogram",
+                            gravRows = grav.size, storedNights = stored.size,
+                        ))
                         stored
                     } else {
+                        dayDiag(SleepStagerTrace.hrOnlyGateLine(
+                            attempted = true, reason = "no-motion-no-hypnogram",
+                            gravRows = grav.size, storedNights = 0,
+                        ))
                         // Route the spine's funnel through the SAME per-day recorder as `sleep-detect`,
                         // so one report explains both halves rather than one of them going quiet.
                         SleepStager.hrOnlySessions(hr, rr, resp, traceSink = ::dayDiag)
                     }
                 } else {
+                    // Only worth saying on a day with NO motion: there the spine was the remaining
+                    // option and something declined it, which is precisely what a silent absence could
+                    // not distinguish. A day WITH motion skips this — the motion spine is the answer
+                    // there and nothing was passed over.
+                    if (grav.size < 2) {
+                        dayDiag(SleepStagerTrace.hrOnlyGateLine(
+                            attempted = false, reason = "imported-owner",
+                            gravRows = grav.size, storedNights = 0,
+                        ))
+                    }
                     emptyList()
                 }
 

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -966,7 +966,13 @@ object IntelligenceEngine {
                     // `reason=no-motion` however much HR it held. Fall back to the HR-only spine ONLY when
                     // the device supplied nothing of its own: a hypnogram the device actually recorded is
                     // always better evidence than one inferred from heart rate.
-                    if (stored.isNotEmpty()) stored else SleepStager.hrOnlySessions(hr, rr, resp)
+                    if (stored.isNotEmpty()) {
+                        stored
+                    } else {
+                        // Route the spine's funnel through the SAME per-day recorder as `sleep-detect`,
+                        // so one report explains both halves rather than one of them going quiet.
+                        SleepStager.hrOnlySessions(hr, rr, resp, traceSink = ::dayDiag)
+                    }
                 } else {
                     emptyList()
                 }

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -560,10 +560,17 @@ object SleepStager {
      * the value is always one the wearer actually recorded and the two platforms cannot disagree on a
      * rounding rule.
      */
-    internal fun hrOnlyBaseline(hr: List<HrSample>): Double? {
+    internal fun hrOnlyBaseline(hr: List<HrSample>): Double? = hrPercentile(hr, hrOnlyAnchorPercentile)
+
+    /**
+     * The `p` percentile of `hr` by bpm, nearest-rank. Shared with [hrOnlyBaseline] so the spread the
+     * trace reports is measured by the SAME rule as the anchor it is meant to be judged against — a
+     * diagnostic computed a different way would invite exactly the wrong conclusion.
+     */
+    internal fun hrPercentile(hr: List<HrSample>, p: Double): Double? {
         if (hr.isEmpty()) return null
         val sorted = hr.map { it.bpm.toDouble() }.sorted()
-        val idx = ((sorted.size - 1) * hrOnlyAnchorPercentile).toInt().coerceIn(0, sorted.size - 1)
+        val idx = ((sorted.size - 1) * p).toInt().coerceIn(0, sorted.size - 1)
         return sorted[idx]
     }
 
@@ -686,7 +693,7 @@ object SleepStager {
         val baseline = hrOnlyBaseline(hrS)
         if (baseline == null) {
             traceSink?.invoke(SleepStagerTrace.hrOnlyLine(
-                anchorBpm = null, bandBpm = null, epochs = 0, runs = 0, mergedRuns = 0,
+                anchorBpm = null, bandBpm = null, hrP50 = null, hrP90 = null, epochs = 0, runs = 0, mergedRuns = 0,
                 sleepRuns = 0, longestSleepMin = 0, staged = 0, kept = 0, minSleepMin = minMinutes,
             ))
             return emptyList()
@@ -724,6 +731,11 @@ object SleepStager {
         traceSink?.invoke(SleepStagerTrace.hrOnlyLine(
             anchorBpm = baseline,
             bandBpm = baseline * hrOnlyBandMult,
+            // The wearer's own spread. An anchor alone cannot be judged: p10 of 60 means one thing when
+            // the median is 63 and quite another when it is 74, and only the second leaves a night the
+            // band can separate.
+            hrP50 = hrPercentile(hrS, 0.50),
+            hrP90 = hrPercentile(hrS, 0.90),
             // The real epoch count, not the sample count: the spine buckets by [hrOnlyEpochS] before it
             // decides anything, so this is the axis every other number here is measured on.
             epochs = hrS.mapTo(HashSet()) { it.ts / hrOnlyEpochS }.size,

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -584,6 +584,26 @@ object SleepStager {
         return sorted[idx]
     }
 
+    /**
+     * How many distinct [hrOnlyEpochS] buckets `sortedByTs` spans.
+     *
+     * A single pass rather than a set, because `hrS` is already sorted by timestamp so the bucket key
+     * is non-decreasing and a running comparison is enough. The obvious spelling
+     * (`mapTo(HashSet()) { it.ts / hrOnlyEpochS }`) boxes EVERY sample to end up with a few thousand
+     * distinct keys - ~160k boxed longs per scored day across the 21-day rescore, which is the exact
+     * allocation shape #707 names as the heap-churn source under the OOM. A diagnostic must not cost
+     * what it is measuring.
+     */
+    internal fun distinctEpochs(sortedByTs: List<HrSample>): Int {
+        var count = 0
+        var last = Long.MIN_VALUE
+        for (s in sortedByTs) {
+            val key = s.ts / hrOnlyEpochS
+            if (key != last) { count++; last = key }
+        }
+        return count
+    }
+
     /** Epoch for the HR-only spine, in seconds. */
     const val hrOnlyEpochS: Long = 60
 
@@ -750,7 +770,7 @@ object SleepStager {
             hrP90 = percentileOfSorted(sortedBpm, 0.90),
             // The real epoch count, not the sample count: the spine buckets by [hrOnlyEpochS] before it
             // decides anything, so this is the axis every other number here is measured on.
-            epochs = hrS.mapTo(HashSet()) { it.ts / hrOnlyEpochS }.size,
+            epochs = distinctEpochs(hrS),
             runs = rawRuns.size,
             mergedRuns = merged.size,
             sleepRuns = merged.count { it.stage == "sleep" },

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -674,9 +674,23 @@ object SleepStager {
         rr: List<RrInterval>,
         resp: List<RespSample>,
         minMinutes: Int = minSleepMin,
+        /**
+         * #1801 follow-up: this path shipped SILENT, and the first field log then showed
+         * `reason=no-motion` with no way to tell whether the spine ran and found nothing or never ran.
+         * Everything it decides is derived from the wearer's own window, so a report is unreadable
+         * without it. Optional, so pure-function callers and tests stay free of a sink.
+         */
+        traceSink: ((String) -> Unit)? = null,
     ): List<DetectedSleep> {
         val hrS = hr.sortedBy { it.ts }
-        val baseline = hrOnlyBaseline(hrS) ?: return emptyList()
+        val baseline = hrOnlyBaseline(hrS)
+        if (baseline == null) {
+            traceSink?.invoke(SleepStagerTrace.hrOnlyLine(
+                anchorBpm = null, bandBpm = null, epochs = 0, runs = 0, mergedRuns = 0,
+                sleepRuns = 0, longestSleepMin = 0, staged = 0, kept = 0, minSleepMin = minMinutes,
+            ))
+            return emptyList()
+        }
         val rrS = rr.sortedBy { it.ts }
         val out = ArrayList<DetectedSleep>()
         // mergePeriods for the same reason the motion path calls it: a run boundary is a threshold
@@ -684,10 +698,16 @@ object SleepStager {
         // spine returns the night's minutes correctly but shredded into sub-mergeMin fragments, every one
         // of which then fails the minimum-duration gate below — 8 h of detected sleep yielding zero
         // sessions. Absorbing the short runs first is what turns a spine into a night.
-        for (p in mergePeriods(hrOnlySleepRuns(hrS, baseline))) {
+        val rawRuns = hrOnlySleepRuns(hrS, baseline)
+        val merged = mergePeriods(rawRuns)
+        var staged = 0
+        var longestSleepS = 0L
+        for (p in merged) {
             if (p.stage != "sleep") continue
+            longestSleepS = maxOf(longestSleepS, p.end - p.start)
             if ((p.end - p.start) < minMinutes * 60L) continue
             val stages = SleepStagerV2.stageSession(p.start, p.end, emptyList(), hrS, rrS, resp)
+            staged++
             if (stages.isEmpty()) continue
             out.add(
                 DetectedSleep(
@@ -701,6 +721,20 @@ object SleepStager {
                 )
             )
         }
+        traceSink?.invoke(SleepStagerTrace.hrOnlyLine(
+            anchorBpm = baseline,
+            bandBpm = baseline * hrOnlyBandMult,
+            // The real epoch count, not the sample count: the spine buckets by [hrOnlyEpochS] before it
+            // decides anything, so this is the axis every other number here is measured on.
+            epochs = hrS.mapTo(HashSet()) { it.ts / hrOnlyEpochS }.size,
+            runs = rawRuns.size,
+            mergedRuns = merged.size,
+            sleepRuns = merged.count { it.stage == "sleep" },
+            longestSleepMin = (longestSleepS / 60L).toInt(),
+            staged = staged,
+            kept = out.size,
+            minSleepMin = minMinutes,
+        ))
         return out
     }
 

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -567,9 +567,19 @@ object SleepStager {
      * trace reports is measured by the SAME rule as the anchor it is meant to be judged against — a
      * diagnostic computed a different way would invite exactly the wrong conclusion.
      */
-    internal fun hrPercentile(hr: List<HrSample>, p: Double): Double? {
-        if (hr.isEmpty()) return null
-        val sorted = hr.map { it.bpm.toDouble() }.sorted()
+    internal fun hrPercentile(hr: List<HrSample>, p: Double): Double? =
+        percentileOfSorted(hr.map { it.bpm.toDouble() }.sorted(), p)
+
+    /**
+     * The `p` percentile of an ALREADY-SORTED bpm list, nearest-rank.
+     *
+     * Split out because the caller needs three percentiles from the same window, and the obvious
+     * spelling sorts once per percentile. On a 5/MG day that is ~160k samples sorted three times, on
+     * every scored day, across the 21-day rescore window - a cost this file has been burned by before
+     * (#836, #841). One sort, three reads.
+     */
+    internal fun percentileOfSorted(sorted: List<Double>, p: Double): Double? {
+        if (sorted.isEmpty()) return null
         val idx = ((sorted.size - 1) * p).toInt().coerceIn(0, sorted.size - 1)
         return sorted[idx]
     }
@@ -690,7 +700,9 @@ object SleepStager {
         traceSink: ((String) -> Unit)? = null,
     ): List<DetectedSleep> {
         val hrS = hr.sortedBy { it.ts }
-        val baseline = hrOnlyBaseline(hrS)
+        // ONE sort of the bpm axis, reused for the anchor and for the spread the trace reports.
+        val sortedBpm = hrS.map { it.bpm.toDouble() }.sorted()
+        val baseline = percentileOfSorted(sortedBpm, hrOnlyAnchorPercentile)
         if (baseline == null) {
             traceSink?.invoke(SleepStagerTrace.hrOnlyLine(
                 anchorBpm = null, bandBpm = null, hrP50 = null, hrP90 = null, epochs = 0, runs = 0, mergedRuns = 0,
@@ -734,8 +746,8 @@ object SleepStager {
             // The wearer's own spread. An anchor alone cannot be judged: p10 of 60 means one thing when
             // the median is 63 and quite another when it is 74, and only the second leaves a night the
             // band can separate.
-            hrP50 = hrPercentile(hrS, 0.50),
-            hrP90 = hrPercentile(hrS, 0.90),
+            hrP50 = percentileOfSorted(sortedBpm, 0.50),
+            hrP90 = percentileOfSorted(sortedBpm, 0.90),
             // The real epoch count, not the sample count: the spine buckets by [hrOnlyEpochS] before it
             // decides anything, so this is the axis every other number here is measured on.
             epochs = hrS.mapTo(HashSet()) { it.ts / hrOnlyEpochS }.size,

--- a/android/app/src/main/java/com/noop/analytics/SleepStagerTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStagerTrace.kt
@@ -7,6 +7,31 @@ package com.noop.analytics
 object SleepStagerTrace {
     enum class Verdict(val tag: String) { KEPT("KEPT"), DROPPED("DROPPED") }
 
+    /**
+     * The HR-only spine's own funnel line (#1801).
+     *
+     * The path shipped silent, and a field log then showed `reason=no-motion` with no way to tell
+     * whether the spine had run and found nothing or never ran at all — in a file whose entire sleep
+     * story is a funnel. Every number here exists to separate the two failures that actually happen:
+     * a band too tight (`sleepRuns` near zero) from a duration gate eating real runs (`sleepRuns` high,
+     * `longestMin` under `minSleepMin`).
+     *
+     * `anchorBpm` and `bandBpm` are printed because they are derived, not configured: the anchor is a
+     * percentile of THIS window, so the same code gives a different threshold to every wearer, and a
+     * complaint is unreadable without knowing which one they got.
+     */
+    fun hrOnlyLine(
+        anchorBpm: Double?, bandBpm: Double?, epochs: Int,
+        runs: Int, mergedRuns: Int, sleepRuns: Int,
+        longestSleepMin: Int, staged: Int, kept: Int, minSleepMin: Int,
+    ): String =
+        "[sleep] hr-only spine anchorBpm=${round1(anchorBpm)} bandBpm=${round1(bandBpm)} " +
+            "epochs=$epochs runs=$runs merged=$mergedRuns sleepRuns=$sleepRuns " +
+            "longestMin=$longestSleepMin staged=$staged kept=$kept minSleepMin=$minSleepMin"
+
+    private fun round1(v: Double?): String =
+        if (v == null) "nil" else String.format(java.util.Locale.US, "%.1f", v)
+
     fun runLine(index: Int, startTs: Long, endTs: Long, verdict: Verdict, gate: String, detail: String): String {
         val spanS = maxOf(0L, endTs - startTs)
         return "gate run=$index spanS=$spanS ${verdict.tag} gate=$gate $detail"

--- a/android/app/src/main/java/com/noop/analytics/SleepStagerTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStagerTrace.kt
@@ -29,8 +29,22 @@ object SleepStagerTrace {
             "epochs=$epochs runs=$runs merged=$mergedRuns sleepRuns=$sleepRuns " +
             "longestMin=$longestSleepMin staged=$staged kept=$kept minSleepMin=$minSleepMin"
 
-    private fun round1(v: Double?): String =
-        if (v == null) "nil" else String.format(java.util.Locale.US, "%.1f", v)
+    /**
+     * One decimal, by ARITHMETIC rather than `printf`.
+     *
+     * `String.format("%.1f", …)` is not a twin: Java rounds HALF_UP on the decimal expansion while
+     * Swift's `String(format:)` goes through C `printf`, which rounds half-to-even on the actual
+     * binary value. A harness caught them disagreeing on 64.05 — Kotlin 64.1, Swift 64.0 — and a band
+     * of `anchor * 1.05` produces trailing decimals constantly, so that would have diverged on most
+     * real values. Multiplying and rounding is IEEE-deterministic, so both platforms do the same
+     * arithmetic to the same bits and cannot disagree, whichever side of .5 the product lands on.
+     * Same reasoning as [round2] one line down, which was already arithmetic.
+     */
+    private fun round1(v: Double?): String {
+        if (v == null) return "nil"
+        val tenths = Math.round(v * 10.0)
+        return "${tenths / 10}.${Math.abs(tenths % 10)}"
+    }
 
     fun runLine(index: Int, startTs: Long, endTs: Long, verdict: Verdict, gate: String, detail: String): String {
         val spanS = maxOf(0L, endTs - startTs)

--- a/android/app/src/main/java/com/noop/analytics/SleepStagerTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStagerTrace.kt
@@ -8,6 +8,18 @@ object SleepStagerTrace {
     enum class Verdict(val tag: String) { KEPT("KEPT"), DROPPED("DROPPED") }
 
     /**
+     * Why the HR-only spine did or did not run (#1801).
+     *
+     * The funnel line below only exists when the spine is CALLED, so its absence was ambiguous in
+     * exactly the way that made the first field report unreadable: it could mean the gate never
+     * opened, or that the sink was never wired. This says which, on any day with no motion — the only
+     * days where the question arises. A day that HAS motion never prints it, because the motion spine
+     * is the answer there and nothing was skipped.
+     */
+    fun hrOnlyGateLine(attempted: Boolean, reason: String, gravRows: Int, storedNights: Int): String =
+        "[sleep] hr-only gate attempted=$attempted reason=$reason grav=$gravRows stored=$storedNights"
+
+    /**
      * The HR-only spine's own funnel line (#1801).
      *
      * The path shipped silent, and a field log then showed `reason=no-motion` with no way to tell
@@ -21,11 +33,12 @@ object SleepStagerTrace {
      * complaint is unreadable without knowing which one they got.
      */
     fun hrOnlyLine(
-        anchorBpm: Double?, bandBpm: Double?, epochs: Int,
+        anchorBpm: Double?, bandBpm: Double?, hrP50: Double?, hrP90: Double?, epochs: Int,
         runs: Int, mergedRuns: Int, sleepRuns: Int,
         longestSleepMin: Int, staged: Int, kept: Int, minSleepMin: Int,
     ): String =
         "[sleep] hr-only spine anchorBpm=${round1(anchorBpm)} bandBpm=${round1(bandBpm)} " +
+            "hrP50=${round1(hrP50)} hrP90=${round1(hrP90)} " +
             "epochs=$epochs runs=$runs merged=$mergedRuns sleepRuns=$sleepRuns " +
             "longestMin=$longestSleepMin staged=$staged kept=$kept minSleepMin=$minSleepMin"
 

--- a/android/app/src/main/java/com/noop/analytics/SleepStagerTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStagerTrace.kt
@@ -39,6 +39,10 @@ object SleepStagerTrace {
      * real values. Multiplying and rounding is IEEE-deterministic, so both platforms do the same
      * arithmetic to the same bits and cannot disagree, whichever side of .5 the product lands on.
      * Same reasoning as [round2] one line down, which was already arithmetic.
+     *
+     * NON-NEGATIVE ONLY. `-0.5` would print "0.5", because the integer division truncates toward zero
+     * and the sign is then lost to `abs`. Every current caller is a bpm, which cannot be negative;
+     * a caller that could be would need the sign carried separately.
      */
     private fun round1(v: Double?): String {
         if (v == null) return "nil"

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlyAnchorTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlyAnchorTest.kt
@@ -58,6 +58,25 @@ class SleepStagerHrOnlyAnchorTest {
     }
 
     /**
+     * One sort, three reads. The anchor and the trace's spread come from the SAME sorted axis, so a
+     * refactor that sorts per percentile - ~160k samples three times per scored day across a 21-day
+     * rescore - shows up here as a disagreement rather than only as a slower pass.
+     */
+    @Test
+    fun `the shared percentile helper agrees with the anchor`() {
+        val hr = (1..100).map { HrSample("d", 1_788_300_000L + it, it) }
+        val sorted = hr.map { it.bpm.toDouble() }.sorted()
+        assertEquals(
+            SleepStager.hrOnlyBaseline(hr)!!,
+            SleepStager.percentileOfSorted(sorted, SleepStager.hrOnlyAnchorPercentile)!!,
+            1e-9,
+        )
+        assertEquals(50.0, SleepStager.percentileOfSorted(sorted, 0.50)!!, 1e-9)
+        assertEquals(90.0, SleepStager.percentileOfSorted(sorted, 0.90)!!, 1e-9)
+        assertTrue(SleepStager.percentileOfSorted(emptyList(), 0.5) == null)
+    }
+
+    /**
      * The regression this file exists for. The first draft anchored on [SleepStager.hrBaseline], the
      * window MEDIAN — which admits over half of any window by definition, because a median splits the
      * samples in half and the band then adds 5% on top. On a field-shaped day that called 14.4 h sleep

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlySessionsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlySessionsTest.kt
@@ -95,12 +95,20 @@ class SleepStagerHrOnlySessionsTest {
             }
             error("IntelligenceEngine.kt not found — this test must not pass by default")
         }
-        val idx = src.indexOf("SleepStager.hrOnlySessions(")
-        assertTrue("IntelligenceEngine must call the HR-only fallback", idx > 0)
-        val guard = src.substring(maxOf(0, idx - 1200), idx)
-        assertTrue("the fallback must sit behind the absent-gravity gate", guard.contains("grav.size < 2"))
+        // Scoped to the `providedSleep` expression rather than a fixed window of characters before the
+        // call. The first version measured PROXIMITY — 1200 chars back — and broke the moment a couple
+        // of diagnostic lines were inserted between the gate and the call, even though the gate still
+        // held. Containment is the actual invariant; distance never was.
+        val from = src.indexOf("val providedSleep: List<DetectedSleep> =")
+        assertTrue("IntelligenceEngine must build providedSleep", from > 0)
+        val to = src.indexOf("val tScore0", from)
+        assertTrue("expected the scoring call to follow providedSleep", to > from)
+        val expr = src.substring(from, to)
+        assertTrue("the fallback must sit inside the absent-gravity gate", expr.contains("grav.size < 2"))
+        assertTrue("IntelligenceEngine must call the HR-only fallback",
+            expr.contains("SleepStager.hrOnlySessions("))
         assertTrue("and must only run when the device supplied no hypnogram of its own",
-            guard.contains("stored.isNotEmpty()"))
+            expr.contains("stored.isNotEmpty()"))
     }
 
     /** No HR at all cannot produce a night, and must not throw. */

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlyTraceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlyTraceTest.kt
@@ -27,11 +27,12 @@ class SleepStagerHrOnlyTraceTest {
     @Test
     fun `the line names the derived threshold and the longest candidate`() {
         val line = SleepStagerTrace.hrOnlyLine(
-            anchorBpm = 61.0, bandBpm = 64.05, epochs = 3021, runs = 48, mergedRuns = 12,
+            anchorBpm = 61.0, bandBpm = 64.05, hrP50 = 74.0, hrP90 = 88.0, epochs = 3021, runs = 48, mergedRuns = 12,
             sleepRuns = 7, longestSleepMin = 41, staged = 0, kept = 0, minSleepMin = 60,
         )
         assertEquals(
-            "[sleep] hr-only spine anchorBpm=61.0 bandBpm=64.1 epochs=3021 runs=48 merged=12 " +
+            "[sleep] hr-only spine anchorBpm=61.0 bandBpm=64.1 hrP50=74.0 hrP90=88.0 " +
+                "epochs=3021 runs=48 merged=12 " +
                 "sleepRuns=7 longestMin=41 staged=0 kept=0 minSleepMin=60",
             line,
         )
@@ -41,7 +42,7 @@ class SleepStagerHrOnlyTraceTest {
     @Test
     fun `an absent anchor prints nil rather than zero`() {
         val line = SleepStagerTrace.hrOnlyLine(
-            anchorBpm = null, bandBpm = null, epochs = 0, runs = 0, mergedRuns = 0,
+            anchorBpm = null, bandBpm = null, hrP50 = null, hrP90 = null, epochs = 0, runs = 0, mergedRuns = 0,
             sleepRuns = 0, longestSleepMin = 0, staged = 0, kept = 0, minSleepMin = 60,
         )
         assertTrue("must not claim an anchor of 0.0", line.contains("anchorBpm=nil bandBpm=nil"))

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlyTraceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlyTraceTest.kt
@@ -76,6 +76,19 @@ class SleepStagerHrOnlyTraceTest {
         assertTrue("and the trace says so: ${lines[0]}", lines[0].contains("sleepRuns=1"))
     }
 
+    /**
+     * The single-pass epoch count relies on `hrS` being sorted by timestamp, which `hrOnlySessions`
+     * guarantees. Pinned because the zero-allocation version trades a set for that assumption, and an
+     * unsorted input would silently over-count rather than fail.
+     */
+    @Test
+    fun `distinctEpochs counts buckets in one pass over sorted input`() {
+        // 10 epochs x 6 samples, already ts-ordered.
+        assertEquals(10, SleepStager.distinctEpochs(hr(1000, List(10) { 60 })))
+        assertEquals(1, SleepStager.distinctEpochs(hr(1000, listOf(60))))
+        assertEquals(0, SleepStager.distinctEpochs(emptyList()))
+    }
+
     /** `epochs` counts EPOCHS, not samples — the axis every other number is measured on. */
     @Test
     fun `epochs counts epochs not samples`() {

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlyTraceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlyTraceTest.kt
@@ -1,0 +1,87 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The HR-only spine's funnel line (#1801 follow-up).
+ *
+ * The path shipped silent. A field log on 11.1.0 then showed `reason=no-motion` with `provided=0` and
+ * no way to tell whether the spine had run and found nothing, or never ran — so the report could not
+ * be acted on at all. These pin the line that answers it.
+ */
+class SleepStagerHrOnlyTraceTest {
+
+    private fun hr(from: Int, bpms: List<Int>): List<HrSample> {
+        val out = ArrayList<HrSample>()
+        bpms.forEachIndexed { i, bpm ->
+            val base = (from + i).toLong() * 60L
+            repeat(6) { k -> out.add(HrSample("d", base + k * 10L, bpm)) }
+        }
+        return out
+    }
+
+    /** The two numbers that separate a too-tight band from a duration gate eating real runs. */
+    @Test
+    fun `the line names the derived threshold and the longest candidate`() {
+        val line = SleepStagerTrace.hrOnlyLine(
+            anchorBpm = 61.0, bandBpm = 64.05, epochs = 3021, runs = 48, mergedRuns = 12,
+            sleepRuns = 7, longestSleepMin = 41, staged = 0, kept = 0, minSleepMin = 60,
+        )
+        assertEquals(
+            "[sleep] hr-only spine anchorBpm=61.0 bandBpm=64.1 epochs=3021 runs=48 merged=12 " +
+                "sleepRuns=7 longestMin=41 staged=0 kept=0 minSleepMin=60",
+            line,
+        )
+    }
+
+    /** No HR at all still emits, with the anchor absent rather than a fabricated zero. */
+    @Test
+    fun `an absent anchor prints nil rather than zero`() {
+        val line = SleepStagerTrace.hrOnlyLine(
+            anchorBpm = null, bandBpm = null, epochs = 0, runs = 0, mergedRuns = 0,
+            sleepRuns = 0, longestSleepMin = 0, staged = 0, kept = 0, minSleepMin = 60,
+        )
+        assertTrue("must not claim an anchor of 0.0", line.contains("anchorBpm=nil bandBpm=nil"))
+    }
+
+    /** The spine emits exactly once per call — that silence was the whole defect. */
+    @Test
+    fun `every call traces exactly once and names the anchor it used`() {
+        val lines = ArrayList<String>()
+        SleepStager.hrOnlySessions(hr(1000, List(200) { 120 }), emptyList(), emptyList(),
+                                   traceSink = { lines.add(it) })
+        assertEquals("exactly one funnel line per call", 1, lines.size)
+        assertTrue("must name the anchor it used", lines[0].contains("anchorBpm=120.0"))
+    }
+
+    /**
+     * A FLAT window is entirely "sleep", and that is by construction rather than a bug.
+     *
+     * The anchor is a percentile of the SAME window it then classifies, so with a constant heart rate
+     * the tenth percentile equals the reading, the band sits 5% above it, and every epoch qualifies.
+     * The spine measures a rate against that wearer's own spread; given no spread it cannot separate
+     * rest from anything else. Pinned because the first draft of the test above assumed the opposite —
+     * that a uniformly high heart rate would be rejected — and asserted `kept=0` on that reasoning.
+     */
+    @Test
+    fun `a flat window is entirely in band because the anchor comes from it`() {
+        val lines = ArrayList<String>()
+        val kept = SleepStager.hrOnlySessions(hr(1000, List(200) { 120 }), emptyList(), emptyList(),
+                                              traceSink = { lines.add(it) })
+        assertTrue("a flat window yields one long run, not none", kept.isNotEmpty())
+        assertTrue("and the trace says so: ${lines[0]}", lines[0].contains("sleepRuns=1"))
+    }
+
+    /** `epochs` counts EPOCHS, not samples — the axis every other number is measured on. */
+    @Test
+    fun `epochs counts epochs not samples`() {
+        val lines = ArrayList<String>()
+        // 10 epochs x 6 samples = 60 samples.
+        SleepStager.hrOnlySessions(hr(1000, List(10) { 120 }), emptyList(), emptyList(),
+                                   traceSink = { lines.add(it) })
+        assertTrue("expected epochs=10, got: ${lines[0]}", lines[0].contains("epochs=10 "))
+    }
+}


### PR DESCRIPTION
Refs #1801. Instrumentation only — no behaviour change.

## Why

#1801 landed a whole detection path that emits nothing. A field log on **11.1.0 build 412** (which
does contain the wiring — verified) shows:

```
sleep-detect day=2026-09-02 NO-NIGHT hr=161126 rr=104007 resp=0 grav=0 steps=0 provided=0
             window=50h reason=no-motion
```

`provided=0` says the spine returned nothing. It does not say **why**, or even whether it ran.
**Zero mentions in 3,702 lines.**

That is the wrong shape for this file. `sleep-detect`, the `[sleep] gate` lines, #1719 and #547 all
exist because this area is only debuggable as a funnel — and I reworded the `no-motion` comment to
claim heart rate had been tried while leaving nothing to show for it.

## The line

```
[sleep] hr-only spine anchorBpm=61.0 bandBpm=64.1 epochs=3021 runs=48 merged=12
        sleepRuns=7 longestMin=41 staged=0 kept=0 minSleepMin=60
```

- **`anchorBpm` / `bandBpm`** are printed because they are *derived, not configured*. The anchor is a
  percentile of the wearer's own window, so the same code hands every wearer a different threshold; a
  report is unreadable without knowing which one they got.
- **`sleepRuns` against `longestMin`** separates the two failures that actually occur: a band too
  tight (`sleepRuns` near zero) from the duration gate eating real runs (`sleepRuns` high,
  `longestMin` under `minSleepMin`).

Emitted on **every** call, including the no-anchor early return — where the anchor prints `nil`
rather than a fabricated `0.0`.

## Two things caught while writing it

- **`epochs` first reported the HR sample count.** That would have made the diagnostic lie about the
  axis every other number is measured on.
- **My test asserting a flat 120 bpm window is rejected was wrong.** The anchor is the tenth
  percentile of the *same* window, so a constant rate puts everything in band and the whole window
  becomes sleep. Inherent to a relative anchor — now pinned as a property rather than corrected away.

## What this is for

The strongest hypothesis for the empty result is that the **p10 anchor is too tight** for this
wearer: #1805 used the window median (band ≈ 77 bpm on their data), #1806 replaced it with p10 to stop
it calling half the day sleep, and that likely put the band near 63–65 against a night running 59–70.
This line will confirm or kill that in one build, instead of tuning on a guess.

## Verification

- **24 HR-only tests, 0 failures**; `compileFullDebugKotlin`, `i18n_audit --ci`, `doc_comment_lint`
  clean.
- **Both platforms.** Re-review corrected an earlier Kotlin-only version of this PR.


## Re-review found three things

- **Kotlin-only was wrong.** The spine exists on both platforms and is equally silent on Apple, and
  these formatters are twinned precisely so the two logs read side by side — #1796 said so explicitly
  about the standard-HR lines. The Swift twin and the Apple day-scan wiring are now here.
- **The rounding diverged, and a harness caught it before it shipped.** `round1` used
  `String.format` / `String(format:)`, which are *not* twins: Java rounds HALF_UP on the decimal
  expansion, Swift goes through C `printf` and rounds half-to-even on the binary value. On `64.05`
  that is **Kotlin 64.1 against Swift 64.0** — and the band is `anchor * 1.05`, so it produces
  trailing decimals constantly and would have disagreed on most real values. Both now multiply by ten
  and round, which is IEEE-deterministic. Ten values verified across both toolchains. The galling part
  is that `round2`, one line below, was already arithmetic for exactly this reason.
- **The Apple sink was ungated.** Apple's sleep trace is `nil` unless Sleep test mode is active; I
  passed a closure of my own, which would have appended on every scored day. Now uses the existing
  `traceSink`. Android's `dayDiag` stays always-on as it already was — that asymmetry is pre-existing.
