### PR TITLE
today: carry HRV and Resting HR on the cards, and stop printing -0.0 (#1842)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SkinTempDisplay.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SkinTempDisplay.swift
@@ -68,7 +68,13 @@ public enum SkinTempDisplay {
         if kind == .absolute {
             return String(format: "%.\(decimals)f", display)
         }
-        return String(format: "%+.\(decimals)f", display)
+        let signed = String(format: "%+.\(decimals)f", display)
+        // #1842: a deviation that ROUNDS to zero must not keep its sign. `%+` prints "-0.0" for anything
+        // in (-0.05, 0), and "-0.0 Δ°C" on a card reads as a fault rather than as "no change from your
+        // baseline" — which is what it means. Drop the sign only when the rounded value is zero; a real
+        // -0.1 keeps it. Twin of the Kotlin numberString.
+        if Double(signed.dropFirst()) == 0 { return String(signed.dropFirst()) }
+        return signed
     }
 
     /// Full `"34.2 °C"` / `"+0.1 Δ°C"` string for one-shot call sites (Today cards, explorers).

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SkinTempDisplayTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SkinTempDisplayTests.swift
@@ -99,4 +99,16 @@ final class SkinTempDisplayTests: XCTestCase {
         let filteredMean = kept.reduce(0, +) / Double(kept.count)
         XCTAssertLessThan(abs(filteredMean), 0.3)
     }
+
+    /// #1842: a deviation that rounds to zero must not carry a sign. `%+` prints "-0.0" for anything in
+    /// (-0.05, 0), and the Today card showed "-0.0 Δ°C" — which reads as a fault rather than as "no
+    /// change from your baseline". A real -0.1 must still keep its sign. Twin of the Kotlin test.
+    func testADeviationRoundingToZeroLosesItsSign() {
+        XCTAssertEqual(SkinTempDisplay.numberString(-0.04, kind: .deviation, fahrenheit: false), "0.0")
+        XCTAssertEqual(SkinTempDisplay.numberString(0.0, kind: .deviation, fahrenheit: false), "0.0")
+        XCTAssertEqual(SkinTempDisplay.numberString(0.04, kind: .deviation, fahrenheit: false), "0.0")
+        XCTAssertEqual(SkinTempDisplay.numberString(-0.1, kind: .deviation, fahrenheit: false), "-0.1")
+        XCTAssertEqual(SkinTempDisplay.numberString(0.1, kind: .deviation, fahrenheit: false), "+0.1")
+        XCTAssertEqual(SkinTempDisplay.numberString(34.2, kind: .absolute, fahrenheit: false), "34.2")
+    }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -152,6 +152,28 @@ public struct DailyMetric: Equatable, Codable {
     public nonisolated static func lastSkinTempDay(days: [DailyMetric], todayKey: String) -> DailyMetric? {
         days.last(where: { $0.skinTempDevC != nil && $0.day < todayKey })
     }
+
+    /// PER-FIELD HRV carry — the twin of `lastSpo2Day` for a field `lastVitalsDay` DOES check, which is
+    /// precisely why it needs one. That predicate is an OR across HRV / resting-HR / respiratory, so it
+    /// resolves the freshest row carrying ANY of the three — including a respiratory-only row whose
+    /// `avgHrv` is nil. The HRV card then reads that nil and renders "—" while a tile carrying a different
+    /// row shows a real number on the same screen (#1842). Resolving per field picks the freshest row that
+    /// actually holds an HRV, the same correction `lastSpo2Day` and `lastSkinTempDay` already make.
+    ///
+    /// Deliberately NOT staleness-bounded, unlike `Repository.lastRespDay`: an old HRV/RHR carry is
+    /// disclosed rather than suppressed — the call sites stamp the row's own date and `carriedCaption`
+    /// relabels a weeks-old one to "Latest sleep" (#779). Respiratory took a hard bound instead because a
+    /// single CSV import's value was reading as today's for a fortnight (#1331). Same `$0.day < todayKey`
+    /// future-clock guard; `days` is oldest→newest. Byte-twin of the Android `lastHrvRow`.
+    public nonisolated static func lastHrvDay(days: [DailyMetric], todayKey: String) -> DailyMetric? {
+        days.last(where: { $0.avgHrv != nil && $0.day < todayKey })
+    }
+
+    /// PER-FIELD resting-HR carry — twin of `lastHrvDay`, same OR-predicate cause and same unbounded-by-
+    /// design carry (#1842). Byte-twin of the Android `lastRestingHrRow`.
+    public nonisolated static func lastRestingHrDay(days: [DailyMetric], todayKey: String) -> DailyMetric? {
+        days.last(where: { $0.restingHr != nil && $0.day < todayKey })
+    }
 }
 
 extension WhoopStore {

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/DailyMetricLastVitalsDayTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/DailyMetricLastVitalsDayTests.swift
@@ -151,4 +151,47 @@ final class DailyMetricLastVitalsDayTests: XCTestCase {
                     fieldDay("2999-01-01", skinTemp: 2.1)]
         XCTAssertEqual(DailyMetric.lastSkinTempDay(days: days, todayKey: "2026-06-19")?.day, "2026-06-16")
     }
+
+    // MARK: PER-FIELD HRV / resting HR — the OR predicate's blind spot (#1842)
+
+    /// The reported shape: the freshest row carries respiratory ONLY, so the OR predicate selects it and its
+    /// nil `avgHrv` renders "—" on the card while a tile carrying a different row shows a number on the same
+    /// screen. Pins the BUG as well as the fix, so a future simplification back onto `lastVitalsDay` fails
+    /// here rather than in the field.
+    func testSharedPredicateSelectsARowWithNoHrv_perFieldDoesNot() {
+        let days = [day("2026-09-01", hrv: 35, rhr: 58),
+                    day("2026-09-02", resp: 14.2),
+                    day("2026-09-03")]   // today, nothing yet
+        let shared = DailyMetric.lastVitalsDay(days: days, todayKey: "2026-09-03")
+        XCTAssertEqual(shared?.day, "2026-09-02", "the OR predicate takes the respiratory-only row")
+        XCTAssertNil(shared?.avgHrv, "...and that row has no HRV — the blank the card was rendering")
+
+        XCTAssertEqual(DailyMetric.lastHrvDay(days: days, todayKey: "2026-09-03")?.avgHrv, 35)
+        XCTAssertEqual(DailyMetric.lastRestingHrDay(days: days, todayKey: "2026-09-03")?.restingHr, 58)
+    }
+
+    /// Freshest wins when several prior rows carry the field.
+    func testPerFieldCarriesTheFreshestRowHoldingTheField() {
+        let days = [day("2026-09-01", hrv: 30, rhr: 62),
+                    day("2026-09-02", hrv: 41, rhr: 55),
+                    day("2026-09-03")]
+        XCTAssertEqual(DailyMetric.lastHrvDay(days: days, todayKey: "2026-09-03")?.avgHrv, 41)
+        XCTAssertEqual(DailyMetric.lastRestingHrDay(days: days, todayKey: "2026-09-03")?.restingHr, 55)
+    }
+
+    /// Same future-clock bound as every sibling: strictly prior to today's key, so today's own still-forming
+    /// row and a bad-clock strap's future-dated row can never be carried as "last night's".
+    func testPerFieldNeverCarriesTodayOrLater() {
+        let days = [day("2026-09-03", hrv: 44, rhr: 50), day("2026-09-04", hrv: 45, rhr: 49)]
+        XCTAssertNil(DailyMetric.lastHrvDay(days: days, todayKey: "2026-09-03"))
+        XCTAssertNil(DailyMetric.lastRestingHrDay(days: days, todayKey: "2026-09-03"))
+    }
+
+    /// Nothing anywhere stays "—": the carry must never invent a value.
+    func testPerFieldCarriesNothingWhenNoRowHasTheField() {
+        let days = [day("2026-09-01", resp: 15.0), day("2026-09-02", resp: 14.0)]
+        XCTAssertNil(DailyMetric.lastHrvDay(days: days, todayKey: "2026-09-03"))
+        XCTAssertNil(DailyMetric.lastRestingHrDay(days: days, todayKey: "2026-09-03"))
+    }
+
 }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -608,6 +608,17 @@ final class Repository: ObservableObject {
         DailyMetric.lastSkinTempDay(days: days, todayKey: todayKey)
     }
 
