### PR TITLE
ble: light the charging pill on a 5/MG, which listens for events nobody sends it

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7360,6 +7360,32 @@ class WhoopBleClient(
                             } else if (ev.startsWith("CHARGING_OFF")) {
                                 _state.update { s -> s.copy(charging = false) }
                             }
+                            // BATTERY_PACK_CONNECTED(21) / BATTERY_PACK_REMOVED(22) are defined in
+                            // EventNumber and handled NOWHERE. On a 5/MG they fire reliably on every
+                            // attach and detach, and they LEAD the 7/8 edges above, so handling them here
+                            // is what makes the pill respond the moment a pack goes on or comes off.
+                            //
+                            // Measured on WHOOP MG fw 50.39.1.0 over two attach/detach cycles, with every
+                            // pushed event logged:
+                            //
+                            //   01:40:51  BATTERY_PACK_CONNECTED(21)      <- attach
+                            //   01:40:51  CHARGING_ON(7)
+                            //   01:41:06  CHARGING_OFF(8)
+                            //   01:41:11  BATTERY_PACK_REMOVED(22)        <- detach
+                            //
+                            // Both families fire; 21/22 are simply the ones nothing was listening to. The
+                            // 7/8 branch above is kept exactly as it is -- this adds a second source for
+                            // the same flag, it does not replace one.
+                            //
+                            // Same replayedOffload gate as the branch above, and it is load-bearing: the
+                            // strap REPLAYS these edges during the next historical offload with identical
+                            // payloads, so an accepted replay would switch the pill back on minutes after
+                            // the pack was physically removed.
+                            if (ev.startsWith("BATTERY_PACK_CONNECTED")) {
+                                _state.update { s -> s.copy(charging = true) }
+                            } else if (ev.startsWith("BATTERY_PACK_REMOVED")) {
+                                _state.update { s -> s.copy(charging = false) }
+                            }
                         }
                         // PR #577: the strap fired its firmware smart alarm (STRAP_DRIVEN_ALARM_EXECUTED,
                         // event 57) → re-arm the next day's instant (single absolute time, no recurrence).


### PR DESCRIPTION
## What this PR does

The Live-screen charging bolt is often dark while a 5/MG is demonstrably sitting on its battery pack.

The pill is driven from `CHARGING_ON(7)` / `CHARGING_OFF(8)` and the `BATTERY_LEVEL` charging bit. On a 5/MG none of those is a dependable source: the strap reads battery from the standard `0x2A19` characteristic — a bare percentage byte with no charge bit — so the flag rests entirely on catching an edge. Miss the edge and there is no level-based source to recover from.

Meanwhile `BATTERY_PACK_CONNECTED(21)` and `BATTERY_PACK_REMOVED(22)` are declared in `EventNumber` and **handled nowhere at all**.

This handles them, alongside the existing 7/8 branch. Five lines of behaviour.

## The evidence

WHOOP MG, fw `50.39.1.0`, two attach/detach cycles with every pushed event logged:

```
01:40:51  BATTERY_PACK_CONNECTED(21)      <- pack attached
01:40:51  CHARGING_ON(7)
01:41:06  CHARGING_OFF(8)
01:41:11  BATTERY_PACK_REMOVED(22)        <- pack removed
01:42:46  BATTERY_PACK_CONNECTED(21)      <- attached again
01:42:47  CHARGING_ON(7)
01:43:43  CHARGING_OFF(8)
01:43:48  BATTERY_PACK_REMOVED(22)        <- removed again
```

Both families fire, and **21/22 lead**. They are simply the ones nothing was listening to.

## This ADDS a source, it does not replace one

- the 7/8 branch is untouched
- a WHOOP 4.0 is unaffected — it never sends 21/22
- no new opcode, no `CommandNumber` case, no send-allowlist entry, no polling, no wire traffic at all

## The replay gate is load-bearing here

The new branch sits inside the existing `shouldApplyChargingFromBatteryEvent(replayedOffload)` gate, and that matters more than it might look. The strap **replays** these edges during the next historical offload with byte-identical payloads:

```
01:40:51 live CHARGING_ON  707d0000  ->  replayed 01:43:00  707d0000
01:41:06 live CHARGING_OFF b87e0000  ->  replayed 01:43:00  b87e0000
01:42:47 live CHARGING_ON  cc0c0000  ->  replayed 01:43:02  cc0c0000
```

An accepted replay would switch the pill back on minutes after the pack was physically removed. Verified in the same capture: the replayed copies are correctly suppressed by the existing gate, so the new branch inherits the right behaviour rather than needing its own.

## A correction to the record

An earlier draft of this work claimed *"a WHOOP MG never emits `CHARGING_ON`/`CHARGING_OFF`"*, drawn from a census over a **single** detach/reattach cycle that logged zero of them.

That was wrong, and the comment in the diff says so rather than leaving it buried. `CHARGING_ON` trails event 21 by about 17 seconds — long enough for a short capture window to miss it. A negative result from one cycle was read as a property of the firmware.

The change is unaffected either way: 21/22 fire reliably and lead 7/8, so handling them improves the pill's latency. It does not repair an absent signal, and this PR does not claim it does.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

**On hardware.** WHOOP MG, hw `WS50_r00`, fw `50.39.1.0` (DIS-attested), no subscription, Pixel 9 Pro / Android 15, local `full` debug build. Two deliberate pack attach/detach cycles with every pushed event logged; the trace above is from that run. The pill tracked both cycles, updating in the same second as the physical attach. The replayed copies arrived ~2 minutes later and did not move it.

**Android unit tests, full suite.** `./gradlew testFullDebugUnitTest` on Windows 11 / JDK 17, compileSdk 35, against `main` @ `d6d84cc5`: **5,039 tests across 614 classes, 0 failures, 0 errors** (10 skipped, pre-existing). Counted from the JUnit XML with the results directory cleared beforehand, so the numbers come from a real run rather than an up-to-date task.

**No new build warnings.**

**`Tools/doc_comment_lint.py`: not run to completion locally** — it fails with a `PermissionError` reading a SwiftPM artifact under `Packages/StrandAnalytics/.build/` on the SMB share this checkout lives on, unrelated to the change. This diff adds no `/** */` doc comments, only inline `//`, so its per-file count is unchanged. Left to `source-hygiene.yml`.

**Not run: `swift test`.** No Apple machine here, and this diff touches no Swift.

## What this does NOT claim

- **One device, one firmware.** Everything above is a WHOOP MG on `50.39.1.0`. Nothing here says another strap or firmware behaves the same.
- **It does not make the pill correct on a 5/MG in every case.** `charging` is still cleared on every disconnect and there is no level-based source to re-read it from, so a pack attached while the app is disconnected is still missed until the next edge. That is a real remaining gap and this PR does not close it.
- `present` on a pack is not the same as *actively* charging — a full or dead pack is attached but not charging. The edges are what the pill has always used, and that limitation is unchanged.
- Nothing about the Apple side: `Strand/BLE/FrameRouter.swift` handles 7/8 and not 21/22, so it has the same gap. Deliberately left out — there is no Swift toolchain here to verify it, and it belongs in its own PR.

## Checklist

- [x] Swift package tests pass for any package I touched — n/a, no Swift touched
- [x] Android unit tests pass (`./gradlew testFullDebugUnitTest`, full suite)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — n/a, no UI
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in `docs/CONTRIBUTING.md`
- [x] I did not commit generated output or any secrets/keystores

## Related issues

None. Does not close anything.

The event logging that produced the trace above is #1825, which is independent of this change — this does not depend on it, but that PR is what makes the capture reproducible.
