### PR TITLE
diag(ble): log a link epitaph on every disconnect (#1809)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
@@ -272,6 +272,31 @@ public enum ConnectionReadout {
         return lead + "Charge the strap to 100% and reconnect so the clock latches."
     }
 
+    /// #1809: one-line account of a finished BLE link, logged on every disconnect.
+    ///
+    /// A strap log could not previously answer "did the strap send anything?". Inbound notifications only
+    /// stamped a liveness timestamp that was then discarded, and the disconnect error reached the log as
+    /// the OS `localizedDescription` while the `CBError` code the #617 branch computes was thrown away. A
+    /// reporter chasing a silent strap had to infer silence from the fact that every LOGGED line happened
+    /// to be outgoing - which measures NOOP's logging, not the strap. This measures the strap.
+    ///
+    /// `armed` matters because the #80 marginal-radio fallback only counts a drop when the R10/R11 burst
+    /// was actually armed; `armed=no` says up front that the detector cannot trip for this link, however
+    /// many times the loop repeats.
+    ///
+    /// Milliseconds are printed raw: no float formatting, so the two platforms cannot round apart.
+    public static func linkEpitaph(upMillis: Int, inboundFrames: Int, inboundBytes: Int,
+                                   cmdChannelFrames: Int, realtimeArmed: Bool, ended: String) -> String {
+        let armed = realtimeArmed ? "yes" : "no"
+        var line = "Link epitaph: up \(max(0, upMillis))ms, inbound \(max(0, inboundFrames)) frames / "
+            + "\(max(0, inboundBytes)) bytes (cmd-channel \(max(0, cmdChannelFrames))), "
+            + "realtime armed=\(armed), ended=\(ended)"
+        if inboundFrames <= 0 {
+            line += " - the strap sent NOTHING on this link"
+        }
+        return line
+    }
+
     /// #987: freshness label for the "last frame" readout row: how long ago the most recent strap frame
     /// was routed ("12s ago"), or "no frames yet" before the first one. `nowUnix` injected for testability.
     public static func lastFrameLabel(lastFrameUnix: Int?, nowUnix: Int) -> String {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
@@ -266,6 +266,33 @@ final class ConnectionReadoutTests: XCTestCase {
                                                   strapNewestUnix: 1_782_475_000, batteryPct: 100))
     }
 
