### PR TITLE
android: make the overlay bar actually overlay something (#1836)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -289,6 +289,25 @@ object BottomBarStyleStore {
     var overlay by mutableStateOf(false)
         private set
 
+    /**
+     * The bar's MEASURED height, published so [ScreenScaffold] can clear it.
+     *
+     * This is the half that makes the overlay actually do something. Moving the bar out of the slot is not
+     * enough on its own: a screen's backdrop is painted INSIDE the screen, so while the screen is inset
+     * above the bar the backdrop stops there too and the glass has nothing behind it but the shell's
+     * container colour. The screen has to reach the bottom edge, with its scrolling CONTENT clearing the
+     * bar instead — which is what this height is for.
+     */
+    var barHeight by mutableStateOf(0.dp)
+        internal set
+
+    /**
+     * The inset a screen's CONTENT should add, which is the bar height only while the overlay is on.
+     * A single accessor so callers cannot forget the `overlay` half and inset content in the slot
+     * layout, where the Scaffold has already reserved that space.
+     */
+    fun barHeightForContent(): Dp = if (overlay) barHeight else 0.dp
+
     fun load(ctx: Context) {
         overlay = NoopPrefs.of(ctx.applicationContext)
             .getBoolean(NoopPrefs.KEY_OVERLAY_BOTTOM_BAR, false)
@@ -337,7 +356,8 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
     // content behind the bar on exactly the devices the report came from. One extra layout pass at
     // startup, then stable.
     var barHeightPx by remember { mutableIntStateOf(0) }
-    val barHeight = with(LocalDensity.current) { barHeightPx.toDp() }
+    val density = LocalDensity.current
+    val barHeight = with(density) { barHeightPx.toDp() }
     Box(Modifier.fillMaxSize()) {
         Scaffold(
             containerColor = Palette.surfaceBase,
@@ -377,7 +397,11 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
                     top = inner.calculateTopPadding(),
                     start = inner.calculateStartPadding(LocalLayoutDirection.current),
                     end = inner.calculateEndPadding(LocalLayoutDirection.current),
-                    bottom = barHeight,
+                    // Bottom is ZERO on purpose: the screen must reach the bottom edge so its own backdrop
+                    // paints behind the glass. ScreenScaffold clears the bar from the scrolling CONTENT
+                    // instead, using BottomBarStyleStore.barHeight. Insetting here is what made the first
+                    // version of this change invisible — the bar moved, the backdrop did not follow.
+                    bottom = 0.dp,
                 ),
                 // README motion: top-level destinations crossfade (~240ms) on the calm,
                 // decelerating global easing — nothing slides or bounces between tabs. The
@@ -688,7 +712,10 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
             },
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .onSizeChanged { barHeightPx = it.height },
+                .onSizeChanged {
+                    barHeightPx = it.height
+                    BottomBarStyleStore.barHeight = with(density) { it.height.toDp() }
+                },
         )
     }
 }

--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -1209,7 +1209,16 @@ fun ScreenScaffold(
         Column(
             modifier = columnModifier
                 .verticalScroll(rememberScrollState())
-                .padding(start = 28.dp, end = 28.dp, top = topPadding, bottom = 28.dp),
+                // #1836: the bar's height is added to the CONTENT's bottom padding, not to the screen's
+                // layout. That distinction is the whole overlay: the screen reaches the bottom edge so its
+                // backdrop paints behind and around the glass, while the scrolling content still stops
+                // clear of the bar. Zero when the overlay is off, so the slot layout is untouched.
+                .padding(
+                    start = 28.dp,
+                    end = 28.dp,
+                    top = topPadding,
+                    bottom = 28.dp + BottomBarStyleStore.barHeightForContent(),
+                ),
             // #765: one shared inter-card spacing token (was a bare `20.dp`), so the eager + lazy scaffolds
             // and every screen through them keep the SAME uniform gap between top-level cards.
             verticalArrangement = Arrangement.spacedBy(Metrics.screenRowSpacing),

--- a/android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StepsCalibrationScreen.kt
@@ -157,7 +157,12 @@ fun StepsCalibrationScreen(
                     .weight(1f)
                     .fillMaxWidth()
                     .verticalScroll(scroll)
-                    .padding(20.dp),
+                    // #1836: this is a NavHost destination that scrolls WITHOUT ScreenScaffold, so it does
+                    // not inherit the scaffold's bar clearance. In the overlay layout the screen reaches the
+                    // bottom edge, so without this the last rows sit behind the bar. Zero when the overlay
+                    // is off. Any future destination that scrolls outside ScreenScaffold needs the same.
+                    .padding(20.dp)
+                    .padding(bottom = BottomBarStyleStore.barHeightForContent()),
                 verticalArrangement = Arrangement.spacedBy(Metrics.sectionGap),
             ) {
                 ExplainerCard()


### PR DESCRIPTION
Follow-up to #1837, which shipped a toggle that changed nothing on screen. Reported straight away:
"I don't see a difference when I enabled bottom bar overlay." Correct, and the reason is a logic error of
mine.

## Why the first version was inert

Moving the bar out of the `Scaffold` slot is not enough on its own. A screen's backdrop
(`LiquidScreenSky` / `BackgroundImageBackdrop`) is painted **inside** the screen, and the overlay path
still inset the `NavHost` by the bar height — so the screen, and its backdrop with it, stopped exactly
where it did before.

The bar floated over a strip of the shell's `containerColor`, not over anything. Hence: identical layout,
and a black band around the bar where the mosaic background should have continued.

I wrote the missing half in #1837's own description as a nice-to-have follow-up:

> **Content scrolling under the glass.** That needs every scrollable to add the bar height to its own
> `contentPadding`; no shared modifier can do it.

That was not a follow-up. It was the mechanism, and calling it optional is what let an inert change ship
behind a switch that promised something.

## What this does

- **The screen reaches the bottom edge.** The `NavHost`'s bottom inset is zero in the overlay path, so a
  screen's full-bleed backdrop paints behind *and around* the glass.
- **`ScreenScaffold` clears the bar from the CONTENT.** The bar's height is added to the scrolling column's
  bottom padding. Because that padding sits inside the scroll viewport, content passes **under** the bar as
  you scroll and the last row still comes to rest clear of it.

That distinction — layout reaches the edge, content clears the bar — is the whole overlay.

## One change, not four

Every top-level screen routes through `ScreenScaffold`: Today, Trends, Sleep, Coupled and More. So none of
them needed touching, and a screen added later inherits it. Checked rather than assumed — Today's other
`verticalScroll` is a bounded editor list, not the page scroll.

The measured height rides on `BottomBarStyleStore`, mirroring `BackgroundImageStore`, and
`barHeightForContent()` returns zero unless the overlay is on — so a caller cannot inset content in the
slot layout, where the Scaffold has already reserved that space.

## Unchanged

Still behind **Settings → Appearance → Bottom bar overlay**, default off. The off-path remains the shipped
slot layout.

## Verification

`compileFullDebugKotlin` clean, full Android suite **5089 tests, 0 failures**, doc-comment gate clean.

Still needs a device — but unlike the first version there is now something to look at: the background
should continue around and behind the bar, and content should pass beneath the glass while scrolling.