### PR TITLE
android: draw the bottom bar as an overlay so its glass has a backdrop (#1836)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -75,6 +75,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import com.noop.R
 import com.noop.analytics.FusionSource
 import androidx.compose.ui.Alignment
@@ -270,6 +271,19 @@ internal object MoreSectionPrefs {
 }
 
 /**
+ * #1836: the height the overlay bar occupies, so content can clear it.
+ *
+ * The bar used to be a `Scaffold(bottomBar = …)` slot, which reserved space OUTSIDE the screen content.
+ * A screen's own backdrop therefore stopped where the bar began, and an 0.80-alpha "glass" surface over
+ * `surfaceBase` is just a flat colour — which is why a bar built to float rendered as a dark strip.
+ *
+ * Exposed as a local so a scrollable can later add it to its own `contentPadding` and let content pass
+ * under the glass. That half is deliberately not here: a single shared modifier cannot do it, so it wants
+ * doing per screen with a device to look at.
+ */
+val LocalBottomBarHeight = staticCompositionLocalOf { 76.dp }
+
+/**
  * App shell: a single [Scaffold] with a floating [GlassBottomBar] (Today · Trends · Sleep · More)
  * driving one [NavHost], mirroring the iOS RootTabView. There is NO global toolbar and no nav drawer
  * — every screen self-titles via [ScreenScaffold], and the "More" sheet (opened from the bar) reaches
@@ -294,7 +308,12 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
     // survives the inbox sheet closing — the tap dismisses the inbox and presents this over the app.
     var showWhatsNewFromInbox by remember { mutableStateOf(false) }
 
-    run {
+    // #1836: an overlay container, not a bottomBar slot. The slot sat OUTSIDE the screen content, so a
+    // screen's own backdrop (LiquidScreenSky / BackgroundImageBackdrop) stopped where the bar began and
+    // the bar's 0.80 "glass" had nothing behind it but surfaceBase — a bar built to float rendered as a
+    // dark strip cut out of the background. As a sibling drawn OVER the Scaffold it sits on the screen's
+    // own sky, which is what the translucency was written for.
+    Box(Modifier.fillMaxSize()) {
         Scaffold(
             containerColor = Palette.surfaceBase,
             bottomBar = {
@@ -303,18 +322,19 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
                 // top-right (balancing the avatar), so the bar is clean tabs only. "More" navigates to
                 // its own page (mirroring the iOS More tab) that reaches every grouped destination, so no
                 // destination is lost without the drawer.
-                GlassBottomBar(
-                    current = current,
-                    onTabSelected = { dest ->
-                        if (dest.route != currentRoute) nav.navigateTopLevel(dest.route)
-                    },
-                )
+                // Intentionally empty: the bar is drawn as an overlay below so the backdrop shows
+                // through it. Content still clears it — the NavHost carries the inset the slot used to.
             },
         ) { inner ->
             NavHost(
                 navController = nav,
                 startDestination = Destination.Today.route,
-                modifier = Modifier.padding(inner),
+                // The empty slot reserves nothing, so the bar's height is added here — the one place the
+                // inset used to come from. A scrollable that later wants content to pass UNDER the glass
+                // adds LocalBottomBarHeight to its own contentPadding instead; a shared modifier cannot.
+                modifier = Modifier
+                    .padding(inner)
+                    .padding(bottom = LocalBottomBarHeight.current),
                 // README motion: top-level destinations crossfade (~240ms) on the calm,
                 // decelerating global easing — nothing slides or bounces between tabs. The
                 // same fade is used for back (pop) so the bar never feels jerky. Drill-ins
@@ -614,6 +634,16 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
                 }
             }
         }
+
+        // Drawn OVER the Scaffold, so it floats on whatever backdrop the current screen painted rather
+        // than on the shell's own container colour. Same composable, same insets — only its parent moved.
+        GlassBottomBar(
+            current = current,
+            onTabSelected = { dest ->
+                if (dest.route != currentRoute) nav.navigateTopLevel(dest.route)
+            },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
     }
 }
 
@@ -777,10 +807,11 @@ private val barTrailingTabs = listOf(
 private fun GlassBottomBar(
     current: Destination,
     onTabSelected: (Destination) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val barShape = RoundedCornerShape(50)
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             // Clear the gesture-nav bar (home indicator) first, then add breathing room so the capsule
             // floats free of the bottom edge rather than jamming against it — iOS clears the home-indicator

--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -100,6 +100,9 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -328,9 +331,18 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
                 // The empty slot reserves nothing, so the bar's height is added here — the one place the
                 // inset used to come from. A scrollable that later wants content to pass UNDER the glass
                 // adds this measured height to its own contentPadding instead; no shared modifier can.
-                modifier = Modifier
-                    .padding(inner)
-                    .padding(bottom = barHeight),
+                modifier = Modifier.padding(
+                    // Take the top and sides from the Scaffold, but REPLACE its bottom rather than adding
+                    // to it. Scaffold's default contentWindowInsets is WindowInsets.systemBars, so
+                    // `inner.bottom` already carries the navigation-bar inset — and the bar's measured
+                    // height carries it too, via its own navigationBarsPadding(). Adding both counted that
+                    // inset twice and left roughly a nav-bar's worth of dead space above the bar, widest
+                    // on 3-button navigation. The bar owns that inset; content just clears the bar.
+                    top = inner.calculateTopPadding(),
+                    start = inner.calculateStartPadding(LocalLayoutDirection.current),
+                    end = inner.calculateEndPadding(LocalLayoutDirection.current),
+                    bottom = barHeight,
+                ),
                 // README motion: top-level destinations crossfade (~240ms) on the calm,
                 // decelerating global easing — nothing slides or bounces between tabs. The
                 // same fade is used for back (pop) so the bar never feels jerky. Drill-ins

--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -75,7 +75,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.staticCompositionLocalOf
 import com.noop.R
 import com.noop.analytics.FusionSource
 import androidx.compose.ui.Alignment
@@ -98,6 +97,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -271,19 +273,6 @@ internal object MoreSectionPrefs {
 }
 
 /**
- * #1836: the height the overlay bar occupies, so content can clear it.
- *
- * The bar used to be a `Scaffold(bottomBar = …)` slot, which reserved space OUTSIDE the screen content.
- * A screen's own backdrop therefore stopped where the bar began, and an 0.80-alpha "glass" surface over
- * `surfaceBase` is just a flat colour — which is why a bar built to float rendered as a dark strip.
- *
- * Exposed as a local so a scrollable can later add it to its own `contentPadding` and let content pass
- * under the glass. That half is deliberately not here: a single shared modifier cannot do it, so it wants
- * doing per screen with a device to look at.
- */
-val LocalBottomBarHeight = staticCompositionLocalOf { 76.dp }
-
-/**
  * App shell: a single [Scaffold] with a floating [GlassBottomBar] (Today · Trends · Sleep · More)
  * driving one [NavHost], mirroring the iOS RootTabView. There is NO global toolbar and no nav drawer
  * — every screen self-titles via [ScreenScaffold], and the "More" sheet (opened from the bar) reaches
@@ -313,6 +302,13 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
     // the bar's 0.80 "glass" had nothing behind it but surfaceBase — a bar built to float rendered as a
     // dark strip cut out of the background. As a sibling drawn OVER the Scaffold it sits on the screen's
     // own sky, which is what the translucency was written for.
+    // #1836: the inset MEASURED, never assumed. The bar's height includes navigationBarsPadding(), which
+    // differs by roughly 24dp between gesture navigation and 3-button navigation, and changes on rotation
+    // and on a foldable unfolding. The Scaffold slot used to measure it for us; a constant here would put
+    // content behind the bar on exactly the devices the report came from. One extra layout pass at
+    // startup, then stable.
+    var barHeightPx by remember { mutableIntStateOf(0) }
+    val barHeight = with(LocalDensity.current) { barHeightPx.toDp() }
     Box(Modifier.fillMaxSize()) {
         Scaffold(
             containerColor = Palette.surfaceBase,
@@ -331,10 +327,10 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
                 startDestination = Destination.Today.route,
                 // The empty slot reserves nothing, so the bar's height is added here — the one place the
                 // inset used to come from. A scrollable that later wants content to pass UNDER the glass
-                // adds LocalBottomBarHeight to its own contentPadding instead; a shared modifier cannot.
+                // adds this measured height to its own contentPadding instead; no shared modifier can.
                 modifier = Modifier
                     .padding(inner)
-                    .padding(bottom = LocalBottomBarHeight.current),
+                    .padding(bottom = barHeight),
                 // README motion: top-level destinations crossfade (~240ms) on the calm,
                 // decelerating global easing — nothing slides or bounces between tabs. The
                 // same fade is used for back (pop) so the bar never feels jerky. Drill-ins
@@ -642,7 +638,9 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
             onTabSelected = { dest ->
                 if (dest.route != currentRoute) nav.navigateTopLevel(dest.route)
             },
-            modifier = Modifier.align(Alignment.BottomCenter),
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .onSizeChanged { barHeightPx = it.height },
         )
     }
 }

--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -1,5 +1,6 @@
 package com.noop.ui
 
+import android.content.Context
 import androidx.annotation.StringRes
 import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.animateFloatAsState
@@ -276,6 +277,31 @@ internal object MoreSectionPrefs {
 }
 
 /**
+ * #1836: which bottom-bar layout to use, snapshot-backed so the Settings toggle applies without a
+ * relaunch (the same shape as `BackgroundImageStore.enabled`).
+ *
+ * Default OFF — the shipped slot layout. The overlay is the better-looking one and the reason this change
+ * exists, but it is app-shell layout no test can judge, so it ships behind a switch people can turn off if
+ * a screen misbehaves rather than as the only option.
+ */
+object BottomBarStyleStore {
+    /** True = the overlay bar (glass over the screen's own backdrop). False = the reserved slot. */
+    var overlay by mutableStateOf(false)
+        private set
+
+    fun load(ctx: Context) {
+        overlay = NoopPrefs.of(ctx.applicationContext)
+            .getBoolean(NoopPrefs.KEY_OVERLAY_BOTTOM_BAR, false)
+    }
+
+    fun set(ctx: Context, value: Boolean) {
+        overlay = value
+        NoopPrefs.of(ctx.applicationContext).edit()
+            .putBoolean(NoopPrefs.KEY_OVERLAY_BOTTOM_BAR, value).apply()
+    }
+}
+
+/**
  * App shell: a single [Scaffold] with a floating [GlassBottomBar] (Today · Trends · Sleep · More)
  * driving one [NavHost], mirroring the iOS RootTabView. There is NO global toolbar and no nav drawer
  * — every screen self-titles via [ScreenScaffold], and the "More" sheet (opened from the bar) reaches
@@ -321,8 +347,16 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
                 // top-right (balancing the avatar), so the bar is clean tabs only. "More" navigates to
                 // its own page (mirroring the iOS More tab) that reaches every grouped destination, so no
                 // destination is lost without the drawer.
-                // Intentionally empty: the bar is drawn as an overlay below so the backdrop shows
-                // through it. Content still clears it — the NavHost carries the inset the slot used to.
+                // DEFAULT path: the shipped reserved slot, unchanged. Empty only when the overlay is
+                // on, where the bar is drawn below as a sibling and the slot must reserve nothing.
+                if (!BottomBarStyleStore.overlay) {
+                    GlassBottomBar(
+                        current = current,
+                        onTabSelected = { dest ->
+                            if (dest.route != currentRoute) nav.navigateTopLevel(dest.route)
+                        },
+                    )
+                }
             },
         ) { inner ->
             NavHost(
@@ -331,7 +365,9 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
                 // The empty slot reserves nothing, so the bar's height is added here — the one place the
                 // inset used to come from. A scrollable that later wants content to pass UNDER the glass
                 // adds this measured height to its own contentPadding instead; no shared modifier can.
-                modifier = Modifier.padding(
+                // Slot layout: the Scaffold measured the bar into `inner`, so use it as-is.
+                // Overlay layout: the slot reserves nothing, so the bottom comes from the measured bar.
+                modifier = if (!BottomBarStyleStore.overlay) Modifier.padding(inner) else Modifier.padding(
                     // Take the top and sides from the Scaffold, but REPLACE its bottom rather than adding
                     // to it. Scaffold's default contentWindowInsets is WindowInsets.systemBars, so
                     // `inner.bottom` already carries the navigation-bar inset — and the bar's measured
@@ -645,7 +681,7 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
 
         // Drawn OVER the Scaffold, so it floats on whatever backdrop the current screen painted rather
         // than on the shell's own container colour. Same composable, same insets — only its parent moved.
-        GlassBottomBar(
+        if (BottomBarStyleStore.overlay) GlassBottomBar(
             current = current,
             onTabSelected = { dest ->
                 if (dest.route != currentRoute) nav.navigateTopLevel(dest.route)

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -146,6 +146,7 @@ class MainActivity : ComponentActivity() {
         // Decode the optional custom background image (if set) + its toggles before first composition so
         // the backdrop is right from the first frame on every tab. No-op when no image is set.
         BackgroundImageStore.load(this)
+        BottomBarStyleStore.load(this)   // #1836: bottom-bar layout choice, default the shipped slot
 
         setContent {
             NoopTheme {
@@ -699,6 +700,10 @@ object NoopPrefs {
     fun setAppIconNavy(context: Context, navy: Boolean) {
         of(context).edit().putBoolean(KEY_APP_ICON_NAVY, navy).apply()
     }
+
+    /** #1836: draw the bottom bar as an overlay (glass over the screen's backdrop) instead of a reserved
+     *  Scaffold slot. Default false — the shipped layout — until the overlay has been seen on a device. */
+    const val KEY_OVERLAY_BOTTOM_BAR = "noop.overlayBottomBar"
 
     /** #1821: Clock format ("system" / "twelveHour" / "twentyFourHour"). Shares its stored vocabulary
      *  with the Apple @AppStorage binding via [com.noop.analytics.ClockFormatPreference]. */

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1308,6 +1308,16 @@ fun SettingsScreen(
                 )
             }
             SettingsRowDivider()
