### PR TITLE
diag(clock): read the strap's answer instead of asserting it (#1823)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
@@ -227,8 +227,13 @@ public enum ConnectionReadout {
         if let d = deviceClockUnix {
             return d < ConnectionTrace.rtcEpochCeilingUnix ? "no (RTC reads 1970/71)" : "yes"
         }
+        // #1823: this branch has NOT read a clock. It is reached when no clock correlation exists - which
+        // is every 5/MG, whose GET_CLOCK reply rides the puffin notify chars and never touches the WHOOP4
+        // correlation path - so the only evidence is how the strap DATED its banked records. Saying "RTC
+        // reads 1970/71" there claimed a reading we never took, in the one readout a reporter quotes when
+        // asking why nothing syncs. Report the evidence we actually have.
         if let n = strapNewestUnix {
-            return n < ConnectionTrace.rtcEpochCeilingUnix ? "no (RTC reads 1970/71)" : "yes"
+            return n < ConnectionTrace.rtcEpochCeilingUnix ? "no (records dated 1970/71)" : "yes"
         }
         return "no (waiting for the strap clock)"
     }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
@@ -204,9 +204,11 @@ final class ConnectionReadoutTests: XCTestCase {
         XCTAssertEqual(
             ConnectionReadout.clockLatchedLabel(deviceClockUnix: nil, strapNewestUnix: 1_782_475_600),
             "yes")
+        // #1823: no clock was READ on this path - it is the 5/MG fallback, where the only evidence is
+        // how the strap dated its records. The wording must not claim a clock reading.
         XCTAssertEqual(
             ConnectionReadout.clockLatchedLabel(deviceClockUnix: nil, strapNewestUnix: 40_000_000),
-            "no (RTC reads 1970/71)")
+            "no (records dated 1970/71)")
         XCTAssertEqual(
             ConnectionReadout.clockLatchedLabel(deviceClockUnix: nil, strapNewestUnix: nil),
             "no (waiting for the strap clock)")

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -6103,7 +6103,11 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                 // Hardware-validated ordering (#78 fork).
                 send(.setClock, payload: BLEManager.setClockPayload())
                 send(.getClock, payload: [])
-                log("WHOOP 5/MG: clock synced (set/get) — strap can persist history now")
+                // #1823: say what was SENT, not what resulted. This previously read "clock synced —
+                // strap can persist history now", logged before any reply had arrived, so a log could
+                // assert the clock was set while the Devices readout said 1970/71. The strap's actual
+                // answer now arrives as the "clock: …" ack line from FrameRouter.
+                log("WHOOP 5/MG: SET_CLOCK + GET_CLOCK sent — awaiting the strap's answer")
                 log("WHOOP 5/MG: scheduling first historical offload (connect)")
                 // Deferred ~1.5s so the puffin notify subscriptions settle before SEND_HISTORICAL_DATA,
                 // mirroring the WHOOP4 kick. requestSync → beginBackfill is itself gated on

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -156,6 +156,18 @@ public final class FrameRouter {
                 let verdict = r == nil ? "no result byte" : (accepted ? "accepted" : "REJECTED")
                 state.append(log: "reboot: strap acked result=\(rhex) (\(verdict))")
             }
