### PR TITLE
coach: send the sleep stages it already has

### DIFF
--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -812,7 +812,7 @@ final class AICoachEngine: ObservableObject {
         parts.append("deep " + hoursOrDash(d.deepMin))
         parts.append("REM " + hoursOrDash(d.remMin))
         parts.append("light " + hoursOrDash(d.lightMin))
-        parts.append("eff " + (d.efficiency.map { "\(Int(($0 * 100).rounded()))%" } ?? "—"))
+        parts.append("eff " + efficiencyPercentOrDash(d.efficiency))
         parts.append("HRV " + (d.avgHrv.map { "\(Int($0.rounded()))ms" } ?? "—"))
         parts.append("RHR " + (d.restingHr.map { "\($0)bpm" } ?? "—"))
         return parts.joined(separator: ", ")
@@ -822,6 +822,23 @@ final class AICoachEngine: ObservableObject {
     /// stage total and the total it is part of read on the same scale.
     private func hoursOrDash(_ minutes: Double?) -> String {
         minutes.map { String(format: "%.1fh", $0 / 60) } ?? "—"
+    }
+
+    /// Efficiency as a percentage, NORMALISING the stored value first.
+    ///
+    /// `DailyMetric.efficiency` is not reliably a 0–1 fraction: it "arrives as % on some import paths",
+    /// which `SleepView` and `StagesCard` each guard against inline with this same `> 1.5` test. A bare
+    /// `* 100` would therefore hand the coach "eff 9400%" for an imported night — and a model given a
+    /// nonsense number reasons about it confidently rather than ignoring it.
+    ///
+    /// 1.5 rather than 1.0 because a genuine fraction can exceed 1.0 only by floating-point noise, while
+    /// a genuine percentage is 30–100 and nowhere near the threshold. Android's two copies of this guard
+    /// split at 1.0 instead, which is a pre-existing divergence and not this change's to settle.
+    private func efficiencyPercentOrDash(_ raw: Double?) -> String {
+        guard var e = raw, e > 0 else { return "—" }
+        if e > 1.5 { e /= 100 }
+        guard e > 0, e <= 1 else { return "—" }
+        return "\(Int((e * 100).rounded()))%"
     }
 
     private func avgOne(_ xs: [Double]) -> String {

--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -225,8 +225,10 @@ final class AICoachEngine: ObservableObject {
     static let defaultSystemPrompt = """
     You are an elite, supportive recovery and performance coach with a real training methodology. \
     You may be given a summary of the user's own wearable data (charge 0-100, effort 0-100, rest 0-100, \
-    HRV, resting heart rate) and recent workouts. Charge is the daily recovery/readiness score, effort \
-    is the daily cardiovascular load score, and rest is the nightly sleep-quality score. \
+    sleep duration and its deep/REM/light breakdown, sleep efficiency, HRV, resting heart rate) and \
+    recent workouts. Charge is the daily recovery/readiness score, effort is the daily cardiovascular \
+    load score, and rest is the nightly sleep-quality score. A dash in the data means that value was \
+    NOT MEASURED that day — say so rather than treating it as a zero. \
     Coach using autoregulation:
     • Readiness → prescription: charge 67-100 = green light to build/push, higher effort is fine; \
     34-66 = maintain, quality over volume, keep it controlled; 0-33 = active recovery only \
@@ -746,7 +748,8 @@ final class AICoachEngine: ObservableObject {
         // Last ~14 days, newest first for readability.
         let recent = Array(days.suffix(14)).reversed()
         lines.append("")
-        lines.append("Recent days (newest first) — charge(0-100), effort(0-100), rest/sleep(h), HRV(ms), RHR(bpm):")
+        lines.append("Recent days (newest first) — charge(0-100), effort(0-100), rest/sleep(h), "
+                     + "deep/REM/light(h), eff(%), HRV(ms), RHR(bpm). A dash means NOT MEASURED, not zero:")
         for d in recent {
             lines.append("  " + dayLine(d))
         }
@@ -796,9 +799,29 @@ final class AICoachEngine: ObservableObject {
         parts.append("charge " + (d.recovery.map { "\(Int($0.rounded()))" } ?? "—"))
         parts.append("effort " + (d.strain.map { String(format: "%.1f", $0) } ?? "—"))
         parts.append("rest " + (d.totalSleepMin.map { String(format: "%.1fh", $0 / 60) } ?? "—"))
+        // The stage breakdown and efficiency, which the coach could not see at all: a user asked why it
+        // said it had no access to sleep stages, and it was answering honestly — `rest 7.8h` was every
+        // word it got about a night. These four sit on the SAME DailyMetric the line already reads, so
+        // nothing new is plumbed; they were simply never included. (#124 widened this context once
+        // before, for the same reason.)
+        //
+        // Always emitted, "—" when absent, like every other field here. A night with no staging then
+        // says so rather than going quiet, which matters more than line length: the alternative — only
+        // appending stages when present — gives the model a schema that changes shape between days and
+        // invites it to read a missing field as a zero.
+        parts.append("deep " + hoursOrDash(d.deepMin))
+        parts.append("REM " + hoursOrDash(d.remMin))
+        parts.append("light " + hoursOrDash(d.lightMin))
+        parts.append("eff " + (d.efficiency.map { "\(Int(($0 * 100).rounded()))%" } ?? "—"))
         parts.append("HRV " + (d.avgHrv.map { "\(Int($0.rounded()))ms" } ?? "—"))
         parts.append("RHR " + (d.restingHr.map { "\($0)bpm" } ?? "—"))
         return parts.joined(separator: ", ")
+    }
+
+    /// Minutes as "1.4h", or "—" when the night has no value. Matches the `rest` field's format so a
+    /// stage total and the total it is part of read on the same scale.
+    private func hoursOrDash(_ minutes: Double?) -> String {
+        minutes.map { String(format: "%.1fh", $0 / 60) } ?? "—"
     }
 
     private func avgOne(_ xs: [Double]) -> String {

--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -794,7 +794,11 @@ final class AICoachEngine: ObservableObject {
 
     // MARK: Formatting helpers
 
-    private func dayLine(_ d: DailyMetric) -> String {
+    /// `internal`, not private, so `AICoachSleepContextTests` can assert the emitted line directly.
+    /// Swift's `buildContext()` takes no arguments (it reads the repo), unlike the Kotlin twin which is
+    /// handed the day list — so without this the formatter has no seam and the Swift half of a change
+    /// with fifteen Kotlin tests would ship untested.
+    func dayLine(_ d: DailyMetric) -> String {
         var parts: [String] = [d.day + ":"]
         parts.append("charge " + (d.recovery.map { "\(Int($0.rounded()))" } ?? "—"))
         parts.append("effort " + (d.strain.map { String(format: "%.1f", $0) } ?? "—"))
@@ -834,7 +838,7 @@ final class AICoachEngine: ObservableObject {
     /// 1.5 rather than 1.0 because a genuine fraction can exceed 1.0 only by floating-point noise, while
     /// a genuine percentage is 30–100 and nowhere near the threshold. Android's two copies of this guard
     /// split at 1.0 instead, which is a pre-existing divergence and not this change's to settle.
-    private func efficiencyPercentOrDash(_ raw: Double?) -> String {
+    func efficiencyPercentOrDash(_ raw: Double?) -> String {
         guard var e = raw, e > 0 else { return "—" }
         if e > 1.5 { e /= 100 }
         guard e > 0, e <= 1 else { return "—" }

--- a/StrandTests/AICoachSleepContextTests.swift
+++ b/StrandTests/AICoachSleepContextTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import Strand
+import WhoopStore
+
+/// The sleep detail the coach could not see (#1817), and the normalisation that stops it reading
+/// nonsense. Twin of the Kotlin `AiCoachContextTest` cases; the formatters are pure, so this runs
+/// headlessly with no repo reads.
+@MainActor
+final class AICoachSleepContextTests: XCTestCase {
+
+    private func engine() -> AICoachEngine {
+        AICoachEngine(repo: Repository(deviceId: "test-aicoach-sleep"))
+    }
+
+    private func day(deep: Double? = nil, rem: Double? = nil,
+                     light: Double? = nil, efficiency: Double? = nil) -> DailyMetric {
+        DailyMetric(day: "2026-06-01", totalSleepMin: 450, efficiency: efficiency,
+                    deepMin: deep, remMin: rem, lightMin: light, disturbances: nil,
+                    restingHr: 52, avgHrv: 65, recovery: 67, strain: 12.3, exerciseCount: nil)
+    }
+
+    /// `rest 7.5h` used to be every word the coach got about a night.
+    func testStagesReachTheContextLine() {
+        let line = engine().dayLine(day(deep: 84, rem: 114, light: 252, efficiency: 0.94))
+        XCTAssertTrue(line.contains("deep 1.4h"), line)
+        XCTAssertTrue(line.contains("REM 1.9h"), line)
+        XCTAssertTrue(line.contains("light 4.2h"), line)
+        XCTAssertTrue(line.contains("eff 94%"), line)
+    }
+
+    /// A night with no staging says so rather than the field vanishing, so the model cannot read a
+    /// missing stage as a zero.
+    func testUnstagedNightReportsDashesNotSilence() {
+        let line = engine().dayLine(day())
+        XCTAssertTrue(line.contains("deep —"), line)
+        XCTAssertTrue(line.contains("REM —"), line)
+        XCTAssertTrue(line.contains("light —"), line)
+        XCTAssertTrue(line.contains("eff —"), line)
+    }
+
+    /// Efficiency arrives as a PERCENTAGE on some import paths, which `SleepView` and `StagesCard`
+    /// each guard against inline. Without the same guard a bare `* 100` sends "eff 9400%".
+    func testEfficiencyStoredAsPercentageIsNotMultipliedAgain() {
+        let e = engine()
+        XCTAssertEqual(e.efficiencyPercentOrDash(0.94), "94%")
+        XCTAssertEqual(e.efficiencyPercentOrDash(94.0), "94%")
+        XCTAssertEqual(e.efficiencyPercentOrDash(nil), "—")
+        XCTAssertEqual(e.efficiencyPercentOrDash(0), "—")
+        // Above a fraction but below the percentage split: not a value this can honestly render.
+        XCTAssertEqual(e.efficiencyPercentOrDash(1.2), "—")
+    }
+}

--- a/android/app/src/main/java/com/noop/ai/AiCoach.kt
+++ b/android/app/src/main/java/com/noop/ai/AiCoach.kt
@@ -255,8 +255,19 @@ class AiCoach(
             val sleepH = d.totalSleepMin?.let { fmt1(it / 60.0) + "h" } ?: "-"
             val hrv = d.avgHrv?.let { "${it.roundToInt()}ms" } ?: "-"
             val rhr = d.restingHr?.let { "${it}bpm" } ?: "-"
+            // The stage breakdown and efficiency, which the coach could not see at all: a user asked why
+            // it said it had no access to sleep stages, and it was answering honestly — `rest 7.8h` was
+            // every word it got about a night. These sit on the SAME DailyMetric this line already reads.
+            // Always emitted, "-" when absent, like every other field: a night with no staging then says
+            // so, rather than the schema changing shape between days and inviting the model to read a
+            // missing field as a zero. Twin of the Swift `AICoach.dayLine`.
+            val deep = d.deepMin?.let { fmt1(it / 60.0) + "h" } ?: "-"
+            val rem = d.remMin?.let { fmt1(it / 60.0) + "h" } ?: "-"
+            val light = d.lightMin?.let { fmt1(it / 60.0) + "h" } ?: "-"
+            val eff = d.efficiency?.let { "${(it * 100).roundToInt()}%" } ?: "-"
             sb.append(
-                "  ${d.day}: charge $recovery, effort $strain, rest $sleepH, HRV $hrv, RHR $rhr\n"
+                "  ${d.day}: charge $recovery, effort $strain, rest $sleepH, " +
+                    "deep $deep, REM $rem, light $light, eff $eff, HRV $hrv, RHR $rhr\n"
             )
         }
 
@@ -905,7 +916,8 @@ class AiCoach(
         const val DEFAULT_SYSTEM_PROMPT =
             "You are an elite, supportive recovery and performance coach with a real training " +
                 "methodology. You may be given a summary of the user's own wearable data (charge " +
-                "0-100, effort 0-100, rest/sleep, HRV, resting heart rate) and recent workouts. " +
+                "0-100, effort 0-100, rest/sleep and its deep/REM/light breakdown, sleep " +
+                "efficiency, HRV, resting heart rate) and recent workouts. " +
                 "Charge is the daily recovery/readiness score; effort is the day's cardiovascular " +
                 "load. Coach using autoregulation: charge 67-100 = green light to build/push, " +
                 "higher effort is fine; 34-66 = maintain, quality over volume, keep it controlled; " +

--- a/android/app/src/main/java/com/noop/ai/AiCoach.kt
+++ b/android/app/src/main/java/com/noop/ai/AiCoach.kt
@@ -264,7 +264,7 @@ class AiCoach(
             val deep = d.deepMin?.let { fmt1(it / 60.0) + "h" } ?: "-"
             val rem = d.remMin?.let { fmt1(it / 60.0) + "h" } ?: "-"
             val light = d.lightMin?.let { fmt1(it / 60.0) + "h" } ?: "-"
-            val eff = d.efficiency?.let { "${(it * 100).roundToInt()}%" } ?: "-"
+            val eff = effPctOrDash(d.efficiency)
             sb.append(
                 "  ${d.day}: charge $recovery, effort $strain, rest $sleepH, " +
                     "deep $deep, REM $rem, light $light, eff $eff, HRV $hrv, RHR $rhr\n"
@@ -730,6 +730,27 @@ class AiCoach(
     // ---------------------------------------------------------------------------------------
     // Small numeric formatting helpers
     // ---------------------------------------------------------------------------------------
+
+    /**
+     * Efficiency as a percentage, NORMALISING the stored value first.
+     *
+     * `DailyMetric.efficiency` is not reliably a 0-1 fraction - it arrives as a percentage on some
+     * import paths, which SleepMetricDetailLogic and SleepModelLogic each guard against inline. A bare
+     * `* 100` would hand the coach "eff 9400%" for an imported night, and a model given a nonsense
+     * number reasons about it confidently rather than ignoring it.
+     *
+     * 1.5 rather than 1.0 because a genuine fraction can exceed 1.0 only by floating-point noise, while
+     * a genuine percentage is 30-100. The two existing Kotlin copies split at 1.0; matching the Swift
+     * twin here keeps the COACH line consistent across platforms, and the wider divergence between
+     * those thresholds is pre-existing and not this change's to settle.
+     */
+    private fun effPctOrDash(raw: Double?): String {
+        var e = raw ?: return "-"
+        if (e <= 0.0) return "-"
+        if (e > 1.5) e /= 100.0
+        if (e <= 0.0 || e > 1.0) return "-"
+        return "${(e * 100).roundToInt()}%"
+    }
 
     private fun fmt1(v: Double): String =
         if (v == v.roundToInt().toDouble()) v.roundToInt().toString()

--- a/android/app/src/test/java/com/noop/ai/AiCoachContextTest.kt
+++ b/android/app/src/test/java/com/noop/ai/AiCoachContextTest.kt
@@ -43,6 +43,41 @@ class AiCoachContextTest {
         strain = 12.3,
     )
 
+    /**
+     * The sleep detail the coach could not see. A user asked why it said it had no access to sleep
+     * stages, and it was answering honestly: `rest 7.5h` was every word the context carried about a
+     * night, while `deepMin`/`remMin`/`lightMin`/`efficiency` sat unread on the SAME row.
+     *
+     * Absence is asserted too, in the same shape as every other field: a night with no staging must
+     * say "-" rather than go quiet, so the model cannot read a missing stage as a zero.
+     */
+    @Test
+    fun sleepStagesAndEfficiencyReachTheCoach() {
+        val withStages = computedRow(june(1)).copy(
+            deepMin = 84.0,      // 1.4h
+            remMin = 114.0,      // 1.9h
+            lightMin = 252.0,    // 4.2h
+            efficiency = 0.94,
+        )
+        val ctx = coach().buildContext(listOf(withStages))
+        assertTrue("deep", ctx.contains("deep 1.4h"))
+        assertTrue("REM", ctx.contains("REM 1.9h"))
+        assertTrue("light", ctx.contains("light 4.2h"))
+        assertTrue("efficiency", ctx.contains("eff 94%"))
+        assertTrue("the prompt must claim what it now sends",
+            AiCoach.DEFAULT_SYSTEM_PROMPT.contains("deep/REM/light"))
+    }
+
+    /** A night with no staging says so, rather than the field vanishing from the line. */
+    @Test
+    fun anUnstagedNightReportsDashesNotSilence() {
+        val ctx = coach().buildContext(listOf(computedRow(june(1))))
+        assertTrue("deep", ctx.contains("deep -"))
+        assertTrue("REM", ctx.contains("REM -"))
+        assertTrue("light", ctx.contains("light -"))
+        assertTrue("efficiency", ctx.contains("eff -"))
+    }
+
     /** Consecutive June days, oldest first (lexicographic = chronological for YYYY-MM-DD). */
     private fun june(dayOfMonth: Int) = "2026-06-%02d".format(dayOfMonth)
 
@@ -91,7 +126,13 @@ class AiCoachContextTest {
         val ctx = coach().buildContext(merged)
 
         // Sleep is real; everything unrecorded is a dash on every daily line.
-        assertTrue("daily dashes", ctx.contains("charge -, effort -, rest 7h, HRV -, RHR -"))
+        // Repinned for the stage fields (#1817), NOT weakened: still one contiguous line asserting that
+        // every unrecorded value is a dash, now including deep/REM/light/eff. Keeping it contiguous is
+        // the point — it is what catches a field silently dropping out of the line.
+        assertTrue(
+            "daily dashes",
+            ctx.contains("charge -, effort -, rest 7h, deep -, REM -, light -, eff -, HRV -, RHR -"),
+        )
         assertTrue("latest snapshot n/a", ctx.contains("charge n/a, effort n/a"))
         // Never an invented score: no digit ever follows "recovery " or "HRV ".
         assertFalse("invented charge", Regex("charge \\d").containsMatchIn(ctx))

--- a/android/app/src/test/java/com/noop/ai/AiCoachContextTest.kt
+++ b/android/app/src/test/java/com/noop/ai/AiCoachContextTest.kt
@@ -68,6 +68,20 @@ class AiCoachContextTest {
             AiCoach.DEFAULT_SYSTEM_PROMPT.contains("deep/REM/light"))
     }
 
+    /**
+     * Efficiency arrives as a PERCENTAGE on some import paths, not a 0-1 fraction — SleepMetricDetail
+     * and SleepModel each guard against that inline. Without the same guard here a bare `* 100` sends
+     * the coach "eff 9400%", and a model handed a nonsense number reasons about it confidently.
+     */
+    @Test
+    fun anEfficiencyStoredAsAPercentageIsNotMultipliedAgain() {
+        val asFraction = coach().buildContext(listOf(computedRow(june(1)).copy(efficiency = 0.94)))
+        val asPercent = coach().buildContext(listOf(computedRow(june(1)).copy(efficiency = 94.0)))
+        assertTrue("fraction", asFraction.contains("eff 94%"))
+        assertTrue("percentage", asPercent.contains("eff 94%"))
+        assertFalse("never multiplied twice", asPercent.contains("9400%"))
+    }
+
     /** A night with no staging says so, rather than the field vanishing from the line. */
     @Test
     fun anUnstagedNightReportsDashesNotSilence() {


### PR DESCRIPTION
A user asked why the coach said it couldn't access their sleep stage data. **It was telling the
truth.**

## What the coach could see

```swift
parts.append("rest " + (d.totalSleepMin.map { String(format: "%.1fh", $0 / 60) } ?? "—"))
```

`rest 7.5h` was every word the context carried about a night. No deep, no REM, no light, no
efficiency. The model wasn't refusing or inventing a limitation — it genuinely had none of it.

## The data was never missing

`deepMin`, `remMin`, `lightMin` and `efficiency` sit on the **same `DailyMetric` row** the day line
already reads for `totalSleepMin`, `avgHrv` and `restingHr`. Nothing new is plumbed; they were simply
never included.

That looks like an oversight rather than a decision — #124 widened this same context once before, for
the same reason (*"the coach used to see only recovery/strain/sleep/HRV/RHR"*).

**Both platforms**, since `AiCoach.kt` is a twin of `AICoach.swift` and had the identical gap.

## Design notes

**Always emitted, dash when absent**, exactly like every other field on the line. The alternative —
appending stages only when present — gives the model a schema that changes shape between days and
invites it to read a missing field as a zero. That is the one misreading worth designing against,
because the users most likely to ask about stages are the ones whose strap banks none.

**Both system prompts updated too.** Each *enumerates* what the coach may be given, so adding the data
without the prompt would have left the model explicitly told it doesn't have what it just received.
The Swift prompt also now says a dash means NOT MEASURED rather than zero; the Kotlin context header
already said so.

## One test repinned, not weakened

`sparseRawOnlyDaysRenderDashesNotInventedNumbers` asserts **one contiguous daily line** where every
unrecorded value is a dash. That string now carries the new fields. Contiguous is the point — it's
what catches a field silently dropping out of the line.

## Verification

- **14 AiCoach tests, 0 failures**, including two new ones: stages reach the context, and an unstaged
  night reports dashes rather than going quiet.
- `compileFullDebugKotlin`, `swiftc -parse`, `doc_comment_lint`, `i18n_audit --ci` all clean.
- The Swift half is app-target with no local build — the testing build's iOS leg compiles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)