+            // #1836: which bottom-bar layout to draw. Default OFF — the shipped reserved slot. The
+            // overlay lets a screen's own backdrop show through the bar's glass, which is what it was
+            // built for, but it is app-shell layout no test can judge, so it ships switchable.
+            SettingsFormRow(label = uiString(R.string.l10n_settings_screen_bottom_bar_overlay_f257c96f)) {
+                Switch(
+                    checked = BottomBarStyleStore.overlay,
+                    onCheckedChange = { BottomBarStyleStore.set(context, it) },
+                )
+            }
+            SettingsRowDivider()
             // #1821: Clock format. Sits with Language because it is an app-owned display CONVENTION, and
             // like Language it offers "System default" - which here means the device's own 12/24h switch,
             // not the region default that was silently deciding this for everyone. Twin of the Apple row.

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -810,6 +810,7 @@
     <string name="l10n_settings_screen_12_hour_41c18ba0">12 Stunden</string>
     <string name="l10n_settings_screen_24_hour_18e86819">24 Stunden</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">AdvancedChevron</string>
+    <string name="l10n_settings_screen_bottom_bar_overlay_f257c96f">Overlay der unteren Leiste</string>
     <string name="l10n_settings_screen_clock_04f6b3ea">Uhr</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -610,6 +610,7 @@
     <string name="l10n_settings_screen_12_hour_41c18ba0">12 horas</string>
     <string name="l10n_settings_screen_24_hour_18e86819">24 horas</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">avanzadoChevron</string>