+    /// PER-FIELD HRV carry — twin of the above, for a field `lastVitalsDay`'s OR predicate DOES check but
+    /// can still resolve nil on (#1842). See `DailyMetric.lastHrvDay`.
+    nonisolated static func lastHrvDay(days: [DailyMetric], todayKey: String) -> DailyMetric? {
+        DailyMetric.lastHrvDay(days: days, todayKey: todayKey)
+    }
+
+    /// PER-FIELD resting-HR carry — twin of `lastHrvDay`. See `DailyMetric.lastRestingHrDay`.
+    nonisolated static func lastRestingHrDay(days: [DailyMetric], todayKey: String) -> DailyMetric? {
+        DailyMetric.lastRestingHrDay(days: days, todayKey: todayKey)
+    }
+
     /// PER-FIELD respiratory carry — twin of `lastSpo2Day`, but STALENESS-BOUNDED to `Baselines.vitalCarryDays`.
     /// SpO₂/skin-temp are sparse/imported so last-known-of-any-age is expected; respiratory is nightly, so a
     /// weeks-old value shown as the current number is the "Respiratory 15.6 a fortnight later" bug that

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -114,6 +114,8 @@ struct LiquidTodayView: View {
     /// resolved in body — body rescans repo.days ~23× per pass, and this cache keeps that read O(1).
     @State private var cachedVitalsDay: DailyMetric?
     @State private var cachedRespDay: DailyMetric?
+    @State private var cachedHrvDay: DailyMetric?
+    @State private var cachedRestingHrDay: DailyMetric?
     /// The Charge hero's resolved state (#543 carry + the honest label), resolved ONCE in load() alongside
     /// the other caches. It composes `TodayView.lastScoredRecoveryDay`, which is O(days) — exactly the scan
     /// this cache exists to keep out of body. Never resolved in body.
@@ -178,6 +180,14 @@ struct LiquidTodayView: View {
     /// The prior-day RESPIRATORY carry (#1331): staleness-bounded, so a recent missed night reads the last
     /// real value while a weeks-old one honestly shows "No Data". Non-nil only at offset 0.
     private var respDay: DailyMetric? { cachedRespDay }
+
+    /// PER-FIELD HRV / resting-HR carries (#1842), read O(1) from the cache like `vitalsDay`. `vitalsDay`'s
+    /// predicate is an OR across HRV / resting-HR / respiratory, so it resolves the freshest row with ANY of
+    /// them — a respiratory-only row blanks HRV and Resting HR on both the vitals card and the Key Metrics
+    /// tiles. Twins of `DailyMetric.lastHrvDay` / `lastRestingHrDay`; mirror the Android per-field rows.
+    private var hrvDay: DailyMetric? { cachedHrvDay }
+
+    private var restingHrDay: DailyMetric? { cachedRestingHrDay }
     /// The Charge hero's resolved state (see `cachedChargeDisplay`), read O(1) from the cache.
     private var chargeDisplay: ChargeDisplay { cachedChargeDisplay }
 
@@ -1078,9 +1088,10 @@ struct LiquidTodayView: View {
 
     private var recoveryVitalsSection: some View {
         // PER-FIELD, today-first carry: each vital reads today's own value, else falls back to the prior
-        // day that recorded it (`vitalsDay`). Coalesce ONCE so the number and its fill fraction agree.
-        let hrv = displayDay?.avgHrv ?? vitalsDay?.avgHrv
-        let rhr = (displayDay?.restingHr ?? vitalsDay?.restingHr).map(Double.init)
+        // day that recorded THAT vital (#1842 — `vitalsDay` is the freshest row with ANY of the three, so it
+        // blanks one the row lacks). Coalesce ONCE so the number and its fill fraction agree.
+        let hrv = displayDay?.avgHrv ?? hrvDay?.avgHrv
+        let rhr = (displayDay?.restingHr ?? restingHrDay?.restingHr).map(Double.init)
         let resp = displayDay?.respRateBpm ?? vitalsDay?.respRateBpm
         return card {
             VStack(alignment: .leading, spacing: 12) {
@@ -1142,8 +1153,8 @@ struct LiquidTodayView: View {
         // HRV / Rest HR (+ Blood Oxygen / Respiratory) tiles share the recovery vitals' per-field
         // today-first carry so they don't blank at the rollover while Recovery/Strain/Rest stay strictly
         // today's own (they are scored surfaces).
-        let hrv = displayDay?.avgHrv ?? vitalsDay?.avgHrv
-        let rhr = (displayDay?.restingHr ?? vitalsDay?.restingHr).map(Double.init)
+        let hrv = displayDay?.avgHrv ?? hrvDay?.avgHrv
+        let rhr = (displayDay?.restingHr ?? restingHrDay?.restingHr).map(Double.init)
         return VStack(spacing: 8) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 sectionHead("KEY METRICS", trailing: trendWindowLabel)
@@ -1434,6 +1445,8 @@ struct LiquidTodayView: View {
         let tkey = cachedDisplayDay?.day ?? selectedDayKey
         cachedVitalsDay = (selectedDayOffset == 0) ? Repository.lastVitalsDay(days: repo.days, todayKey: tkey) : nil
         cachedRespDay = (selectedDayOffset == 0) ? Repository.lastRespDay(days: repo.days, todayKey: tkey) : nil
+        cachedHrvDay = (selectedDayOffset == 0) ? Repository.lastHrvDay(days: repo.days, todayKey: tkey) : nil
+        cachedRestingHrDay = (selectedDayOffset == 0) ? Repository.lastRestingHrDay(days: repo.days, todayKey: tkey) : nil
         // Charge carry (#543) + the honest label, resolved here for the same reason as the two above: the
         // selector below scans repo.days. Calibration nights come from the SAME `RecoveryScorer` helper the
         // classic Today reads, so the two screens agree on when a wearer is genuinely mid-calibration
@@ -1794,11 +1807,15 @@ struct LiquidTodayView: View {
     /// "Latest sleep · <date>" (#779) instead of a false "Last night". When every shown vital is today's
     /// own (or there's nothing to carry), it returns nil — the card must not claim "Last night" at all.
     private var vitalsProvenanceLine: String? {
-        guard let carried = vitalsDay else { return nil }
-        let carriedHrv = displayDay?.avgHrv == nil && carried.avgHrv != nil
-        let carriedRhr = displayDay?.restingHr == nil && carried.restingHr != nil
-        let carriedResp = displayDay?.respRateBpm == nil && carried.respRateBpm != nil
-        guard carriedHrv || carriedRhr || carriedResp else { return nil }
+        // Each vital can carry from a DIFFERENT row (#1842), so the one card-level footnote stamps the
+        // OLDEST row any SHOWN carried vital came from — erring old is the only safe direction for a caption
+        // whose job is to stop a stale read passing as today's, and it keeps the "Latest sleep" relabel
+        // (#779) firing on the value that actually is weeks old. A row counts only if it SUPPLIED the value.
+        let fromHrv: DailyMetric? = (displayDay?.avgHrv == nil && hrvDay?.avgHrv != nil) ? hrvDay : nil
+        let fromRhr: DailyMetric? = (displayDay?.restingHr == nil && restingHrDay?.restingHr != nil) ? restingHrDay : nil
+        let fromResp: DailyMetric? = (displayDay?.respRateBpm == nil && vitalsDay?.respRateBpm != nil) ? vitalsDay : nil
+        let sources: [DailyMetric] = [fromHrv, fromRhr, fromResp].compactMap { $0 }
+        guard let carried = sources.min(by: { $0.day < $1.day }) else { return nil }
         return TodayView.carriedCaption(priorDayKey: carried.day,
                                         todayKey: displayDay?.day ?? selectedDayKey)
     }

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -594,13 +594,13 @@ struct TodayView: View {
     /// still resolve nil on: it picks the freshest row with ANY vital, so a respiratory-only row blanks HRV
     /// (#1842). Mirrors the Android `lastHrvRow`.
     private var lastHrvDay: DailyMetric? {
-        guard isToday else { return nil }
+        guard selectedDayOffset == 0 else { return nil }
         return Repository.lastHrvDay(days: repo.days, todayKey: displayDay?.day ?? selectedDayKey)
     }
 
     /// PER-FIELD resting-HR carry — twin of `lastHrvDay`. Mirrors the Android `lastRestingHrRow`.
     private var lastRestingHrDay: DailyMetric? {
-        guard isToday else { return nil }
+        guard selectedDayOffset == 0 else { return nil }
         return Repository.lastRestingHrDay(days: repo.days, todayKey: displayDay?.day ?? selectedDayKey)
     }
 
@@ -4988,7 +4988,7 @@ struct TodayView: View {
     /// unit that read as broken. Returns nil off-today (a past day keeps the plain unit, it's missing data the
     /// user can't act on now). Pure copy/gate so it can be unit-tested without a live view. Mirror in Kotlin.
     static func emptyVitalCaption(unit: String, isToday: Bool) -> String? {
-        guard isToday else { return nil }
+        guard selectedDayOffset == 0 else { return nil }
         return String(localized: "After tonight's sleep")
     }
 
@@ -5003,7 +5003,7 @@ struct TodayView: View {
     /// Rest fills in after a night's sleep; Effort fills in once cardio load is logged. Em-dash-free
     /// house style. Returns nil off-today and for any metric other than Effort/Rest (#527).
     static func buildingHintCopy(_ metric: KeyMetric, isToday: Bool) -> String? {
-        guard isToday else { return nil }
+        guard selectedDayOffset == 0 else { return nil }
         switch metric {
         case .rest:   return String(localized: "Building, wear it tonight")
         case .effort: return String(localized: "Building, moves as you do")

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4988,7 +4988,7 @@ struct TodayView: View {
     /// unit that read as broken. Returns nil off-today (a past day keeps the plain unit, it's missing data the
     /// user can't act on now). Pure copy/gate so it can be unit-tested without a live view. Mirror in Kotlin.
     static func emptyVitalCaption(unit: String, isToday: Bool) -> String? {
-        guard selectedDayOffset == 0 else { return nil }
+        guard isToday else { return nil }
         return String(localized: "After tonight's sleep")
     }
 
@@ -5003,7 +5003,7 @@ struct TodayView: View {
     /// Rest fills in after a night's sleep; Effort fills in once cardio load is logged. Em-dash-free
     /// house style. Returns nil off-today and for any metric other than Effort/Rest (#527).
     static func buildingHintCopy(_ metric: KeyMetric, isToday: Bool) -> String? {
-        guard selectedDayOffset == 0 else { return nil }
+        guard isToday else { return nil }
         switch metric {
         case .rest:   return String(localized: "Building, wear it tonight")
         case .effort: return String(localized: "Building, moves as you do")

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -590,6 +590,20 @@ struct TodayView: View {
         return Repository.lastSpo2Day(days: repo.days, todayKey: displayDay?.day ?? selectedDayKey)
     }
 
+    /// PER-FIELD HRV carry — twin of `lastSpo2Day` for a field `lastVitalsDay`'s OR predicate checks but can
+    /// still resolve nil on: it picks the freshest row with ANY vital, so a respiratory-only row blanks HRV
+    /// (#1842). Mirrors the Android `lastHrvRow`.
+    private var lastHrvDay: DailyMetric? {
+        guard isToday else { return nil }
+        return Repository.lastHrvDay(days: repo.days, todayKey: displayDay?.day ?? selectedDayKey)
+    }
+
+    /// PER-FIELD resting-HR carry — twin of `lastHrvDay`. Mirrors the Android `lastRestingHrRow`.
+    private var lastRestingHrDay: DailyMetric? {
+        guard isToday else { return nil }
+        return Repository.lastRestingHrDay(days: repo.days, todayKey: displayDay?.day ?? selectedDayKey)
+    }
+
     /// PER-FIELD skin-temperature-deviation carry — twin of `lastSpo2Day`; mirrors the Android `lastSkinTempRow`.
     private var lastSkinTempDay: DailyMetric? {
         guard selectedDayOffset == 0 else { return nil }
@@ -2574,12 +2588,18 @@ struct TodayView: View {
             #if DEBUG
             if let f = DemoDayHarness.active { return withUnit("\(f.hrvMs)") }
             #endif
-            return withUnit(d?.avgHrv.map { "\(Int($0.rounded()))" } ?? "—")
+            // PER-FIELD carry: today → the freshest prior row that actually HAS an HRV (#1842). Was
+            // today-only, so this card blanked to "—" every rollover while the Key Metrics tile — which
+            // has carried via `carriedVital(perField:)` all along — showed a number on the same screen.
+            // Not the whole-row `lastVitalsDay`: its OR predicate resolves nil HRV on a respiratory-only
+            // row. Mirrors the Android dashboardCardValue.
+            return withUnit((d?.avgHrv ?? lastHrvDay?.avgHrv).map { "\(Int($0.rounded()))" } ?? "—")
         case .restingHr:
             #if DEBUG
             if let f = DemoDayHarness.active { return withUnit("\(f.rhrBpm)") }
             #endif
-            return withUnit(d?.restingHr.map { "\($0)" } ?? "—")
+            // PER-FIELD carry — twin of `.hrv` above (#1842).
+            return withUnit((d?.restingHr ?? lastRestingHrDay?.restingHr).map { "\($0)" } ?? "—")
         case .respiratory:
             // PER-FIELD carry: today → the STALENESS-BOUNDED prior night (`lastRespDay`). Recovery-
             // independent, so a night with real R-R but a null recovery still carries.
@@ -2793,16 +2813,26 @@ struct TodayView: View {
         // falls back to the last night that recorded THAT vital (`lastVitalsDay`, recovery-INDEPENDENT — a
         // night with real HRV/RHR but a null recovery is a valid source, which the old `lastScoredRecoveryDay`
         // row-swap skipped). Today's own value always wins the instant it lands.
+        // ...and PER FIELD means per field: `lastVitalsDay`'s predicate is an OR across the three, so it
+        // resolves the freshest row with ANY of them and blanks a vital that row happens to lack (#1842).
+        let hd = lastHrvDay
+        let rd = lastRestingHrDay
         let vd = lastVitalsDay
-        let hrv = d?.avgHrv ?? vd?.avgHrv
-        let rhr = d?.restingHr ?? vd?.restingHr
+        let hrv = d?.avgHrv ?? hd?.avgHrv
+        let rhr = d?.restingHr ?? rd?.restingHr
         let resp = d?.respRateBpm ?? vd?.respRateBpm
         // The provenance row a shown vital fell back to (nil when every shown vital is today's own): stamps
         // that row's own date, so the footnote can't claim "Last night" for a value that IS today's.
-        let carriedFromHrv = d?.avgHrv == nil && vd?.avgHrv != nil
-        let carriedFromRhr = d?.restingHr == nil && vd?.restingHr != nil
-        let carriedFromResp = d?.respRateBpm == nil && vd?.respRateBpm != nil
-        let provenance: DailyMetric? = (carriedFromHrv || carriedFromRhr || carriedFromResp) ? vd : nil
+        // Each vital can now carry from a DIFFERENT row, so the one card-level footnote stamps the OLDEST
+        // row any SHOWN carried vital came from. Erring old is the only safe direction for a caption whose
+        // job is to stop a stale read passing as today's, and it keeps `carriedCaption`'s "Latest sleep"
+        // relabel (#779) firing on the value that actually is weeks old. A row is only a source if it
+        // SUPPLIED the value — `vd` can hold a nil respiratory, which carries nothing and stamps nothing.
+        let carriedFromHrv: DailyMetric? = (d?.avgHrv == nil && hd?.avgHrv != nil) ? hd : nil
+        let carriedFromRhr: DailyMetric? = (d?.restingHr == nil && rd?.restingHr != nil) ? rd : nil
+        let carriedFromResp: DailyMetric? = (d?.respRateBpm == nil && vd?.respRateBpm != nil) ? vd : nil
+        let sources: [DailyMetric] = [carriedFromHrv, carriedFromRhr, carriedFromResp].compactMap { $0 }
+        let provenance: DailyMetric? = sources.min(by: { $0.day < $1.day })
         NoopCard(tint: StrandPalette.chargeColor) {
             VStack(spacing: 0) {
                 // DEBUG promo harness: pin HRV / Resting HR to the active frame's values. No-op otherwise.

--- a/android/app/src/main/java/com/noop/analytics/SkinTempDisplay.kt
+++ b/android/app/src/main/java/com/noop/analytics/SkinTempDisplay.kt
@@ -64,11 +64,15 @@ object SkinTempDisplay {
         } else {
             value
         }
-        return if (kind == Kind.ABSOLUTE) {
-            String.format(java.util.Locale.US, "%.${decimals}f", display)
-        } else {
-            String.format(java.util.Locale.US, "%+.${decimals}f", display)
+        if (kind == Kind.ABSOLUTE) {
+            return String.format(java.util.Locale.US, "%.${decimals}f", display)
         }
+        val signed = String.format(java.util.Locale.US, "%+.${decimals}f", display)
+        // #1842: a deviation that ROUNDS to zero must not keep its sign. `%+` prints "-0.0" for anything
+        // in (-0.05, 0), and "-0.0 Δ°C" on a card reads as a fault rather than as "no change from your
+        // baseline" — which is exactly what it means. Drop the sign only when the rounded value is zero;
+        // a real -0.1 keeps it.
+        return if (signed.drop(1).toDoubleOrNull() == 0.0) signed.drop(1) else signed
     }
 
     /** Full `"34.2 °C"` / `"+0.1 Δ°C"` string for one-shot call sites (Today cards, explorers). */

--- a/android/app/src/main/java/com/noop/ui/LogicalDay.kt
+++ b/android/app/src/main/java/com/noop/ui/LogicalDay.kt
@@ -117,6 +117,19 @@ internal fun lastVitalsRow(days: List<DailyMetric>, todayKey: String): DailyMetr
 internal fun lastSpo2Row(days: List<DailyMetric>, todayKey: String): DailyMetric? =
     days.lastOrNull { it.spo2Pct != null && it.day < todayKey }
 
+/**
+ * PER-FIELD twin of [lastVitalsRow] for HRV. [lastVitalsRow]'s predicate is an OR across HRV /
+ * resting-HR / respiratory, so it can select a row that has respRateBpm and a NULL avgHrv while an older
+ * row holds a real HRV — the card then reads null and prints "No Data" beside a tile showing a value
+ * (#1842). Same `it.day < todayKey` future-clock guard as its siblings.
+ */
+internal fun lastHrvRow(days: List<DailyMetric>, todayKey: String): DailyMetric? =
+    days.lastOrNull { it.avgHrv != null && it.day < todayKey }
+
+/** PER-FIELD twin of [lastVitalsRow] for resting heart rate. See [lastHrvRow]. */
+internal fun lastRestingHrRow(days: List<DailyMetric>, todayKey: String): DailyMetric? =
+    days.lastOrNull { it.restingHr != null && it.day < todayKey }
+
 /** PER-FIELD twin of [lastVitalsRow] for skin temperature deviation. See [lastSpo2Row]. */
 internal fun lastSkinTempRow(days: List<DailyMetric>, todayKey: String): DailyMetric? =
     days.lastOrNull { it.skinTempDevC != null && it.day < todayKey }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1021,6 +1021,14 @@ fun TodayScreen(
     val lastSkinTempDay: DailyMetric? = remember(days, carryOverTodayKey, selectedDayOffset, displayMetric) {
         if (selectedDayOffset == 0) lastSkinTempRow(days, maxOf(displayMetric?.day ?: "", carryOverTodayKey)) else null
     }
+    // #1842: per-field HRV / resting-HR carries, the twins of the SpO₂ and skin-temp rows above. Same
+    // shape, same future-clock bound; see lastHrvRow for why the shared lastVitalsRow is not enough.
+    val lastHrvDay: DailyMetric? = remember(days, carryOverTodayKey, selectedDayOffset, displayMetric) {
+        if (selectedDayOffset == 0) lastHrvRow(days, maxOf(displayMetric?.day ?: "", carryOverTodayKey)) else null
+    }
+    val lastRestingHrDay: DailyMetric? = remember(days, carryOverTodayKey, selectedDayOffset, displayMetric) {
+        if (selectedDayOffset == 0) lastRestingHrRow(days, maxOf(displayMetric?.day ?: "", carryOverTodayKey)) else null
+    }
     // PER-FIELD respiratory carry (#1331): the freshest strictly-prior row that actually HAS a breaths/min,
     // since lastVitalsDay can land on a night with HRV/RHR but no respiratory. Twin of lastSpo2Day.
     val lastRespDay: DailyMetric? = remember(days, carryOverTodayKey, selectedDayOffset, displayMetric) {
@@ -1619,6 +1627,8 @@ fun TodayScreen(
                             vitalsDay = lastVitalsDay,
                             spo2Day = lastSpo2Day,
                             skinTempDay = lastSkinTempDay,
+                            hrvDay = lastHrvDay,
+                            rhrDay = lastRestingHrDay,
                             respDay = lastRespDay,
                             stress = stressToday,
                             fitnessAge = fitnessAgeToday,
@@ -3295,6 +3305,8 @@ private fun YourCardsSection(
     vitalsDay: DailyMetric?,
     spo2Day: DailyMetric?,
     skinTempDay: DailyMetric?,
+    hrvDay: DailyMetric?,
+    rhrDay: DailyMetric?,
     respDay: DailyMetric?,
     stress: Double?,
     fitnessAge: Double?,
@@ -3337,6 +3349,8 @@ private fun YourCardsSection(
                         vitalsDay = vitalsDay,
                         spo2Day = spo2Day,
                         skinTempDay = skinTempDay,
+                        hrvDay = hrvDay,
+                        rhrDay = rhrDay,
                         respDay = respDay,
                         fahrenheit = fahrenheit,
                         stress = stress,
@@ -3542,6 +3556,8 @@ private fun dashboardCardValue(
     vitalsDay: DailyMetric?,
     spo2Day: DailyMetric?,
     skinTempDay: DailyMetric?,
+    hrvDay: DailyMetric?,
+    rhrDay: DailyMetric?,
     respDay: DailyMetric?,
     stress: Double?,
     fitnessAge: Double?,
@@ -3562,16 +3578,19 @@ private fun dashboardCardValue(
     val vd = carriedDay ?: day
 
     return when (card) {
-        // #1842: the CARRIED day is in the chain, matching the Key Metrics tile a section above
-        // (`d?.avgHrv ?: carriedDay?.avgHrv`). Without it the tile carried last night's value while the
-        // card for the same metric read "No data" on the same screen — and tapping that card opened a
-        // detail screen full of graph, because the detail reads history directly. The Blood Oxygen branch
-        // below already states this precedence as deliberate; HRV and Resting HR were simply missed.
+        // #1842: PER-FIELD carry, the fourth of these. `lastVitalsRow`'s predicate is an OR across
+        // HRV / resting-HR / respiratory, so it can select a row that has respRateBpm and a NULL avgHrv —
+        // and the card then reads null and prints "No data" while the tile, carrying a different row,
+        // shows a value. That is the same failure `lastSpo2Row` and `lastSkinTempRow` were split out to
+        // fix ("can select a row whose spo2Pct is null … while an OLDER row has a real reading"); HRV and
+        // resting HR were the two left on the shared predicate.
+        //
+        // Deliberately NOT the recovery-scored carry: the comment on `lastVitalsDay` is explicit that
+        // vitals must not fall back to an older recovery-scored day.
         DashboardCard.HRV ->
-            withUnit((day?.avgHrv ?: vd?.avgHrv ?: vitalsDay?.avgHrv)?.let { it.roundToInt().toString() }
-                ?: NO_DATA)
+            withUnit((day?.avgHrv ?: hrvDay?.avgHrv)?.let { it.roundToInt().toString() } ?: NO_DATA)
         DashboardCard.RESTING_HR ->
-            withUnit((day?.restingHr ?: vd?.restingHr ?: vitalsDay?.restingHr)?.toString() ?: NO_DATA)
+            withUnit((day?.restingHr ?: rhrDay?.restingHr)?.toString() ?: NO_DATA)
         DashboardCard.RESPIRATORY ->
             // PER-FIELD carry: today → the STALENESS-BOUNDED `respDay` (lastRespRow). The unbounded
             // `vitalsDay?.respRateBpm` is dropped on purpose (see the gauge site + Swift `lastRespDay`):

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3562,10 +3562,16 @@ private fun dashboardCardValue(
     val vd = carriedDay ?: day
 
     return when (card) {
+        // #1842: the CARRIED day is in the chain, matching the Key Metrics tile a section above
+        // (`d?.avgHrv ?: carriedDay?.avgHrv`). Without it the tile carried last night's value while the
+        // card for the same metric read "No data" on the same screen — and tapping that card opened a
+        // detail screen full of graph, because the detail reads history directly. The Blood Oxygen branch
+        // below already states this precedence as deliberate; HRV and Resting HR were simply missed.
         DashboardCard.HRV ->
-            withUnit((day?.avgHrv ?: vitalsDay?.avgHrv)?.let { it.roundToInt().toString() } ?: NO_DATA)
+            withUnit((day?.avgHrv ?: vd?.avgHrv ?: vitalsDay?.avgHrv)?.let { it.roundToInt().toString() }
+                ?: NO_DATA)
         DashboardCard.RESTING_HR ->
-            withUnit((day?.restingHr ?: vitalsDay?.restingHr)?.toString() ?: NO_DATA)
+            withUnit((day?.restingHr ?: vd?.restingHr ?: vitalsDay?.restingHr)?.toString() ?: NO_DATA)
         DashboardCard.RESPIRATORY ->
             // PER-FIELD carry: today → the STALENESS-BOUNDED `respDay` (lastRespRow). The unbounded
             // `vitalsDay?.respRateBpm` is dropped on purpose (see the gauge site + Swift `lastRespDay`):

--- a/android/app/src/test/java/com/noop/analytics/SkinTempDisplayTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SkinTempDisplayTest.kt
@@ -106,4 +106,20 @@ class SkinTempDisplayTest {
         assertEquals(SkinTempDisplay.Kind.DEVIATION, SkinTempDisplay.kind(unfilteredMean))
         assertTrue(kotlin.math.abs(kept.average()) < 0.3)
     }
+
+    /**
+     * #1842: a deviation that rounds to zero must not carry a sign. `%+` prints "-0.0" for anything in
+     * (-0.05, 0), and the Today card showed "-0.0 Δ°C" — which reads as a fault rather than as "no change
+     * from your baseline". A real -0.1 must still keep its sign.
+     */
+    @Test fun aDeviationRoundingToZeroLosesItsSign() {
+        assertEquals("0.0", SkinTempDisplay.numberString(-0.04, SkinTempDisplay.Kind.DEVIATION, false))
+        assertEquals("0.0", SkinTempDisplay.numberString(0.0, SkinTempDisplay.Kind.DEVIATION, false))
+        assertEquals("0.0", SkinTempDisplay.numberString(0.04, SkinTempDisplay.Kind.DEVIATION, false))
+        // Real deviations keep theirs.
+        assertEquals("-0.1", SkinTempDisplay.numberString(-0.1, SkinTempDisplay.Kind.DEVIATION, false))
+        assertEquals("+0.1", SkinTempDisplay.numberString(0.1, SkinTempDisplay.Kind.DEVIATION, false))
+        // Absolute readings were never signed and must be untouched.
+        assertEquals("34.2", SkinTempDisplay.numberString(34.2, SkinTempDisplay.Kind.ABSOLUTE, false))
+    }
 }

--- a/android/app/src/test/java/com/noop/ui/LastHrvRowTest.kt
+++ b/android/app/src/test/java/com/noop/ui/LastHrvRowTest.kt
@@ -1,0 +1,58 @@
+package com.noop.ui
+
+import com.noop.data.DailyMetric
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #1842: per-field HRV / resting-HR carries, the twins of [lastSpo2Row] and [lastSkinTempRow].
+ *
+ * [lastVitalsRow]'s predicate is an OR across HRV / resting-HR / respiratory, so it selects the freshest
+ * row having ANY of them — which can be a row whose `avgHrv` is null. The HRV card then read null and
+ * printed "No data" while the Key Metrics tile, carrying a different row, showed a value on the same
+ * screen. Same failure the SpO₂ and skin-temp twins were split out to fix.
+ */
+class LastHrvRowTest {
+
+    private fun day(d: String, hrv: Double? = null, rhr: Int? = null, resp: Double? = null) =
+        DailyMetric(deviceId = "my-whoop", day = d, restingHr = rhr, avgHrv = hrv, respRateBpm = resp)
+
+    /** The reported shape: the freshest row has respiratory only, so the shared predicate picks it and
+     *  its null avgHrv becomes "No data" — while a real HRV sits one row back. */
+    @Test
+    fun sharedPredicatePicksARowWithNoHrv() {
+        val days = listOf(day("2026-09-01", hrv = 35.0, rhr = 58), day("2026-09-02", resp = 14.2))
+
+        // The bug, pinned: lastVitalsRow selects the respiratory-only row and yields no HRV.
+        assertEquals("2026-09-02", lastVitalsRow(days, todayKey = "2026-09-03")?.day)
+        assertNull(lastVitalsRow(days, todayKey = "2026-09-03")?.avgHrv)
+
+        // The per-field resolvers find the row that actually holds each value.
+        assertEquals(35.0, lastHrvRow(days, todayKey = "2026-09-03")?.avgHrv)
+        assertEquals(58, lastRestingHrRow(days, todayKey = "2026-09-03")?.restingHr)
+    }
+
+    /** Freshest wins when several rows carry the field. */
+    @Test
+    fun theFreshestRowWithTheFieldIsChosen() {
+        val days = listOf(day("2026-09-01", hrv = 30.0), day("2026-09-02", hrv = 41.0))
+        assertEquals(41.0, lastHrvRow(days, todayKey = "2026-09-03")?.avgHrv)
+    }
+
+    /** Same future-clock guard as its siblings: strictly prior to today's key, never today or later. */
+    @Test
+    fun todayAndLaterRowsAreNeverCarried() {
+        val days = listOf(day("2026-09-03", hrv = 44.0), day("2026-09-04", hrv = 45.0))
+        assertNull(lastHrvRow(days, todayKey = "2026-09-03"))
+        assertNull(lastRestingHrRow(days, todayKey = "2026-09-03"))
+    }
+
+    /** Nothing anywhere stays "No data" — the carry must never invent a value. */
+    @Test
+    fun noRowWithTheFieldCarriesNothing() {
+        val days = listOf(day("2026-09-01", resp = 15.0), day("2026-09-02", resp = 14.0))
+        assertNull(lastHrvRow(days, todayKey = "2026-09-03"))
+        assertNull(lastRestingHrRow(days, todayKey = "2026-09-03"))
+    }
+}


### PR DESCRIPTION
Reported on #1842: the HRV and Resting HR cards read "No data" while tapping through to the same metric graphs a value, and Skin Temp showed `-0.0 Δ°C`.

## The cards

My first attempt at this was wrong, and the code said so. It put the recovery-scored carry into the card's chain; a comment 500 lines up exists specifically to forbid that:

> re-analysis that nulls last night's recovery while preserving its avgHrv/restingHr must **NOT** fall back to an OLDER recovery-scored day for the vitals (that's the tile-vs-card mismatch …)

`lastVitalsDay` was written to fix that mismatch and is deliberately kept separate from `lastScoredRecoveryDay`. That version would have reintroduced the thing the comment was written to prevent, and it would have looked like it worked.

The real cause is one level in. The predicate is an **OR**:

```
(avgHrv != null || restingHr != null || respRateBpm != null) && day < todayKey
```

so it resolves the freshest row carrying *any* of the three — including a respiratory-only row whose `avgHrv` is null. The card reads that null and prints "No data" while the tile, carrying a different row, shows a value on the same screen.

That is verbatim the failure `lastSpo2Row` and `lastSkinTempRow` were split out to fix — *"can select a row whose spo2Pct is null … while an OLDER row has a real reading"*. HRV and resting HR were the two fields left on the shared predicate. `lastHrvRow`/`lastHrvDay` and `lastRestingHrRow`/`lastRestingHrDay` are the fourth and fifth per-field twins, same shape and same future-clock bound.

## Parity

Apple has the same OR predicate, on three live surfaces: `TodayView.recoveryVitalsCard`, and both `recoveryVitalsSection` and `keyMetricsSection` on Liquid.

`TodayView.dashboardValue` turned out **worse than the Android card that was reported**. Its `.hrv` and `.restingHr` cases had no carry at all — today's row or "—" — while `.respiratory`, `.bloodOxygen` and `.skinTemp` beside them all carry, and the Key Metrics tile has carried via `carriedVital(perField:)` the whole time. Same reported symptom, different cause, so it would have survived a fix that only ported the Android change.

Two judgement calls worth flagging:

- **Not staleness-bounded**, and the doc says why so it doesn't get "fixed" later. Respiratory took a hard `vitalCarryDays` bound because one CSV import's 15.6 read as today's for a fortnight (#1331); HRV/RHR disclose age through the caption instead, since `carriedCaption` relabels a weeks-old carry to "Latest sleep" (#779). Bounding them here would blank values that currently render.
- **The provenance footnote.** One card-level caption now covers vitals that can come from different rows, so it stamps the **oldest** row any shown carried vital came from — erring old is the only safe direction for a caption whose job is to stop a stale read passing as today's, and it keeps the "Latest sleep" relabel firing on the value that actually is weeks old. A row counts only if it *supplied* the value; `lastVitalsDay` can hold a null respiratory, which carries nothing and stamps nothing.

## Skin Temp

`-0.0 Δ°C` was a signed zero: a deviation that rounds to zero from below keeps its minus through `%+.1f`. Both platforms re-read the formatted string and drop the sign when the magnitude is zero, so it renders `0.0` — an unsigned zero, not a fake positive.

## Verification

- Kotlin: full suite **5098 / 0**, four new cases in `LastHrvRowTest`; `compileFullDebugKotlin` clean.
- Swift: GRDB's CSQLite will not build on Linux, so the four XCTest cases are unrun until app-build. They were exercised here by extracting the five selector bodies **verbatim** into an isolated harness against identical fixtures to the Kotlin — all pass, so the twins agree behaviourally.
- Doc-comment and i18n gates clean.

The tests pin the **bug** as well as the fix: each asserts that `lastVitalsRow`/`lastVitalsDay` picks the respiratory-only row and yields no HRV, so a future simplification back onto the shared predicate fails in CI rather than in the field.