+    /// #1809: the epitaph exists so a strap log can STATE that nothing arrived, rather than a reporter
+    /// inferring it from the fact that every logged line happened to be outgoing.
+    func testLinkEpitaph() {
+        let silent = ConnectionReadout.linkEpitaph(upMillis: 4_123, inboundFrames: 0, inboundBytes: 0,
+                                                   cmdChannelFrames: 0, realtimeArmed: false,
+                                                   ended: "CBError.connectionTimeout(6)")
+        XCTAssertEqual(silent,
+                       "Link epitaph: up 4123ms, inbound 0 frames / 0 bytes (cmd-channel 0), "
+                       + "realtime armed=no, ended=CBError.connectionTimeout(6)"
+                       + " - the strap sent NOTHING on this link")
+
+        // A link that carried traffic must NOT claim silence.
+        let alive = ConnectionReadout.linkEpitaph(upMillis: 61_000, inboundFrames: 812,
+                                                  inboundBytes: 40_990, cmdChannelFrames: 9,
+                                                  realtimeArmed: true, ended: "intentional")
+        XCTAssertEqual(alive,
+                       "Link epitaph: up 61000ms, inbound 812 frames / 40990 bytes (cmd-channel 9), "
+                       + "realtime armed=yes, ended=intentional")
+        XCTAssertFalse(alive.contains("NOTHING"))
+
+        // Negatives are clamped rather than printed: a monotonic-clock hiccup must not emit "up -3ms".
+        XCTAssertTrue(ConnectionReadout.linkEpitaph(upMillis: -3, inboundFrames: -1, inboundBytes: -9,
+                                                    cmdChannelFrames: -2, realtimeArmed: false,
+                                                    ended: "x")
+                        .hasPrefix("Link epitaph: up 0ms, inbound 0 frames / 0 bytes (cmd-channel 0)"))
+    }
+
     func testLastFrameLabel() {
         XCTAssertEqual(ConnectionReadout.lastFrameLabel(lastFrameUnix: 990, nowUnix: 1_002), "12s ago")
         XCTAssertEqual(ConnectionReadout.lastFrameLabel(lastFrameUnix: nil, nowUnix: 1_002), "no frames yet")

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -726,7 +726,6 @@ public final class BLEManager: NSObject, ObservableObject {
     /// DIAGNOSTIC ONLY — it never cancels or retries; recovery is separate work.
     private var pendingConnectProbe: DispatchWorkItem?
     static let pendingConnectProbeSeconds: TimeInterval = 15
-    /// Last time ANY notification arrived — drives the liveness watchdog.
     /// #1809: per-connection inbound accounting for the link epitaph. A strap log could not say whether
     /// the strap transmitted anything; these three make it a measurement. Reset in `didConnect`, so they
     /// describe THIS link and never carry a previous session's traffic into its epitaph.
@@ -735,6 +734,7 @@ public final class BLEManager: NSObject, ObservableObject {
     private var cmdChannelFrames = 0
     /// Uptime clock for the epitaph. Monotonic, so a wall-clock change mid-link cannot make it negative.
     private var linkUpSince: DispatchTime?
+    /// Last time ANY notification arrived — drives the liveness watchdog.
     private var lastDataAt = Date()
     /// True while a Live/Health screen is on-screen and wants the realtime stream. One of the two
     /// inputs to `wantsRealtime`. Driven by `startRealtime()` / `stopRealtime()`.

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -5392,12 +5392,16 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         } else {
             endedReason = "no error reported"
         }
-        let upMs = linkUpSince.map {
-            Int(Double(DispatchTime.now().uptimeNanoseconds &- $0.uptimeNanoseconds) / 1_000_000)
-        } ?? 0
-        log(ConnectionReadout.linkEpitaph(upMillis: upMs, inboundFrames: inboundFrames,
-                                          inboundBytes: inboundBytes, cmdChannelFrames: cmdChannelFrames,
-                                          realtimeArmed: realtimeArmedAt != nil, ended: endedReason))
+        // Only for a link we actually held. Emitting without one would report "the strap sent NOTHING on
+        // this link" using the PREVIOUS link's counters, fabricating the very symptom #1809 is about.
+        if let since = linkUpSince {
+            let upMs = Int(Double(DispatchTime.now().uptimeNanoseconds &- since.uptimeNanoseconds) / 1_000_000)
+            log(ConnectionReadout.linkEpitaph(upMillis: upMs, inboundFrames: inboundFrames,
+                                              inboundBytes: inboundBytes, cmdChannelFrames: cmdChannelFrames,
+                                              realtimeArmed: realtimeArmedAt != nil, ended: endedReason))
+        }
+        // Clear the tally with the link, so a second teardown for the same drop cannot re-report it.
+        inboundFrames = 0; inboundBytes = 0; cmdChannelFrames = 0
         linkUpSince = nil
 
         let timedOut = !intentionalDisconnect && error != nil

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -727,6 +727,14 @@ public final class BLEManager: NSObject, ObservableObject {
     private var pendingConnectProbe: DispatchWorkItem?
     static let pendingConnectProbeSeconds: TimeInterval = 15
     /// Last time ANY notification arrived — drives the liveness watchdog.
+    /// #1809: per-connection inbound accounting for the link epitaph. A strap log could not say whether
+    /// the strap transmitted anything; these three make it a measurement. Reset in `didConnect`, so they
+    /// describe THIS link and never carry a previous session's traffic into its epitaph.
+    private var inboundFrames = 0
+    private var inboundBytes = 0
+    private var cmdChannelFrames = 0
+    /// Uptime clock for the epitaph. Monotonic, so a wall-clock change mid-link cannot make it negative.
+    private var linkUpSince: DispatchTime?
     private var lastDataAt = Date()
     /// True while a Live/Health screen is on-screen and wants the realtime stream. One of the two
     /// inputs to `wantsRealtime`. Driven by `startRealtime()` / `stopRealtime()`.
@@ -5230,6 +5238,10 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         cancelScanFallback()
         cancelPendingConnectProbe()   // #730: the connect resolved; no pending-connect log needed
         failedConnectAttempts = 0   // a successful connect clears the reconnect backoff (#414)
+        // #1809: this link's inbound tally starts empty; the epitaph on disconnect reports exactly what
+        // arrived between here and there.
+        inboundFrames = 0; inboundBytes = 0; cmdChannelFrames = 0
+        linkUpSince = DispatchTime.now()
         standingConnectAt = nil     // #1413: a live link means no standing connect is outstanding
         restoredPeripheral = nil
         preparePeripheral(peripheral)
@@ -5367,6 +5379,27 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         // arm timestamp. A drop that is unintentional, error-bearing, and lands shortly after we armed
         // the R10/R11 burst is the marginal-radio tell. Feed the detector; if it trips, the NEXT connect
         // skips the heavy arm (the flag is intentionally NOT reset on disconnect so it survives rescan).
+        // #1809: the epitaph goes out BEFORE the resets below, for the same reason the two detectors read
+        // their state here - `realtimeArmedAt` is about to be cleared. `ended` carries the CBError CASE, not
+        // just the OS sentence: the #617 branch already computes that code and the strap log never saw it.
+        let endedReason: String
+        if intentionalDisconnect {
+            endedReason = "intentional"
+        } else if let cb = error as? CBError {
+            endedReason = "CBError.\(cb.code)(\(cb.code.rawValue))"
+        } else if let error {
+            endedReason = "\(error)"
+        } else {
+            endedReason = "no error reported"
+        }
+        let upMs = linkUpSince.map {
+            Int(Double(DispatchTime.now().uptimeNanoseconds &- $0.uptimeNanoseconds) / 1_000_000)
+        } ?? 0
+        log(ConnectionReadout.linkEpitaph(upMillis: upMs, inboundFrames: inboundFrames,
+                                          inboundBytes: inboundBytes, cmdChannelFrames: cmdChannelFrames,
+                                          realtimeArmed: realtimeArmedAt != nil, ended: endedReason))
+        linkUpSince = nil
+
         let timedOut = !intentionalDisconnect && error != nil
         let sinceArm = realtimeArmedAt.map { Date().timeIntervalSince($0) }
         if marginalRadio.connectionEnded(wasArmed: realtimeArmedAt != nil,
@@ -6341,6 +6374,11 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
         guard let data = characteristic.value else { return }
         let bytes = [UInt8](data)
         lastDataAt = Date()   // feed the liveness watchdog on every notification
+        // #1809: count BEFORE the per-characteristic switch below, so the tally covers every inbound
+        // frame including ones no branch consumes - the epitaph must answer "did anything arrive at all".
+        inboundFrames += 1
+        inboundBytes += bytes.count
+        if characteristic.uuid == BLEManager.cmdNotifyChar { cmdChannelFrames += 1 }
 
         switch characteristic.uuid {
         case BLEManager.heartRateChar:

--- a/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
@@ -252,6 +252,30 @@ object ConnectionReadout {
         return lead + "Charge the strap to 100% and reconnect so the clock latches."
     }
 
+    /** #1809: one-line account of a finished BLE link, logged on every disconnect. Twin of the Swift
+     *  formatter.
+     *
+     *  A strap log could not previously answer "did the strap send anything?". Inbound notifications only
+     *  stamped a liveness timestamp that was then discarded, so a reporter chasing a silent strap had to
+     *  infer silence from the fact that every LOGGED line happened to be outgoing - which measures NOOP's
+     *  logging, not the strap. This measures the strap.
+     *
+     *  [realtimeArmed] matters because the #80 marginal-radio fallback only counts a drop when the R10/R11
+     *  burst was actually armed; armed=no says up front that the detector cannot trip for this link,
+     *  however many times the loop repeats.
+     *
+     *  Milliseconds are printed raw: no float formatting, so the two platforms cannot round apart. */
+    fun linkEpitaph(upMillis: Int, inboundFrames: Int, inboundBytes: Int, cmdChannelFrames: Int,
+                    realtimeArmed: Boolean, ended: String): String {
+        var line = "Link epitaph: up ${maxOf(0, upMillis)}ms, inbound ${maxOf(0, inboundFrames)} frames / " +
+            "${maxOf(0, inboundBytes)} bytes (cmd-channel ${maxOf(0, cmdChannelFrames)}), " +
+            "realtime armed=${if (realtimeArmed) "yes" else "no"}, ended=$ended"
+        if (inboundFrames <= 0) {
+            line += " - the strap sent NOTHING on this link"
+        }
+        return line
+    }
+
     /** #987: freshness label for the "last frame" readout row ("12s ago" / "no frames yet"). [nowUnix]
      *  injected for testability. Twin of the Swift labeller. */
     fun lastFrameLabel(lastFrameUnix: Long?, nowUnix: Long): String {

--- a/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
@@ -264,10 +264,13 @@ object ConnectionReadout {
      *  burst was actually armed; armed=no says up front that the detector cannot trip for this link,
      *  however many times the loop repeats.
      *
-     *  Milliseconds are printed raw: no float formatting, so the two platforms cannot round apart. */
-    fun linkEpitaph(upMillis: Int, inboundFrames: Int, inboundBytes: Int, cmdChannelFrames: Int,
+     *  Milliseconds are printed raw: no float formatting, so the two platforms cannot round apart.
+     *  [upMillis] is Long, not Int: Swift's Int is 64-bit, so an Int here would be the NARROWER type and
+     *  a link held past ~24.8 days would wrap negative and print "up 0ms" - a dead-looking link that was
+     *  in fact the healthiest one we ever had. Rare, silent, and exactly backwards, so use the real twin. */
+    fun linkEpitaph(upMillis: Long, inboundFrames: Int, inboundBytes: Int, cmdChannelFrames: Int,
                     realtimeArmed: Boolean, ended: String): String {
-        var line = "Link epitaph: up ${maxOf(0, upMillis)}ms, inbound ${maxOf(0, inboundFrames)} frames / " +
+        var line = "Link epitaph: up ${maxOf(0L, upMillis)}ms, inbound ${maxOf(0, inboundFrames)} frames / " +
             "${maxOf(0, inboundBytes)} bytes (cmd-channel ${maxOf(0, cmdChannelFrames)}), " +
             "realtime armed=${if (realtimeArmed) "yes" else "no"}, ended=$ended"
         if (inboundFrames <= 0) {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -6145,6 +6145,7 @@ class WhoopBleClient(
                     // #1809: this link's inbound tally starts empty, so the epitaph on disconnect reports
                     // exactly what arrived on THIS link and never a previous session's traffic.
                     inboundFrames = 0; inboundBytes = 0; cmdChannelFrames = 0
+                    realtimeArmedThisLink = false
                     // A connect succeeded → clear the stale-bond re-pair guide UNLESS we are in a known
                     // bond-loop (#617). In that loop the strap "connects" every ~3 s before timing out
                     // again, so clearing here wiped the guide on EVERY cycle: it flashed for ~1 s and
@@ -6543,7 +6544,7 @@ class WhoopBleClient(
                     // window would re-arm the stream from it and stay armed until the next tick.
                     val realtimeWantNow = screenWantsRealtime || continuousCaptureWantsNow()
                     wantsRealtime = realtimeWantNow
-                    if (realtimeWantNow) { realtimeArmed = true; send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(1)) }
+                    if (realtimeWantNow) { realtimeArmed = true; realtimeArmedThisLink = true; send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(1)) }
                 }
             } else if (!didBond && connectedFamily == DeviceFamily.WHOOP4) {
                 didBond = true
@@ -6671,6 +6672,11 @@ class WhoopBleClient(
     private var inboundFrames = 0
     private var inboundBytes = 0
     private var cmdChannelFrames = 0
+    /** #1809: was realtime armed at ANY point on THIS link. Not the same thing as [realtimeArmed], which
+     *  is persistent edge state: it can carry true in from a previous link, or read false at the drop
+     *  after a mid-link disarm. The epitaph needs the per-link fact, which is what the Apple twin's
+     *  `realtimeArmedAt` gives (it is cleared on every disconnect). Reset with the counters on connect. */
+    private var realtimeArmedThisLink = false
 
     private fun onInbound(uuid: UUID, bytes: ByteArray) {
         // Count BEFORE any routing below, so the tally covers every inbound frame including ones no branch
@@ -7561,7 +7567,7 @@ class WhoopBleClient(
         // outside the overnight window must not arm the stream from a stale precomputed [wantsRealtime].
         val realtimeWantNow = screenWantsRealtime || continuousCaptureWantsNow()
         wantsRealtime = realtimeWantNow
-        if (realtimeWantNow) { realtimeArmed = true; send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(1)) }
+        if (realtimeWantNow) { realtimeArmed = true; realtimeArmedThisLink = true; send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(1)) }
     }
 
     // ====================================================================================
@@ -7671,7 +7677,7 @@ class WhoopBleClient(
                     flushCaptureLog()
                 }
                 if (connectedFamily == DeviceFamily.WHOOP4) {
-                    if (wantsRealtime) { realtimeArmed = true; send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(1)) }
+                    if (wantsRealtime) { realtimeArmed = true; realtimeArmedThisLink = true; send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(1)) }
                     // #battery: ~60 s normally, ~30 s while charging (see [batteryPollDue]).
                     if (batteryPollDue(keepAliveTick, s.charging == true)) send(CommandNumber.GET_BATTERY_LEVEL)
                 } else if (connectedFamily == DeviceFamily.WHOOP5 &&
@@ -7797,6 +7803,7 @@ class WhoopBleClient(
         if (want == realtimeArmed) return                          // no edge — nothing to send
         if (connectedFamily != DeviceFamily.WHOOP4 && !_state.value.bonded) return   // can't reach the strap yet
         realtimeArmed = want
+        if (want) realtimeArmedThisLink = true   // #1809: latch the per-link fact
         // Both families arm/disarm via TOGGLE_REALTIME_HR; send() frames it correctly per family (puffin
         // for 5/MG). A screen re-entry blanks its own smoothing window in the view-model, not here.
         send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(if (want) 1.toByte() else 0.toByte()))
@@ -8323,6 +8330,7 @@ class WhoopBleClient(
                 // cadence, not this drop path, so a persistently-busy stack retries once per tick, never in a loop.
                 if (shouldReArmRealtimeAfterDrop(item.cmd)) {
                     realtimeArmed = !realtimeArmed
+                    if (realtimeArmed) realtimeArmedThisLink = true   // #1809: per-link latch
                     log("realtime toggle dropped — reconciling on the next keep-alive tick (#312)")
                 }
                 writeRetries = 0
@@ -9790,12 +9798,21 @@ class WhoopBleClient(
         // #1809: the epitaph reads linkUpSinceMs BEFORE the snapshot below clears it, and realtimeArmed
         // before the state reset further down. Twin of the Apple disconnect epitaph: it answers "did the
         // strap send anything on this link", which no strap log could previously state as a measurement.
-        val upMs = linkUpSinceMs?.let { (System.currentTimeMillis() - it).toInt() } ?: 0
-        log(ConnectionReadout.linkEpitaph(
-            upMillis = upMs, inboundFrames = inboundFrames, inboundBytes = inboundBytes,
-            cmdChannelFrames = cmdChannelFrames, realtimeArmed = realtimeArmed,
-            ended = "status=$status",
-        ))
+        // Only for a link that actually reached STATE_CONNECTED. handleDisconnect also runs for a FAILED
+        // connect attempt and for the radio-off teardown, where linkUpSinceMs is null and the counters
+        // still hold the PREVIOUS link's traffic - emitting there would report "the strap sent NOTHING on
+        // this link" about a link that never existed, fabricating the very symptom #1809 is about. Same
+        // hazard the hold-time snapshot below already guards.
+        linkUpSinceMs?.let { since ->
+            log(ConnectionReadout.linkEpitaph(
+                upMillis = (System.currentTimeMillis() - since).toInt(),
+                inboundFrames = inboundFrames, inboundBytes = inboundBytes,
+                cmdChannelFrames = cmdChannelFrames, realtimeArmed = realtimeArmedThisLink,
+                ended = "status=$status",
+            ))
+        }
+        // Clear the tally with the link, so a second teardown for the same drop cannot re-report it.
+        inboundFrames = 0; inboundBytes = 0; cmdChannelFrames = 0
 
         val heldSuffix = heldForLogSuffix()
         linkUpSinceMs = null

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -9811,7 +9811,7 @@ class WhoopBleClient(
         // hazard the hold-time snapshot below already guards.
         linkUpSinceMs?.let { since ->
             log(ConnectionReadout.linkEpitaph(
-                upMillis = (System.currentTimeMillis() - since).toInt(),
+                upMillis = System.currentTimeMillis() - since,
                 inboundFrames = inboundFrames, inboundBytes = inboundBytes,
                 cmdChannelFrames = cmdChannelFrames, realtimeArmed = realtimeArmedThisLink,
                 ended = "status=$status",

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -6675,8 +6675,14 @@ class WhoopBleClient(
     /** #1809: was realtime armed at ANY point on THIS link. Not the same thing as [realtimeArmed], which
      *  is persistent edge state: it can carry true in from a previous link, or read false at the drop
      *  after a mid-link disarm. The epitaph needs the per-link fact, which is what the Apple twin's
-     *  `realtimeArmedAt` gives (it is cleared on every disconnect). Reset with the counters on connect. */
-    private var realtimeArmedThisLink = false
+     *  `realtimeArmedAt` gives (it is cleared on every disconnect). Reset with the counters on connect.
+     *
+     *  @Volatile for the same reason [realtimeArmed] is: the arm sites include the reconcile path, which
+     *  does not run on the GATT callback thread that reads this at the drop. A stale read here would print
+     *  "armed=no" for a link that WAS armed, and that word is what a reader uses to decide whether #80
+     *  applies. The frame/byte counters above are deliberately plain - ++ is not atomic whatever we
+     *  annotate them with, and an approximate count still answers "did anything arrive at all". */
+    @Volatile private var realtimeArmedThisLink = false
 
     private fun onInbound(uuid: UUID, bytes: ByteArray) {
         // Count BEFORE any routing below, so the tally covers every inbound frame including ones no branch

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -63,6 +63,7 @@ import com.noop.protocol.WhoopGattServiceFamily
 import com.noop.protocol.whoopGattScanDecision
 import com.noop.analytics.Baselines
 import com.noop.analytics.BatterySocLine
+import com.noop.analytics.ConnectionReadout
 import com.noop.analytics.IntelligenceEngine
 import com.noop.analytics.NapDetector
 import com.noop.analytics.NapPrefs
@@ -6141,6 +6142,9 @@ class WhoopBleClient(
                     // exactly what distinguishes a healthy connection from the flapping loop that keeps
                     // the reconnect streak — and so the scan mode — pinned at its most power-hungry.
                     linkUpSinceMs = System.currentTimeMillis()
+                    // #1809: this link's inbound tally starts empty, so the epitaph on disconnect reports
+                    // exactly what arrived on THIS link and never a previous session's traffic.
+                    inboundFrames = 0; inboundBytes = 0; cmdChannelFrames = 0
                     // A connect succeeded → clear the stale-bond re-pair guide UNLESS we are in a known
                     // bond-loop (#617). In that loop the strap "connects" every ~3 s before timing out
                     // again, so clearing here wiped the guide on EVERY cycle: it flashed for ~1 s and
@@ -6662,7 +6666,18 @@ class WhoopBleClient(
     // MARK: Inbound routing  (port of didUpdateValueFor + FrameRouter.handle)
     // ====================================================================================
 
+    /** #1809: per-connection inbound accounting for the link epitaph - the strap log could not previously
+     *  say whether the strap transmitted anything at all. Twin of the Swift counters. */
+    private var inboundFrames = 0
+    private var inboundBytes = 0
+    private var cmdChannelFrames = 0
+
     private fun onInbound(uuid: UUID, bytes: ByteArray) {
+        // Count BEFORE any routing below, so the tally covers every inbound frame including ones no branch
+        // consumes - the epitaph must answer "did anything arrive at all".
+        inboundFrames++
+        inboundBytes += bytes.size
+        if (uuid == CMD_NOTIFY_CHAR) cmdChannelFrames++
         lastDataAtMs = System.currentTimeMillis()   // feeds the keep-alive liveness watchdog
         resubscribedSinceData = false               // data is flowing again — re-arm the one-shot resubscribe
         when {
@@ -9772,6 +9787,16 @@ class WhoopBleClient(
         // Snapshot the hold time and clear it IMMEDIATELY: every drop log below reads the snapshot, and a
         // stale `linkUpSinceMs` surviving into the next drop would report a hold time for a link that never
         // reached STATE_CONNECTED — the diagnostic would then invent exactly the evidence it exists to find.
+        // #1809: the epitaph reads linkUpSinceMs BEFORE the snapshot below clears it, and realtimeArmed
+        // before the state reset further down. Twin of the Apple disconnect epitaph: it answers "did the
+        // strap send anything on this link", which no strap log could previously state as a measurement.
+        val upMs = linkUpSinceMs?.let { (System.currentTimeMillis() - it).toInt() } ?: 0
+        log(ConnectionReadout.linkEpitaph(
+            upMillis = upMs, inboundFrames = inboundFrames, inboundBytes = inboundBytes,
+            cmdChannelFrames = cmdChannelFrames, realtimeArmed = realtimeArmed,
+            ended = "status=$status",
+        ))
+
         val heldSuffix = heldForLogSuffix()
         linkUpSinceMs = null
         // Reboot trail: if a user reboot is in flight, this drop is the strap acting on it. Log how long the

--- a/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
@@ -260,6 +260,40 @@ class ConnectionReadoutTest {
         assertNull(ConnectionReadout.rtcWarning(1_782_475_600L, 1_782_475_000L, batteryPct = 100.0))
     }
 
+    /** #1809: the epitaph exists so a strap log can STATE that nothing arrived, rather than a reporter
+     *  inferring it from the fact that every logged line happened to be outgoing. Twin of the Swift test -
+     *  the two strings must match byte for byte or one platform's report reads differently. */
+    @Test fun linkEpitaph() {
+        val silent = ConnectionReadout.linkEpitaph(
+            upMillis = 4_123, inboundFrames = 0, inboundBytes = 0, cmdChannelFrames = 0,
+            realtimeArmed = false, ended = "CBError.connectionTimeout(6)",
+        )
+        assertEquals(
+            "Link epitaph: up 4123ms, inbound 0 frames / 0 bytes (cmd-channel 0), " +
+                "realtime armed=no, ended=CBError.connectionTimeout(6)" +
+                " - the strap sent NOTHING on this link",
+            silent,
+        )
+
+        // A link that carried traffic must NOT claim silence.
+        val alive = ConnectionReadout.linkEpitaph(
+            upMillis = 61_000, inboundFrames = 812, inboundBytes = 40_990, cmdChannelFrames = 9,
+            realtimeArmed = true, ended = "intentional",
+        )
+        assertEquals(
+            "Link epitaph: up 61000ms, inbound 812 frames / 40990 bytes (cmd-channel 9), " +
+                "realtime armed=yes, ended=intentional",
+            alive,
+        )
+        assertFalse(alive.contains("NOTHING"))
+
+        // Negatives are clamped rather than printed: a clock hiccup must not emit "up -3ms".
+        assertTrue(
+            ConnectionReadout.linkEpitaph(-3, -1, -9, -2, false, "x")
+                .startsWith("Link epitaph: up 0ms, inbound 0 frames / 0 bytes (cmd-channel 0)"),
+        )
+    }
+
     @Test fun lastFrameLabel() {
         assertEquals("12s ago", ConnectionReadout.lastFrameLabel(990L, nowUnix = 1_002L))
         assertEquals("no frames yet", ConnectionReadout.lastFrameLabel(null, nowUnix = 1_002L))

--- a/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
@@ -265,7 +265,7 @@ class ConnectionReadoutTest {
      *  the two strings must match byte for byte or one platform's report reads differently. */
     @Test fun linkEpitaph() {
         val silent = ConnectionReadout.linkEpitaph(
-            upMillis = 4_123, inboundFrames = 0, inboundBytes = 0, cmdChannelFrames = 0,
+            upMillis = 4_123L, inboundFrames = 0, inboundBytes = 0, cmdChannelFrames = 0,
             realtimeArmed = false, ended = "CBError.connectionTimeout(6)",
         )
         assertEquals(
@@ -277,7 +277,7 @@ class ConnectionReadoutTest {
 
         // A link that carried traffic must NOT claim silence.
         val alive = ConnectionReadout.linkEpitaph(
-            upMillis = 61_000, inboundFrames = 812, inboundBytes = 40_990, cmdChannelFrames = 9,
+            upMillis = 61_000L, inboundFrames = 812, inboundBytes = 40_990, cmdChannelFrames = 9,
             realtimeArmed = true, ended = "intentional",
         )
         assertEquals(
@@ -289,7 +289,7 @@ class ConnectionReadoutTest {
 
         // Negatives are clamped rather than printed: a clock hiccup must not emit "up -3ms".
         assertTrue(
-            ConnectionReadout.linkEpitaph(-3, -1, -9, -2, false, "x")
+            ConnectionReadout.linkEpitaph(-3L, -1, -9, -2, false, "x")
                 .startsWith("Link epitaph: up 0ms, inbound 0 frames / 0 bytes (cmd-channel 0)"),
         )
     }


### PR DESCRIPTION
Instrumentation for #1809, where a WHOOP 4.0 bonds, subscribes every notify, and then transmits nothing
until the link dies at the 4 s supervision timeout, forever.

## Why

A strap log could not answer the first question that report raises: **did the strap send anything at
all?** Inbound notifications only stamped `lastDataAt` for the liveness watchdog and the value was then
discarded - no frame count, no byte count, nothing. The disconnect reached the log as the OS
`localizedDescription`, while the `CBError` code the #617 branch already computes was never written down.

So the reporter established silence by observing that all 1027 logged lines happened to be outgoing, then
corroborated it by hand from macOS `bluetoothd`. That measures NOOP's logging, not the strap - and it has
a real blind spot, since before #1697 this side decoded the strap's own `CONSOLE_LOGS` and discarded them.

## What lands

Every inbound frame and byte is counted per connection, plus the cmd-channel subset, and one line is
emitted when the link ends:

```
Link epitaph: up 4123ms, inbound 0 frames / 0 bytes (cmd-channel 0), realtime armed=no,
ended=CBError.connectionTimeout(6) - the strap sent NOTHING on this link
```

`realtime armed` is in the line because the **#80 marginal-radio fallback only counts a drop when the
R10/R11 burst was actually armed**. On #1809 it never was - the connect burst sends R10/R11 `[0x00]`,
which is the *stop*; the arm is gated behind `screenWantsRealtime || continuousCaptureWantsNow()`. So
`armed=no` states up front that the detector cannot trip however long the loop runs. Establishing that
took a code read; now the log says it.

## Two re-review catches

**The epitaph could fabricate its own symptom.** `handleDisconnect` also runs for a FAILED connect
attempt (`STATE_DISCONNECTED` with no preceding `STATE_CONNECTED`) and for the radio-off teardown. In
both, `linkUpSinceMs` is null and the counters still hold the *previous* link's traffic - so the line
would have read "the strap sent NOTHING on this link" about a link that never existed, manufacturing
exactly the symptom #1809 is about, inside the diagnostic built to investigate it. The hold-time snapshot
directly below already guards this hazard and warns about it in its own comment. The epitaph now emits
only for a link that reached connected, and the tally is cleared with the link so a second teardown for
one drop cannot re-report it.

**The armed flag was not the twin it claimed to be.** Apple's `realtimeArmedAt` is cleared on every
disconnect, so at the drop it means "armed on THIS link" - the fact the line needs. Kotlin's
`realtimeArmed` is persistent edge state: it can carry `true` in from a previous link, or read `false` at
the drop after a mid-link disarm. Android would have reported a different fact under the same word.
Added a per-link latch, set at all five arm sites and reset with the counters on connect.

## Details worth noting in review

- Counting happens **before** the per-characteristic routing, so a frame that no branch consumes still
  proves the strap transmitted.
- Both platforms read uptime and armed state **before** the existing resets clear them - the same
  ordering constraint the #80 and #617 detectors already observe in these handlers.
- Milliseconds are printed raw. No float formatting, so the platforms cannot round apart the way
  `String.format("%.1f", ...)` and `String(format:)` do.
- Negative inputs clamp instead of printing `up -3ms`.
- The line carries no identifiers - counts, milliseconds and a status code only. Safe to paste into a
  public issue, which is the point.

## Tests

Pinned on both platforms: the exact string, that a link carrying traffic never claims silence, and the
clamping.

- Kotlin: `:app:testFullDebugUnitTest --tests "com.noop.analytics.ConnectionReadoutTest"` - **22/22**,
  forced re-run rather than a cached task result.
- Swift: covered by the `test (StrandAnalytics)` CI job. The `BLEManager` wiring is app-target and
  compiles only under the app-build gate, which has not been run.

## Scope

Diagnostics only - no behaviour change, and nothing repaired here. #1809 stays open: this is what makes
the next capture answer the question instead of raising it.