+    <string name="l10n_settings_screen_bottom_bar_overlay_f257c96f">Superposición de la barra inferior</string>
     <string name="l10n_settings_screen_clock_04f6b3ea">Reloj</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -628,6 +628,7 @@
     <string name="l10n_settings_screen_12_hour_41c18ba0">12 heures</string>
     <string name="l10n_settings_screen_24_hour_18e86819">24 heures</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">avancéChevron</string>
+    <string name="l10n_settings_screen_bottom_bar_overlay_f257c96f">Barre inférieure en surimpression</string>
     <string name="l10n_settings_screen_clock_04f6b3ea">Horloge</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -767,6 +767,7 @@
     <string name="l10n_settings_screen_12_hour_41c18ba0">12-godzinny</string>
     <string name="l10n_settings_screen_24_hour_18e86819">24-godzinny</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">zaawansowanyChevron</string>
+    <string name="l10n_settings_screen_bottom_bar_overlay_f257c96f">Nakładkowy pasek dolny</string>
     <string name="l10n_settings_screen_clock_04f6b3ea">Zegar</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -775,6 +775,7 @@
     <string name="l10n_settings_screen_12_hour_41c18ba0">12 horas</string>
     <string name="l10n_settings_screen_24_hour_18e86819">24 horas</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">avançadoChevron</string>
