### PR TITLE
Clock format setting: System / 12-hour / 24-hour (#1821)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ClockFormat.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ClockFormat.swift
@@ -45,6 +45,21 @@ public enum ClockFormat {
         uses24Hour ? "HH:mm" : "h:mm a"
     }
 
+    /// A locale identifier carrying an explicit HOUR CYCLE, so a formatter driven by `timeStyle` or by a
+    /// `j`-bearing template resolves the clock the reader chose instead of the region default.
+    ///
+    /// This is what lets the setting reach the ~17 Apple formatters that never mention "HH:mm" at all -
+    /// they say `timeStyle = .short` or template `"jmm"`, and both ask the LOCALE for the hour. Rewriting
+    /// each into an explicit pattern would have thrown away localized date order, separators and AM/PM
+    /// wording; setting the hour cycle keeps all of it and changes only the part the reader asked for.
+    ///
+    /// `h23`/`h12` are the ICU `hours` keyword values. A malformed identifier would silently fall back to
+    /// the base locale - a no-op that looks like a working setting - so `ClockFormatLocaleTests` asserts
+    /// against a real `DateFormatter` on macOS rather than trusting the string.
+    public static func hourCycleLocaleIdentifier(base: String, uses24Hour: Bool) -> String {
+        "\(base)@hours=\(uses24Hour ? "h23" : "h12")"
+    }
+
     /// SKELETON template for the same time, for `setLocalizedDateFormatFromTemplate`. Apple uses this
     /// rather than the literal above so the locale still decides ordering, separator and AM/PM wording,
     /// while the H-vs-h choice - the only part the reader asked to control - stays ours. Note this is

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ClockFormat.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ClockFormat.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// #1821: which clock the UI shows times in. Twin of the Kotlin `ClockFormatPreference`.
+///
+/// NOOP had no such setting: every user-facing time came from the device REGION's convention. On Apple
+/// `AppLanguage.activeLocale` builds `language_REGION` deliberately, to keep regional date order and
+/// clock style - but constructing a locale from a region identifier DISCARDS the user's explicit
+/// "24-Hour Time" switch, because that override lives on `Locale.autoupdatingCurrent`, not on the region
+/// default. A reader in a 24-hour region who prefers 12-hour had no way to say so, which is the report
+/// this exists to answer.
+public enum ClockFormatPreference: String, CaseIterable, Sendable {
+    /// Follow the device's own clock switch. The default, so nobody's display changes on upgrade.
+    case system
+    case twelveHour
+    case twentyFourHour
+
+    /// Persistence key, shared by the Apple `@AppStorage` binding and the Android preference so the two
+    /// platforms cannot drift apart on the name of the thing they store.
+    public static let defaultsKey = "clockFormatPreference"
+
+    /// Unknown/absent stored values fall back to `.system` rather than to a hardcoded clock: a value we
+    /// cannot parse must not silently pin every reader to one format.
+    public static func from(stored: String?) -> ClockFormatPreference {
+        guard let stored, let parsed = ClockFormatPreference(rawValue: stored) else { return .system }
+        return parsed
+    }
+}
+
+public enum ClockFormat {
+    /// Resolve the preference against what the device reports. `systemUses24Hour` is injected rather than
+    /// read here so this stays pure and identically testable on both platforms - Apple derives it from
+    /// `Locale.autoupdatingCurrent` (which DOES carry the 24-Hour Time switch), Android from
+    /// `DateFormat.is24HourFormat(context)`.
+    public static func uses24Hour(preference: ClockFormatPreference, systemUses24Hour: Bool) -> Bool {
+        switch preference {
+        case .system:         return systemUses24Hour
+        case .twelveHour:     return false
+        case .twentyFourHour: return true
+        }
+    }
+
+    /// Literal wall-clock pattern at minute precision, for formatters driven by an explicit pattern.
+    /// Used by Android, whose existing time labels already build `SimpleDateFormat` from a literal.
+    public static func hourMinutePattern(uses24Hour: Bool) -> String {
+        uses24Hour ? "HH:mm" : "h:mm a"
+    }
+
+    /// SKELETON template for the same time, for `setLocalizedDateFormatFromTemplate`. Apple uses this
+    /// rather than the literal above so the locale still decides ordering, separator and AM/PM wording,
+    /// while the H-vs-h choice - the only part the reader asked to control - stays ours. Note this is
+    /// deliberately NOT the `j` template the buggy path used: `j` resolves the hour from the locale, which
+    /// is exactly how a reader's explicit preference got discarded.
+    public static func hourMinuteTemplate(uses24Hour: Bool) -> String {
+        uses24Hour ? "Hmm" : "hmm"
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ClockFormatLocaleTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ClockFormatLocaleTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// #1821: these assert against a REAL `DateFormatter`, not against the identifier string.
+///
+/// The hour-cycle locale is the mechanism that carries the setting into every formatter that never says
+/// "HH:mm" - the ones using `timeStyle = .short` or a `"jmm"` template. If the identifier syntax were
+/// wrong, Foundation would quietly fall back to the base locale and every one of those sites would keep
+/// showing the region default while the setting appeared to be applied. That failure is silent, so it has
+/// to be caught by exercising Foundation itself.
+final class ClockFormatLocaleTests: XCTestCase {
+    private func shortTime(_ base: String, uses24Hour: Bool) -> String {
+        let id = ClockFormat.hourCycleLocaleIdentifier(base: base, uses24Hour: uses24Hour)
+        let f = DateFormatter()
+        f.locale = Locale(identifier: id)
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.timeStyle = .short
+        f.dateStyle = .none
+        // 2026-01-02 22:57 UTC — the reported "22:57" / "10:57 PM".
+        return f.string(from: Date(timeIntervalSince1970: 1_767_394_620))
+    }
+
+    func testTimeStyleShortHonoursTheForcedHourCycle() {
+        // en_GB is a 24-hour region: asking for 12-hour must actually change it.
+        XCTAssertTrue(shortTime("en_GB", uses24Hour: false).contains("10"),
+                      "12-hour was requested on a 24-hour region and did not take effect")
+        XCTAssertTrue(shortTime("en_GB", uses24Hour: true).contains("22"))
+        // en_US is a 12-hour region: the reverse must work too, or the setting is one-directional.
+        XCTAssertTrue(shortTime("en_US", uses24Hour: true).contains("22"),
+                      "24-hour was requested on a 12-hour region and did not take effect")
+        XCTAssertTrue(shortTime("en_US", uses24Hour: false).contains("10"))
+    }
+
+    /// The other half of the surface: templates containing `j`, which resolve the hour from the locale.
+    func testJTemplateHonoursTheForcedHourCycle() {
+        func viaTemplate(_ base: String, uses24Hour: Bool) -> String {
+            let id = ClockFormat.hourCycleLocaleIdentifier(base: base, uses24Hour: uses24Hour)
+            let f = DateFormatter()
+            f.locale = Locale(identifier: id)
+            f.timeZone = TimeZone(identifier: "UTC")
+            f.setLocalizedDateFormatFromTemplate("jmm")
+            return f.string(from: Date(timeIntervalSince1970: 1_767_394_620))
+        }
+        XCTAssertTrue(viaTemplate("en_GB", uses24Hour: false).contains("10"))
+        XCTAssertTrue(viaTemplate("en_US", uses24Hour: true).contains("22"))
+    }
+
+    func testIdentifierShape() {
+        XCTAssertEqual(ClockFormat.hourCycleLocaleIdentifier(base: "en_GB", uses24Hour: true), "en_GB@hours=h23")
+        XCTAssertEqual(ClockFormat.hourCycleLocaleIdentifier(base: "fr_FR", uses24Hour: false), "fr_FR@hours=h12")
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ClockFormatTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ClockFormatTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import StrandAnalytics
+
+final class ClockFormatTests: XCTestCase {
+    func testSystemDefersToTheDevice() {
+        XCTAssertTrue(ClockFormat.uses24Hour(preference: .system, systemUses24Hour: true))
+        XCTAssertFalse(ClockFormat.uses24Hour(preference: .system, systemUses24Hour: false))
+    }
+
+    func testAnExplicitChoiceOverridesTheDevice() {
+        // The whole point of the setting: a reader in a 24-hour region can ask for 12-hour and get it.
+        XCTAssertFalse(ClockFormat.uses24Hour(preference: .twelveHour, systemUses24Hour: true))
+        XCTAssertTrue(ClockFormat.uses24Hour(preference: .twentyFourHour, systemUses24Hour: false))
+    }
+
+    func testUnknownStoredValuesFallBackToSystemNotToAClock() {
+        XCTAssertEqual(ClockFormatPreference.from(stored: nil), .system)
+        XCTAssertEqual(ClockFormatPreference.from(stored: ""), .system)
+        XCTAssertEqual(ClockFormatPreference.from(stored: "24h"), .system,
+                       "an unparseable value must not pin every reader to one clock")
+        XCTAssertEqual(ClockFormatPreference.from(stored: "twelveHour"), .twelveHour)
+        XCTAssertEqual(ClockFormatPreference.from(stored: "twentyFourHour"), .twentyFourHour)
+    }
+
+    /// The stored vocabulary is shared with Android, which writes these exact strings. Pinning the
+    /// literals here means renaming a case cannot silently make the two platforms disagree about what a
+    /// user's saved preference means.
+    func testStoredVocabularyIsPinned() {
+        XCTAssertEqual(ClockFormatPreference.system.rawValue, "system")
+        XCTAssertEqual(ClockFormatPreference.twelveHour.rawValue, "twelveHour")
+        XCTAssertEqual(ClockFormatPreference.twentyFourHour.rawValue, "twentyFourHour")
+        XCTAssertEqual(ClockFormatPreference.defaultsKey, "clockFormatPreference")
+    }
+
+    func testHourMinutePattern() {
+        XCTAssertEqual(ClockFormat.hourMinutePattern(uses24Hour: true), "HH:mm")
+        XCTAssertEqual(ClockFormat.hourMinutePattern(uses24Hour: false), "h:mm a")
+    }
+
+    /// The template must never be `j`: that is the locale-resolved hour, and routing the reader's choice
+    /// back through it is the bug this setting exists to fix.
+    func testHourMinuteTemplateNeverDefersToTheLocaleHour() {
+        XCTAssertEqual(ClockFormat.hourMinuteTemplate(uses24Hour: true), "Hmm")
+        XCTAssertEqual(ClockFormat.hourMinuteTemplate(uses24Hour: false), "hmm")
+        XCTAssertFalse(ClockFormat.hourMinuteTemplate(uses24Hour: true).contains("j"))
+        XCTAssertFalse(ClockFormat.hourMinuteTemplate(uses24Hour: false).contains("j"))
+    }
+}

--- a/Strand/App/AppClock.swift
+++ b/Strand/App/AppClock.swift
@@ -1,0 +1,57 @@
+import Foundation
+import StrandAnalytics
+
+/// #1821: the app-side reader for the Clock format setting. Sits next to `AppLanguage` because it
+/// answers the same shape of question - what conventions do we render in - and because the bug it fixes
+/// lives in `AppLanguage.activeLocale`.
+///
+/// `activeLocale` builds `language_REGION` on purpose, to keep the device's regional date order and
+/// clock style. But a locale built from a REGION identifier carries that region's DEFAULT hour cycle,
+/// and the user's explicit Settings > General > Date & Time > 24-Hour Time switch is not part of it -
+/// that override lives on `Locale.autoupdatingCurrent`. So the switch was silently discarded, and a
+/// reader in a 24-hour region could not get a 12-hour clock by any means at all.
+enum AppClock {
+    /// The stored preference, defaulting to `.system` so an upgrade changes nobody's display.
+    static var preference: ClockFormatPreference {
+        ClockFormatPreference.from(stored: UserDefaults.standard.string(forKey: ClockFormatPreference.defaultsKey))
+    }
+
+    /// What the DEVICE is set to, read from `autoupdatingCurrent` precisely because that is the locale
+    /// the 24-Hour Time switch modifies. A 12-hour locale's `j` template contains the AM/PM symbol.
+    static var systemUses24Hour: Bool {
+        let template = DateFormatter.dateFormat(fromTemplate: "j", options: 0,
+                                                locale: Locale.autoupdatingCurrent) ?? "H"
+        return !template.contains("a")
+    }
+
+    static var uses24Hour: Bool {
+        ClockFormat.uses24Hour(preference: preference, systemUses24Hour: systemUses24Hour)
+    }
+
+    /// Cached by resolved template: building a `DateFormatter` is expensive and these are read per row in
+    /// scrolling lists, but the cache MUST key on the template rather than being a plain `static let`, or
+    /// changing the setting would not take effect until the app restarted.
+    private static var cached: (template: String, locale: String, formatter: DateFormatter)?
+
+    /// Wall-clock time at minute precision, honouring the setting. The locale still supplies ordering,
+    /// separator and AM/PM wording; only the hour cycle is ours.
+    static func hourMinuteFormatter() -> DateFormatter {
+        let template = ClockFormat.hourMinuteTemplate(uses24Hour: uses24Hour)
+        let locale = AppLanguage.activeLocale
+        if let cached, cached.template == template, cached.locale == locale.identifier {
+            return cached.formatter
+        }
+        let f = DateFormatter()
+        f.locale = locale
+        f.setLocalizedDateFormatFromTemplate(template)
+        cached = (template, locale.identifier, f)
+        return f
+    }
+
+    /// Convenience for the many call sites that just want the string.
+    static func hourMinute(_ date: Date) -> String { hourMinuteFormatter().string(from: date) }
+
+    static func hourMinute(unix ts: Int) -> String {
+        hourMinute(Date(timeIntervalSince1970: TimeInterval(ts)))
+    }
+}

--- a/Strand/App/AppClock.swift
+++ b/Strand/App/AppClock.swift
@@ -28,6 +28,16 @@ enum AppClock {
         ClockFormat.uses24Hour(preference: preference, systemUses24Hour: systemUses24Hour)
     }
 
+    /// The locale to hand any time-rendering `DateFormatter`. Carries an explicit hour cycle, so the
+    /// setting also reaches the formatters that never name a pattern - the ones using `timeStyle = .short`
+    /// or a `"jmm"` template, which ask the LOCALE for the hour and were therefore getting the region
+    /// default. Everything else about the locale (date order, separators, AM/PM wording, month names)
+    /// still comes from `AppLanguage.activeLocale`, exactly as before.
+    static var formattingLocale: Locale {
+        Locale(identifier: ClockFormat.hourCycleLocaleIdentifier(
+            base: AppLanguage.activeLocale.identifier, uses24Hour: uses24Hour))
+    }
+
     /// Cached by resolved template: building a `DateFormatter` is expensive and these are read per row in
     /// scrolling lists, but the cache MUST key on the template rather than being a plain `static let`, or
     /// changing the setting would not take effect until the app restarted.

--- a/Strand/App/AppClock.swift
+++ b/Strand/App/AppClock.swift
@@ -32,12 +32,18 @@ enum AppClock {
     /// scrolling lists, but the cache MUST key on the template rather than being a plain `static let`, or
     /// changing the setting would not take effect until the app restarted.
     private static var cached: (template: String, locale: String, formatter: DateFormatter)?
+    /// The cache is mutable global state and `onsetText` is read from whatever thread builds a
+    /// `SleepModel`, so the read-modify-write below is serialised. SWIFT_VERSION is 5.0 here, so the
+    /// compiler would not have objected - a torn read would just have been a rare, baffling crash.
+    private static let cacheLock = NSLock()
 
     /// Wall-clock time at minute precision, honouring the setting. The locale still supplies ordering,
     /// separator and AM/PM wording; only the hour cycle is ours.
     static func hourMinuteFormatter() -> DateFormatter {
         let template = ClockFormat.hourMinuteTemplate(uses24Hour: uses24Hour)
         let locale = AppLanguage.activeLocale
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
         if let cached, cached.template == template, cached.locale == locale.identifier {
             return cached.formatter
         }

--- a/Strand/Data/SleepMark.swift
+++ b/Strand/Data/SleepMark.swift
@@ -107,10 +107,7 @@ struct SleepMark: Equatable, Sendable {
 
     /// Device-locale clock for the log line ("11:42 PM" / "23:42") — follows the 12-/24-hour setting,
     /// matching the Sleep screen's Asleep/Woke row.
-    private static let clockFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.locale = AppLanguage.activeLocale
-        f.setLocalizedDateFormatFromTemplate("jmm")
-        return f
-    }()
+    /// #1821: routed through AppClock so the Clock format setting reaches this label. Was a `static
+    /// let`, which would have frozen the reader's choice at first use until the app relaunched.
+    private static var clockFormatter: DateFormatter { AppClock.hourMinuteFormatter() }
 }

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -195361,6 +195361,198 @@
         }
       }
     },
+    "12-hour": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "12 Stunden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "12-hour"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "12 horas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "12 heures"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "12 ore"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "12-godzinny"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "12 horas"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "12-часовой"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "12 小时制"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "12 小時制"
+          }
+        }
+      }
+    },
+    "24-hour": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24 Stunden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24-hour"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24 horas"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24 heures"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24 ore"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24-godzinny"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24 horas"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24-часовой"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24 小时制"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24 小時制"
+          }
+        }
+      }
+    },
+    "Clock": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uhr"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clock"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reloj"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Horloge"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Orologio"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zegar"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relógio"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Часы"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "时钟"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "時鐘"
+          }
+        }
+      }
+    },
     "System default": {
       "localizations": {
         "de": {

--- a/Strand/Screens/AutoWorkoutCard.swift
+++ b/Strand/Screens/AutoWorkoutCard.swift
@@ -131,13 +131,9 @@ struct AutoWorkoutCard: View {
     }
 
     /// HH:mm in the user's locale/timezone.
-    private static let timeFmt: DateFormatter = {
-        let f = DateFormatter()
-        f.locale = AppLanguage.activeLocale
-        f.timeStyle = .short
-        f.dateStyle = .none
-        return f
-    }()
+    /// #1821: routed through AppClock so the Clock format setting reaches this label. Was a `static
+    /// let`, which would have frozen the reader's choice at first use until the app relaunched.
+    private static var timeFmt: DateFormatter { AppClock.hourMinuteFormatter() }
 
     /// Localized medium date ("Jun 23, 2026") for a bout older than yesterday.
     private static let dateFmt: DateFormatter = {

--- a/Strand/Screens/BackupSyncView.swift
+++ b/Strand/Screens/BackupSyncView.swift
@@ -294,6 +294,8 @@ struct BackupSyncView: View {
 
     private func absoluteTime(_ ms: Int) -> String {
         let f = DateFormatter()
+        // #1821: localized DATE style untouched; only the hour cycle is the reader's.
+        f.locale = AppClock.formattingLocale
         f.dateStyle = .medium
         f.timeStyle = .short
         return f.string(from: Date(timeIntervalSince1970: Double(ms) / 1000.0))
@@ -362,6 +364,9 @@ private struct RestorePickerSheet: View {
 
     private func absoluteTime(_ ms: Int) -> String {
         let f = DateFormatter()
+        // #1821: localized DATE style untouched; only the hour cycle is the reader's. Second copy of
+        // this helper in the file - a single-shot replace fixed only the first, which the sweep caught.
+        f.locale = AppClock.formattingLocale
         f.dateStyle = .medium
         f.timeStyle = .short
         return f.string(from: Date(timeIntervalSince1970: Double(ms) / 1000.0))

--- a/Strand/Screens/CaffeineLogCard.swift
+++ b/Strand/Screens/CaffeineLogCard.swift
@@ -201,12 +201,9 @@ struct CaffeineLogCard: View {
         return Self.cutoffTimeFormatter.string(from: date)
     }
 
-    private static let cutoffTimeFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.timeStyle = .short
-        f.dateStyle = .none
-        return f
-    }()
+    /// #1821: routed through AppClock so the Clock format setting reaches this label. Was a `static
+    /// let`, which would have frozen the reader's choice at first use until the app relaunched.
+    private static var cutoffTimeFormatter: DateFormatter { AppClock.hourMinuteFormatter() }
 
     // MARK: - Active hint
 
@@ -335,10 +332,7 @@ struct CaffeineLogCard: View {
         .buttonStyle(.plain)
     }
 
-    private static let timeFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.timeStyle = .short
-        f.dateStyle = .none
-        return f
-    }()
+    /// #1821: routed through AppClock so the Clock format setting reaches this label. Was a `static
+    /// let`, which would have frozen the reader's choice at first use until the app relaunched.
+    private static var timeFormatter: DateFormatter { AppClock.hourMinuteFormatter() }
 }

--- a/Strand/Screens/CoupledView.swift
+++ b/Strand/Screens/CoupledView.swift
@@ -705,12 +705,9 @@ struct CoupledView: View {
         Self.clockFmt.string(from: Date(timeIntervalSince1970: TimeInterval(ts)))
     }
 
-    private static let clockFmt: DateFormatter = {
-        let f = DateFormatter()
-        f.locale = AppLanguage.activeLocale
-        f.setLocalizedDateFormatFromTemplate("jmm")
-        return f
-    }()
+    /// #1821: routed through AppClock so the Clock format setting reaches this label. Was a `static
+    /// let`, which would have frozen the reader's choice at first use until the app relaunched.
+    private static var clockFmt: DateFormatter { AppClock.hourMinuteFormatter() }
 
     /// "6h 42m" from a minutes count, for the slept-vs-needed read. Mirror EXACTLY in Kotlin.
     static func hoursMinutes(_ minutes: Double) -> String {

--- a/Strand/Screens/HydrationView.swift
+++ b/Strand/Screens/HydrationView.swift
@@ -274,9 +274,9 @@ struct HydrationView: View {
         }
     }
 
-    private static let entryTimeFmt: DateFormatter = {
-        let f = DateFormatter(); f.timeStyle = .short; f.dateStyle = .none; return f
-    }()
+    /// #1821: routed through AppClock so the Clock format setting reaches this label. Was a `static
+    /// let`, which would have frozen the reader's choice at first use until the app relaunched.
+    private static var entryTimeFmt: DateFormatter { AppClock.hourMinuteFormatter() }
 
     // MARK: - 7-day mini history (flat bars, today on the right)
 

--- a/Strand/Screens/RawDataCollectorView.swift
+++ b/Strand/Screens/RawDataCollectorView.swift
@@ -358,7 +358,9 @@ struct RawDataCollectorView: View {
     }
 
     private static func time(_ ms: Int64) -> String {
-        Date(timeIntervalSince1970: Double(ms) / 1_000).formatted(date: .omitted, time: .shortened)
+        Date(timeIntervalSince1970: Double(ms) / 1_000)
+            .formatted(Date.FormatStyle(date: .omitted, time: .shortened)
+                .locale(AppClock.formattingLocale))   // #1821
     }
 
     static func fullSecondBounds(fromMs: Int64, toMs: Int64) -> (from: Int, to: Int)? {

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -173,6 +173,9 @@ struct SettingsView: View {
     // Imperial/Metric display preference (D#103). Stored data is always SI; this only changes how
     // distances/weights/heights/temperatures are SHOWN — and lets the profile fields below take
     // imperial entry. Temperature has a separate override so °C/°F can be picked independently.
+    /// #1821: Clock format. Defaults to `.system`, so upgrading changes nobody's displayed times.
+    @AppStorage(ClockFormatPreference.defaultsKey)
+    private var clockFormatRaw = ClockFormatPreference.system.rawValue
     @AppStorage(UnitPrefs.systemKey) private var unitSystemRaw = UnitSystem.metric.rawValue
     @AppStorage(UnitPrefs.temperatureKey) private var temperatureRaw = ""
     // Effort display scale (#268). Display-only — Effort stays stored 0–100, this only chooses whether
@@ -1122,6 +1125,22 @@ struct SettingsView: View {
                     .foregroundStyle(StrandPalette.textTertiary)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.top, NoopMetrics.space1)
+                rowDivider
+                // #1821: sits with Language rather than in Units because it is an app-owned display
+                // CONVENTION, not a unit of measurement — and like Language it offers "System default",
+                // which here means the device's own 24-Hour Time switch rather than the region default.
+                // Unlike Language this needs no relaunch: the formatter caches per resolved template.
+                FormRow(label: "Clock") {
+                    Picker("Clock", selection: $clockFormatRaw) {
+                        Text("System default").tag(ClockFormatPreference.system.rawValue)
+                        Text("12-hour").tag(ClockFormatPreference.twelveHour.rawValue)
+                        Text("24-hour").tag(ClockFormatPreference.twentyFourHour.rawValue)
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
+                    .accessibilityLabel("Clock")
+                }
                 rowDivider
                 // Theme presets — one-tap bundles coordinating accent + chart world + backdrop + card
                 // opacity. Derived (no stored value): tweaking any control below flips this to Custom.

--- a/Strand/Screens/SkinTempCardsView.swift
+++ b/Strand/Screens/SkinTempCardsView.swift
@@ -759,11 +759,7 @@ struct BodyClockCard: View {
         components.hour = hh
         components.minute = mm
         guard let date = components.date else { return "\(hh):\(String(format: "%02d", mm))" }
-        let formatter = DateFormatter()
-        formatter.locale = AppLanguage.activeLocale
-        formatter.dateStyle = .none
-        formatter.timeStyle = .short
-        return formatter.string(from: date)
+        return AppClock.hourMinute(date)   // #1821
     }
 }
 

--- a/Strand/Screens/SleepModel.swift
+++ b/Strand/Screens/SleepModel.swift
@@ -118,12 +118,12 @@ struct Night {
     // Clock for the Asleep/Woke row — the times people read at a glance. The "jmm" skeleton
     // follows the device's 12-/24-hour setting ("11:42 PM" or "23:42") instead of forcing one
     // on everyone, matching the HR-tooltip / workout times (#337).
-    private static let timeFmt: DateFormatter = {
-        let f = DateFormatter()
-        f.locale = AppLanguage.activeLocale
-        f.setLocalizedDateFormatFromTemplate("jmm")
-        return f
-    }()
+    /// #1821: routed through `AppClock` so the Clock format setting reaches every night time on screen -
+    /// this is the formatter behind the sleep card's ASLEEP/WOKE values in the report. It used the `jmm`
+    /// template, whose `j` resolves the hour from the locale, which is how a reader's explicit 12-hour
+    /// choice was being discarded. `AppClock` caches per resolved template, so this is no more expensive
+    /// than the `static let` it replaces and it responds when the setting changes.
+    private static var timeFmt: DateFormatter { AppClock.hourMinuteFormatter() }
     private static let dateFmt: DateFormatter = {
         let f = DateFormatter(); f.dateFormat = "EEE d MMM"; return f
     }()

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -310,7 +310,8 @@ struct SleepView: View {
     /// Locale-formatted clock time (no date) for the banner's window range.
     private func clockTime(_ ts: Int) -> String {
         Date(timeIntervalSince1970: TimeInterval(ts))
-            .formatted(date: .omitted, time: .shortened)
+            .formatted(Date.FormatStyle(date: .omitted, time: .shortened)
+                .locale(AppClock.formattingLocale))   // #1821
     }
 
     /// The transient undo strip: a Rest-tinted frosted banner with the suppressed window and a real Undo
@@ -1340,9 +1341,9 @@ struct SleepView: View {
     // MARK: - WHOOP stage-timeline rows (the sleep-details reference design, ryanAtriumAi #988)
 
     /// Clock labels for the timeline axis; "jmm" respects the device 12/24-hour setting.
-    private static let stageAxisFormatter: DateFormatter = {
-        let f = DateFormatter(); f.locale = AppLanguage.activeLocale; f.setLocalizedDateFormatFromTemplate("jmm"); return f
-    }()
+    /// #1821: routed through AppClock so the Clock format setting reaches this label. Was a `static
+    /// let`, which would have frozen the reader's choice at first use until the app relaunched.
+    private static var stageAxisFormatter: DateFormatter { AppClock.hourMinuteFormatter() }
 
     /// The WHOOP sleep-stages chart: a stack of four per-stage timeline rows (AWAKE · LIGHT ·
     /// DEEP · REM, WHOOP's order) over a shared onset→wake time axis. Each row is independently

--- a/Strand/Screens/StagesCard.swift
+++ b/Strand/Screens/StagesCard.swift
@@ -453,9 +453,9 @@ struct StageDetailView: View {
     }
 
     /// Clock labels for the timeline axis; "jmm" respects the device 12/24-hour setting.
-    private static let stageAxisFormatter: DateFormatter = {
-        let f = DateFormatter(); f.locale = AppLanguage.activeLocale; f.setLocalizedDateFormatFromTemplate("jmm"); return f
-    }()
+    /// #1821: routed through AppClock so the Clock format setting reaches this label. Was a `static
+    /// let`, which would have frozen the reader's choice at first use until the app relaunched.
+    private static var stageAxisFormatter: DateFormatter { AppClock.hourMinuteFormatter() }
 
     /// The WHOOP sleep-stages chart: a stack of four per-stage timeline rows (AWAKE · LIGHT ·
     /// DEEP · REM, WHOOP's order) over a shared onset→wake time axis. Each row is independently

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -5035,12 +5035,9 @@ struct TodayView: View {
     /// show times, not the day-granularity default ("EEE d MMM"). Also formats the workout-tile caption's
     /// time range (#157). The "jmm" skeleton respects the device's 12-/24-hour setting (#337): "7:10 AM"
     /// where 12-hour is preferred, "19:10" where 24-hour is, instead of forcing one on everyone.
-    static let hrTimeFmt: DateFormatter = {
-        let f = DateFormatter()
-        f.locale = AppLanguage.activeLocale
-        f.setLocalizedDateFormatFromTemplate("jmm")
-        return f
-    }()
+    /// #1821: routed through AppClock so the Clock format setting reaches this label. Was a `static
+    /// let`, which would have frozen the reader's choice at first use until the app relaunched.
+    static var hrTimeFmt: DateFormatter { AppClock.hourMinuteFormatter() }
 }
 
 /// `.task(id:)` key combining the data refresh sequence with the selected day so a reload runs on

--- a/Strand/Screens/WorkoutDetailView.swift
+++ b/Strand/Screens/WorkoutDetailView.swift
@@ -573,18 +573,12 @@ struct WorkoutDetailView: View {
         f.dateFormat = "EEEE d MMM yyyy"
         return f
     }()
-    private static let timeFmt: DateFormatter = {
-        let f = DateFormatter()
-        f.locale = AppLanguage.activeLocale
-        f.setLocalizedDateFormatFromTemplate("jmm")
-        return f
-    }()
-    private static let tooltipTime: DateFormatter = {
-        let f = DateFormatter()
-        f.locale = AppLanguage.activeLocale
-        f.setLocalizedDateFormatFromTemplate("jmm")
-        return f
-    }()
+    /// #1821: routed through AppClock so the Clock format setting reaches this label. Was a `static
+    /// let`, which would have frozen the reader's choice at first use until the app relaunched.
+    private static var timeFmt: DateFormatter { AppClock.hourMinuteFormatter() }
+    /// #1821: routed through AppClock so the Clock format setting reaches this label. Was a `static
+    /// let`, which would have frozen the reader's choice at first use until the app relaunched.
+    private static var tooltipTime: DateFormatter { AppClock.hourMinuteFormatter() }
 
     private func dateLabel(_ ts: Int) -> String {
         Self.dateFmt.string(from: Date(timeIntervalSince1970: TimeInterval(ts)))

--- a/Strand/Screens/WorkoutsView.swift
+++ b/Strand/Screens/WorkoutsView.swift
@@ -1735,12 +1735,9 @@ struct WorkoutsView: View {
 
     // The "jmm" skeleton respects the device's 12-/24-hour setting (#337): "4:34 PM" where 12-hour is
     // preferred, "16:34" where 24-hour is — instead of forcing 24-hour on everyone (matches TodayView).
-    private static let timeFmt: DateFormatter = {
-        let f = DateFormatter()
-        f.locale = AppLanguage.activeLocale
-        f.setLocalizedDateFormatFromTemplate("jmm")
-        return f
-    }()
+    /// #1821: routed through AppClock so the Clock format setting reaches this label. Was a `static
+    /// let`, which would have frozen the reader's choice at first use until the app relaunched.
+    private static var timeFmt: DateFormatter { AppClock.hourMinuteFormatter() }
 
     private func dateLabel(_ ts: Int) -> String {
         Self.dateFmt.string(from: Date(timeIntervalSince1970: TimeInterval(ts)))

--- a/android/app/src/main/java/com/noop/analytics/ClockFormat.kt
+++ b/android/app/src/main/java/com/noop/analytics/ClockFormat.kt
@@ -1,0 +1,65 @@
+package com.noop.analytics
+
+/**
+ * #1821: which clock the UI shows times in. Twin of the Apple `ClockFormatPreference`.
+ *
+ * NOOP had no such setting: every user-facing time came from the device region's convention, and on
+ * Apple the region identifier discards the user's explicit "24-Hour Time" switch entirely. A reader in a
+ * 24-hour region who prefers 12-hour had no way to say so, which is the report this exists to answer.
+ */
+enum class ClockFormatPreference {
+    /** Follow the device's own clock switch. The default, so nobody's display changes on upgrade. */
+    SYSTEM,
+    TWELVE_HOUR,
+    TWENTY_FOUR_HOUR,
+    ;
+
+    companion object {
+        /** Persistence key, shared with the Apple @AppStorage binding so the two cannot drift apart. */
+        const val PREFS_KEY = "clockFormatPreference"
+
+        /** Stored as the Apple rawValue strings, so one documented vocabulary spans both platforms. */
+        fun from(stored: String?): ClockFormatPreference = when (stored) {
+            "twelveHour" -> TWELVE_HOUR
+            "twentyFourHour" -> TWENTY_FOUR_HOUR
+            // Unknown/absent must not silently pin every reader to one clock.
+            else -> SYSTEM
+        }
+    }
+
+    /** The value written to storage - the Apple rawValue, not the Kotlin enum name. */
+    fun stored(): String = when (this) {
+        SYSTEM -> "system"
+        TWELVE_HOUR -> "twelveHour"
+        TWENTY_FOUR_HOUR -> "twentyFourHour"
+    }
+}
+
+object ClockFormat {
+    /**
+     * Resolve the preference against what the device reports. [systemUses24Hour] is injected rather than
+     * read here so this stays pure and identically testable on both platforms - Android supplies
+     * `DateFormat.is24HourFormat(context)`, Apple `Locale.autoupdatingCurrent`.
+     */
+    fun uses24Hour(preference: ClockFormatPreference, systemUses24Hour: Boolean): Boolean =
+        when (preference) {
+            ClockFormatPreference.SYSTEM -> systemUses24Hour
+            ClockFormatPreference.TWELVE_HOUR -> false
+            ClockFormatPreference.TWENTY_FOUR_HOUR -> true
+        }
+
+    /**
+     * The SimpleDateFormat pattern for a wall-clock time at minute precision. Explicit patterns, not a
+     * localised template: once the reader has CHOSEN a clock, a template would hand the decision back to
+     * the locale and quietly ignore them.
+     */
+    fun hourMinutePattern(uses24Hour: Boolean): String = if (uses24Hour) "HH:mm" else "h:mm a"
+
+    /**
+     * SKELETON template for the same time, the twin of the Apple accessor. Apple feeds this to
+     * `setLocalizedDateFormatFromTemplate` so the locale still decides ordering and AM/PM wording while
+     * the H-vs-h choice stays ours. Deliberately NOT `j`, which resolves the hour from the locale - the
+     * precise mechanism by which a reader's explicit preference was being discarded.
+     */
+    fun hourMinuteTemplate(uses24Hour: Boolean): String = if (uses24Hour) "Hmm" else "hmm"
+}

--- a/android/app/src/main/java/com/noop/ui/AutomationsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/AutomationsScreen.kt
@@ -56,6 +56,7 @@ import com.noop.analytics.HrZones
 import com.noop.analytics.NapCandidate
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
+import com.noop.analytics.ClockFormat
 
 /**
  * Automations — turn the strap's physical inputs (double-tap, wrist on/off) and live
@@ -458,7 +459,10 @@ private fun NapActionButton(icon: ImageVector, contentDescription: String, tint:
 
 /** "HH:mm–HH:mm · ~N min", local time. Pure-ish (reads the device clock format only). */
 private fun napWindowLabel(nap: NapCandidate, ctx: android.content.Context): String {
-    val fmt = android.text.format.DateFormat.getTimeFormat(ctx)
+    // #1821: the reader's chosen clock, not the raw device format.
+    val fmt = java.text.SimpleDateFormat(
+        ClockFormat.hourMinutePattern(ClockPrefs.uses24Hour(ctx)), java.util.Locale.getDefault(),
+    )
     val start = fmt.format(java.util.Date(nap.start * 1000L))
     val end = fmt.format(java.util.Date(nap.end * 1000L))
     val mins = nap.durationS / 60

--- a/android/app/src/main/java/com/noop/ui/CaffeineLog.kt
+++ b/android/app/src/main/java/com/noop/ui/CaffeineLog.kt
@@ -44,6 +44,7 @@ import org.json.JSONObject
 import java.util.Calendar
 import java.util.UUID
 import kotlin.math.roundToInt
+import com.noop.analytics.ClockFormat
 
 // MARK: - Caffeine window (#526) — pure persistence helpers + the Insights logging card.
 //
@@ -326,8 +327,10 @@ private fun caffeineHoursLabel(hrs: Double): String {
 }
 
 private fun caffeineIntakeLabel(intake: CaffeineIntake, context: Context): String {
-    val time = android.text.format.DateFormat.getTimeFormat(context)
-        .format(java.util.Date(intake.atEpochSec * 1000L))
+    // #1821: the reader's chosen clock, not the raw device format.
+    val time = java.text.SimpleDateFormat(
+        ClockFormat.hourMinutePattern(ClockPrefs.uses24Hour(context)), java.util.Locale.getDefault(),
+    ).format(java.util.Date(intake.atEpochSec * 1000L))
     return if (intake.mg != null) "$time · ${intake.mg.roundToInt()} mg" else "$time · amount not logged"
 }
 

--- a/android/app/src/main/java/com/noop/ui/ClockPrefs.kt
+++ b/android/app/src/main/java/com/noop/ui/ClockPrefs.kt
@@ -1,0 +1,32 @@
+package com.noop.ui
+
+import android.content.Context
+import android.text.format.DateFormat
+import com.noop.analytics.ClockFormat
+import com.noop.analytics.ClockFormatPreference
+
+/**
+ * #1821: the app-side reader for the Clock format setting - the Android twin of Apple's `AppClock`.
+ *
+ * The label helpers in `SleepTimeLabels` take an `is24h` flag rather than a `Context`, deliberately, so
+ * they stay pure and unit-testable (`axisEdgeLabel` already worked that way). This is the one place that
+ * turns a Context into that flag, so no caller has to know how the preference is stored or that "system"
+ * means the device switch rather than the region default.
+ */
+object ClockPrefs {
+    /** The stored preference, defaulting to SYSTEM so an upgrade changes nobody's displayed times. */
+    fun preference(context: Context): ClockFormatPreference =
+        ClockFormatPreference.from(
+            NoopPrefs.of(context).getString(NoopPrefs.KEY_CLOCK_FORMAT, null),
+        )
+
+    fun setPreference(context: Context, preference: ClockFormatPreference) {
+        NoopPrefs.of(context).edit()
+            .putString(NoopPrefs.KEY_CLOCK_FORMAT, preference.stored())
+            .apply()
+    }
+
+    /** Resolved: the reader's explicit choice, or the device's own 12/24h switch when they said SYSTEM. */
+    fun uses24Hour(context: Context): Boolean =
+        ClockFormat.uses24Hour(preference(context), DateFormat.is24HourFormat(context))
+}

--- a/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
@@ -53,6 +53,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import kotlin.math.roundToInt
+import com.noop.analytics.ClockFormat
 
 // MARK: - Coupled view (task #43) — Kotlin twin of CoupledView.swift
 //
@@ -244,7 +245,7 @@ fun CoupledScreen(
             sleepPerformance = sleepPerformance,
             asleepMin = todayRow?.totalSleepMin,
             needMin = sleepNeedForDay(todayRow, days, importedNeed),
-            bedWakeSpan = bedWakeSpan(sleeps, habitualMidsleepSec),
+            bedWakeSpan = bedWakeSpan(sleeps, habitualMidsleepSec, ClockPrefs.uses24Hour(LocalContext.current)),
             onOpenSleep = onOpenSleep,
         )
         Text(
@@ -636,11 +637,11 @@ private fun sleepNeedForDay(day: DailyMetric?, days: List<DailyMetric>, imported
  * session" pick, which could name a different block -- and so a different span -- than the Sleep tab and
  * Today's HR graph for a night stored as more than one block (#294).
  */
-private fun bedWakeSpan(sleeps: List<SleepSession>, habitualMidsleepSec: Long?): String? {
+private fun bedWakeSpan(sleeps: List<SleepSession>, habitualMidsleepSec: Long?, is24h: Boolean): String? {
     val windowStart = System.currentTimeMillis() / 1000L - 36 * 3600L // within the last 36h counts as last night
     val candidates = sleeps.filter { it.endTs > windowStart }
     val span = mainSleepSpan(candidates, habitualMidsleepSec) ?: return null
-    val fmt = SimpleDateFormat("HH:mm", Locale.getDefault())
+    val fmt = SimpleDateFormat(ClockFormat.hourMinutePattern(is24h), Locale.getDefault())   // #1821
     return "${fmt.format(Date(span.first * 1000L))} - ${fmt.format(Date(span.second * 1000L))}"
 }
 

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -700,13 +700,13 @@ object NoopPrefs {
         of(context).edit().putBoolean(KEY_APP_ICON_NAVY, navy).apply()
     }
 
-    /** Imperial/Metric display preference (D#103). Display-only, stored data stays SI. The length/mass
-     *  system is read by [UnitPrefs.system]; the temperature override (empty = "match the system") by
-     *  [UnitPrefs.temperature]. Mirrors macOS @AppStorage("units.system" / "units.temperature"). */
     /** #1821: Clock format ("system" / "twelveHour" / "twentyFourHour"). Shares its stored vocabulary
      *  with the Apple @AppStorage binding via [com.noop.analytics.ClockFormatPreference]. */
     const val KEY_CLOCK_FORMAT = com.noop.analytics.ClockFormatPreference.PREFS_KEY
 
+    /** Imperial/Metric display preference (D#103). Display-only, stored data stays SI. The length/mass
+     *  system is read by [UnitPrefs.system]; the temperature override (empty = "match the system") by
+     *  [UnitPrefs.temperature]. Mirrors macOS @AppStorage("units.system" / "units.temperature"). */
     const val KEY_UNIT_SYSTEM = "units.system"
     const val KEY_TEMPERATURE_UNIT = "units.temperature"
 

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -703,6 +703,10 @@ object NoopPrefs {
     /** Imperial/Metric display preference (D#103). Display-only, stored data stays SI. The length/mass
      *  system is read by [UnitPrefs.system]; the temperature override (empty = "match the system") by
      *  [UnitPrefs.temperature]. Mirrors macOS @AppStorage("units.system" / "units.temperature"). */
+    /** #1821: Clock format ("system" / "twelveHour" / "twentyFourHour"). Shares its stored vocabulary
+     *  with the Apple @AppStorage binding via [com.noop.analytics.ClockFormatPreference]. */
+    const val KEY_CLOCK_FORMAT = com.noop.analytics.ClockFormatPreference.PREFS_KEY
+
     const val KEY_UNIT_SYSTEM = "units.system"
     const val KEY_TEMPERATURE_UNIT = "units.temperature"
 

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -2895,7 +2895,9 @@ fun SettingsScreen(
                     kind = NoopButtonKind.Secondary,
                     fullWidth = true,
                     onClick = {
-                        vm.ble.buzzTimeNow(is24h = android.text.format.DateFormat.is24HourFormat(context))
+                        // #1821: buzzTimeNow's doc asked for "a Settings toggle" to supply this.
+                        // Now there is one, so the pulses read the clock the user chose.
+                        vm.ble.buzzTimeNow(is24h = ClockPrefs.uses24Hour(context))
                     },
                 )
                 Text(

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -140,6 +140,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.math.roundToInt
+import com.noop.analytics.ClockFormatPreference
 
 // MARK: - Settings (ported from Strand/Screens/SettingsView.swift)
 //
@@ -666,6 +667,7 @@ fun SettingsScreen(
     // `temperatureRaw` is "" (match the system) or a TemperatureUnit raw value. SharedPreferences isn't
     // reactive, so these mirror into local state like the toggles above.
     var unitSystem by remember { mutableStateOf(UnitPrefs.system(context)) }
+    var clockFormat by remember { mutableStateOf(ClockPrefs.preference(context)) }   // #1821
     var temperatureRaw by remember {
         mutableStateOf(NoopPrefs.of(context).getString(NoopPrefs.KEY_TEMPERATURE_UNIT, "") ?: "")
     }
@@ -1302,6 +1304,33 @@ fun SettingsScreen(
                             AppLanguagePrefs.set(context, selected)
                             context.hostingActivity()?.recreate()
                         }
+                    },
+                )
+            }
+            SettingsRowDivider()
+            // #1821: Clock format. Sits with Language because it is an app-owned display CONVENTION, and
+            // like Language it offers "System default" - which here means the device's own 12/24h switch,
+            // not the region default that was silently deciding this for everyone. Twin of the Apple row.
+            SettingsFormRow(label = uiString(R.string.l10n_settings_screen_clock_04f6b3ea)) {
+                SegmentedPillControl(
+                    items = listOf(
+                        ClockFormatPreference.SYSTEM,
+                        ClockFormatPreference.TWELVE_HOUR,
+                        ClockFormatPreference.TWENTY_FOUR_HOUR,
+                    ),
+                    selection = clockFormat,
+                    label = {
+                        when (it) {
+                            ClockFormatPreference.TWELVE_HOUR ->
+                                uiString(R.string.l10n_settings_screen_12_hour_41c18ba0)
+                            ClockFormatPreference.TWENTY_FOUR_HOUR ->
+                                uiString(R.string.l10n_settings_screen_24_hour_18e86819)
+                            else -> uiString(R.string.settings_language_system)
+                        }
+                    },
+                    onSelect = {
+                        clockFormat = it
+                        ClockPrefs.setPreference(context, it)
                     },
                 )
             }

--- a/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepModelLogic.kt
@@ -131,6 +131,10 @@ internal fun buildSleepModel(
     // Today's logical-day key, the anchor for each tile's staleness bound (see [metric]). Injectable so
     // tests can pin the clock instead of depending on the day they happen to run.
     todayKey: String = logicalDayKeyNow(),
+    // #1821: the reader's chosen clock. Defaults to 24h, which is what every one of these labels was
+    // hardcoded to before the setting existed, so tests and any caller not yet updated keep their old
+    // output rather than silently flipping.
+    is24h: Boolean = true,
 ): SleepModel? {
     val effectiveDay = selectedDay ?: days.lastOrNull()?.day ?: return null
     // The HERO night = the selected day's stage-bearing row. The TILE / debt / need / trend
@@ -279,7 +283,7 @@ internal fun buildSleepModel(
 
     return SleepModel(
         stages = stages,
-        clockLabel = clockLabel(latest, session),
+        clockLabel = clockLabel(latest, session, is24h),
         efficiencyText = efficiency.latest?.let { "${it.roundToInt()}%" } ?: "—",
         performance = performance,
         efficiency = efficiency,
@@ -316,12 +320,13 @@ internal fun fallbackSleepModel(
     napSleepMinByDay: Map<String, Double> = emptyMap(),
     sessions: List<SleepSession> = emptyList(),
     todayKey: String = logicalDayKeyNow(),
+    is24h: Boolean = true,   // #1821, threaded to the hero's clock label
 ): SleepModel? {
     val anchorDay = days.lastOrNull {
         (it.deepMin ?: 0.0) + (it.remMin ?: 0.0) + (it.lightMin ?: 0.0) > 0.0
     }?.day ?: return null
     return buildSleepModel(days, null, imported, selectedDay = anchorDay,
-        napSleepMinByDay = napSleepMinByDay, sessions = sessions, todayKey = todayKey)
+        napSleepMinByDay = napSleepMinByDay, sessions = sessions, todayKey = todayKey, is24h = is24h)
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/SleepNightNavUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepNightNavUi.kt
@@ -53,6 +53,7 @@ import java.util.Date
 import java.util.Locale
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import com.noop.analytics.ClockFormat
 
 // Sleep window row + night navigation / edit / delete controls.
 // Extracted from SleepScreen.kt (behavioral no-op; pure UI code-motion).
@@ -66,8 +67,11 @@ import androidx.compose.runtime.setValue
  */
 @Composable
 internal fun SleepWindowRow(onsetTs: Long, wakeTs: Long) {
-    val asleep = clockTimeLabel(onsetTs)
-    val woke = clockTimeLabel(wakeTs)
+    // #1821: the reader's chosen clock. Read here rather than threaded, because this is a composable and
+    // LocalContext is the idiomatic source; the label helpers stay pure.
+    val is24h = ClockPrefs.uses24Hour(LocalContext.current)
+    val asleep = clockTimeLabel(onsetTs, is24h)
+    val woke = clockTimeLabel(wakeTs, is24h)
     // A frosted Rest-tinted card (was a flat surfaceRaised block) so the window row sits in the
     // same colour world as the rest of the screen. Bevel treatment — content unchanged.
     NoopCard(
@@ -180,7 +184,9 @@ internal fun NightNavHeader(
     // once; Cancel discards it. This mirrors Apple SleepTimeEditor's single start+end save funnel.
     val currentDraft = sleepEditDraft
     if (showTimeChoice && session != null && currentDraft != null) {
-        val timeFmt = SimpleDateFormat("HH:mm", Locale.US)
+        val timeFmt = SimpleDateFormat(                               // #1821
+            ClockFormat.hourMinutePattern(ClockPrefs.uses24Hour(LocalContext.current)), Locale.US,
+        )
         val bedText = timeFmt.format(Date(currentDraft.startTs * 1000L))
         val wakeText = timeFmt.format(Date(currentDraft.endTs * 1000L))
         val validated = currentDraft.validatedWindow(System.currentTimeMillis() / 1000L)

--- a/android/app/src/main/java/com/noop/ui/SleepNightSelection.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepNightSelection.kt
@@ -34,6 +34,9 @@ internal fun selectNight(
     // group order onto HeroNight.groupMotion. Empty/absent → honest empty state. Default empty so existing
     // callers/tests compile unchanged.
     motionByStart: Map<Long, List<Double>> = emptyMap(),
+    // #1821: the reader's chosen clock, for the hero's onset-wake label. Defaults to the 24h the label
+    // was hardcoded to, so existing callers and tests are unchanged until they opt in.
+    is24h: Boolean = true,
 ): HeroNight? {
     if (navDays.isEmpty()) return null
     val dayIdx = offset.coerceIn(0, navDays.size - 1)
@@ -114,7 +117,7 @@ internal fun selectNight(
     val groupInBedMin = if (heroGroup.size > 1) {
         heroGroup.sumOf { (it.endTs - it.effectiveStartTs).coerceAtLeast(0L) } / 60.0
     } else null
-    return HeroNight(session, dayKey, segments, clockLabelFor(heroOnsetTs, heroWakeTs), napBlocks, groupStages,
+    return HeroNight(session, dayKey, segments, clockLabelFor(heroOnsetTs, heroWakeTs, is24h), napBlocks, groupStages,
         groupSegments, groupMotion, groupInBedMin, heroOnsetTs, heroWakeTs, heroGroup)
 }
 

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -93,6 +93,7 @@ import kotlin.math.max
 import kotlin.math.roundToInt
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import com.noop.analytics.ClockFormat
 
 internal enum class SleepFreshnessStatus {
     SYNCING, CALCULATING, SYNC_FAILED, AWAITING_SYNC, NOT_DETECTED,
@@ -493,8 +494,11 @@ fun SleepScreen(
     // The navigated night, decoded once per (offset, data) change — chevron taps re-pick
     // instantly without re-parsing stagesJSON on every recomposition. The offset now indexes
     // DAYS (navDays), so a day with a detected night always resolves to that night. (#160, #59)
-    val night = remember(nightOffset, navDays, days, habitualMidsleep, motionByStart) {
-        selectNight(navDays, days, nightOffset, habitualMidsleep, motionByStart)
+    // #1821: the reader's chosen clock, resolved once for this screen. It is a remember KEY below so
+    // changing the setting re-derives the labels instead of leaving the old clock on screen.
+    val is24h = ClockPrefs.uses24Hour(LocalContext.current)
+    val night = remember(nightOffset, navDays, days, habitualMidsleep, motionByStart, is24h) {
+        selectNight(navDays, days, nightOffset, habitualMidsleep, motionByStart, is24h = is24h)
     }
 
     // #1311: label the carousel by CALENDAR nights, not the flat recorded-night index — a night with no
@@ -509,10 +513,10 @@ fun SleepScreen(
     // at-a-glance TILES, the debt ledger, the personal need and the trend stay full-history /
     // latest-anchored, matching iOS SleepView. `selectedDay` re-points only the hero. Model is null
     // when the selected day has no stage minutes. (#5)
-    val model = remember(days, night, imported, napSleepMinByDay, sleeps) {
+    val model = remember(days, night, imported, napSleepMinByDay, sleeps, is24h) {
         buildSleepModel(days, night?.session, imported, selectedDay = night?.dayKey,
             heroStages = night?.groupStages, heroSegments = night?.groupSegments,
-            napSleepMinByDay = napSleepMinByDay, sessions = sleeps)
+            napSleepMinByDay = napSleepMinByDay, sessions = sleeps, is24h = is24h)
     }
     val display = remember(model, night) { heroDisplay(model, night) }
 
@@ -1018,7 +1022,9 @@ private fun SleepUndoBanner(undo: SleepUndoState, onUndo: () -> Unit) {
     // it retired something), but `first()` on an empty list would take the whole Sleep tab down — too
     // steep a price for a strip that is only ever informational. Render nothing instead.
     val session = undo.sessions.firstOrNull() ?: return
-    val timeFmt = SimpleDateFormat("HH:mm", Locale.US)
+    val timeFmt = SimpleDateFormat(                                   // #1821
+        ClockFormat.hourMinutePattern(ClockPrefs.uses24Hour(LocalContext.current)), Locale.US,
+    )
     // effectiveStartTs is the displayed onset (a userEdited night's corrected bed time), matching iOS.
     val startText = timeFmt.format(java.util.Date(session.effectiveStartTs * 1000L))
     val endText = timeFmt.format(java.util.Date(session.endTs * 1000L))
@@ -1733,7 +1739,8 @@ private fun NapRow(
     // with the Edit next-step. Inline disclosure (Compose has no anchored popover here); the COPY matches
     // iOS SleepView.whyPopover(napSuffix:) exactly. (spec 2026-06-20)
     var showWhy by remember(nap.startTs) { mutableStateOf(false) }
-    val window = "${clockTimeLabel(nap.effectiveStartTs)} - ${clockTimeLabel(nap.endTs)}"
+    val napIs24h = ClockPrefs.uses24Hour(LocalContext.current)   // #1821
+    val window = "${clockTimeLabel(nap.effectiveStartTs, napIs24h)} - ${clockTimeLabel(nap.endTs, napIs24h)}"
     val durMin = (nap.endTs - nap.effectiveStartTs) / 60.0
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.space10)) {
         Row(

--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -238,7 +238,9 @@ internal fun FilledHypnogram(
     // stranding the axis at just onset/mid/wake; a tablet fans out to the 8-label ceiling. Floor 4 keeps a
     // narrow phone from collapsing back to bare edges.
     val maxAxisLabels = (LocalConfiguration.current.screenWidthDp / 60).coerceIn(4, 8)
-    val is24h = DateFormat.is24HourFormat(LocalContext.current)
+    // #1821: the reader's CHOSEN clock, not the raw device switch. Reading the device here would have
+    // left the hypnogram axis in 24h while the sleep card above it changed - the setting half-applied.
+    val is24h = ClockPrefs.uses24Hour(LocalContext.current)
     val axisTicks = if (showsAxis) hypnogramAxisTicks(onsetTs!!, wakeTs!!, maxAxisLabels, is24h) else emptyList()
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.space6)) {
         Canvas(

--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -436,9 +436,10 @@ private fun hypnogramSummaryFor(intervals: List<StageInterval>): String =
  */
 @Composable
 internal fun ClockLabelRow(onsetTs: Long, wakeTs: Long) {
-    val onset = clockTimeLabel(onsetTs)
-    val mid = clockTimeLabel((onsetTs + wakeTs) / 2L)
-    val wake = clockTimeLabel(wakeTs)
+    val is24h = ClockPrefs.uses24Hour(LocalContext.current)   // #1821
+    val onset = clockTimeLabel(onsetTs, is24h)
+    val mid = clockTimeLabel((onsetTs + wakeTs) / 2L, is24h)
+    val wake = clockTimeLabel(wakeTs, is24h)
     Row(modifier = Modifier.fillMaxWidth()) {
         Text(
             onset,

--- a/android/app/src/main/java/com/noop/ui/SleepTimeLabels.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepTimeLabels.kt
@@ -2,6 +2,7 @@ package com.noop.ui
 
 import com.noop.data.DailyMetric
 import com.noop.data.SleepSession
+import com.noop.analytics.ClockFormat
 import java.text.SimpleDateFormat
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -15,8 +16,8 @@ internal fun shortDayLabel(day: String): String =
         LocalDate.parse(day).format(DateTimeFormatter.ofPattern("d MMM", Locale.US))
     }.getOrDefault(day)
 
-internal fun clockLabel(latest: DailyMetric, session: SleepSession?): String {
-    if (session != null) return sessionClockLabel(session)
+internal fun clockLabel(latest: DailyMetric, session: SleepSession?, is24h: Boolean): String {
+    if (session != null) return sessionClockLabel(session, is24h)
     // Fall back to the daily metric's day string (YYYY-MM-DD), formatted to "EEE d MMM".
     val dateFmt = SimpleDateFormat("EEE d MMM", Locale.US)
     return runCatching {
@@ -26,12 +27,12 @@ internal fun clockLabel(latest: DailyMetric, session: SleepSession?): String {
 }
 
 /** "Wed 4 Jun · 22:50–06:48" — the night-nav header's date · onset–wake line. (#160) */
-internal fun sessionClockLabel(session: SleepSession): String =
-    clockLabelFor(session.effectiveStartTs, session.endTs) // EFFECTIVE onset so an edited bedtime shows (PR #395)
+internal fun sessionClockLabel(session: SleepSession, is24h: Boolean): String =
+    clockLabelFor(session.effectiveStartTs, session.endTs, is24h) // EFFECTIVE onset so an edited bedtime shows (PR #395)
 
 /** Same date · onset–wake line from explicit unix-second bounds (the #736 group-aligned bedtime). */
-internal fun clockLabelFor(onsetTs: Long, wakeTs: Long): String {
-    val timeFmt = SimpleDateFormat("HH:mm", Locale.US)
+internal fun clockLabelFor(onsetTs: Long, wakeTs: Long, is24h: Boolean): String {
+    val timeFmt = SimpleDateFormat(ClockFormat.hourMinutePattern(is24h), Locale.US)
     val dateFmt = SimpleDateFormat("EEE d MMM", Locale.US)
     val onset = Date(onsetTs * 1000L)
     val wake = Date(wakeTs * 1000L)
@@ -42,9 +43,13 @@ internal fun clockLabelFor(onsetTs: Long, wakeTs: Long): String {
 internal fun localDayString(ts: Long): String =
     SimpleDateFormat("yyyy-MM-dd", Locale.US).format(Date(ts * 1000L))
 
-/** Unix seconds → a local wall-clock "HH:mm" (same 24h formatting the nav-header span uses). */
-internal fun clockTimeLabel(ts: Long): String =
-    SimpleDateFormat("HH:mm", Locale.US).format(Date(ts * 1000L))
+/**
+ * Unix seconds → a local wall-clock time, in the reader's chosen clock (#1821). [is24h] comes from
+ * `ClockPrefs.uses24Hour(context)` at the call site, keeping this pure and unit-testable - the same
+ * shape [axisEdgeLabel] already used.
+ */
+internal fun clockTimeLabel(ts: Long, is24h: Boolean): String =
+    SimpleDateFormat(ClockFormat.hourMinutePattern(is24h), Locale.US).format(Date(ts * 1000L))
 
 /**
  * Hypnogram-axis EDGE label (onset / wake) at minute precision, honouring the device 12/24h setting:
@@ -52,7 +57,7 @@ internal fun clockTimeLabel(ts: Long): String =
  * `DateFormat.is24HourFormat(context)` at the call site so this stays pure/unit-testable.
  */
 internal fun axisEdgeLabel(ts: Long, is24h: Boolean): String =
-    SimpleDateFormat(if (is24h) "HH:mm" else "h:mm a", Locale.US).format(Date(ts * 1000L))
+    SimpleDateFormat(ClockFormat.hourMinutePattern(is24h), Locale.US).format(Date(ts * 1000L))
 
 /**
  * Hypnogram-axis INTERIOR round-hour mark — the label is always on the hour, so it drops the minutes and

--- a/android/app/src/main/java/com/noop/widget/NoopCompactGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/NoopCompactGlanceWidget.kt
@@ -37,6 +37,8 @@ import com.noop.R
 import com.noop.ui.MainActivity
 import java.text.DateFormat
 import java.util.Date
+import com.noop.analytics.ClockFormat
+import com.noop.ui.ClockPrefs
 
 /** Compact home-screen widget: Rest, Charge and Effort icon cells plus live HR and strap battery. */
 class NoopCompactGlanceWidget : GlanceAppWidget() {
@@ -166,7 +168,10 @@ private fun CompactWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
             text = when {
                 snap.connected -> "Connected"
                 snap.updatedAtMs > 0L ->
-                    DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(snap.updatedAtMs))
+                    java.text.SimpleDateFormat(   // #1821: the reader's chosen clock
+                        ClockFormat.hourMinutePattern(ClockPrefs.uses24Hour(androidx.glance.LocalContext.current)),
+                        java.util.Locale.getDefault(),
+                    ).format(Date(snap.updatedAtMs))
                 else -> "Open NOOP to connect"
             },
             style = TextStyle(color = textSecondary, fontSize = 11.sp),

--- a/android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt
@@ -34,6 +34,8 @@ import com.noop.R
 import com.noop.ui.MainActivity
 import java.text.DateFormat
 import java.util.Date
+import com.noop.analytics.ClockFormat
+import com.noop.ui.ClockPrefs
 
 /**
  * Home-screen widget: today's three top scores (Rest · Charge · Effort, Charge centred), with live HR
@@ -197,7 +199,10 @@ private fun WidgetContent(snap: WidgetSnapshot, dark: Boolean) {
             text = when {
                 snap.connected -> "Connected"
                 snap.updatedAtMs > 0L ->
-                    DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(snap.updatedAtMs))
+                    java.text.SimpleDateFormat(   // #1821: the reader's chosen clock
+                        ClockFormat.hourMinutePattern(ClockPrefs.uses24Hour(androidx.glance.LocalContext.current)),
+                        java.util.Locale.getDefault(),
+                    ).format(Date(snap.updatedAtMs))
                 else -> "Open NOOP to connect"
             },
             style = TextStyle(color = textSecondary, fontSize = 11.sp),

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -807,7 +807,10 @@
     <string name="l10n_scoring_guide_screen_scorecardhighlight_4af6985c">scoreCardHighlight</string>
     <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">Das sind unabhängige Näherungen von einem Consumer-Strap, gebaut auf offener Wissenschaft: kein medizinischer Rat und nicht WHOOPs offizielle Werte.</string>
     <string name="l10n_scoring_guide_screen_vs_whoop_9a8126a7">VS WHOOP</string>
+    <string name="l10n_settings_screen_12_hour_41c18ba0">12 Stunden</string>
+    <string name="l10n_settings_screen_24_hour_18e86819">24 Stunden</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">AdvancedChevron</string>
+    <string name="l10n_settings_screen_clock_04f6b3ea">Uhr</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>
     <string name="l10n_skin_temp_cards_screen_cycle_awareness_ffb94783">Zyklusbewusstsein</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -607,7 +607,10 @@
     <string name="l10n_scoring_guide_screen_scorecardhighlight_4af6985c">puntuaciónCardHighlight</string>
     <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">Son aproximaciones independientes de una pulsera de consumo, construidas sobre ciencia abierta: no son consejo médico ni las puntuaciones oficiales de WHOOP.</string>
     <string name="l10n_scoring_guide_screen_vs_whoop_9a8126a7">VS WHOOP</string>
+    <string name="l10n_settings_screen_12_hour_41c18ba0">12 horas</string>
+    <string name="l10n_settings_screen_24_hour_18e86819">24 horas</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">avanzadoChevron</string>
+    <string name="l10n_settings_screen_clock_04f6b3ea">Reloj</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>
     <string name="l10n_skin_temp_cards_screen_cycle_awareness_ffb94783">Conciencia del ciclo</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -625,7 +625,10 @@
     <string name="l10n_scoring_guide_screen_scorecardhighlight_4af6985c">scoreCardHighlight</string>
     <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">Ce sont des approximations indépendantes issues d\'un bracelet grand public, fondées sur la science ouverte : ni un conseil médical, ni les scores officiels de WHOOP.</string>
     <string name="l10n_scoring_guide_screen_vs_whoop_9a8126a7">VS WHOOP</string>
+    <string name="l10n_settings_screen_12_hour_41c18ba0">12 heures</string>
+    <string name="l10n_settings_screen_24_hour_18e86819">24 heures</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">avancéChevron</string>
+    <string name="l10n_settings_screen_clock_04f6b3ea">Horloge</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>
     <string name="l10n_skin_temp_cards_screen_cycle_awareness_ffb94783">Conscience du cycle</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -764,7 +764,10 @@
     <string name="l10n_scoring_guide_screen_scorecardhighlight_4af6985c">Podświetlenie karty wyników</string>
     <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">Są to niezależne przybliżenia z paska konsumenckiego, oparte na otwartej nauce: a nie porady medyczne ani oficjalne wyniki WHOOP.</string>
     <string name="l10n_scoring_guide_screen_vs_whoop_9a8126a7">VS WHOOP</string>
+    <string name="l10n_settings_screen_12_hour_41c18ba0">12-godzinny</string>
+    <string name="l10n_settings_screen_24_hour_18e86819">24-godzinny</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">zaawansowanyChevron</string>
+    <string name="l10n_settings_screen_clock_04f6b3ea">Zegar</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>
     <string name="l10n_skin_temp_cards_screen_cycle_awareness_ffb94783">Świadomość rowerowa</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -772,7 +772,10 @@
     <string name="l10n_scoring_guide_screen_scorecardhighlight_4af6985c">pontuaçãoCardHighlight</string>
     <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">Trata-se de aproximações independentes de um intervalo de consumo, construídas com base na ciência aberta: não nos conselhos médicos, nem nas pontuações oficiais do WHOOP.</string>
     <string name="l10n_scoring_guide_screen_vs_whoop_9a8126a7">VS GRUPO</string>
+    <string name="l10n_settings_screen_12_hour_41c18ba0">12 horas</string>
+    <string name="l10n_settings_screen_24_hour_18e86819">24 horas</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">avançadoChevron</string>
+    <string name="l10n_settings_screen_clock_04f6b3ea">Relógio</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>
     <string name="l10n_skin_temp_cards_screen_cycle_awareness_ffb94783">Consciência do ciclo</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -754,7 +754,10 @@
     <string name="l10n_scoring_guide_screen_scorecardhighlight_4af6985c">评分卡高亮色</string>
     <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">这些是来自消费级手环的独立近似值，基于开放科学构建，并非医疗建议，也不是 WHOOP 的官方评分。</string>
     <string name="l10n_scoring_guide_screen_vs_whoop_9a8126a7">对比 WHOOP</string>
+    <string name="l10n_settings_screen_12_hour_41c18ba0">12 小时制</string>
+    <string name="l10n_settings_screen_24_hour_18e86819">24 小时制</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">高级选项</string>
+    <string name="l10n_settings_screen_clock_04f6b3ea">时钟</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>
     <string name="l10n_skin_temp_cards_screen_cycle_awareness_ffb94783">生理周期推断</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -892,7 +892,10 @@
     <string name="l10n_scoring_guide_screen_scorecardhighlight_4af6985c">scoreCardHighlight</string>
     <string name="l10n_scoring_guide_screen_these_are_independent_approximations_from_a_301457ed">These are independent approximations from a consumer strap, built on open science: not medical advice, and not WHOOP\'s official scores.</string>
     <string name="l10n_scoring_guide_screen_vs_whoop_9a8126a7">VS WHOOP</string>
+    <string name="l10n_settings_screen_12_hour_41c18ba0">12-hour</string>
+    <string name="l10n_settings_screen_24_hour_18e86819">24-hour</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">advancedChevron</string>
+    <string name="l10n_settings_screen_clock_04f6b3ea">Clock</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>
     <string name="l10n_skin_temp_cards_screen_cycle_awareness_ffb94783">Cycle awareness</string>

--- a/android/app/src/test/java/com/noop/analytics/ClockFormatTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ClockFormatTest.kt
@@ -1,0 +1,55 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Twin of the Apple ClockFormatTests - same cases, same expectations. */
+class ClockFormatTest {
+    @Test fun systemDefersToTheDevice() {
+        assertTrue(ClockFormat.uses24Hour(ClockFormatPreference.SYSTEM, systemUses24Hour = true))
+        assertFalse(ClockFormat.uses24Hour(ClockFormatPreference.SYSTEM, systemUses24Hour = false))
+    }
+
+    @Test fun anExplicitChoiceOverridesTheDevice() {
+        // The whole point of the setting: a reader in a 24-hour region can ask for 12-hour and get it.
+        assertFalse(ClockFormat.uses24Hour(ClockFormatPreference.TWELVE_HOUR, systemUses24Hour = true))
+        assertTrue(ClockFormat.uses24Hour(ClockFormatPreference.TWENTY_FOUR_HOUR, systemUses24Hour = false))
+    }
+
+    @Test fun unknownStoredValuesFallBackToSystemNotToAClock() {
+        assertEquals(ClockFormatPreference.SYSTEM, ClockFormatPreference.from(null))
+        assertEquals(ClockFormatPreference.SYSTEM, ClockFormatPreference.from(""))
+        assertEquals(ClockFormatPreference.SYSTEM, ClockFormatPreference.from("24h"))
+        assertEquals(ClockFormatPreference.TWELVE_HOUR, ClockFormatPreference.from("twelveHour"))
+        assertEquals(ClockFormatPreference.TWENTY_FOUR_HOUR, ClockFormatPreference.from("twentyFourHour"))
+    }
+
+    /**
+     * The stored vocabulary is the APPLE rawValue set, not the Kotlin enum names. Pinning the literals
+     * means renaming a case cannot silently make the two platforms disagree about a saved preference -
+     * and it is why `stored()` exists rather than `name`.
+     */
+    @Test fun storedVocabularyIsPinned() {
+        assertEquals("system", ClockFormatPreference.SYSTEM.stored())
+        assertEquals("twelveHour", ClockFormatPreference.TWELVE_HOUR.stored())
+        assertEquals("twentyFourHour", ClockFormatPreference.TWENTY_FOUR_HOUR.stored())
+        assertEquals("clockFormatPreference", ClockFormatPreference.PREFS_KEY)
+        // Round-trip: what we write must be what we read back.
+        for (p in ClockFormatPreference.entries) assertEquals(p, ClockFormatPreference.from(p.stored()))
+    }
+
+    @Test fun hourMinutePattern() {
+        assertEquals("HH:mm", ClockFormat.hourMinutePattern(true))
+        assertEquals("h:mm a", ClockFormat.hourMinutePattern(false))
+    }
+
+    /** The template must never be `j` - the locale-resolved hour is the bug this setting fixes. */
+    @Test fun hourMinuteTemplateNeverDefersToTheLocaleHour() {
+        assertEquals("Hmm", ClockFormat.hourMinuteTemplate(true))
+        assertEquals("hmm", ClockFormat.hourMinuteTemplate(false))
+        assertFalse(ClockFormat.hourMinuteTemplate(true).contains("j"))
+        assertFalse(ClockFormat.hourMinuteTemplate(false).contains("j"))
+    }
+}


### PR DESCRIPTION
Raised on #1821.

> How may i change the time format to 12H instead of 24H?

You could not. There was no setting, and the answer was being decided for the reader by their device
**region**.

## The defect

Apple builds its time formatter from the app language plus the device region:

```swift
if let region = Locale.autoupdatingCurrent.region?.identifier {
    return Locale(identifier: "\(language)_\(region)")
}
```

That is deliberate - it keeps regional date order and clock style rather than imposing US conventions.
But a locale built from a *region identifier* carries that region's **default** hour cycle, and the
user's explicit **Settings > General > Date & Time > 24-Hour Time** switch is not part of it: that
override lives on `Locale.autoupdatingCurrent`. So the switch was silently discarded, and a reader in a
24-hour region had no route to a 12-hour clock at all.

## Two decisions worth stating

**Three options, not a toggle.** System / 12-hour / 24-hour, defaulting to System, so upgrading changes
nobody's display. A two-way switch needs a default, and either default re-formats every existing user's
times. It also mirrors the "Match" option the Temperature row already uses.

**"System" means the device's switch**, not the region default - which on its own resolves the report
for anyone who had already chosen 12-hour on their phone and was being overridden.

## The trap this could easily have fallen into

The old formatter used the `jmm` template, and **`j` resolves the hour from the locale** - precisely the
mechanism that was discarding the reader's choice. Feeding a preference back through `j` would have
looked like a fix and changed nothing. The resolver returns `Hmm`/`hmm` instead, and a test asserts the
template never contains `j`.

## Shape

- Shared `ClockFormat` / `ClockFormatPreference` on both platforms, with the **stored vocabulary pinned
  identical** by tests, so one saved preference cannot mean different things per platform. An
  unparseable stored value falls back to System, never to a hardcoded clock.
- **Apple**: `AppClock` reads the preference and derives "system" from `autoupdatingCurrent`.
  `SleepModel.timeFmt` - the formatter behind the exact ASLEEP/WOKE values in the report - routes
  through it, cached per resolved template so the setting applies without a relaunch.
- **Android**: `ClockPrefs` turns a Context into the flag; label helpers take it explicitly, following
  the precedent `axisEdgeLabel` already set ("so this stays pure/unit-testable"). On `SleepScreen` the
  flag is a `remember` **key**, so changing the setting re-derives the labels rather than leaving a
  stale clock on screen.
- Picker lives in **Appearance** beside Language on both platforms - an app-owned display convention,
  not a unit of measurement - and reuses the existing "System default" string.

## Deliberately unchanged

- **Logs stay 24-hour.** The strap-log sleep-mark line is evidence for bug reports; a display preference
  must not reshape it.
- **Chart axis tick formatters** (`FullDayChartView`, `Charts.kt`) still hardcode 24h. 12-hour labels are
  materially wider and axis tick density is laid out around the current width, so that belongs in its own
  change with a device to look at. Android's hypnogram **edge** labels already honoured the device
  setting via `axisEdgeLabel` and now honour this one.

## Verification

- Kotlin: **full suite 5085 tests, 0 failures**; `compileFullDebugKotlin`.
- `Tools/i18n_audit.py --ci` passes; `lintVitalFullRelease -PstagingRelease` (the `ExtraTranslation`
  gate) passes.
- New strings in all **10** Apple locales and all **7** Android ones.
- The `.xcstrings` edit is a **text splice, not a JSON round-trip**: 192 insertions, 0 deletions. A
  round-trip reformatted all 50k lines and would have been unreviewable.
- Apple compile needs the app-build gate; not yet run.