### PR TITLE
android: hide the bottom bar while scrolling down (#1839)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -101,6 +101,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -418,10 +419,22 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
     val collapseTarget = barCollapseFraction(hidden, reduceMotion)
     // The transform is a graphicsLayer only — GPU, per frame, NO relayout — so content never reflows as
     // the bar comes and goes and scrolling stays smooth. (The approach #90 got right.)
-    val collapse by animateFloatAsState(
+    // Held as the State, not unwrapped with `by`, ON PURPOSE. Reading a `Float` in composition would
+    // recompose this whole shell — Scaffold and NavHost included — on EVERY animation frame, which is the
+    // exact jank the graphicsLayer-only approach exists to avoid. Instead:
+    //   - the transform reads `.value` INSIDE graphicsLayer, a deferred read that updates the layer with
+    //     no recomposition at all;
+    //   - presence is a derivedStateOf, so composition is invalidated once when the bar appears or
+    //     disappears, not sixty times a second while it moves.
+    val collapseState = animateFloatAsState(
         targetValue = collapseTarget,
         animationSpec = tween(durationMillis = 220),
     )
+    val barPresent by remember { derivedStateOf { collapseState.value < 1f } }
+    // Landing on a new screen with no visible way to navigate is disorienting, and the bar cannot be
+    // tapped to fix it because it is the thing that is hidden. Reset on every route change so a screen
+    // always opens with its navigation present; scrolling down again hides it as before.
+    LaunchedEffect(currentRoute) { scrollingDown = false }
     val autoHideScroll = remember {
         object : NestedScrollConnection {
             override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
@@ -777,7 +790,11 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
 
         // Drawn OVER the Scaffold, so it floats on whatever backdrop the current screen painted rather
         // than on the shell's own container colour. Same composable, same insets — only its parent moved.
-        if (BottomBarStyleStore.overlay) GlassBottomBar(
+        // `collapse < 1f` and not just `overlay`: at alpha 0 the bar is invisible but still COMPOSED, so
+        // TalkBack could focus a bar nobody can see and a tap could land on a control that is not there.
+        // Dropping it at the end of the animation removes both. Safe precisely because it is an overlay —
+        // it reserves no space, so composing or not composing it never reflows content.
+        if (BottomBarStyleStore.overlay && barPresent) GlassBottomBar(
             current = current,
             onTabSelected = { dest ->
                 if (dest.route != currentRoute) nav.navigateTopLevel(dest.route)
@@ -787,8 +804,9 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
                 .graphicsLayer {
                     // Slide it out past its own height so the whole capsule clears the edge, and fade so
                     // it does not read as a bar stuck half off-screen mid-animation.
-                    translationY = collapse * (barHeightPx.toFloat())
-                    alpha = 1f - collapse
+                    val c = collapseState.value      // deferred read: layer only, no recomposition
+                    translationY = c * (barHeightPx.toFloat())
+                    alpha = 1f - c
                 }
                 .onSizeChanged {
                     barHeightPx = it.height

--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -421,7 +421,6 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
     val collapse by animateFloatAsState(
         targetValue = collapseTarget,
         animationSpec = tween(durationMillis = 220),
-        label = "bottomBarCollapse",
     )
     val autoHideScroll = remember {
         object : NestedScrollConnection {

--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -104,6 +104,10 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
@@ -277,6 +281,41 @@ internal object MoreSectionPrefs {
 }
 
 /**
+ * #1839: should the overlay bar be hidden right now?
+ *
+ * Pure so the decision is testable without Compose — the separation the #90 prototype got right.
+ *
+ * Gated on [overlay] deliberately. In the slot layout the Scaffold has RESERVED the bar's space, so
+ * translating the bar away would leave an empty band rather than handing the space back to content —
+ * visibly worse than not hiding at all. Auto-hide only makes sense over content.
+ */
+internal fun shouldHideBar(autoHide: Boolean, overlay: Boolean, scrollingDown: Boolean): Boolean =
+    autoHide && overlay && scrollingDown
+
+/**
+ * #1839: does this scroll delta change the direction, or is it noise?
+ *
+ * Returns true for "scrolling down into the page", false for up, and null when the movement is under
+ * [threshold] and should be ignored — without that, a fingertip tremor flickers the bar continuously.
+ * A NEGATIVE delta means content moved up, which is the user scrolling down.
+ */
+internal fun scrollDirectionChange(delta: Float, threshold: Float): Boolean? = when {
+    delta <= -threshold -> true
+    delta >= threshold -> false
+    else -> null
+}
+
+/**
+ * #1839: the 0..1 collapse fraction the bar's transform rides.
+ *
+ * Reduce Motion pins it to 0 — VISIBLE — rather than snapping between hidden and shown. A bar that
+ * teleports away without animation reads as a glitch, and someone who has asked for less motion is the
+ * last person who should get that. #90 snapped to 0/1 instead; keeping the bar put is the kinder reading.
+ */
+internal fun barCollapseFraction(hidden: Boolean, reduceMotion: Boolean): Float =
+    if (reduceMotion) 0f else if (hidden) 1f else 0f
+
+/**
  * #1836: which bottom-bar layout to use, snapshot-backed so the Settings toggle applies without a
  * relaunch (the same shape as `BackgroundImageStore.enabled`).
  *
@@ -308,9 +347,21 @@ object BottomBarStyleStore {
      */
     fun barHeightForContent(): Dp = if (overlay) barHeight else 0.dp
 
+    /** #1839: hide the overlay bar while scrolling down, bring it back on scrolling up. Default off. */
+    var autoHide by mutableStateOf(false)
+        private set
+
+    fun setAutoHide(ctx: Context, value: Boolean) {
+        autoHide = value
+        NoopPrefs.of(ctx.applicationContext).edit()
+            .putBoolean(NoopPrefs.KEY_BOTTOM_BAR_AUTO_HIDE, value).apply()
+    }
+
     fun load(ctx: Context) {
         overlay = NoopPrefs.of(ctx.applicationContext)
             .getBoolean(NoopPrefs.KEY_OVERLAY_BOTTOM_BAR, false)
+        autoHide = NoopPrefs.of(ctx.applicationContext)
+            .getBoolean(NoopPrefs.KEY_BOTTOM_BAR_AUTO_HIDE, false)
     }
 
     fun set(ctx: Context, value: Boolean) {
@@ -358,7 +409,29 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
     var barHeightPx by remember { mutableIntStateOf(0) }
     val density = LocalDensity.current
     val barHeight = with(density) { barHeightPx.toDp() }
-    Box(Modifier.fillMaxSize()) {
+    // #1839: auto-hide. ONE NestedScrollConnection on the shell means every screen gets the behaviour with
+    // no per-screen wiring — scrollable children dispatch their deltas up to it. onPreScroll only flips a
+    // Boolean, and only on a movement past the threshold, so a fingertip tremor cannot flicker the bar.
+    var scrollingDown by remember { mutableStateOf(false) }
+    val reduceMotion = rememberReduceMotion()
+    val hidden = shouldHideBar(BottomBarStyleStore.autoHide, BottomBarStyleStore.overlay, scrollingDown)
+    val collapseTarget = barCollapseFraction(hidden, reduceMotion)
+    // The transform is a graphicsLayer only — GPU, per frame, NO relayout — so content never reflows as
+    // the bar comes and goes and scrolling stays smooth. (The approach #90 got right.)
+    val collapse by animateFloatAsState(
+        targetValue = collapseTarget,
+        animationSpec = tween(durationMillis = 220),
+        label = "bottomBarCollapse",
+    )
+    val autoHideScroll = remember {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                scrollDirectionChange(available.y, threshold = 3f)?.let { scrollingDown = it }
+                return Offset.Zero
+            }
+        }
+    }
+    Box(Modifier.fillMaxSize().nestedScroll(autoHideScroll)) {
         Scaffold(
             containerColor = Palette.surfaceBase,
             bottomBar = {
@@ -712,6 +785,12 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
             },
             modifier = Modifier
                 .align(Alignment.BottomCenter)
+                .graphicsLayer {
+                    // Slide it out past its own height so the whole capsule clears the edge, and fade so
+                    // it does not read as a bar stuck half off-screen mid-animation.
+                    translationY = collapse * (barHeightPx.toFloat())
+                    alpha = 1f - collapse
+                }
                 .onSizeChanged {
                     barHeightPx = it.height
                     BottomBarStyleStore.barHeight = with(density) { it.height.toDp() }

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -701,6 +701,10 @@ object NoopPrefs {
         of(context).edit().putBoolean(KEY_APP_ICON_NAVY, navy).apply()
     }
 
+    /** #1839: hide the overlay bottom bar while scrolling down, restore it on scrolling up. Default
+     *  false. Only meaningful with the overlay layout, where the bar sits over content. */
+    const val KEY_BOTTOM_BAR_AUTO_HIDE = "noop.bottomBarAutoHide"
+
     /** #1836: draw the bottom bar as an overlay (glass over the screen's backdrop) instead of a reserved
      *  Scaffold slot. Default false — the shipped layout — until the overlay has been seen on a device. */
     const val KEY_OVERLAY_BOTTOM_BAR = "noop.overlayBottomBar"

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1318,6 +1318,17 @@ fun SettingsScreen(
                 )
             }
             SettingsRowDivider()
+            // #1839: hide the bar while scrolling down, bring it back on scrolling up. Only does anything
+            // with the overlay on, because in the slot layout the space is reserved and hiding the bar
+            // would leave an empty band — so the row is disabled rather than silently inert.
+            SettingsFormRow(label = uiString(R.string.l10n_settings_screen_hide_bar_when_scrolling_b077d9f3)) {
+                Switch(
+                    checked = BottomBarStyleStore.autoHide,
+                    enabled = BottomBarStyleStore.overlay,
+                    onCheckedChange = { BottomBarStyleStore.setAutoHide(context, it) },
+                )
+            }
+            SettingsRowDivider()
             // #1821: Clock format. Sits with Language because it is an app-owned display CONVENTION, and
             // like Language it offers "System default" - which here means the device's own 12/24h switch,
             // not the region default that was silently deciding this for everyone. Twin of the Apple row.

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1321,10 +1321,15 @@ fun SettingsScreen(
             // #1839: hide the bar while scrolling down, bring it back on scrolling up. Only does anything
             // with the overlay on, because in the slot layout the space is reserved and hiding the bar
             // would leave an empty band — so the row is disabled rather than silently inert.
+            // Reduce Motion pins the bar visible (a bar that vanishes without animation reads as a
+            // glitch), so with it on the toggle would flip and change nothing. A switch that silently
+            // does nothing is worse than one that is plainly unavailable, so it greys out for the same
+            // reason it does without the overlay.
+            val autoHideAvailable = BottomBarStyleStore.overlay && !rememberReduceMotion()
             SettingsFormRow(label = uiString(R.string.l10n_settings_screen_hide_bar_when_scrolling_b077d9f3)) {
                 Switch(
                     checked = BottomBarStyleStore.autoHide,
-                    enabled = BottomBarStyleStore.overlay,
+                    enabled = autoHideAvailable,
                     onCheckedChange = { BottomBarStyleStore.setAutoHide(context, it) },
                 )
             }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -812,6 +812,7 @@
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">AdvancedChevron</string>
     <string name="l10n_settings_screen_bottom_bar_overlay_f257c96f">Overlay der unteren Leiste</string>
     <string name="l10n_settings_screen_clock_04f6b3ea">Uhr</string>
+    <string name="l10n_settings_screen_hide_bar_when_scrolling_b077d9f3">Leiste beim Scrollen ausblenden</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>
     <string name="l10n_skin_temp_cards_screen_cycle_awareness_ffb94783">Zyklusbewusstsein</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -612,6 +612,7 @@
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">avanzadoChevron</string>
     <string name="l10n_settings_screen_bottom_bar_overlay_f257c96f">Superposición de la barra inferior</string>
     <string name="l10n_settings_screen_clock_04f6b3ea">Reloj</string>
+    <string name="l10n_settings_screen_hide_bar_when_scrolling_b077d9f3">Ocultar la barra al desplazarse</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>
     <string name="l10n_skin_temp_cards_screen_cycle_awareness_ffb94783">Conciencia del ciclo</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -630,6 +630,7 @@
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">avancéChevron</string>
     <string name="l10n_settings_screen_bottom_bar_overlay_f257c96f">Barre inférieure en surimpression</string>
     <string name="l10n_settings_screen_clock_04f6b3ea">Horloge</string>
+    <string name="l10n_settings_screen_hide_bar_when_scrolling_b077d9f3">Masquer la barre pendant le défilement</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>
     <string name="l10n_skin_temp_cards_screen_cycle_awareness_ffb94783">Conscience du cycle</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -769,6 +769,7 @@
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">zaawansowanyChevron</string>
     <string name="l10n_settings_screen_bottom_bar_overlay_f257c96f">Nakładkowy pasek dolny</string>
     <string name="l10n_settings_screen_clock_04f6b3ea">Zegar</string>
+    <string name="l10n_settings_screen_hide_bar_when_scrolling_b077d9f3">Ukryj pasek podczas przewijania</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>
     <string name="l10n_skin_temp_cards_screen_cycle_awareness_ffb94783">Świadomość rowerowa</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -777,6 +777,7 @@
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">avançadoChevron</string>
     <string name="l10n_settings_screen_bottom_bar_overlay_f257c96f">Sobreposição da barra inferior</string>
     <string name="l10n_settings_screen_clock_04f6b3ea">Relógio</string>
+    <string name="l10n_settings_screen_hide_bar_when_scrolling_b077d9f3">Ocultar a barra ao deslocar</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>
     <string name="l10n_skin_temp_cards_screen_cycle_awareness_ffb94783">Consciência do ciclo</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -759,6 +759,7 @@
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">高级选项</string>
     <string name="l10n_settings_screen_bottom_bar_overlay_f257c96f">底部栏叠加显示</string>
     <string name="l10n_settings_screen_clock_04f6b3ea">时钟</string>
+    <string name="l10n_settings_screen_hide_bar_when_scrolling_b077d9f3">滚动时隐藏底部栏</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>
     <string name="l10n_skin_temp_cards_screen_cycle_awareness_ffb94783">生理周期推断</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -897,6 +897,7 @@
     <string name="l10n_settings_screen_advancedchevron_f22dfa01">advancedChevron</string>
     <string name="l10n_settings_screen_bottom_bar_overlay_f257c96f">Bottom bar overlay</string>
     <string name="l10n_settings_screen_clock_04f6b3ea">Clock</string>
+    <string name="l10n_settings_screen_hide_bar_when_scrolling_b077d9f3">Hide bar when scrolling</string>
     <string name="l10n_settings_screen_note_a2481d6c">· %1$s</string>
     <string name="l10n_settings_screen_repo_note_0a694b50">%1$s, %2$s</string>
     <string name="l10n_skin_temp_cards_screen_cycle_awareness_ffb94783">Cycle awareness</string>

--- a/android/app/src/test/java/com/noop/ui/BottomBarAutoHideTest.kt
+++ b/android/app/src/test/java/com/noop/ui/BottomBarAutoHideTest.kt
@@ -1,0 +1,51 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1839: the auto-hide state machine, kept pure so it is testable without Compose.
+ *
+ * Design borrowed from the #90 prototype, which separated the same decision into plain functions with
+ * their own test rather than burying it in composition. That is the part of #90 worth keeping.
+ */
+class BottomBarAutoHideTest {
+
+    @Test fun hiddenOnlyWhileScrollingDownAndOnlyWhenEnabled() {
+        // The feature does nothing unless it is switched on.
+        assertFalse(shouldHideBar(autoHide = false, overlay = true, scrollingDown = true))
+        // Enabled and scrolling down: hidden.
+        assertTrue(shouldHideBar(autoHide = true, overlay = true, scrollingDown = true))
+        // Enabled but scrolling up: shown again.
+        assertFalse(shouldHideBar(autoHide = true, overlay = true, scrollingDown = false))
+    }
+
+    /**
+     * The bar can only be hidden when it OVERLAYS content. In the slot layout the Scaffold has reserved
+     * its space, so translating it away would leave an empty band rather than giving the space back —
+     * worse than not hiding at all.
+     */
+    @Test fun neverHidesInTheSlotLayout() {
+        assertFalse(shouldHideBar(autoHide = true, overlay = false, scrollingDown = true))
+        assertFalse(shouldHideBar(autoHide = true, overlay = false, scrollingDown = false))
+    }
+
+    /** A drag has to exceed the threshold before it counts, or a fingertip tremor flickers the bar. */
+    @Test fun tinyScrollsDoNotFlipTheDirection() {
+        assertEquals(null, scrollDirectionChange(delta = -0.5f, threshold = 3f))
+        assertEquals(null, scrollDirectionChange(delta = 2.9f, threshold = 3f))
+        // Content moving UP (negative delta) is the user scrolling DOWN into the page.
+        assertEquals(true, scrollDirectionChange(delta = -8f, threshold = 3f))
+        assertEquals(false, scrollDirectionChange(delta = 8f, threshold = 3f))
+    }
+
+    /** Reduce Motion keeps the bar put: a bar that vanishes without animation reads as a glitch. */
+    @Test fun reduceMotionPinsTheBarVisible() {
+        assertEquals(0f, barCollapseFraction(hidden = true, reduceMotion = true), 0f)
+        assertEquals(0f, barCollapseFraction(hidden = false, reduceMotion = true), 0f)
+        assertEquals(1f, barCollapseFraction(hidden = true, reduceMotion = false), 0f)
+        assertEquals(0f, barCollapseFraction(hidden = false, reduceMotion = false), 0f)
+    }
+}


### PR DESCRIPTION
Raised on #1839. **Settings → Appearance → Hide bar when scrolling**, default off, and disabled unless the
overlay bar (#1838) is on.

## That gate is real, not caution

In the slot layout the Scaffold has **reserved** the bar's space, so translating the bar away leaves an
empty band rather than handing the space back to content — visibly worse than not hiding at all. Auto-hide
only makes sense over content, so the row greys out rather than silently doing nothing.

## Built on what #90 got right

That prototype is `CONFLICTING`, two months stale, and restructured the same composable the overlay work
has since rewritten — so this is a fresh implementation of its idea, not a rebase of its diff. Three things
in it were worth keeping:

- **One `NestedScrollConnection` on the shell.** Every screen inherits the behaviour with no per-screen
  wiring, because scrollable children dispatch their deltas up to it.
- **`graphicsLayer` only.** GPU, per frame, no relayout — content never reflows as the bar comes and goes,
  so scrolling stays smooth.
- **The decision in plain functions with their own test**, rather than buried in composition.

`onPreScroll` only flips a Boolean, and only past a 3 px threshold, so a fingertip tremor cannot flicker
the bar.

## One deliberate difference: Reduce Motion

#90 snapped the bar between hidden and shown with no animation. This keeps it **visible** instead:

```kotlin
internal fun barCollapseFraction(hidden: Boolean, reduceMotion: Boolean): Float =
    if (reduceMotion) 0f else if (hidden) 1f else 0f
```

A bar that teleports away reads as a glitch, and someone who has asked for less motion is the last person
who should be handed one. Pinned by a test.

## Tests

`BottomBarAutoHideTest` — 4 cases, no Compose needed: hidden only while scrolling down and only when
enabled, never hidden in the slot layout, sub-threshold movements ignored, and Reduce Motion pinning the
bar visible.

## Verification

`compileFullDebugKotlin`, doc-comment gate, `Tools/i18n_audit.py --ci` and `lintVitalFullRelease` all
clean. Full Android suite **5093 tests, 0 failures** (4 new). String added in all 7 locales.

Second commit removes an `animateFloatAsState` `label` the i18n gate correctly flagged as a bare string —
dropped rather than baselined, since teaching the gate to ignore that class would cost more than the label
is worth.

**Not seen on a device.** What wants checking: that the bar returns promptly on an upward flick, that a
short screen with nothing to scroll never hides it, and that it does not fight the pull-to-sync gesture on
Today.