### PR TITLE
test centre: log every pushed strap EVENT under the Connection domain

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7309,6 +7309,19 @@ class WhoopBleClient(
 
             "EVENT" -> {
                 (parsed.parsed["event"] as? String)?.let { ev ->
+                    // Test-Centre-gated census of EVERY event the strap pushes. Nothing logs event names
+                    // today, so a strap log cannot answer "does this strap emit CHARGING_ON?" or
+                    // "does it emit BATTERY_PACK_CONNECTED?" — the absence of a line proves nothing,
+                    // because no line was ever written. That blind spot is what made the charging-pill
+                    // bug and the cmd-151 dead end hard to reason about. Logs the name, whether the frame
+                    // is a replayed offload record (so a historical event is never mistaken for a live
+                    // one), and the 5/MG opaque payload hex — which is where a pack charge would live if
+                    // any event carries one. Read-only; sends nothing and decodes nothing into state.
+                    if (testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
+                        val payHex = parsed.parsed["event_payload_hex"] as? String
+                        log("[event] $ev${if (replayedOffload) " (replayed offload)" else ""}" +
+                            (payHex?.let { " payload=$it" } ?: ""))
+                    }
                     // Event strings are "NAME(rawValue)", e.g. "WRIST_ON(9)" (see Schema.enumName).
                     // Pure [isGestureEvent] so the gesture-vs-non-gesture routing is unit-testable (PR #577).
                     val isGesture = isGestureEvent(ev)

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -10891,8 +10891,44 @@ internal fun alarmReadbackLocalTime(epochSec: Long): String =
  *  TOTAL — never throws: a redaction failure returns a safe placeholder rather than leaking the raw
  *  line or crashing the caller (#453). The MAC regex captures exactly two groups (first + last octet),
  *  so the replacement references $1/$2 only. */
+/**
+ * #1833: a serial hidden inside a HEX payload. The text rules below scrub a serial that is written as
+ * text; they cannot see one that arrives as `payload=…5742423541503035…`, because the redactor is
+ * looking at hex digits, not at the ASCII those bytes decode to. Event 109 on a 5/MG carries the strap
+ * serial in plain ASCII inside its payload, so a hex dump of it walks straight past every rule here —
+ * into the log a reporter pastes into a public issue.
+ *
+ * Decode each `payload=`/`frame=` hex run, find printable ASCII stretches inside it, and if one looks
+ * like a WHOOP serial, mask THOSE BYTES back in the hex. Everything else in the payload survives
+ * untouched, which is the point: the payload is exactly where an undocumented field would be found, so
+ * blanket-truncating it would remove the reason the dump exists.
+ */
+private val PII_HEX_DUMP_RE = Regex("((?:payload|frame)=)([0-9a-fA-F]{8,})")
+/** A WHOOP serial as it appears in a payload: a leading letter then 8+ alphanumerics (e.g. WBB5AP0539852). */
+private val PII_SERIAL_IN_ASCII_RE = Regex("[A-Za-z][0-9A-Za-z]{8,}")
+
+internal fun redactHexDumpPii(hex: String): String {
+    val bytes = ArrayList<Int>(hex.length / 2)
+    var i = 0
+    while (i + 1 < hex.length) {
+        bytes.add(hex.substring(i, i + 2).toIntOrNull(16) ?: return hex)
+        i += 2
+    }
+    val ascii = StringBuilder(bytes.size)
+    for (b in bytes) ascii.append(if (b in 32..126) b.toChar() else '.')
+    var out = hex
+    for (m in PII_SERIAL_IN_ASCII_RE.findAll(ascii.toString())) {
+        // Two hex chars per byte: mask exactly the run's bytes, leaving the rest of the dump intact.
+        val start = m.range.first * 2
+        val end = (m.range.last + 1) * 2
+        out = out.substring(0, start) + "••".repeat(m.value.length) + out.substring(end)
+    }
+    return out
+}
+
 internal fun redactStrapLogPii(s: String): String = try {
-    s.replace(PII_MAC_RE, "$1:••:••:••:••:$2")
+    s.replace(PII_HEX_DUMP_RE) { m -> m.groupValues[1] + redactHexDumpPii(m.groupValues[2]) }
+        .replace(PII_MAC_RE, "$1:••:••:••:••:$2")
         .replace(PII_WHOOP_SERIAL_RE, "WHOOP <serial>")
         // MAC first, deliberately: `whoop-<MAC>` is already `whoop-FD:••…` by now and cannot be mistaken
         // for an adopted id. The -noop form runs before the general one so the sibling suffix survives.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -10982,10 +10982,6 @@ internal fun alarmReadbackLocalTime(epochSec: Long): String =
     java.text.SimpleDateFormat("EEE HH:mm zzz", java.util.Locale.US)
         .format(java.util.Date(epochSec * 1000L))
 
-/** Mask MAC addresses and WHOOP serials in a strap-log line before it's shown/exported.
- *  TOTAL — never throws: a redaction failure returns a safe placeholder rather than leaking the raw
- *  line or crashing the caller (#453). The MAC regex captures exactly two groups (first + last octet),
- *  so the replacement references $1/$2 only. */
 /**
  * #1833: a serial hidden inside a HEX payload. The text rules below scrub a serial that is written as
  * text; they cannot see one that arrives as `payload=…5742423541503035…`, because the redactor is
@@ -11027,6 +11023,10 @@ internal fun redactHexDumpPii(hex: String): String {
     return out
 }
 
+/** Mask MAC addresses and WHOOP serials in a strap-log line before it's shown/exported.
+ *  TOTAL — never throws: a redaction failure returns a safe placeholder rather than leaking the raw
+ *  line or crashing the caller (#453). The MAC regex captures exactly two groups (first + last octet),
+ *  so the replacement references $1/$2 only. */
 internal fun redactStrapLogPii(s: String): String = try {
     s.replace(PII_HEX_DUMP_RE) { m -> redactHexDumpPii(m.value) }
         .replace(PII_MAC_RE, "$1:••:••:••:••:$2")

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -10898,12 +10898,18 @@ internal fun alarmReadbackLocalTime(epochSec: Long): String =
  * serial in plain ASCII inside its payload, so a hex dump of it walks straight past every rule here —
  * into the log a reporter pastes into a public issue.
  *
- * Decode each `payload=`/`frame=` hex run, find printable ASCII stretches inside it, and if one looks
- * like a WHOOP serial, mask THOSE BYTES back in the hex. Everything else in the payload survives
- * untouched, which is the point: the payload is exactly where an undocumented field would be found, so
- * blanket-truncating it would remove the reason the dump exists.
+ * Decode ANY long hex run, find printable ASCII stretches inside it, and if one looks like a WHOOP
+ * serial, mask THOSE BYTES back in the hex. Everything else survives untouched, which is the point: the
+ * payload is exactly where an undocumented field would be found, so blanket-truncating it would remove
+ * the reason the dump exists.
+ *
+ * Deliberately NOT keyed on `payload=` / `frame=`. Both platforms label hex differently and
+ * inconsistently — `payload=`, `frame=`, `[raw …]`, `(raw …)`, the #900 whole-frame dump — and a rule
+ * that enumerates today's labels is a rule the next diagnostic slips past. Matching the hex itself
+ * needs no maintenance. The false-positive cost is negligible: masking requires nine consecutive
+ * alphanumeric ASCII bytes, which random binary produces about once in a million runs.
  */
-private val PII_HEX_DUMP_RE = Regex("((?:payload|frame)=)([0-9a-fA-F]{8,})")
+private val PII_HEX_DUMP_RE = Regex("[0-9a-fA-F]{16,}")
 /** A WHOOP serial as it appears in a payload: a leading letter then 8+ alphanumerics (e.g. WBB5AP0539852). */
 private val PII_SERIAL_IN_ASCII_RE = Regex("[A-Za-z][0-9A-Za-z]{8,}")
 
@@ -10927,7 +10933,7 @@ internal fun redactHexDumpPii(hex: String): String {
 }
 
 internal fun redactStrapLogPii(s: String): String = try {
-    s.replace(PII_HEX_DUMP_RE) { m -> m.groupValues[1] + redactHexDumpPii(m.groupValues[2]) }
+    s.replace(PII_HEX_DUMP_RE) { m -> redactHexDumpPii(m.value) }
         .replace(PII_MAC_RE, "$1:••:••:••:••:$2")
         .replace(PII_WHOOP_SERIAL_RE, "WHOOP <serial>")
         // MAC first, deliberately: `whoop-<MAC>` is already `whoop-FD:••…` by now and cannot be mistaken

--- a/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
@@ -16,6 +16,35 @@ import org.junit.Test
  */
 class PiiRedactionTest {
 
+    /**
+     * #1833: the serial that arrives as HEX. The event census (#1825) dumps `payload=<hex>` for every
+     * pushed event, and event 109 on a 5/MG carries the strap serial as plain ASCII inside that payload.
+     * The text rules cannot see it — they are reading hex digits — so it walked past every one of them
+     * into the log people paste into public issues. This is the exact payload from that PR's own sample.
+     */
+    @Test fun masksAWhoopSerialHiddenInsideAHexPayload() {
+        val line = "[event] 0x6D(109) payload=142e1c0001d36e3d1c12a3574242354150303533393835320000"
+        val out = redactStrapLogPii(line)
+        // "WBB5AP0539852" as hex is 5742423541503035333938353 2 — none of it may survive.
+        assertFalse("serial must not survive as hex: $out", out.contains("4242354150303533393835"))
+        assertTrue("the dump must still be recognisable", out.startsWith("[event] 0x6D(109) payload="))
+        // The non-serial bytes are the reason the dump exists — they must be untouched.
+        assertTrue("leading bytes must survive: $out", out.contains("142e1c0001d36e3d1c12a3"))
+    }
+
+    @Test fun leavesAHexPayloadWithNoSerialAlone() {
+        // The charging payloads from the same capture carry no ASCII run — they must pass through whole.
+        for (p in listOf("707d0000", "b87e0000", "00000000")) {
+            assertEquals("payload=$p", redactStrapLogPii("payload=$p"))
+        }
+    }
+
+    /** Odd-length or non-hex content must return unchanged rather than throwing — redaction failing
+     *  open would withhold the whole line ("[redaction error - line withheld]"). */
+    @Test fun malformedHexIsLeftAloneRatherThanThrowing() {
+        assertEquals("payload=zzzzzzzzz", redactStrapLogPii("payload=zzzzzzzzz"))
+    }
+
     @Test fun masksMacKeepingFirstAndLastOctet() {
         // The exact line that triggered #421 (a generic-HR strap's address being logged).
         val out = redactStrapLogPii("HR-strap: connecting to A1:B2:C3:D4:E5:F6")

--- a/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
@@ -32,6 +32,17 @@ class PiiRedactionTest {
         assertTrue("leading bytes must survive: $out", out.contains("142e1c0001d36e3d1c12a3"))
     }
 
+    /** The rule is deliberately not keyed on `payload=`: Apple labels the same dumps `[raw …]` and the
+     *  #900 whole-frame dump has no label at all. A serial must not survive by arriving under a
+     *  different word. */
+    @Test fun masksASerialUnderAnyLabelIncludingNone() {
+        val hex = "142e1c0001d36e3d1c12a3574242354150303533393835320000"
+        for (line in listOf("[raw $hex]", "(raw $hex)", "raw frame (#900) $hex", hex)) {
+            val out = redactStrapLogPii(line)
+            assertFalse("serial survived under this label: $out", out.contains("4242354150303533393835"))
+        }
+    }
+
     @Test fun leavesAHexPayloadWithNoSerialAlone() {
         // The charging payloads from the same capture carry no ASCII run — they must pass through whole.
         for (p in listOf("707d0000", "b87e0000", "00000000")) {


### PR DESCRIPTION
## What this PR does

Nothing logs event names. So a strap log cannot answer *"does this strap emit `CHARGING_ON`?"* or *"does it emit `BATTERY_PACK_CONNECTED`?"* — the handler sets state without logging, and the absence of a line is not evidence about that event, because no line was ever written for **any** event, fired or not.

That blind spot is not hypothetical. Two conclusions were drawn from it while investigating the 5/MG charging indicator, and both were wrong:

1. **"A WHOOP MG never emits `CHARGING_ON`/`CHARGING_OFF`."** It does. `CHARGING_ON` trails `BATTERY_PACK_CONNECTED(21)` by about 17 seconds — long enough for a short capture window to miss it, and long enough for a single detach/reattach cycle to "prove" absence.
2. **"The silent log shows the feature is absent."** It showed only that nothing logs.

While Test Centre → Connection is armed, and only then, each pushed EVENT frame logs three things:

- the event **name as rendered**, so an uncatalogued event appears as `0x6D(109)` instead of vanishing
- whether the frame is a **replayed offload** record, so a historical event is never mistaken for a live one
- the **5/MG opaque payload hex**

## Why it is safe

Read-only: it sends nothing, decodes nothing into state, and changes no behaviour. It costs one boolean check when the domain is not armed. Both fields it reads already exist — `TestDomain.CONNECTION` and `event_payload_hex` (`Framing.kt`) — so there is no new plumbing.

## What it produces

A sample from a real capture, WHOOP MG fw `50.39.1.0`, two attach/detach cycles:

```
01:40:51  [event] 0x6D(109) payload=142e1c0001<6-byte BT address><serial ASCII>0000…
01:40:51  [event] CHARGING_ON(7) payload=707d0000
01:40:51  [event] BATTERY_PACK_CONNECTED(21) payload=707d0000
01:41:06  [event] CHARGING_OFF(8) payload=b87e0000
01:41:11  [event] BATTERY_PACK_REMOVED(22) payload=00000000
01:43:00  [event] CHARGING_ON(7) (replayed offload) payload=707d0000
```

> **Payload redacted 2026-09-05.** The `0x6D(109)` line above originally carried this strap's BT address and serial verbatim, as ASCII inside the hex run — the leak @ryanbr found reviewing this PR and fixed in #1833. Only those two fields are masked; every other byte is as captured. Left in place rather than deleted because the shape of that payload is what the census exists to expose.

The last line is why the replayed-offload marker is in there. The strap **replays** its pack events during the next historical offload with byte-identical payloads. Without the marker there is no way to tell that copy from the live one — and treating it as live would switch the charging pill back on minutes after the pack came off.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / tooling

Closest fit is tooling — it is a Test Centre diagnostic, not a user-facing feature.

## How it was tested

**On hardware.** WHOOP MG, hw `WS50_r00`, fw `50.39.1.0` (DIS-attested), no subscription, Pixel 9 Pro / Android 15, on a local `full` debug build. The capture above is from that run: two deliberate pack attach/detach cycles with the domain armed, 24 event lines recorded. The output is the evidence base for follow-up work on the 5/MG charging indicator, so it has been exercised for its actual purpose rather than merely compiled.

**Android unit tests, full suite.** `./gradlew testFullDebugUnitTest` on Windows 11 / JDK 17, compileSdk 35, against `main` @ `d6d84cc5`: **5,039 tests across 614 classes, 0 failures, 0 errors** (10 skipped, pre-existing). Counted from the JUnit XML with the results directory cleared beforehand, so the numbers are from an actual run rather than an up-to-date task.

**No new build warnings** — zero warnings mentioning `WhoopBleClient` in the build log.

**`Tools/doc_comment_lint.py`: not run to completion locally.** It fails with a `PermissionError` reading `Packages/StrandAnalytics/.build/checkouts/GRDB.swift` — a SwiftPM artifact on the SMB share this checkout lives on, unrelated to the change. `.build/` is gitignored so a clean CI checkout will not hit it, and this diff adds no `/** */` doc comments at all (only inline `//` inside a function body), so its per-file count is unchanged. Left to `source-hygiene.yml`.

**Not run: `swift test`.** No Apple machine here, and this diff touches no Swift.

## What this does NOT claim

- **One device, one firmware.** The 17-second `CHARGING_ON` lag is what a WHOOP MG on `50.39.1.0` did. Nothing here says another strap or firmware agrees.
- It does not fix the charging indicator, or change any behaviour at all. It only makes the events visible so the question can be answered from a log instead of inferred.
- The `event_payload_hex` field is logged verbatim as the framing layer already produces it; no new offsets or protocol facts are asserted.

## Checklist

- [x] Swift package tests pass for any package I touched — n/a, no Swift touched
- [x] Android unit tests pass (`./gradlew testFullDebugUnitTest`, full suite)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — n/a, no UI
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in `docs/CONTRIBUTING.md`
- [x] I did not commit generated output or any secrets/keystores

## Related issues

None. Does not close anything.