### PR TITLE
sleep: stop the HR-only fallback inheriting an exclusion written to keep WHOOP out

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1167,45 +1167,44 @@ final class IntelligenceEngine: ObservableObject {
                 // untouched; analyzeDay still lets a DETECTED session win where the two overlap. Reconstruct the
                 // pure SleepSession from each stored CachedSleepSession (a minute-dict import row decodes to
                 // nothing and is skipped, so only real stage timelines are injected).
+                // #804 Fix A + #1801. Two different questions share the "this day has no motion" gate.
+                //
+                // #804 hands over a device's OWN persisted hypnogram (an Oura ring's SleepNet night) and is
+                // deliberately not applied to the import namespace. #1801 stages from heart rate when there
+                // is no hypnogram at all — and must NOT inherit #804's owner exclusion, which is the bug
+                // this replaces: `resolveDayOwner` returns the imported id whenever the owner source is
+                // absent or the candidates collapse to it, so on a live 5/MG install the whole branch was
+                // skipped before any heart rate was looked at.
+                //
+                // The stored lookup now runs for every no-motion day, so "nothing else knows about this
+                // night" is checked rather than assumed. A day that HAS stored sessions is left alone
+                // whoever owns it.
                 let providedSleep: [SleepSession]
-                if owner != Repository.whoopSource, grav.count < 2 {
+                if grav.count < 2 {
                     let persisted = (try? await store.sleepSessions(deviceId: owner, from: from, to: to,
                                                                     limit: 4000)) ?? []
                     let stored = persisted.compactMap { AnalyticsEngine.sleepSession(fromProvided: $0) }
-                    // #1801: the comment above assumes a WHOOP always streams a gravity vector. A 5/MG that
-                    // cannot bond does not — it is never clocked, so it banks nothing and persists no
-                    // hypnogram either, leaving neither a spine nor a stored night however much HR it holds.
-                    // Fall back to the HR-only spine ONLY when the device supplied nothing of its own: a
-                    // hypnogram the device actually recorded is always better evidence than one inferred
-                    // from heart rate.
-                    // Route the spine's funnel through the SAME `traceSink` the gate lines use, so one
-                    // report explains both halves rather than one going quiet — which is exactly what
-                    // shipping it silent cost on Android (#1801). That sink is nil unless Sleep test mode
-                    // is active, so this collects nothing on a normal pass; passing a closure of my own
-                    // here would have appended on every scored day regardless.
-                    if stored.isEmpty {
+                    if owner != Repository.whoopSource, !stored.isEmpty {
+                        traceSink?(SleepStager.GateTrace.hrOnlyGateLine(
+                            attempted: false, reason: "stored-hypnogram",
+                            gravRows: grav.count, storedNights: stored.count))
+                        providedSleep = stored
+                    } else if !stored.isEmpty {
+                        traceSink?(SleepStager.GateTrace.hrOnlyGateLine(
+                            attempted: false, reason: "stored-sessions-exist",
+                            gravRows: grav.count, storedNights: stored.count))
+                        providedSleep = []
+                    } else {
                         traceSink?(SleepStager.GateTrace.hrOnlyGateLine(
                             attempted: true, reason: "no-motion-no-hypnogram",
                             gravRows: grav.count, storedNights: 0))
                         providedSleep = SleepStager.hrOnlySessions(hr: hr, rr: rr, resp: resp,
                                                                    traceSink: traceSink)
-                    } else {
-                        traceSink?(SleepStager.GateTrace.hrOnlyGateLine(
-                            attempted: false, reason: "stored-hypnogram",
-                            gravRows: grav.count, storedNights: stored.count))
-                        providedSleep = stored
                     }
                 } else {
-                    // Only worth saying on a day with NO motion: there the spine was the remaining option
-                    // and something declined it, which a silent absence could not distinguish. A day WITH
-                    // motion skips this — the motion spine is the answer there.
-                    if grav.count < 2 {
-                        traceSink?(SleepStager.GateTrace.hrOnlyGateLine(
-                            attempted: false, reason: "imported-owner",
-                            gravRows: grav.count, storedNights: 0))
-                    }
                     providedSleep = []
                 }
+
                 let tScore0 = Date()
                 dayPrepSeconds += tScore0.timeIntervalSince(tPrep0)
                 // #1770 follow-up: the Effort ring's funnel. Collected here rather than sent straight

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1195,6 +1195,10 @@ final class IntelligenceEngine: ObservableObject {
                             gravRows: grav.count, storedNights: stored.count))
                         providedSleep = []
                     } else {
+                        // Reachable for ANY owner now, which widens this past the 5/MG it was built for:
+                        // a WHOOP 4.0 day that banked nothing at all also lands here, where the owner
+                        // check previously blocked it. A normal 4.0 day is untouched — it streams
+                        // gravity, so it never reaches this gate.
                         traceSink?(SleepStager.GateTrace.hrOnlyGateLine(
                             attempted: true, reason: "no-motion-no-hypnogram",
                             gravRows: grav.count, storedNights: 0))

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -993,6 +993,13 @@ object IntelligenceEngine {
                         emptyList()
                     }
                     else -> {
+                        // Reachable for ANY owner now, which widens this past the 5/MG it was built for:
+                        // a WHOOP 4.0 day that banked nothing at all (`grav.size < 2`, no stored night)
+                        // also lands here, where the owner check previously blocked it. A normal 4.0 day
+                        // is untouched — it streams gravity, so it never reaches this gate — and a day
+                        // with no motion has too little of anything to clear `minSleepMin`, but "too
+                        // little" is not "none", so the night it could produce is display-only and
+                        // marked [DetectedSleep.hrOnly] like every other.
                         dayDiag(SleepStagerTrace.hrOnlyGateLine(
                             attempted = true, reason = "no-motion-no-hypnogram",
                             gravRows = grav.size, storedNights = 0,

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -956,44 +956,53 @@ object IntelligenceEngine {
             // scores. Gated on absent gravity (`grav.size < 2` — a ring streams zero; a WHOOP always streams a
             // gravity vector) plus a non-canonical-WHOOP-import owner, so WHOOP straps and the "my-whoop"
             // import namespace are untouched; analyzeDay still lets a DETECTED session win where they overlap.
-            val providedSleep: List<DetectedSleep> =
-                if (owner != importedDeviceId && grav.size < 2) {
-                    val stored = repo.sleepSessionsForDevice(owner, from, to, 4000)
-                        .mapNotNull { AnalyticsEngine.sleepSessionFromProvided(it) }
-                    // #1801: a ring persists its OWN hypnogram, so `stored` covers it. A 5/MG that cannot
-                    // bond persists nothing (it is never clocked, so it banks nothing) and streams no motion
-                    // either — neither a spine nor a stored night, which is why this day scored blank with
-                    // `reason=no-motion` however much HR it held. Fall back to the HR-only spine ONLY when
-                    // the device supplied nothing of its own: a hypnogram the device actually recorded is
-                    // always better evidence than one inferred from heart rate.
-                    if (stored.isNotEmpty()) {
+            // #804 Fix A + #1801. Two different questions share the "this day has no motion" gate.
+            //
+            // #804 hands over a device's OWN persisted hypnogram (an Oura ring's SleepNet night), and is
+            // deliberately not applied to the import namespace. #1801 stages from heart rate when there is
+            // no hypnogram at all — and that one must NOT inherit #804's owner exclusion, which is the bug
+            // this replaces: `resolveDayOwner` returns [importedDeviceId] whenever the owner source is
+            // absent or the candidates collapse to it, so on a live 5/MG install the whole branch was
+            // skipped before any heart rate was looked at. The field log said so outright once the gate
+            // line existed: `attempted=false reason=imported-owner grav=0`, on a day holding 165,980 HR
+            // rows. A condition written to exclude WHOOP straps was guarding a fallback FOR one.
+            //
+            // The stored lookup now runs for every no-motion day, so "nothing else knows about this
+            // night" is checked rather than assumed. A day that HAS stored sessions is left alone whoever
+            // owns it: inferring a night from heart rate when the device recorded a real one would be
+            // strictly worse evidence replacing better.
+            val providedSleep: List<DetectedSleep> = if (grav.size < 2) {
+                val stored = repo.sleepSessionsForDevice(owner, from, to, 4000)
+                    .mapNotNull { AnalyticsEngine.sleepSessionFromProvided(it) }
+                when {
+                    owner != importedDeviceId && stored.isNotEmpty() -> {
                         dayDiag(SleepStagerTrace.hrOnlyGateLine(
                             attempted = false, reason = "stored-hypnogram",
                             gravRows = grav.size, storedNights = stored.size,
                         ))
                         stored
-                    } else {
+                    }
+                    stored.isNotEmpty() -> {
+                        // The import namespace keeps #804's exclusion — its rows are not handed to
+                        // analyzeDay as "provided" — but they still mean this night is already known,
+                        // so the heart-rate fallback stays out of it.
+                        dayDiag(SleepStagerTrace.hrOnlyGateLine(
+                            attempted = false, reason = "stored-sessions-exist",
+                            gravRows = grav.size, storedNights = stored.size,
+                        ))
+                        emptyList()
+                    }
+                    else -> {
                         dayDiag(SleepStagerTrace.hrOnlyGateLine(
                             attempted = true, reason = "no-motion-no-hypnogram",
                             gravRows = grav.size, storedNights = 0,
                         ))
-                        // Route the spine's funnel through the SAME per-day recorder as `sleep-detect`,
-                        // so one report explains both halves rather than one of them going quiet.
                         SleepStager.hrOnlySessions(hr, rr, resp, traceSink = ::dayDiag)
                     }
-                } else {
-                    // Only worth saying on a day with NO motion: there the spine was the remaining
-                    // option and something declined it, which is precisely what a silent absence could
-                    // not distinguish. A day WITH motion skips this — the motion spine is the answer
-                    // there and nothing was passed over.
-                    if (grav.size < 2) {
-                        dayDiag(SleepStagerTrace.hrOnlyGateLine(
-                            attempted = false, reason = "imported-owner",
-                            gravRows = grav.size, storedNights = 0,
-                        ))
-                    }
-                    emptyList()
                 }
+            } else {
+                emptyList()
+            }
 
             val tScore0 = System.nanoTime()
             dayPrepNanos += tScore0 - tPrep0

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlySessionsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlySessionsTest.kt
@@ -109,6 +109,17 @@ class SleepStagerHrOnlySessionsTest {
             expr.contains("SleepStager.hrOnlySessions("))
         assertTrue("and must only run when the device supplied no hypnogram of its own",
             expr.contains("stored.isNotEmpty()"))
+        // The bug this replaced: the fallback inherited #804's `owner != importedDeviceId` exclusion,
+        // written to keep WHOOP straps OUT of a ring's hypnogram path — and so it never fired on the
+        // WHOOP strap it exists for. `resolveDayOwner` returns importedDeviceId whenever the owner
+        // source is absent, which on a live 5/MG install is every day. Pinned by asserting the owner
+        // check does not stand between the gravity gate and the call: it may still scope the STORED
+        // branch, but not the heart-rate one.
+        val hrOnlyBranch = expr.substring(expr.indexOf("else ->"))
+        assertTrue("the HR-only branch must not be gated on the day's owner",
+            !hrOnlyBranch.contains("importedDeviceId"))
+        assertTrue("but the stored-hypnogram branch keeps #804's exclusion",
+            expr.substring(0, expr.indexOf("else ->")).contains("owner != importedDeviceId"))
     }
 
     /** No HR at all cannot produce a night, and must not throw. */


### PR DESCRIPTION
Refs #1801. **The spine has never once run.**

## What the instrumentation found

The gate line from #1812 answered it on the first build that carried it:

```
[sleep] hr-only gate attempted=false reason=imported-owner grav=0 stored=0
sleep-detect day=2026-09-02 NO-NIGHT hr=165980 rr=106585 resp=0 grav=0 ... reason=no-motion
```

165,980 HR rows for the day, and the branch was skipped **before any heart rate was looked at**. Not
a band too tight, not the duration gate — the two failures the funnel was built to separate. It never
got that far.

## The bug, and it is mine

#1806 took its condition verbatim from **#804 Fix A**, whose comment states it exists *"so WHOOP
straps and the `my-whoop` import namespace are untouched"*. #804 is about **Oura rings** and
deliberately excludes WHOOP.

The HR-only fallback is **for a WHOOP strap**. It inherited a condition whose entire purpose was to
exclude the case it was built for.

`resolveDayOwner` returns `importedDeviceId` whenever the owner source is absent or the candidates
collapse to it — which on this install is every day. So it was never going to fire, and the p10 anchor
I spent a review pass tuning in #1806 was never reached. That tuning may still have been right; there
is simply no evidence either way yet.

Worth noting the two owner concepts disagree, which is why older logs could not show this: the
`[universal] dayOwner` line reports `readId=whoop-MGB…` while `resolveDayOwner` returns `my-whoop`.

## The fix — split by question, not by gate

| branch | owner check | why |
|---|---|---|
| #804 stored hypnogram | **kept** | a ring's own SleepNet night still should not come from the import namespace |
| stored sessions exist | none | the night is already known — inferring one from HR replaces better evidence with worse |
| #1801 HR-only | **dropped** | a WHOOP strap owning the day is precisely the target |

The stored lookup now runs for **every** no-motion day, so "nothing else knows about this night" is
checked rather than assumed. That is a **new query per no-motion day for the import namespace**, which
previously skipped it — one indexed `LIMIT` read. Not free, and it is the read that stops this
inventing nights for import users who already have real ones.

## Verification

- **26 HR-only tests, 0 failures**; `compileFullDebugKotlin`, `doc_comment_lint`, `i18n_audit --ci`
  clean; both platforms restructured identically.
- The guard test now pins the specific bug: the HR-only branch must **not** mention
  `importedDeviceId`, and the stored branch must. A source-reading test because the gate needs a
  repository to reach behaviourally, and because the failure mode is someone reinstating the exclusion
  for symmetry.
- **Still unproven end to end.** This makes the spine reachable; whether it then finds a night on real
  data is the next question, and #1812's funnel line is what will answer it.


## Re-review: the gate widened for everyone, not just the 5/MG

Dropping the owner exclusion makes the branch reachable for **any** owner — including a WHOOP 4.0 day
that banked nothing at all (`grav.size < 2`, no stored night). I had described a 4.0 as untouched
"because `grav.size < 2` is false", which is true of a *normal* 4.0 day and not of an empty one.

Low risk and not zero: such a day has too little of anything to clear `minSleepMin`, but "too little"
is not "none", and any night it produced would be display-only and marked `hrOnly`. Now stated at the
branch rather than left for the next reader to derive.

Also verified and sound: the guard test splits on `else ->`, and there is exactly one, one
`importedDeviceId`, none after the split. The middle branch returning `[]` for an import-namespace day
with stored sessions preserves what both #804 and pre-#1806 did — that path has always yielded nothing
there. And a normal WHOOP day never reaches the stored lookup at all, since `grav.size >= 2`
short-circuits it, so the added query lands only on days that were already scoring blank.
