### PR TITLE
rtc: stop telling an already-charged strap to charge it (#1818)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
@@ -244,9 +244,15 @@ public enum ConnectionReadout {
     /// the Devices / Test Centre connection readout, naming the consequence and the fix.
     ///
     /// #1818: the remedy is battery-dependent. A flat battery resets the RTC, so on a low strap
-    /// "charge it" is real advice. On an ALREADY-charged strap it is not: `runConnectHandshake` sends
-    /// SET_CLOCK (both payload forms, #120) on every WHOOP4 connect with no battery gate, so charging
-    /// again changes nothing and the old copy sent users at 100% round a loop they had already run.
+    /// "charge it" is real advice. On an ALREADY-charged strap it is not, and the old copy sent users
+    /// at 100% round a loop they had already run.
+    ///
+    /// The charged branch deliberately states only what holds for EVERY strap - that charging again
+    /// will not change it - and asks for a log. It must NOT claim NOOP re-sends the clock on every
+    /// connect: that is true on WHOOP4 (`runConnectHandshake` calls SET_CLOCK unconditionally, both
+    /// payload forms, #120) but FALSE on a 5/MG, where the clock write is gated behind `didBond`, and
+    /// an unbondable 5/MG (#1635) is never clocked at all - precisely the strap most likely to be
+    /// showing this warning. Explaining the mechanism in the sentence is how the original bug happened.
     /// `batteryPct` nil (not yet read) keeps the charge advice - we only withdraw it on evidence.
     /// Callers MUST pass a reading from the CURRENT link (iOS: `batterySamples.last?.soc`, which is
     /// cleared on disconnect) and not a last-known charge that outlives it - a stale 100% would
@@ -260,9 +266,8 @@ public enum ConnectionReadout {
         let lead = "Strap clock reads 1970/71 (never set since its last reset), so it is not banking history. "
         if let batteryPct, batteryPct >= rtcAlreadyChargedPct {
             return lead
-                + "The strap is already charged and NOOP resends the clock on every connect, so charging "
-                + "again will not change this. Export a strap log from Test Centre so the clock exchange "
-                + "can be read."
+                + "The strap is already charged, so charging again will not change this. Export a strap "
+                + "log from Test Centre so the clock exchange can be read."
         }
         return lead + "Charge the strap to 100% and reconnect so the clock latches."
     }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
@@ -233,17 +233,35 @@ public enum ConnectionReadout {
         return "no (waiting for the strap clock)"
     }
 
+    /// #1818: at or above this charge the "charge it" remedy is already satisfied, so repeating it is
+    /// noise. Twin of the Kotlin constant - the two must move together or the platforms give
+    /// different advice for the same strap.
+    public static let rtcAlreadyChargedPct: Double = 95
+
     /// #987: a plain-words warning when the strap RTC reads epoch-era (~1970/71), from EITHER signal we
     /// hold: the correlated device clock or the strap's newest banked-record timestamp. nil when both
     /// look sane (or neither was seen yet - we never fabricate a fault). One string, shown verbatim on
     /// the Devices / Test Centre connection readout, naming the consequence and the fix.
-    public static func rtcWarning(deviceClockUnix: Int?, strapNewestUnix: Int?) -> String? {
+    ///
+    /// #1818: the remedy is battery-dependent. A flat battery resets the RTC, so on a low strap
+    /// "charge it" is real advice. On an ALREADY-charged strap it is not: `runConnectHandshake` sends
+    /// SET_CLOCK (both payload forms, #120) on every WHOOP4 connect with no battery gate, so charging
+    /// again changes nothing and the old copy sent users at 100% round a loop they had already run.
+    /// `batteryPct` nil (not yet read) keeps the charge advice - we only withdraw it on evidence.
+    public static func rtcWarning(deviceClockUnix: Int?, strapNewestUnix: Int?,
+                                  batteryPct: Double? = nil) -> String? {
         let ceiling = ConnectionTrace.rtcEpochCeilingUnix
         let clockBad = deviceClockUnix.map { $0 > 0 && $0 < ceiling } ?? false
         let newestBad = strapNewestUnix.map { $0 > 0 && $0 < ceiling } ?? false
         guard clockBad || newestBad else { return nil }
-        return "Strap clock reads 1970/71 (never set since its last reset), so it is not banking history. "
-            + "Charge the strap to 100% and reconnect so the clock latches."
+        let lead = "Strap clock reads 1970/71 (never set since its last reset), so it is not banking history. "
+        if let batteryPct, batteryPct >= rtcAlreadyChargedPct {
+            return lead
+                + "The strap is already charged and NOOP resends the clock on every connect, so charging "
+                + "again will not change this. Export a strap log from Test Centre so the clock exchange "
+                + "can be read."
+        }
+        return lead + "Charge the strap to 100% and reconnect so the clock latches."
     }
 
     /// #987: freshness label for the "last frame" readout row: how long ago the most recent strap frame

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
@@ -248,6 +248,9 @@ public enum ConnectionReadout {
     /// SET_CLOCK (both payload forms, #120) on every WHOOP4 connect with no battery gate, so charging
     /// again changes nothing and the old copy sent users at 100% round a loop they had already run.
     /// `batteryPct` nil (not yet read) keeps the charge advice - we only withdraw it on evidence.
+    /// Callers MUST pass a reading from the CURRENT link (iOS: `batterySamples.last?.soc`, which is
+    /// cleared on disconnect) and not a last-known charge that outlives it - a stale 100% would
+    /// suppress the advice in the one case it is right, a strap that ran flat and reset its RTC.
     public static func rtcWarning(deviceClockUnix: Int?, strapNewestUnix: Int?,
                                   batteryPct: Double? = nil) -> String? {
         let ceiling = ConnectionTrace.rtcEpochCeilingUnix

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
@@ -224,6 +224,36 @@ final class ConnectionReadoutTests: XCTestCase {
                      "no signal seen yet must not fabricate a fault")
     }
 
+    /// #1818: the remedy must track the battery. A charged strap told to "charge to 100%" is the bug
+    /// the field report hit - the user had already done it, twice.
+    func testRtcWarningRemedyTracksBattery() {
+        let flat = ConnectionReadout.rtcWarning(deviceClockUnix: 40_000_000, strapNewestUnix: nil,
+                                                batteryPct: 40)
+        XCTAssertEqual(flat?.contains("Charge the strap to 100%"), true,
+                       "a low strap keeps the charge advice - a flat battery really does reset the RTC")
+
+        let charged = ConnectionReadout.rtcWarning(deviceClockUnix: 40_000_000, strapNewestUnix: nil,
+                                                   batteryPct: 100)
+        XCTAssertEqual(charged?.contains("Charge the strap to 100%"), false,
+                       "an already-charged strap must not be sent round the loop it just ran")
+        XCTAssertEqual(charged?.contains("already charged"), true)
+        XCTAssertEqual(charged?.contains("strap log"), true, "it must name the next actionable step")
+
+        // Boundary: the constant is inclusive, so exactly-at-threshold takes the charged branch.
+        let atThreshold = ConnectionReadout.rtcWarning(
+            deviceClockUnix: 40_000_000, strapNewestUnix: nil,
+            batteryPct: ConnectionReadout.rtcAlreadyChargedPct)
+        XCTAssertEqual(atThreshold?.contains("already charged"), true)
+
+        // Battery not read yet: we only withdraw advice on evidence, so the default stands.
+        let unknown = ConnectionReadout.rtcWarning(deviceClockUnix: 40_000_000, strapNewestUnix: nil)
+        XCTAssertEqual(unknown?.contains("Charge the strap to 100%"), true)
+
+        // A sane clock stays silent no matter how full the battery is.
+        XCTAssertNil(ConnectionReadout.rtcWarning(deviceClockUnix: 1_782_475_600,
+                                                  strapNewestUnix: 1_782_475_000, batteryPct: 100))
+    }
+
     func testLastFrameLabel() {
         XCTAssertEqual(ConnectionReadout.lastFrameLabel(lastFrameUnix: 990, nowUnix: 1_002), "12s ago")
         XCTAssertEqual(ConnectionReadout.lastFrameLabel(lastFrameUnix: nil, nowUnix: 1_002), "no frames yet")

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
@@ -244,11 +244,18 @@ final class ConnectionReadoutTests: XCTestCase {
         XCTAssertEqual(charged?.contains("every connect"), false,
                        "no model-specific mechanism claim in copy shown to every model")
 
-        // Boundary: the constant is inclusive, so exactly-at-threshold takes the charged branch.
-        let atThreshold = ConnectionReadout.rtcWarning(
-            deviceClockUnix: 40_000_000, strapNewestUnix: nil,
-            batteryPct: ConnectionReadout.rtcAlreadyChargedPct)
+        // Pin the VALUE, not just the symbol: feeding the constant back into the function under test
+        // can never catch a wrong threshold, and nothing else would catch it drifting away from the
+        // Kotlin twin - the two platforms would each keep passing while giving different advice.
+        XCTAssertEqual(ConnectionReadout.rtcAlreadyChargedPct, 95)
+
+        // Boundary, from both sides, with literals: inclusive at 95, charge advice at 94.
+        let atThreshold = ConnectionReadout.rtcWarning(deviceClockUnix: 40_000_000,
+                                                       strapNewestUnix: nil, batteryPct: 95)
         XCTAssertEqual(atThreshold?.contains("already charged"), true)
+        let justBelow = ConnectionReadout.rtcWarning(deviceClockUnix: 40_000_000,
+                                                     strapNewestUnix: nil, batteryPct: 94)
+        XCTAssertEqual(justBelow?.contains("Charge the strap to 100%"), true)
 
         // Battery not read yet: we only withdraw advice on evidence, so the default stands.
         let unknown = ConnectionReadout.rtcWarning(deviceClockUnix: 40_000_000, strapNewestUnix: nil)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
@@ -238,6 +238,11 @@ final class ConnectionReadoutTests: XCTestCase {
                        "an already-charged strap must not be sent round the loop it just ran")
         XCTAssertEqual(charged?.contains("already charged"), true)
         XCTAssertEqual(charged?.contains("strap log"), true, "it must name the next actionable step")
+        // The charged copy must stay true for EVERY strap. "NOOP re-sends the clock on every connect"
+        // holds on WHOOP4 but not on a 5/MG, where the write is gated behind didBond and an unbondable
+        // strap (#1635) is never clocked at all - the strap most likely to be showing this warning.
+        XCTAssertEqual(charged?.contains("every connect"), false,
+                       "no model-specific mechanism claim in copy shown to every model")
 
         // Boundary: the constant is inclusive, so exactly-at-threshold takes the charged branch.
         let atThreshold = ConnectionReadout.rtcWarning(

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -100,7 +100,8 @@ private struct DevicesContent: View {
         let frame = ConnectionReadout.lastFrameLabel(lastFrameUnix: live.lastFrameAtUnix,
                                                      nowUnix: Int(Date().timeIntervalSince1970))
         let warning = ConnectionReadout.rtcWarning(deviceClockUnix: deviceClock,
-                                                   strapNewestUnix: live.strapRange?.newestUnix)
+                                                   strapNewestUnix: live.strapRange?.newestUnix,
+                                                   batteryPct: live.batteryPct)
         return (String(localized: "Clock latched: \(latched) · last frame \(frame)"), warning)
     }
 

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -91,6 +91,13 @@ private struct DevicesContent: View {
     /// has produced any clock signal - a routed frame, a clock correlation, or a data-range reply - so a
     /// generic HR strap or an idle card never shows a fabricated "waiting" state. One computation for
     /// both the line and the warning (the log scan is the cost worth paying once, not twice).
+    ///
+    /// #1818: the battery term reads `batterySamples.last`, NOT `batteryPct`. `batteryPct` deliberately
+    /// outlives the link (`clearBiometrics` leaves it) so Today/the widget can show a last-known charge,
+    /// and a 21 h old reading is indistinguishable from a fresh one there (#530). Withdrawing the "charge
+    /// it" advice on a stale 100% would suppress it in exactly the case it is right - a strap that ran
+    /// flat, which is what reset the RTC, reconnecting before its first battery event. `batterySamples`
+    /// is cleared on disconnect, so `.last` is a reading from THIS link or nothing.
     private var strapClockState: (line: String, warning: String?)? {
         guard live.connected else { return nil }
         let deviceClock = ConnectionReadout.clockCorrelatedDevice(logLines: live.log)
@@ -101,7 +108,7 @@ private struct DevicesContent: View {
                                                      nowUnix: Int(Date().timeIntervalSince1970))
         let warning = ConnectionReadout.rtcWarning(deviceClockUnix: deviceClock,
                                                    strapNewestUnix: live.strapRange?.newestUnix,
-                                                   batteryPct: live.batteryPct)
+                                                   batteryPct: live.batterySamples.last?.soc)
         return (String(localized: "Clock latched: \(latched) · last frame \(frame)"), warning)
     }
 

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -749,7 +749,7 @@ private struct ConnectionReadoutPanel: View {
         let deviceClock = ConnectionReadout.clockCorrelatedDevice(logLines: live.log)
         let rtcWarning = ConnectionReadout.rtcWarning(deviceClockUnix: deviceClock,
                                                       strapNewestUnix: live.strapRange?.newestUnix,
-                                                      batteryPct: live.batteryPct)
+                                                      batteryPct: live.batterySamples.last?.soc)
         VStack(alignment: .leading, spacing: 4) {
             ReadoutRow(label: String(localized: "Connection uptime"), value: uptime)
             ReadoutRow(label: String(localized: "Reconnects this run"), value: String(reconnects))

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -748,7 +748,8 @@ private struct ConnectionReadoutPanel: View {
         // LiveState field FrameRouter writes.
         let deviceClock = ConnectionReadout.clockCorrelatedDevice(logLines: live.log)
         let rtcWarning = ConnectionReadout.rtcWarning(deviceClockUnix: deviceClock,
-                                                      strapNewestUnix: live.strapRange?.newestUnix)
+                                                      strapNewestUnix: live.strapRange?.newestUnix,
+                                                      batteryPct: live.batteryPct)
         VStack(alignment: .leading, spacing: 4) {
             ReadoutRow(label: String(localized: "Connection uptime"), value: uptime)
             ReadoutRow(label: String(localized: "Reconnects this run"), value: String(reconnects))

--- a/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
@@ -215,16 +215,33 @@ object ConnectionReadout {
         return "no (waiting for the strap clock)"
     }
 
+    /** #1818: at or above this charge the "charge it" remedy is already satisfied, so repeating it is
+     *  noise. Twin of the Swift constant - the two must move together or the platforms give different
+     *  advice for the same strap. */
+    const val RTC_ALREADY_CHARGED_PCT: Double = 95.0
+
     /** #987: a plain-words warning when the strap RTC reads epoch-era (~1970/71), from EITHER signal we
      *  hold (the correlated device clock or the strap's newest banked-record timestamp). null when both
-     *  look sane or neither was seen yet - we never fabricate a fault. Twin of the Swift warning. */
-    fun rtcWarning(deviceClockUnix: Long?, strapNewestUnix: Long?): String? {
+     *  look sane or neither was seen yet - we never fabricate a fault. Twin of the Swift warning.
+     *
+     *  #1818: the remedy is battery-dependent. A flat battery resets the RTC, so on a low strap
+     *  "charge it" is real advice. On an ALREADY-charged strap it is not: runConnectHandshake sends
+     *  SET_CLOCK (both payload forms, #120) on every WHOOP4 connect with no battery gate, so charging
+     *  again changes nothing and the old copy sent users at 100% round a loop they had already run.
+     *  [batteryPct] null (not yet read) keeps the charge advice - we only withdraw it on evidence. */
+    fun rtcWarning(deviceClockUnix: Long?, strapNewestUnix: Long?, batteryPct: Double? = null): String? {
         val ceiling = ConnectionTrace.RTC_EPOCH_CEILING_UNIX
         val clockBad = deviceClockUnix != null && deviceClockUnix > 0L && deviceClockUnix < ceiling
         val newestBad = strapNewestUnix != null && strapNewestUnix > 0L && strapNewestUnix < ceiling
         if (!clockBad && !newestBad) return null
-        return "Strap clock reads 1970/71 (never set since its last reset), so it is not banking history. " +
-            "Charge the strap to 100% and reconnect so the clock latches."
+        val lead = "Strap clock reads 1970/71 (never set since its last reset), so it is not banking history. "
+        if (batteryPct != null && batteryPct >= RTC_ALREADY_CHARGED_PCT) {
+            return lead +
+                "The strap is already charged and NOOP resends the clock on every connect, so charging " +
+                "again will not change this. Export a strap log from Test Centre so the clock exchange " +
+                "can be read."
+        }
+        return lead + "Charge the strap to 100% and reconnect so the clock latches."
     }
 
     /** #987: freshness label for the "last frame" readout row ("12s ago" / "no frames yet"). [nowUnix]

--- a/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
@@ -228,7 +228,10 @@ object ConnectionReadout {
      *  "charge it" is real advice. On an ALREADY-charged strap it is not: runConnectHandshake sends
      *  SET_CLOCK (both payload forms, #120) on every WHOOP4 connect with no battery gate, so charging
      *  again changes nothing and the old copy sent users at 100% round a loop they had already run.
-     *  [batteryPct] null (not yet read) keeps the charge advice - we only withdraw it on evidence. */
+     *  [batteryPct] null (not yet read) keeps the charge advice - we only withdraw it on evidence.
+     *  Callers MUST pass a reading from the CURRENT link and not a last-known charge that outlives it -
+     *  a stale 100% would suppress the advice in the one case it is right, a strap that ran flat and
+     *  reset its RTC. */
     fun rtcWarning(deviceClockUnix: Long?, strapNewestUnix: Long?, batteryPct: Double? = null): String? {
         val ceiling = ConnectionTrace.RTC_EPOCH_CEILING_UNIX
         val clockBad = deviceClockUnix != null && deviceClockUnix > 0L && deviceClockUnix < ceiling

--- a/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
@@ -225,9 +225,15 @@ object ConnectionReadout {
      *  look sane or neither was seen yet - we never fabricate a fault. Twin of the Swift warning.
      *
      *  #1818: the remedy is battery-dependent. A flat battery resets the RTC, so on a low strap
-     *  "charge it" is real advice. On an ALREADY-charged strap it is not: runConnectHandshake sends
-     *  SET_CLOCK (both payload forms, #120) on every WHOOP4 connect with no battery gate, so charging
-     *  again changes nothing and the old copy sent users at 100% round a loop they had already run.
+     *  "charge it" is real advice. On an ALREADY-charged strap it is not, and the old copy sent users
+     *  at 100% round a loop they had already run.
+     *
+     *  The charged branch deliberately states only what holds for EVERY strap - that charging again
+     *  will not change it - and asks for a log. It must NOT claim NOOP re-sends the clock on every
+     *  connect: that is true on WHOOP4 (runConnectHandshake calls SET_CLOCK unconditionally, both
+     *  payload forms, #120) but FALSE on a 5/MG, where the clock write is gated behind didBond, and an
+     *  unbondable 5/MG (#1635) is never clocked at all - precisely the strap most likely to be showing
+     *  this warning. Explaining the mechanism in the sentence is how the original bug happened.
      *  [batteryPct] null (not yet read) keeps the charge advice - we only withdraw it on evidence.
      *  Callers MUST pass a reading from the CURRENT link and not a last-known charge that outlives it -
      *  a stale 100% would suppress the advice in the one case it is right, a strap that ran flat and
@@ -240,9 +246,8 @@ object ConnectionReadout {
         val lead = "Strap clock reads 1970/71 (never set since its last reset), so it is not banking history. "
         if (batteryPct != null && batteryPct >= RTC_ALREADY_CHARGED_PCT) {
             return lead +
-                "The strap is already charged and NOOP resends the clock on every connect, so charging " +
-                "again will not change this. Export a strap log from Test Centre so the clock exchange " +
-                "can be read."
+                "The strap is already charged, so charging again will not change this. Export a strap " +
+                "log from Test Centre so the clock exchange can be read."
         }
         return lead + "Charge the strap to 100% and reconnect so the clock latches."
     }

--- a/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
@@ -242,10 +242,16 @@ class ConnectionReadoutTest {
         // strap (#1635) is never clocked at all - the strap most likely to be showing this warning.
         assertFalse(charged.contains("every connect"))
 
-        // Boundary: the constant is inclusive, so exactly-at-threshold takes the charged branch.
-        val atThreshold = ConnectionReadout.rtcWarning(
-            40_000_000L, null, batteryPct = ConnectionReadout.RTC_ALREADY_CHARGED_PCT)!!
+        // Pin the VALUE, not just the symbol: feeding the constant back into the function under test
+        // can never catch a wrong threshold, and nothing else would catch it drifting away from the
+        // Swift twin - the two platforms would each keep passing while giving different advice.
+        assertEquals(95.0, ConnectionReadout.RTC_ALREADY_CHARGED_PCT, 0.0)
+
+        // Boundary, from both sides, with literals: inclusive at 95, charge advice at 94.
+        val atThreshold = ConnectionReadout.rtcWarning(40_000_000L, null, batteryPct = 95.0)!!
         assertTrue(atThreshold.contains("already charged"))
+        val justBelow = ConnectionReadout.rtcWarning(40_000_000L, null, batteryPct = 94.0)!!
+        assertTrue(justBelow.contains("Charge the strap to 100%"))
 
         // Battery not read yet: we only withdraw advice on evidence, so the default stands.
         assertTrue(ConnectionReadout.rtcWarning(40_000_000L, null)!!.contains("Charge the strap to 100%"))

--- a/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
@@ -227,6 +227,29 @@ class ConnectionReadoutTest {
         assertNull(ConnectionReadout.rtcWarning(null, null))
     }
 
+    /** #1818: the remedy must track the battery. A charged strap told to "charge to 100%" is the bug
+     *  the field report hit - the user had already done it, twice. Twin of the Swift test. */
+    @Test fun rtcWarningRemedyTracksBattery() {
+        val flat = ConnectionReadout.rtcWarning(40_000_000L, null, batteryPct = 40.0)
+        assertTrue(flat!!.contains("Charge the strap to 100%"))
+
+        val charged = ConnectionReadout.rtcWarning(40_000_000L, null, batteryPct = 100.0)!!
+        assertFalse(charged.contains("Charge the strap to 100%"))
+        assertTrue(charged.contains("already charged"))
+        assertTrue(charged.contains("strap log"))
+
+        // Boundary: the constant is inclusive, so exactly-at-threshold takes the charged branch.
+        val atThreshold = ConnectionReadout.rtcWarning(
+            40_000_000L, null, batteryPct = ConnectionReadout.RTC_ALREADY_CHARGED_PCT)!!
+        assertTrue(atThreshold.contains("already charged"))
+
+        // Battery not read yet: we only withdraw advice on evidence, so the default stands.
+        assertTrue(ConnectionReadout.rtcWarning(40_000_000L, null)!!.contains("Charge the strap to 100%"))
+
+        // A sane clock stays silent no matter how full the battery is.
+        assertNull(ConnectionReadout.rtcWarning(1_782_475_600L, 1_782_475_000L, batteryPct = 100.0))
+    }
+
     @Test fun lastFrameLabel() {
         assertEquals("12s ago", ConnectionReadout.lastFrameLabel(990L, nowUnix = 1_002L))
         assertEquals("no frames yet", ConnectionReadout.lastFrameLabel(null, nowUnix = 1_002L))

--- a/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
@@ -237,6 +237,10 @@ class ConnectionReadoutTest {
         assertFalse(charged.contains("Charge the strap to 100%"))
         assertTrue(charged.contains("already charged"))
         assertTrue(charged.contains("strap log"))
+        // The charged copy must stay true for EVERY strap. "NOOP re-sends the clock on every connect"
+        // holds on WHOOP4 but not on a 5/MG, where the write is gated behind didBond and an unbondable
+        // strap (#1635) is never clocked at all - the strap most likely to be showing this warning.
+        assertFalse(charged.contains("every connect"))
 
         // Boundary: the constant is inclusive, so exactly-at-threshold takes the charged branch.
         val atThreshold = ConnectionReadout.rtcWarning(


### PR DESCRIPTION
Reported on #1818.

`ConnectionReadout.rtcWarning` decided purely on the two clock values, so a strap at 100% was handed
the same remedy as a strap at 4%:

> Strap clock reads 1970/71 (never set since its last reset), so it is not banking history.
> **Charge the strap to 100% and reconnect so the clock latches.**

A WHOOP 4.0 user on fw 41.17.4.0 did that, twice, and nothing changed. The advice does not describe a
precondition NOOP enforces, so following it could not have helped.

## The change

The remedy now takes a battery reading and splits:

| battery | copy |
|---|---|
| below threshold | unchanged - a flat battery really does reset the RTC, so "charge it" is real advice |
| at or above threshold | says charging again will not change it, and asks for a strap log |
| not read yet (`nil`) | unchanged - advice is only withdrawn on evidence |

The threshold is a named constant on both platforms (`rtcAlreadyChargedPct` / `RTC_ALREADY_CHARGED_PCT`,
95) and the copy is byte-identical Swift/Kotlin, verified fragment-by-fragment.

## Two re-review catches

**The battery term has to come from the current link.** Both call sites first read `live.batteryPct`,
which **deliberately outlives the link** - `clearBiometrics` leaves it so Today and the widget can show a
last-known charge, and #530 records that a 21 h old reading there renders identically to a fresh one.
Depending on it inverted the remedy in the case it most needs to be right: a strap that **ran flat** -
which is what resets the RTC - reconnecting before its first battery event (~8 min cadence) would be
judged on last session's 100%. Both sites now read `batterySamples.last?.soc`, which `clearBiometrics`
clears on disconnect alongside `strapRange` and `lastFrameAtUnix` - the other two signals this warning
already reads - so it is a reading from **this** link or nothing. Clearing `batteryPct` itself would have
been the wrong fix; its persistence is load-bearing elsewhere.

**The copy must not explain the mechanism.** The charged branch first asserted that NOOP re-sends the
clock on every connect. True on WHOOP4, where `runConnectHandshake` calls `SET_CLOCK` unconditionally in
both payload forms (#120) - but **false on a 5/MG**, where that write is gated behind `didBond`, and a
strap answering SMP with `Pairing Not Supported` (#1635) is never clocked at all. That is precisely the
strap most likely to be sitting at 1970/71 showing this warning, so the sentence would have told the
affected users something untrue about their own device - the very thing this PR exists to stop. The
charged branch now states only what holds for every strap and asks for the log. Tests pin the absence of
the claim so it is not reintroduced.

## Reach, honestly

User-visible on **Apple only**. The Kotlin `rtcWarning` has no Android caller - and neither does
`clockLatchedLabel`, so Android renders neither the symptom nor the advice today. The Kotlin half is
maintained-in-step twin code with tests, not a shipped Android fix. Whether the Android Devices screen
should surface clock state at all is worth its own issue.

## Scope

Copy only. Why the clock is not latching on fw 41.17.4.0 despite `SET_CLOCK` going out is still open on
#1818 - the corrected copy asks for the strap log that can tell a rejected write apart from an RTC
resetting again.

## Verification

Twin tests on each platform pin the split, the inclusive boundary, the unknown-battery default, the
absence of the mechanism claim, and that a sane clock stays silent whatever the battery reads.

- Kotlin: `:app:testFullDebugUnitTest` - **21/21**, forced re-run rather than a cached task result, new
  cases confirmed present in the result XML.
- Swift: covered by the `test (StrandAnalytics)` CI job on macOS, green on the previous head. The two
  app-target call sites (`DevicesView`, `TestCentreView`) compile only under the app-build gate, which
  has not been run.
- Both render sites use `fixedSize(horizontal: false, vertical: true)`, so the longer copy wraps rather
  than clipping. `Tools/i18n_audit.py --ci` passes.
