### PR TITLE
ble: redact a hex-hidden serial on Apple too (#1833)

### DIFF
--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -806,11 +806,22 @@ public final class LiveState: ObservableObject {
         var runStart = -1
         func closeRun(_ end: Int) {
             defer { runStart = -1 }
-            guard runStart >= 0, end - runStart >= 9 else { return }
-            let first = bytes[runStart]
-            let isLetter = (first >= 65 && first <= 90) || (first >= 97 && first <= 122)
-            guard isLetter else { return }          // a serial starts with a letter, not a digit
-            for k in runStart..<end { out[k * 2] = "•"; out[k * 2 + 1] = "•" }
+            guard runStart >= 0 else { return }
+            // Anchor on the first LETTER with enough run left after it, mirroring the Kotlin regex
+            // `[A-Za-z][0-9A-Za-z]{8,}` — which finds a serial ANYWHERE inside an alphanumeric run, not
+            // only at its start. Testing just the run's first byte left the serial exposed whenever a
+            // digit happened to precede it with no separator, and Kotlin masked the same bytes. Two
+            // halves of one rule disagreeing about which payloads are safe is the failure to avoid.
+            var i = runStart
+            while i < end {
+                let b = bytes[i]
+                let isLetter = (b >= 65 && b <= 90) || (b >= 97 && b <= 122)
+                if isLetter, end - i >= 9 {
+                    for k in i..<end { out[k * 2] = "•"; out[k * 2 + 1] = "•" }
+                    return
+                }
+                i += 1
+            }
         }
         for (idx, b) in bytes.enumerated() {
             let alnum = (b >= 48 && b <= 57) || (b >= 65 && b <= 90) || (b >= 97 && b <= 122)

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -773,8 +773,68 @@ public final class LiveState: ObservableObject {
     /// service base (…-8d6d-82b8-614a-1c8cb0f8dcc6) — those are public, identical on every strap, and
     /// are exactly the GATT diagnostics a shared log needs to be useful (#421). Thanks @ujix (#447) for
     /// catching the peripheral-UUID leak; this is a targeted form so we don't redact the service UUIDs.
+    /// #1833: mask a WHOOP serial that arrives as HEX rather than as text.
+    ///
+    /// Every rule in `redactPii` matches an identifier written as characters. None can see one encoded
+    /// as hex, because they are reading hex digits and not the ASCII those bytes decode to. On a 5/MG,
+    /// event 109 carries the strap serial as plain ASCII inside its payload, so any diagnostic that dumps
+    /// a frame or payload puts the serial into the log we ask people to attach to public issues — while
+    /// the MAC rule keeps firing, so the line still LOOKS redacted.
+    ///
+    /// Deliberately NOT keyed on a label. This side writes hex as `frame=…` (the clock diagnostic),
+    /// `[raw …]` and `(raw …)` (the alarm readback), and the #900 whole-frame dump carries none. A rule
+    /// enumerating today's phrasings is one the next diagnostic slips past. Matching the hex itself needs
+    /// no maintenance and covers dumps not yet written.
+    ///
+    /// Only bytes inside a serial-shaped ASCII run are masked; the rest of the dump survives, because the
+    /// payload is exactly where an undocumented field would be found. Twin of `redactHexDumpPii`.
+    nonisolated static func redactHexDump(_ hex: String) -> String {
+        let chars = Array(hex)
+        guard chars.count >= 16, chars.count % 2 == 0 else { return hex }
+        var bytes = [UInt8](); bytes.reserveCapacity(chars.count / 2)
+        var i = 0
+        while i + 1 < chars.count {
+            guard let b = UInt8(String(chars[i...(i + 1)]), radix: 16) else { return hex }
+            bytes.append(b); i += 2
+        }
+        var out = chars
+        var runStart = -1
+        func closeRun(_ end: Int) {
+            defer { runStart = -1 }
+            guard runStart >= 0, end - runStart >= 9 else { return }
+            let first = bytes[runStart]
+            let isLetter = (first >= 65 && first <= 90) || (first >= 97 && first <= 122)
+            guard isLetter else { return }          // a serial starts with a letter, not a digit
+            for k in runStart..<end { out[k * 2] = "•"; out[k * 2 + 1] = "•" }
+        }
+        for (idx, b) in bytes.enumerated() {
+            let alnum = (b >= 48 && b <= 57) || (b >= 65 && b <= 90) || (b >= 97 && b <= 122)
+            if alnum { if runStart < 0 { runStart = idx } } else { closeRun(idx) }
+        }
+        closeRun(bytes.count)
+        return String(out)
+    }
+
+    private static let hexRunRegex = try? NSRegularExpression(pattern: "[0-9a-fA-F]{16,}")
+
     nonisolated static func redactPii(_ s: String) -> String {
         var out = s
+        // Hex first: the text rules below must not see (or mangle) a run we are about to mask.
+        if let re = Self.hexRunRegex {
+            let ns = out as NSString
+            let matches = re.matches(in: out, range: NSRange(location: 0, length: ns.length))
+            if !matches.isEmpty {
+                var rebuilt = ""
+                var last = 0
+                for m in matches {
+                    rebuilt += ns.substring(with: NSRange(location: last, length: m.range.location - last))
+                    rebuilt += Self.redactHexDump(ns.substring(with: m.range))
+                    last = m.range.location + m.range.length
+                }
+                rebuilt += ns.substring(from: last)
+                out = rebuilt
+            }
+        }
         out = out.replacingOccurrences(
             of: "([0-9A-Fa-f]{2}):[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:([0-9A-Fa-f]{2})",
             with: "$1:••:••:••:••:$2", options: .regularExpression)

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -790,7 +790,12 @@ public final class LiveState: ObservableObject {
     /// payload is exactly where an undocumented field would be found. Twin of `redactHexDumpPii`.
     nonisolated static func redactHexDump(_ hex: String) -> String {
         let chars = Array(hex)
-        guard chars.count >= 16, chars.count % 2 == 0 else { return hex }
+        // NO even-length requirement, deliberately. The run regex matches consecutive hex characters, so
+        // a dump abutting other hex-valid text yields an ODD-length match — and bailing on that returned
+        // the serial UNREDACTED, while the Kotlin twin processed the even prefix and masked it. Swift was
+        // the weaker half of a pair that has to behave identically. Process what pairs up, ignore a
+        // trailing half-byte.
+        guard chars.count >= 16 else { return hex }
         var bytes = [UInt8](); bytes.reserveCapacity(chars.count / 2)
         var i = 0
         while i + 1 < chars.count {

--- a/StrandTests/HexPayloadRedactionTests.swift
+++ b/StrandTests/HexPayloadRedactionTests.swift
@@ -36,6 +36,14 @@ final class HexPayloadRedactionTests: XCTestCase {
         }
     }
 
+    /// The run regex matches consecutive hex characters, so a dump abutting other hex-valid text gives
+    /// an ODD-length match. Bailing on that returned the serial unredacted while Kotlin masked it — the
+    /// two halves of one rule must not disagree about which lines are safe.
+    func testOddLengthRunStillMasksTheSerial() {
+        let out = LiveState.redactPii("payload=\(payloadWithSerial)f")   // 1 trailing half-byte
+        XCTAssertFalse(out.contains(serialAsHex), "odd-length run left the serial exposed: \(out)")
+    }
+
     func testPayloadWithNoAsciiRunIsUntouched() {
         // The charging payloads from the same capture carry no ASCII run — they must pass through whole.
         for p in ["707d0000707d0000", "b87e0000b87e0000", "0000000000000000"] {

--- a/StrandTests/HexPayloadRedactionTests.swift
+++ b/StrandTests/HexPayloadRedactionTests.swift
@@ -44,6 +44,17 @@ final class HexPayloadRedactionTests: XCTestCase {
         XCTAssertFalse(out.contains(serialAsHex), "odd-length run left the serial exposed: \(out)")
     }
 
+    /// The Kotlin rule is a regex over the printable projection (`[A-Za-z][0-9A-Za-z]{8,}`), so it finds
+    /// a serial ANYWHERE inside an alphanumeric run. Testing only the run's first byte left the serial
+    /// exposed when a digit preceded it with no separator — masked on Android, printed on Apple.
+    func testSerialIsMaskedEvenWhenDigitsPrecedeItInTheSameRun() {
+        // "0123" + "WBB5AP0539852" as one unbroken alphanumeric run, then a NUL to close it.
+        let hex = "3031323357424235415030353339383532" + "00" + "0000000000000000"
+        let out = LiveState.redactPii("payload=\(hex)")
+        XCTAssertFalse(out.contains(serialAsHex), "digit-prefixed run left the serial exposed: \(out)")
+        XCTAssertTrue(out.contains("30313233"), "the non-serial digits must survive: \(out)")
+    }
+
     func testPayloadWithNoAsciiRunIsUntouched() {
         // The charging payloads from the same capture carry no ASCII run — they must pass through whole.
         for p in ["707d0000707d0000", "b87e0000b87e0000", "0000000000000000"] {

--- a/StrandTests/HexPayloadRedactionTests.swift
+++ b/StrandTests/HexPayloadRedactionTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import Strand
+
+/// #1833: a WHOOP serial that arrives as HEX rather than as text.
+///
+/// Every rule in `LiveState.redactPii` matches an identifier written as characters, so none of them can
+/// see one encoded as hex. On a 5/MG, event 109 carries the strap serial as plain ASCII inside its
+/// payload, and this side dumps hex in several places — `frame=` (the clock diagnostic), `[raw …]` and
+/// `(raw …)` (the alarm readback), and the #900 whole-frame dump. The serial went into the log we ask
+/// people to attach to public issues while the MAC rule kept firing, so the line still looked redacted.
+///
+/// Twin of the Kotlin `PiiRedactionTest` cases; the payload below is the real one from the capture on
+/// #1825, which is how the leak was found.
+final class HexPayloadRedactionTests: XCTestCase {
+
+    /// `…WBB5AP0539852…` — a real serial, ASCII inside the payload bytes.
+    private let payloadWithSerial = "142e1c0001d36e3d1c12a3574242354150303533393835320000"
+    private let serialAsHex = "4242354150303533393835"
+
+    func testSerialInsideAHexPayloadIsMasked() {
+        let out = LiveState.redactPii("[event] 0x6D(109) payload=\(payloadWithSerial)")
+        XCTAssertFalse(out.contains(serialAsHex), "serial must not survive as hex: \(out)")
+        XCTAssertTrue(out.contains("142e1c0001d36e3d1c12a3"),
+                      "the non-serial bytes are the reason the dump exists: \(out)")
+    }
+
+    /// Not keyed on a label: this side writes the same dumps four different ways.
+    func testMaskedUnderEveryLabelThisSideUses() {
+        for line in ["frame=\(payloadWithSerial)",
+                     "[raw \(payloadWithSerial)]",
+                     "(raw \(payloadWithSerial))",
+                     "raw frame (#900) \(payloadWithSerial)",
+                     payloadWithSerial] {
+            XCTAssertFalse(LiveState.redactPii(line).contains(serialAsHex),
+                           "serial survived under this label: \(line)")
+        }
+    }
+
+    func testPayloadWithNoAsciiRunIsUntouched() {
+        // The charging payloads from the same capture carry no ASCII run — they must pass through whole.
+        for p in ["707d0000707d0000", "b87e0000b87e0000", "0000000000000000"] {
+            XCTAssertEqual(LiveState.redactPii("payload=\(p)"), "payload=\(p)")
+        }
+    }
+
+    /// The existing text rules must keep working — the hex pass runs first and must not eat them.
+    func testTextRulesStillApply() {
+        XCTAssertEqual(LiveState.redactPii("connecting to A1:B2:C3:D4:E5:F6"),
+                       "connecting to A1:••:••:••:••:F6")
+        XCTAssertTrue(LiveState.redactPii("Discovered WHOOP 4A2B9C1D").contains("<serial>"))
+    }
+
+    /// A vendor/service UUID's longest contiguous hex run is 12 characters, below the 16 the rule needs,
+    /// so a UUID cannot be partially masked into something unreadable.
+    func testServiceUuidIsNotTouched() {
+        let uuid = "61080003-8d6d-82b8-614a-1c8cb0f8dcc6"
+        XCTAssertTrue(LiveState.redactPii("Notify active \(uuid)").contains("8d6d"))
+    }
+
+    /// Odd-length or non-hex content returns unchanged rather than throwing: a redactor that throws
+    /// withholds the entire line.
+    func testMalformedHexIsLeftAlone() {
+        XCTAssertEqual(LiveState.redactPii("payload=zzzzzzzzzzzzzzzzzz"), "payload=zzzzzzzzzzzzzzzzzz")
+    }
+}


### PR DESCRIPTION
Apple twin of the redaction change landing alongside #1825.

## The gap

Every rule in `LiveState.redactPii` matches an identifier written as **characters** — MAC, `WHOOP
<serial>`, CoreBluetooth UUID, adopted id. None can see one encoded as **hex**, because they are reading
hex digits rather than the ASCII those bytes decode to.

On a 5/MG, event `0x6D(109)` carries the strap serial as plain ASCII inside its payload:

```
142e1c0001d36e3d1c12a35742423541503035333938353 20000
\x14.\x1c\x00\x01\xd3n=\x1c\x12\xa3WBB5AP0539852\x00\x00
                                   ^^^^^^^^^^^^^ serial
```

This side dumps hex in four shapes:

- `frame=…` — the clock diagnostic, added in #1824
- `[raw …]` and `(raw …)` — the alarm readback
- the #900 whole-frame dump, with no label at all

Any of them puts the serial into the strap log, which is the file we ask people to attach to public
issues. The MAC rule keeps firing in the same line (`device=FD:••:••:••:••:4A`), so the log *looks*
redacted while an identifier leaves in a different encoding.

## Shape of the fix

Matches the **hex itself**, not a label — the same choice as the Android commit, for the same reason: a
rule enumerating today's phrasings is a rule the next diagnostic slips past, and the leak exists precisely
because redaction was matching a shape rather than the thing.

Only bytes inside a serial-shaped ASCII run are masked. The rest of the dump survives, deliberately: the
payload is exactly where an undocumented field would be found, so truncating it removes the reason the
dump exists.

Two ordering/safety details, both pinned by tests:

- the hex pass runs **before** the text rules, so it cannot mangle a match they own;
- a service UUID's longest contiguous hex run is 12 characters, below the 16 this rule needs, so UUIDs are
  untouched. A half-masked UUID would be worse than no redaction.

False-positive cost is negligible: masking needs nine consecutive alphanumeric ASCII bytes, which random
binary produces about once in a million runs.

## Provenance

I widened this exposure two merges ago by adding `frame=` hex to the clock diagnostic, and only found it
while reviewing @Zebsi235's event census — their sample output carried a live serial, which is how the
route proved itself.

## Tests

`StrandTests/HexPayloadRedactionTests` is the twin of the Kotlin `PiiRedactionTest` cases and uses the same
real payload: serial masked, non-serial bytes preserved, masked under every label this side uses and under
none, payloads without an ASCII run untouched, existing text rules still working, UUIDs unharmed, and
malformed hex returned unchanged rather than throwing (a throwing redactor withholds the whole line).

`StrandTests` runs only under the app-build gate, so that is the verification — not yet run.