+            // #1823: the clock exchange, on BOTH families. NOOP wrote "clock synced" the instant it queued
+            // the writes and never read the answer, so a strap log asserted the clock was set while the
+            // readout said 1970/71 — two contradictory lines with nothing to separate them. Same
+            // accept/reject shape REBOOT_STRAP already uses: the family's own result offset and polarity
+            // (5/MG 1=SUCCESS, 4.0 0=SUCCESS). LOG-ONLY; it never gates behaviour.
+            if let cmd = parsed.cmdName, cmd.hasPrefix("SET_CLOCK") || cmd.hasPrefix("GET_CLOCK") {
+                let r = Self.commandResultByte(in: frame, family: family)
+                let rhex = r.map { String(format: "0x%02x", UInt8(truncatingIfNeeded: $0)) } ?? "none"
+                let accepted = (family == .whoop5) ? (r == 1) : (r == 0)
+                let verdict = r == nil ? "no result byte" : (accepted ? "accepted" : "REJECTED")
+                state.append(log: "clock: \(cmd) strap acked result=\(rhex) (\(verdict))", domain: .connection)
+            }
             if family == .whoop4, let cmd = parsed.cmdName {
                 if cmd.hasPrefix("GET_ADVERTISING_NAME_HARVARD") {
                     if let name = Self.advertisingName(in: frame), !name.isEmpty {

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -164,9 +164,29 @@ public final class FrameRouter {
             if let cmd = parsed.cmdName, cmd.hasPrefix("SET_CLOCK") || cmd.hasPrefix("GET_CLOCK") {
                 let r = Self.commandResultByte(in: frame, family: family)
                 let rhex = r.map { String(format: "0x%02x", UInt8(truncatingIfNeeded: $0)) } ?? "none"
-                let accepted = (family == .whoop5) ? (r == 1) : (r == 0)
-                let verdict = r == nil ? "no result byte" : (accepted ? "accepted" : "REJECTED")
-                state.append(log: "clock: \(cmd) strap acked result=\(rhex) (\(verdict))", domain: .connection)
+                // A VERDICT only where the polarity is known. 5/MG's 1=SUCCESS is established (the
+                // BodyLocation probe + MG vectors); WHOOP 4.0's 0=accepted is the reboot probe's
+                // explicitly UNVERIFIED reading. #1818 is a 4.0 report, so rendering "REJECTED" there
+                // from a guess would hand that triage a confident answer resting on nothing - the exact
+                // mistake this whole line exists to stop. Print the raw byte and say the meaning is
+                // unverified; a maintainer can still compare it across straps, which is the point.
+                let verdict: String
+                if r == nil {
+                    verdict = "no result byte"
+                } else if family == .whoop5 {
+                    verdict = (r == 1) ? "accepted" : "REJECTED"
+                } else {
+                    verdict = "meaning unverified on 4.0"
+                }
+                // The strap's own answer to GET_CLOCK is the direct evidence of whether the write took,
+                // and on 5/MG nothing else decodes it - the reply never reaches the WHOOP4 correlation
+                // path. Raw hex, uncapped: a truncated clock payload answers nothing.
+                let payload = cmd.hasPrefix("GET_CLOCK")
+                    ? (Self.commandResponsePayloadHex(in: frame, family: family)
+                        .map { " payload=\($0)" } ?? " payload=empty")
+                    : ""
+                state.append(log: "clock: \(cmd) strap acked result=\(rhex) (\(verdict))\(payload)",
+                             domain: .connection)
             }
             if family == .whoop4, let cmd = parsed.cmdName {
                 if cmd.hasPrefix("GET_ADVERTISING_NAME_HARVARD") {
@@ -474,8 +494,14 @@ public final class FrameRouter {
 
     /// Space-separated lowercase hex of a COMMAND_RESPONSE payload, for the raw-hex diagnostic fallback
     /// when a readback payload doesn't decode. nil when the frame carries no payload.
-    nonisolated static func commandResponsePayloadHex(in frame: [UInt8]) -> String? {
-        guard let payload = commandResponsePayload(in: frame), !payload.isEmpty else { return nil }
+    /// #1823: takes `family` because `commandResponsePayload` slices at a family-specific inner offset
+    /// (5/MG 8, 4.0 its own). This wrapper used to drop the argument and always slice at the 4.0 offset,
+    /// so a 5/MG payload came back shifted - the same fixed-offset mistake the REBOOT_STRAP comment
+    /// records, and it would have mis-read the clock payload on the family the clock diagnostic is for.
+    /// Defaulted to `.whoop4` so the existing WHOOP4-gated alarm caller is unchanged.
+    nonisolated static func commandResponsePayloadHex(in frame: [UInt8],
+                                                      family: DeviceFamily = .whoop4) -> String? {
+        guard let payload = commandResponsePayload(in: frame, family: family), !payload.isEmpty else { return nil }
         return payload.map { String(format: "%02x", $0) }.joined(separator: " ")
     }
 

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -162,30 +162,24 @@ public final class FrameRouter {
             // accept/reject shape REBOOT_STRAP already uses: the family's own result offset and polarity
             // (5/MG 1=SUCCESS, 4.0 0=SUCCESS). LOG-ONLY; it never gates behaviour.
             if let cmd = parsed.cmdName, cmd.hasPrefix("SET_CLOCK") || cmd.hasPrefix("GET_CLOCK") {
+                // NO accept/reject verdict here, on EITHER family, and that is deliberate.
+                //
+                // 4.0's 0=accepted is the reboot probe's own explicitly UNVERIFIED reading. And on 5/MG
+                // the result byte may not exist at all for this command: the captured-frame fixture builds
+                // a puffin COMMAND_RESPONSE as [36, seq, cmd] + payload at offset 8, so @11 is already
+                // PAYLOAD and the @12 that `commandResultByte` reads is a payload byte, not a result code.
+                // REBOOT_STRAP's use of it was validated against reboot's own frames; nothing establishes
+                // it for the clock.
+                //
+                // Inventing a verdict from that is precisely the fault this line was added to fix - the
+                // old "clock synced" log asserted an outcome nobody had checked. So quote the evidence
+                // and let a maintainer decode it: the byte at the family's result offset, and the WHOLE
+                // frame (#900's format), uncapped. A truncated clock frame answers nothing, and the full
+                // frame is what makes a wrong offset assumption visible instead of silently misleading.
                 let r = Self.commandResultByte(in: frame, family: family)
                 let rhex = r.map { String(format: "0x%02x", UInt8(truncatingIfNeeded: $0)) } ?? "none"
-                // A VERDICT only where the polarity is known. 5/MG's 1=SUCCESS is established (the
-                // BodyLocation probe + MG vectors); WHOOP 4.0's 0=accepted is the reboot probe's
-                // explicitly UNVERIFIED reading. #1818 is a 4.0 report, so rendering "REJECTED" there
-                // from a guess would hand that triage a confident answer resting on nothing - the exact
-                // mistake this whole line exists to stop. Print the raw byte and say the meaning is
-                // unverified; a maintainer can still compare it across straps, which is the point.
-                let verdict: String
-                if r == nil {
-                    verdict = "no result byte"
-                } else if family == .whoop5 {
-                    verdict = (r == 1) ? "accepted" : "REJECTED"
-                } else {
-                    verdict = "meaning unverified on 4.0"
-                }
-                // The strap's own answer to GET_CLOCK is the direct evidence of whether the write took,
-                // and on 5/MG nothing else decodes it - the reply never reaches the WHOOP4 correlation
-                // path. Raw hex, uncapped: a truncated clock payload answers nothing.
-                let payload = cmd.hasPrefix("GET_CLOCK")
-                    ? (Self.commandResponsePayloadHex(in: frame, family: family)
-                        .map { " payload=\($0)" } ?? " payload=empty")
-                    : ""
-                state.append(log: "clock: \(cmd) strap acked result=\(rhex) (\(verdict))\(payload)",
+                state.append(log: "clock: \(cmd) reply byte@resultOffset=\(rhex) "
+                                + "frame=\(Self.fullFrameHex(frame))",
                              domain: .connection)
             }
             if family == .whoop4, let cmd = parsed.cmdName {

--- a/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
@@ -211,7 +211,10 @@ object ConnectionReadout {
     fun clockLatchedLabel(deviceClockUnix: Long?, strapNewestUnix: Long? = null): String {
         val ceiling = ConnectionTrace.RTC_EPOCH_CEILING_UNIX
         if (deviceClockUnix != null) return if (deviceClockUnix < ceiling) "no (RTC reads 1970/71)" else "yes"
-        if (strapNewestUnix != null) return if (strapNewestUnix < ceiling) "no (RTC reads 1970/71)" else "yes"
+        // #1823: this branch has NOT read a clock - it is reached when no correlation exists, which is
+        // every 5/MG. The only evidence is how the strap DATED its records, so say that rather than
+        // claiming a clock reading we never took. Twin of the Swift wording.
+        if (strapNewestUnix != null) return if (strapNewestUnix < ceiling) "no (records dated 1970/71)" else "yes"
         return "no (waiting for the strap clock)"
     }
 

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7209,6 +7209,19 @@ class WhoopBleClient(
                     }
                     log("reboot: strap acked result=${result ?: "none"} ($verdict)")
                 }
+                // #1823: the clock exchange, on BOTH families. NOOP wrote "clock synced" the moment it
+                // queued the writes and never read the answer, so a strap log asserted the clock was set
+                // while the readout said 1970/71. Android has the DECODED result name here - the richer
+                // twin of the Apple raw byte, and the reason the reboot verdict was correct on this side -
+                // but for the clock nothing establishes what a result means, so this states no verdict
+                // either. It quotes the decoded name when there is one and the WHOLE frame in hex, which
+                // is what makes a wrong assumption visible instead of silently misleading. Log-only.
+                if (respCmd?.startsWith("SET_CLOCK") == true || respCmd?.startsWith("GET_CLOCK") == true) {
+                    log(
+                        "clock: $respCmd reply result=${result ?: "none"} " +
+                            "frame=${frame.joinToString("") { "%02x".format(it) }}",
+                    )
+                }
                 // 5/MG range-query gate: a GET_DATA_RANGE SUCCESS releases the history request
                 // (PENDING precedes it; the 2s fail-open fallback covers a swallowed reply). (#78 fork)
                 if (connectedFamily == DeviceFamily.WHOOP5 && backfilling && !historicalKickSent &&
@@ -8765,7 +8778,11 @@ class WhoopBleClient(
                 // #520: read the DIS identity on the same post-handshake schedule, staggered after the
                 // battery read so the two do not contend for the serialized GATT queue.
                 handler.postDelayed({ readDisIdentity() }, BATTERY_ON_CONNECT_DELAY_MS * 2)
-                log("WHOOP 5/MG: clock synced (set/get) — strap can persist history now")
+                // #1823: say what was SENT, not what resulted. This read "clock synced — strap can
+                // persist history now", logged before any reply existed, so a log could assert the clock
+                // was set while the Devices readout said 1970/71. The strap's own answer now arrives as
+                // the "clock: …" line above. Twin of the Apple wording.
+                log("WHOOP 5/MG: SET_CLOCK + GET_CLOCK sent — awaiting the strap's answer")
                 if (!backfillStarted) {
                     backfillStarted = true
                     handler.postDelayed({ requestSync(BackfillTrigger.CONNECT) }, INITIAL_BACKFILL_DELAY_MS)

--- a/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
@@ -213,7 +213,8 @@ class ConnectionReadoutTest {
     // "waiting" forever on a strap that's actually fine.
     @Test fun clockLatchedLabelFallsBackToStrapNewestForFiveMG() {
         assertEquals("yes", ConnectionReadout.clockLatchedLabel(null, 1_782_475_600L))
-        assertEquals("no (RTC reads 1970/71)", ConnectionReadout.clockLatchedLabel(null, 40_000_000L))
+        // #1823: no clock was READ on this path - the wording must not claim one.
+        assertEquals("no (records dated 1970/71)", ConnectionReadout.clockLatchedLabel(null, 40_000_000L))
         assertEquals("no (waiting for the strap clock)", ConnectionReadout.clockLatchedLabel(null, null))
         // deviceClockUnix wins when BOTH signals are present (the WHOOP4 correlation is the more direct one).
         assertEquals("yes", ConnectionReadout.clockLatchedLabel(1_782_475_600L, 40_000_000L))


### PR DESCRIPTION
Raised on #1823.

A WHOOP 5/MG owner on firmware **50.41.1.0** reports nothing syncs: live HR fine, strap history **synced
<1m ago**, Today at **0 of 4 nights**, and `Clock latched: no (RTC reads 1970/71)`.

## It is not #1635

That was my first reading, and the evidence rules it out:

- `lastSyncedAt` is stamped on **HISTORY_COMPLETE** (`BLEManager:2525`), so a completed offload really did
  happen.
- A 5/MG offload requires `connectHandshakeDone`; `HealthView.canSync` additionally requires
  `historyReady`.
- `historyReady = true` and the `SET_CLOCK` write sit in the **same post-`CLIENT_HELLO` block**, eleven
  lines apart.

So the handshake completed, the clock write went out, and the strap still banks nothing usable — the #78
signature of a strap that has not actually latched a clock.

## Two things were stopping anyone from seeing why

**We claimed success without checking.**

```swift
send(.setClock, payload: BLEManager.setClockPayload())
send(.getClock, payload: [])
log("WHOOP 5/MG: clock synced (set/get) — strap can persist history now")
```

Logged the instant the writes were queued, before any reply existed. So a strap log asserted the clock
was set while the Devices readout said 1970/71 — two contradictory lines and nothing to separate them.

`FrameRouter` already surfaces non-SUCCESS `COMMAND_RESPONSE`s on both families (#900) and already logs
accept/reject for `REBOOT_STRAP` using the family's own result offset and polarity. The signal existed;
it just was never read for the clock. Now it is:

```
clock: SET_CLOCK(10) strap acked result=0x01 (accepted)
```

and the send line says what it **sent**, leaving the outcome to the reply.

**The readout claimed a clock reading it never took.** `clockCorrelatedDevice` parses `"Clock
correlated:"`, emitted only on the WHOOP4 decode path — the 5/MG `GET_CLOCK` reply "rides the puffin
notify chars and never touches the WHOOP4 clockRef correlation path", as the code itself says. So on
**every** 5/MG that lookup returns nil and the label falls back to `strapNewestUnix`, the newest *banked
record* timestamp, while wording it as an RTC reading.

That branch now reads `no (records dated 1970/71)` — the evidence we actually hold. The `deviceClockUnix`
branch, which does read a clock, is unchanged.

## Why it matters beyond this reporter

#1818 is the same shape from the other family: a WHOOP 4.0 on fw 41.17.4.0 where `SET_CLOCK` is
demonstrably sent and the RTC stays 1970/71. Two families, two firmwares, one question no strap log could
answer. This makes the next capture answer it.

## Tests

The two tests that pinned the old wording covered exactly the 5/MG fallback path (the Kotlin one is even
named `clockLatchedLabelFallsBackToStrapNewestForFiveMG`). Repinned to the same shape rather than
deleted, with the reason recorded.

- Kotlin: `ConnectionReadoutTest` **22/22**, forced re-run.
- `Tools/doc_comment_lint.py` clean — run locally this time.
- Swift: covered by `test (StrandAnalytics)`; the `FrameRouter` / `BLEManager` edits are app-target and
  need the app-build gate.

## Scope

Diagnostics and wording only — no behaviour change. #1823 and #1818 both stay open: this is what lets the
next log say whether the strap accepted the clock.