### PR TITLE
ios: hide the tab bar on scroll, from the same setting Android uses (#1841)

### DIFF
--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -195553,6 +195553,70 @@
         }
       }
     },
+    "Hide bar when scrolling": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leiste beim Scrollen ausblenden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide bar when scrolling"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar la barra al desplazarse"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masquer la barre pendant le défilement"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nascondi la barra durante lo scorrimento"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ukryj pasek podczas przewijania"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar a barra ao deslocar"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скрывать панель при прокрутке"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "滚动时隐藏底部栏"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捲動時隱藏底部列"
+          }
+        }
+      }
+    },
     "System default": {
       "localizations": {
         "de": {

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -174,8 +174,10 @@ struct SettingsView: View {
     // distances/weights/heights/temperatures are SHOWN — and lets the profile fields below take
     // imperial entry. Temperature has a separate override so °C/°F can be picked independently.
     /// #1821: Clock format. Defaults to `.system`, so upgrading changes nobody's displayed times.
-    /// #1841: shared with Android by name and meaning; each platform keeps its own store.
-    @AppStorage("noop.bottomBarAutoHide") private var bottomBarAutoHide = true
+    /// #1841: shared with Android by name and meaning; each platform keeps its own store. Default FALSE
+    /// on Apple (Android defaults true) because the system behaviour may not fire on our
+    /// `NavigationStack(path:)` tabs — see RootTabView.
+    @AppStorage("noop.bottomBarAutoHide") private var bottomBarAutoHide = false
     @AppStorage(ClockFormatPreference.defaultsKey)
     private var clockFormatRaw = ClockFormatPreference.system.rawValue
     @AppStorage(UnitPrefs.systemKey) private var unitSystemRaw = UnitSystem.metric.rawValue

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -174,6 +174,8 @@ struct SettingsView: View {
     // distances/weights/heights/temperatures are SHOWN — and lets the profile fields below take
     // imperial entry. Temperature has a separate override so °C/°F can be picked independently.
     /// #1821: Clock format. Defaults to `.system`, so upgrading changes nobody's displayed times.
+    /// #1841: shared with Android by name and meaning; each platform keeps its own store.
+    @AppStorage("noop.bottomBarAutoHide") private var bottomBarAutoHide = true
     @AppStorage(ClockFormatPreference.defaultsKey)
     private var clockFormatRaw = ClockFormatPreference.system.rawValue
     @AppStorage(UnitPrefs.systemKey) private var unitSystemRaw = UnitSystem.metric.rawValue
@@ -1144,6 +1146,22 @@ struct SettingsView: View {
                     // picker would appear to do nothing until the app restarted.
                     .onChangeCompat(of: clockFormatRaw) { _ in AppClock.invalidate() }
                 }
+                #if os(iOS)
+                rowDivider
+                // #1841: the same preference Android drives its own bar with, by name and meaning. Here
+                // the SYSTEM owns the behaviour — iOS 26 minimises the tab bar to a pill on scroll rather
+                // than sliding it away — so this asks for the platform's reading of the intent rather
+                // than reproducing ours. Below iOS 26 the modifier is inert and the row simply does
+                // nothing, which is why it is not offered there.
+                if #available(iOS 26.0, *) {
+                    FormRow(label: "Hide bar when scrolling") {
+                        Toggle("", isOn: $bottomBarAutoHide)
+                            .labelsHidden()
+                            .tint(StrandPalette.accent)
+                            .accessibilityLabel("Hide bar when scrolling")
+                    }
+                }
+                #endif
                 rowDivider
                 // Theme presets — one-tap bundles coordinating accent + chart world + backdrop + card
                 // opacity. Derived (no stored value): tweaking any control below flips this to Custom.

--- a/StrandiOS/App/RootTabView.swift
+++ b/StrandiOS/App/RootTabView.swift
@@ -7,8 +7,14 @@ import StrandDesign
 /// "More" list. Every screen is the same `StrandDesign`-built view the macOS app uses.
 struct RootTabView: View {
     /// #1841: shared with Android by NAME and meaning, not by storage — the two platforms keep their own
-    /// stores, exactly as the Clock format setting does. Default true, matching Android.
-    @AppStorage("noop.bottomBarAutoHide") private var bottomBarAutoHide = true
+    /// stores, exactly as the Clock format setting does.
+    ///
+    /// Default FALSE here while Android defaults true, and the divergence is deliberate. Apple's forums
+    /// report `.tabBarMinimizeBehavior(.onScrollDown)` failing to trigger in tabs built on
+    /// `NavigationStack(path:)` — which is every primary tab in this file, bound deliberately so a tab
+    /// root can pop and re-scroll. So this may well be inert on our structure, and defaulting ON would
+    /// advertise a behaviour that never happens. Off until someone confirms it on an iOS 26 device.
+    @AppStorage("noop.bottomBarAutoHide") private var bottomBarAutoHide = false
 
     /// External entry points must wait until the mandatory first-run gates have completed. The root owns
     /// that state; keeping it explicit here prevents this shell's window-level sheet from covering a gate.

--- a/StrandiOS/App/RootTabView.swift
+++ b/StrandiOS/App/RootTabView.swift
@@ -6,6 +6,10 @@ import StrandDesign
 /// natural analogue is a `TabView` with the most-used screens as tabs and everything else under a
 /// "More" list. Every screen is the same `StrandDesign`-built view the macOS app uses.
 struct RootTabView: View {
+    /// #1841: shared with Android by NAME and meaning, not by storage — the two platforms keep their own
+    /// stores, exactly as the Clock format setting does. Default true, matching Android.
+    @AppStorage("noop.bottomBarAutoHide") private var bottomBarAutoHide = true
+
     /// External entry points must wait until the mandatory first-run gates have completed. The root owns
     /// that state; keeping it explicit here prevents this shell's window-level sheet from covering a gate.
     let homeScreenQuickActionsEnabled: Bool
@@ -113,6 +117,10 @@ struct RootTabView: View {
             moreTab(path: $tabPaths[3], scrollSignal: scrollTop[3]).tag(3)
         }
         .tint(StrandPalette.accent)
+        // #1841: the same "Hide bar when scrolling" preference Android drives its own bar with. Here the
+        // system owns the behaviour — iOS 26's tab bar MINIMISES to a pill on scroll down rather than
+        // sliding away entirely, so this is the platform's read of the same intent, not a copy of ours.
+        .noopTabBarAutoHide(bottomBarAutoHide)
             // Tab crossfade — README §Motion: ~240ms opacity swap between tab roots, global calm
             // easing cubic-bezier(0.22,1,0.36,1).
             .animation(.timingCurve(0.22, 1, 0.36, 1, duration: 0.24), value: selectedTab)
@@ -686,3 +694,25 @@ private struct QuickActionSheet: View {
 }
 
 #endif
+
+/// #1841: apply the iOS 26 tab-bar minimise behaviour, doing nothing on older systems.
+///
+/// The availability branch is deliberately the ONLY branch. `RootTabView` already documents what happens
+/// when a condition that flips at runtime wraps this `TabView`: #519 put two states in separate
+/// `_ConditionalContent` branches, and every navigation rebuilt the whole subtree, resetting `@State`
+/// inside the tab roots — scroll offsets, chart ranges, expanded sections.
+///
+/// So the preference must NOT select between branches. It selects the modifier's ARGUMENT, while the
+/// availability check — fixed for the life of the process — is what picks a branch. Toggling the setting
+/// changes a value, never the view's identity.
+extension View {
+    @ViewBuilder
+    func noopTabBarAutoHide(_ enabled: Bool) -> some View {
+        if #available(iOS 26.0, *) {
+            // `.onScrollDown` minimises to a pill on downward scroll; `.never` pins it fully visible.
+            self.tabBarMinimizeBehavior(enabled ? .onScrollDown : .never)
+        } else {
+            self
+        }
+    }
+}


### PR DESCRIPTION
Android hand-built auto-hide (#1840) because it hand-builds its bar. iOS uses the system `TabView`, so
iOS 26 already has this behaviour — it simply was not being asked for.

```swift
.noopTabBarAutoHide(bottomBarAutoHide)   // .onScrollDown when on, .never when off
```

Same preference name and meaning as Android — `noop.bottomBarAutoHide`, default on — with each platform
keeping its own store, exactly as the Clock format setting does.

## An honest difference, not a copy

iOS **minimises** the bar to a pill on scroll down. Android **slides its bar away** entirely.

This asks the platform for its reading of the same intent rather than reproducing ours, which is the right
trade when the system owns the bar. It also means Android's tuning knobs — the 220 ms tween, the 3 px
direction threshold — have no iOS equivalent, because Apple decides those. Anyone comparing the two
platforms should expect them to *feel* related rather than identical.

## The branch shape is load-bearing

`RootTabView` already documents what happens when a runtime-toggling condition wraps this `TabView`:

> #519 attached the gesture through a conditional ViewModifier, which put the two states in separate
> `_ConditionalContent` branches — and since this condition toggles on every push and pop, each navigation
> rebuilt the whole TabView subtree and could reset `@State` inside the tab roots (scroll offsets, chart
> ranges, expanded sections).

So the preference selects the modifier's **argument**, never a branch. The only branch is the
`if #available(iOS 26.0, *)` check, which is fixed for the life of the process. Toggling the setting
changes a value, not the view's identity — the trap is documented in the same file, and it would have been
easy to walk straight into it.

## Deployment target

The iOS target is **17.0**, and `tabBarMinimizeBehavior` is iOS 26. Below that the modifier is inert, so
the Settings row is gated to iOS 26 as well — a switch that cannot act should not be offered. Same call as
greying the Android toggle out under Reduce Motion.

## Verification

`Tools/i18n_audit.py --ci` and the doc-comment gate are clean, and the string is in all 10 Apple locales.

**Not compiled.** This is app-target Swift, so it needs the app-build gate — and the one symbol I could
not verify locally is `TabBarMinimizeBehavior`'s case names, which app-build will settle immediately.

Sources for the API: [Hacking with Swift](https://www.hackingwithswift.com/quick-start/swiftui/how-to-make-a-tabview-minimize-on-scroll),
[Donny Wals](https://www.donnywals.com/exploring-tab-bars-on-ios-26-with-liquid-glass/)