### PR TITLE
ble: handle the pack-attach events on Apple too (#1826)

### DIFF
--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -407,6 +407,22 @@ public final class FrameRouter {
                 } else if ev.hasPrefix("CHARGING_OFF") {
                     state.charging = false
                 }
+                // #1826: BATTERY_PACK_CONNECTED(21) / BATTERY_PACK_REMOVED(22), declared in the shared
+                // schema and handled on neither platform until @Zebsi235 measured them. On a 5/MG they
+                // fire on every attach and detach and LEAD the 7/8 edges above, so the pill responds when
+                // a pack goes on instead of waiting to catch a later edge. A WHOOP 4.0 never sends them.
+                //
+                // NO replay guard here, unlike the Kotlin twin. That is deliberate and not an omission:
+                // this router is live-only — the Backfiller holds no reference to it, so a replayed
+                // offload event never reaches this code, which is the same reason the CHARGING_ON/OFF
+                // branch above carries none. Android's EVENT routing does see replays, and its capture
+                // showed the strap re-sending these edges with byte-identical payloads, so the gate is
+                // load-bearing THERE. Copying it here would guard against something that cannot happen.
+                if ev.hasPrefix("BATTERY_PACK_CONNECTED") {
+                    state.charging = true
+                } else if ev.hasPrefix("BATTERY_PACK_REMOVED") {
+                    state.charging = false
+                }
                 // Physical inputs the strap exposes — live only (this path never sees historical
                 // replay, which goes through the Backfiller). Event strings are "NAME(rawValue)".
                 if ev.hasPrefix("DOUBLE_TAP") {


### PR DESCRIPTION
Apple twin of @Zebsi235's Android change in #1826.

`BATTERY_PACK_CONNECTED(21)` and `BATTERY_PACK_REMOVED(22)` are declared in the **shared** protocol
schema, so both platforms already decode the names. Neither was listening to them.

On a 5/MG they fire on every attach and detach and **lead** the `CHARGING_ON`/`CHARGING_OFF` edges, so
the charging pill responds when a pack goes on rather than waiting to catch a later edge. Measured on
WHOOP MG fw 50.39.1.0 across two attach/detach cycles (capture on #1826). A WHOOP 4.0 never sends them.

## Why there is no replay guard here

The Kotlin branch sits inside `shouldApplyChargingFromBatteryEvent(replayedOffload)`, and on Android that
gate is load-bearing: its capture shows the strap **replaying** these edges during the next historical
offload with byte-identical payloads, which would relight the pill minutes after the pack came off.

This router is **live-only** — `Backfiller` holds no reference to `FrameRouter`, so a replayed event never
reaches this code. That is the same reason the `CHARGING_ON`/`CHARGING_OFF` branch immediately above
carries no guard, and I verified it against the call graph rather than trusting the comment that says so.

Copying the Android gate would guard against something that cannot happen on this path, and would imply a
hazard that does not exist here. The asymmetry is deliberate and the diff says so.

## It reaches the family it targets

Checked rather than assumed, because a handler that can never fire is the obvious way this goes wrong:

- `case "EVENT"` is **not** family-gated, so 5/MG frames reach the branch.
- `Whoop5EventTests` verifies puffin EVENT (type 48) decodes with `typeName == "EVENT"` against real
  captured frames, so the routing path is real for this family.
- Event names come from the shared schema (`"21": "BATTERY_PACK_CONNECTED"`), and `Schema.enumName`
  appends the raw value, so `hasPrefix` matches `BATTERY_PACK_CONNECTED(21)`.

## Scope note, on both platforms

`charging` is not only the pill. Apple feeds it through `batteryPctAndCharging()` into the low-battery
offload interval; Android feeds `idleThrottleActive`, which gates GATT connection priority and pausing
background capture. So a strap sitting on a pack now stops throttling sooner on both. That is the
direction those gates intend — "a charging strap never throttles" — but it is behaviour outside the Live
screen and worth stating rather than leaving to be discovered.

## Tests — correcting my own first claim

I originally wrote that no test was feasible here. That was wrong: `StrandTests` has an end-to-end router
harness (`BatteryResultProvenanceDumpTests` builds a `LiveState`, drives `router.handle(frame:)` and
asserts on the resulting state), so a test that proves this branch flips `charging` is entirely
writable.

What is missing is a **real captured 21/22 frame**. `Whoop5EventTests` states its own rule plainly — "all
fixtures are real frames" — and I am not going to fabricate one with hand-computed CRCs to satisfy a
test, because a synthetic fixture proves the branch matches a string I invented rather than what the
strap sends.

@Zebsi235 — if your capture has the raw frame bytes for a `BATTERY_PACK_CONNECTED(21)` and a
`BATTERY_PACK_REMOVED(22)`, those two hex strings would let this ship with a real routing test on both
platforms. No rush, and the change stands without it.

## Verification

`Tools/doc_comment_lint.py` clean. App-target Swift, so the compile needs the app-build gate — not yet
run.

## An honest caveat about what 21 asserts

`BATTERY_PACK_CONNECTED(21)` means *a pack was attached*. `CHARGING_ON(7)` means *charging began*. This
change (and the merged Android one) treats the first as the second.

In the normal case that is purely a latency win — @Zebsi235's capture shows 7 trailing 21 by under a
second in one cycle and ~17s in another. The edge is a pack attached that never starts charging: a
depleted pack, a poor contact. Then 21 fires, 7 never does, and `charging` stays true until
`BATTERY_PACK_REMOVED(22)`.

Two consequences, and the second is the one that matters:

- the pill reads charging while nothing is charging;
- `lowPowerThrottleActive` is `thresholdPct > 0 && !charging && batteryPct <= thresholdPct`, so a true
  `charging` **disables** the low-battery throttle. A strap at low battery on a dead pack would stop
  stretching its offload interval — the opposite of what that gate exists to do — for as long as the pack
  stays attached.

I am **not** changing it here. `charging` is a single field serving both the pill and the throttle, so
separating "pack attached" from "actually charging" needs a second piece of state, and doing that on Apple
alone would put the platforms out of step on something the merged Android change already does.

Worth its own issue if it should be split. Flagged rather than left to be found in a battery report months
from now.