+    <string name="l10n_settings_screen_bottom_bar_overlay_f257c96f">Sobreposição da barra inferior</string>
     <string name="l10n_settings_screen_clock_04f6b3ea">Relógio</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -757,6 +757,7 @@
     <string name="l10n_settings_screen_12_hour_41c18ba0">12 小时制</string>
     <string name="l10n_settings_screen_24_hour_18e86819">24 小时制</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">高级选项</string>
+    <string name="l10n_settings_screen_bottom_bar_overlay_f257c96f">底部栏叠加显示</string>
     <string name="l10n_settings_screen_clock_04f6b3ea">时钟</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -895,6 +895,7 @@
     <string name="l10n_settings_screen_12_hour_41c18ba0">12-hour</string>
     <string name="l10n_settings_screen_24_hour_18e86819">24-hour</string>
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">advancedChevron</string>
+    <string name="l10n_settings_screen_bottom_bar_overlay_f257c96f">Bottom bar overlay</string>
     <string name="l10n_settings_screen_clock_04f6b3ea">Clock</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>


### PR DESCRIPTION
Draft — this is a layout change I cannot see. It compiles and the suite is green, but somebody has to look
at it on a phone before it should land.

Raised on #1836.

## The bar was never the problem

`GlassBottomBar` is already built to float: pill shape, 22 dp inset, `navigationBarsPadding()`, hairline
rim, 0.80 alpha, soft shadow. It rendered as a dark strip regardless — because of **where it was mounted**,
not how it was styled.

