### PR TITLE
perf(clock): memoise the resolved clock instead of rebuilding it per label (#1829)

### DIFF
--- a/Strand/App/AppClock.swift
+++ b/Strand/App/AppClock.swift
@@ -25,6 +25,12 @@ enum AppClock {
     /// converted from `static let` to computed properties, that put an ICU build behind every time label
     /// on screen. The cache saved the cheap allocation and missed the expensive call entirely.
     static var systemUses24Hour: Bool {
+        // Arm the invalidator HERE, not in hourMinuteFormatter(): four call sites reach AppClock only
+        // through `formattingLocale` and would never have registered it, leaving their memo pinned to a
+        // stale clock for the life of the process. Every path lands here — Swift evaluates both arguments
+        // of ClockFormat.uses24Hour(preference:systemUses24Hour:) eagerly — so this is the one chokepoint.
+        // Touched before the lock: registration does not need it, and taking it twice would not nest.
+        _ = localeObserver
         cacheLock.lock(); defer { cacheLock.unlock() }
         if let cachedSystem24 { return cachedSystem24 }
         let template = DateFormatter.dateFormat(fromTemplate: "j", options: 0,
@@ -94,7 +100,6 @@ enum AppClock {
 
     /// Wall-clock time at minute precision, honouring the setting.
     static func hourMinuteFormatter() -> DateFormatter {
-        _ = localeObserver   // first call registers the invalidator; later calls are a no-op read
         let template = ClockFormat.hourMinuteTemplate(uses24Hour: uses24Hour)
         let locale = activeLocale
         cacheLock.lock(); defer { cacheLock.unlock() }

--- a/Strand/App/AppClock.swift
+++ b/Strand/App/AppClock.swift
@@ -17,43 +17,87 @@ enum AppClock {
     }
 
     /// What the DEVICE is set to, read from `autoupdatingCurrent` precisely because that is the locale
-    /// the 24-Hour Time switch modifies. A 12-hour locale's `j` template contains the AM/PM symbol.
+    /// the 24-Hour Time switch modifies.
+    ///
+    /// #1829: MEMOISED. This calls `DateFormatter.dateFormat(fromTemplate:options:locale:)`, which builds
+    /// an ICU pattern generator - one of the more expensive things Foundation offers - and the first cut
+    /// of this ran it on EVERY access, ahead of the formatter cache. Since ~17 call sites had just been
+    /// converted from `static let` to computed properties, that put an ICU build behind every time label
+    /// on screen. The cache saved the cheap allocation and missed the expensive call entirely.
     static var systemUses24Hour: Bool {
+        cacheLock.lock(); defer { cacheLock.unlock() }
+        if let cachedSystem24 { return cachedSystem24 }
         let template = DateFormatter.dateFormat(fromTemplate: "j", options: 0,
                                                 locale: Locale.autoupdatingCurrent) ?? "H"
-        return !template.contains("a")
+        let v = !template.contains("a")
+        cachedSystem24 = v
+        return v
     }
 
     static var uses24Hour: Bool {
         ClockFormat.uses24Hour(preference: preference, systemUses24Hour: systemUses24Hour)
     }
 
-    /// The locale to hand any time-rendering `DateFormatter`. Carries an explicit hour cycle, so the
-    /// setting also reaches the formatters that never name a pattern - the ones using `timeStyle = .short`
-    /// or a `"jmm"` template, which ask the LOCALE for the hour and were therefore getting the region
-    /// default. Everything else about the locale (date order, separators, AM/PM wording, month names)
-    /// still comes from `AppLanguage.activeLocale`, exactly as before.
-    static var formattingLocale: Locale {
-        Locale(identifier: ClockFormat.hourCycleLocaleIdentifier(
-            base: AppLanguage.activeLocale.identifier, uses24Hour: uses24Hour))
+    /// #1829: memoised for the same reason - `AppLanguage.activeLocale` reads
+    /// `Bundle.main.preferredLocalizations` and then CONSTRUCTS a `Locale`, per access.
+    static var activeLocale: Locale {
+        cacheLock.lock(); defer { cacheLock.unlock() }
+        if let cachedActiveLocale { return cachedActiveLocale }
+        let l = AppLanguage.activeLocale
+        cachedActiveLocale = l
+        return l
     }
 
-    /// Cached by resolved template: building a `DateFormatter` is expensive and these are read per row in
-    /// scrolling lists, but the cache MUST key on the template rather than being a plain `static let`, or
-    /// changing the setting would not take effect until the app restarted.
+    /// The locale to hand any time-rendering `DateFormatter`. Carries an explicit hour cycle, so the
+    /// setting also reaches formatters that never name a pattern (`timeStyle`, a `"jmm"` template).
+    static var formattingLocale: Locale {
+        let id = ClockFormat.hourCycleLocaleIdentifier(base: activeLocale.identifier,
+                                                       uses24Hour: uses24Hour)
+        cacheLock.lock(); defer { cacheLock.unlock() }
+        if let cachedFormattingLocale, cachedFormattingLocaleID == id { return cachedFormattingLocale }
+        let l = Locale(identifier: id)
+        cachedFormattingLocale = l
+        cachedFormattingLocaleID = id
+        return l
+    }
+
     private static var cached: (template: String, locale: String, formatter: DateFormatter)?
-    /// The cache is mutable global state and `onsetText` is read from whatever thread builds a
-    /// `SleepModel`, so the read-modify-write below is serialised. SWIFT_VERSION is 5.0 here, so the
-    /// compiler would not have objected - a torn read would just have been a rare, baffling crash.
+    private static var cachedSystem24: Bool?
+    private static var cachedActiveLocale: Locale?
+    private static var cachedFormattingLocale: Locale?
+    private static var cachedFormattingLocaleID: String?
+    /// One lock for every cache here. Each accessor takes it around its own read-modify-write and
+    /// releases before returning, so none of them nest - NSLock is not recursive and a nested take would
+    /// deadlock the main thread, which is a far worse failure than the cost this exists to avoid.
     private static let cacheLock = NSLock()
 
-    /// Wall-clock time at minute precision, honouring the setting. The locale still supplies ordering,
-    /// separator and AM/PM wording; only the hour cycle is ours.
-    static func hourMinuteFormatter() -> DateFormatter {
-        let template = ClockFormat.hourMinuteTemplate(uses24Hour: uses24Hour)
-        let locale = AppLanguage.activeLocale
+    /// Drop every memo. Called when the reader changes the setting, and when the SYSTEM clock or locale
+    /// changes underneath us - `systemUses24Hour` can flip with no write of our own, so without this the
+    /// memo would pin a stale answer for the life of the process.
+    static func invalidate() {
         cacheLock.lock()
-        defer { cacheLock.unlock() }
+        cached = nil
+        cachedSystem24 = nil
+        cachedActiveLocale = nil
+        cachedFormattingLocale = nil
+        cachedFormattingLocaleID = nil
+        cacheLock.unlock()
+    }
+
+    /// #1829: registers exactly once, on first use — a `static let` is lazy and thread-safe in Swift, so
+    /// touching it below is the whole registration. The system 24-hour switch and the device locale can
+    /// both change with no write from us; without this the memo above would serve a stale answer for the
+    /// rest of the process, which is worse than the per-access cost it replaced.
+    private static let localeObserver: NSObjectProtocol = NotificationCenter.default.addObserver(
+        forName: NSLocale.currentLocaleDidChangeNotification, object: nil, queue: nil
+    ) { _ in AppClock.invalidate() }
+
+    /// Wall-clock time at minute precision, honouring the setting.
+    static func hourMinuteFormatter() -> DateFormatter {
+        _ = localeObserver   // first call registers the invalidator; later calls are a no-op read
+        let template = ClockFormat.hourMinuteTemplate(uses24Hour: uses24Hour)
+        let locale = activeLocale
+        cacheLock.lock(); defer { cacheLock.unlock() }
         if let cached, cached.template == template, cached.locale == locale.identifier {
             return cached.formatter
         }

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -1140,6 +1140,9 @@ struct SettingsView: View {
                     .pickerStyle(.menu)
                     .tint(StrandPalette.accent)
                     .accessibilityLabel("Clock")
+                    // #1829: the resolved clock is memoised, so the write has to drop the memo or the
+                    // picker would appear to do nothing until the app restarted.
+                    .onChangeCompat(of: clockFormatRaw) { _ in AppClock.invalidate() }
                 }
                 rowDivider
                 // Theme presets — one-tap bundles coordinating accent + chart world + backdrop + card


### PR DESCRIPTION
Raised on #1829.

## The regression

#1822 converted ~17 Apple `DateFormatter`s from `static let` (built once) to computed properties routed
through `AppClock`, so the Clock setting would apply without a relaunch. The cache added with them guards
the wrong half:

```swift
let template = ClockFormat.hourMinuteTemplate(uses24Hour: uses24Hour)  // ICU pattern build, every call
let locale = AppLanguage.activeLocale                                  // Bundle lookup + Locale build
cacheLock.lock()                                                       // only NOW is the cache consulted
```

- `uses24Hour` → `systemUses24Hour` → `DateFormatter.dateFormat(fromTemplate:options:locale:)`, which
  constructs an ICU pattern generator — routinely cached precisely because it is expensive.
- `AppLanguage.activeLocale` reads `Bundle.main.preferredLocalizations`, then constructs a `Locale`.

Both ran on **every access**. The cache only ever saved the `DateFormatter()` allocation. So every time
label — Asleep/Woke, workout and nap times, caffeine and hydration entries, backup timestamps,
stage-timeline axes — paid an ICU build plus a bundle query where 11.0.0 paid a dictionary read.

## The fix

Memoise the resolved system clock, the active locale and the formatting locale, and invalidate on:

- `NSLocale.currentLocaleDidChangeNotification` — the system 24-hour switch changes with no write of
  ours, and a memo without this would pin a stale answer for the life of the process, making the picker
  look broken until relaunch. That is the exact failure #1822 existed to avoid, so it must not be traded
  for speed.
- the settings write, via `onChangeCompat` on the picker.

The observer is a `static let`, which in Swift is lazy and thread-safe, so touching it in the hot path is
the entire registration.

**On the lock:** each accessor takes it around its own read and releases before returning, so none nest.
`NSLock` is not recursive and a nested take would deadlock the main thread — far worse than the cost being
removed. The accessors that read others (`formattingLocale`, `hourMinuteFormatter`) evaluate them
**before** taking the lock, deliberately.

## What this is not

**This is not established as the cause of the "stuck on opening, can't scroll" report** that prompted the
look, and I am not going to imply otherwise. I checked the paths I suspected and the evidence did not
support them:

- the chart `dateFormat:` closures are **tooltip** paths — one selected point, not per sample;
- `WhatsNewView` is already a `LazyVStack`, so its 273 entries render on demand;
- the HR-only sleep spine runs only for a day with **no motion and no stored night**.

A handful of calls per render is jank, not a freeze. That report still needs a platform and a log, and is
tracked separately.

It is fixed here because it is a genuine regression against 11.0.0 that should not sit in a shipped
release, whatever whaleeam's problem turns out to be.

## Android

Deliberately untouched. `DateFormat.is24HourFormat` reads a process-cached setting, materially cheaper
than ICU pattern generation, and not worth churning on speculation.

## Verification

`Tools/doc_comment_lint.py` and `Tools/i18n_audit.py --ci` both clean. The change is Apple-only and
app-target, so the compile needs the app-build gate — not yet run.