### PR TITLE
steps: stop the calibration card asking for the half the user already has

### DIFF
--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -3497,6 +3497,18 @@ struct StepsCalibrationSheet: View {
                     Text("Not calibrated yet")
                         .font(StrandFont.bodyNumber)
                         .foregroundStyle(StrandPalette.textPrimary)
+                    // Only ask for phone-step days when phone-step days are what is actually missing.
+                    //
+                    // A step estimate is `motion * coefficient` (`StepsEstimateEngine.estimate`) and a
+                    // calibration point is the ratio `steps / motion`, so BOTH halves are required. With no
+                    // banked strap motion neither the estimate nor the fit can move however many days the
+                    // phone counts. The countdown below then names the half the user already has and hides
+                    // the half they do not — a field report asked whether entering Apple Health steps by
+                    // hand would start the calibration, which is exactly the conclusion it invites.
+                    //
+                    // The no-motion banner at the top of this sheet already explains the real blocker, so
+                    // the honest move is to stop competing with it rather than to add more copy.
+                    if sampleMotion != nil {
                     // #589: a concrete countdown instead of a vague "a few days". Headline comes straight
                     // from the engine's needsMoreDays state so the wording matches the Today steps tile.
                     // #693: drive `have` off `profile.stepsCalibrationSampleDays` — the value the engine
@@ -3514,6 +3526,7 @@ struct StepsCalibrationSheet: View {
                         .font(StrandFont.footnote)
                         .foregroundStyle(StrandPalette.textTertiary)
                         .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
             }
         }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -3319,6 +3319,15 @@ struct StepsCalibrationSheet: View {
     @State private var draftManual: Double = 0
     @State private var didLoad = false
 
+    /// The strap has banked no motion, and we have looked.
+    ///
+    /// Named once because two places depend on it and they must stay exactly complementary: the
+    /// no-motion banner appears, and the calibration countdown does NOT. Written as two separate
+    /// expressions they drifted immediately — the guard's first draft tested `sampleMotion == nil`
+    /// alone, which is also true during the load, so the countdown vanished in a window where the
+    /// banner had not appeared yet and the card explained nothing at all.
+    private var strapHasNoMotion: Bool { didLoad && sampleMotion == nil }
+
     /// #107: the sheet's guidance depends on the strap family. A WHOOP 4.0 streams motion automatically, so
     /// "let it sync" is right; a 5/MG only streams motion once the experimental deep-data unlock is on, so
     /// the 4.0 advice is futile there and the empty state must say so instead.
@@ -3339,7 +3348,7 @@ struct StepsCalibrationSheet: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: NoopMetrics.sectionSpacing) {
                     explainerCard
-                    if didLoad && sampleMotion == nil { noMotionNote }
+                    if strapHasNoMotion { noMotionNote }
                     currentFitCard
                     comparisonCard
                     manualAdjustCard
@@ -3508,7 +3517,7 @@ struct StepsCalibrationSheet: View {
                     //
                     // The no-motion banner at the top of this sheet already explains the real blocker, so
                     // the honest move is to stop competing with it rather than to add more copy.
-                    if sampleMotion != nil {
+                    if !strapHasNoMotion {
                     // #589: a concrete countdown instead of a vague "a few days". Headline comes straight
                     // from the engine's needsMoreDays state so the wording matches the Today steps tile.
                     // #693: drive `have` off `profile.stepsCalibrationSampleDays` — the value the engine


### PR DESCRIPTION
A WHOOP 4.0 user with no synced motion asked whether entering their Apple Health steps by hand would
start NOOP counting and calibrating. **It wouldn't** — and the sheet is why they thought it might.

## The misdirection

With no banked motion, the card still showed:

> **Need 1 more day where your phone also counted steps**

That names phone-step days as the blocker. They aren't:

```swift
public static func estimate(motion: Double, calibration: Calibration) -> Int? {
    guard motion >= minMotionForFit, calibration.coefficient > 0 else { return nil }
    let raw = motion * calibration.coefficient
```

A step estimate is `motion * coefficient`, and a calibration point is the ratio `steps / motion`. Both
halves are required, so with the motion half missing neither the estimate nor the fit moves however
many days the phone counts. Setting the coefficient by hand doesn't help either — that sets the
multiplier, and the thing being multiplied is what's absent.

So the countdown pointed at the one input the user *could* supply, while the input they actually
needed went unmentioned in that card. The no-motion banner at the top of the same sheet explains the
real blocker, and the two were competing — the user believed the countdown.

## The fix

The countdown and its explanatory line now render only when motion exists.

**Deliberately no new copy.** The banner already says the right thing; the fix is to stop
contradicting it rather than add a third message. The comparison card is untouched for the same
reason — *"no days yet where both counted"* is simply true in this state.

Net diff is two lines of code and a comment explaining why.

## Scope

Not a fix for the underlying no-motion case, which on a 4.0 is a history sync that hasn't completed —
#1149 covers the harder version. This only stops the UI sending someone down a road that cannot work.

## Verification

- `swiftc -parse` clean; `doc_comment_lint` and `i18n_audit --ci` clean; no strings added or changed.
- **Not compiled and not seen.** App-target Swift with no local build and no default CI job — `-parse`
  is syntax, not type-checking, and this changes what a card renders. The testing build's iOS leg
  compiles it; the state is reachable on any strap that hasn't synced motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)