It sat in `Scaffold(bottomBar = …)`, a slot **outside** the screen content. Each screen paints its own
backdrop via `LiquidScreenSky` / `BackgroundImageBackdrop`, so that backdrop stopped where the bar began,
and behind the glass there was only `containerColor = Palette.surfaceBase`.

Translucency over a flat colour is a slightly different flat colour. With a custom background (#1234) it
reads as a block cut out of the image, which is what the side-by-side screenshots show.

## What changed

The bar is drawn as a sibling **over** the Scaffold, so it floats on whatever the current screen painted.
Same composable, same insets — only its parent moved. The slot stays but empty, so the Scaffold reserves
nothing, and the inset it used to contribute is applied to the `NavHost`. Content clears the bar exactly as
before; only what sits *behind* the glass differs.

## Deliberately not in this change

- **Content scrolling under the glass.** That needs every scrollable to add the bar height to its own
  `contentPadding`; no shared modifier can do it. `LocalBottomBarHeight` is exposed for that work, screen
  by screen, with a device to look at.
- **The active-tab pill.** `BarSlot` changes only colour and weight, where the system iOS bar draws a
  filled rounded background behind the selected item. That is the other visible gap and belongs in its own
  change.
- **Real backdrop blur.** Compose has no cheap way to sample what is behind a composable, so this is not
  blur parity — it is making the translucency that already exists show something.

## Why iOS looks native

Because it is. `RootTabView` uses SwiftUI's `TabView`, so iOS 26 supplies the Liquid Glass bar, the
selected-item pill, real blur and scroll behaviour for free. Android's bar is hand-built and always will
be an approximation; this closes the part of the gap that was a mounting mistake rather than a platform
limit.

## On #90

#90 is an open prototype (July) for a scroll-reactive version of this same bar, editing the same
composable and two months stale. Whichever lands first, the other should be rebased onto it rather than
both restructuring `GlassBottomBar` in parallel. Notes on that PR separately.

## Verification

- `compileFullDebugKotlin` clean; full Android suite **5089 tests, 0 failures**; doc-comment gate clean.
- **Not seen on a device.** The specific risks are the bar overlapping content on a screen whose scrollable
  does not honour the NavHost inset, and the overlay's behaviour with the keyboard open.

## Now behind a setting, default off

**Settings → Appearance → Bottom bar overlay**, default **off**. Merging changes nothing on screen until
someone turns it on.

The off-path resolves to exactly what ships today — the slot renders the bar, the NavHost pads by `inner`,
and the overlay composable is never composed, so its measurement never runs. What changes unconditionally
is structural only: `run { }` became a `Box`, two remembered values the off-path never reads, and the
`BottomBarStyleStore` object.

That is the right shape for this change. Both inset bugs found while writing it were invisible without a
device, so shipping it as the only option would have been asking users to find the third one. A switch
makes it reachable for testing without a special build, while the default stays inert.

**Still unverified on a device.** It should be described as experimental wherever it is announced until
someone reports back from having flipped it.
