### PR TITLE
today: lead skin temp with the measured temperature, with a Settings choice (#1844, #1846)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SkinTempDisplay.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SkinTempDisplay.swift
@@ -64,11 +64,19 @@ public enum SkinTempDisplay {
     ///    (~4 nights) while the absolute is measured from night one, so those wearers otherwise see an
     ///    empty card with a real temperature sitting behind it.
     ///
+    /// `prefer` is the user's Settings choice (#1846): `.absolute` — the default, a temperature — or
+    /// `.deviation` for wearers who read the ±baseline move, which is the more sensitive illness signal. It
+    /// picks which number is tried FIRST; the other is still the fallback, so choosing one never blanks a
+    /// card whose night only measured the other, and the unit always names the scale actually shown.
+    ///
     /// Both values must come from the SAME row; see `DailyMetric.lastSkinTempReadingDay`. Twin of the
     /// Kotlin `SkinTempDisplay.leadReading`.
-    public static func leadReading(absC: Double?, devC: Double?) -> Reading? {
-        if let a = absC { return Reading(value: a, kind: .absolute) }
-        if let d = devC { return Reading(value: d, kind: .deviation) }
+    public static func leadReading(absC: Double?, devC: Double?, prefer: Kind = .absolute) -> Reading? {
+        let first = prefer == .absolute ? absC : devC
+        if let f = first { return Reading(value: f, kind: prefer) }
+        let other = prefer == .absolute ? devC : absC
+        let otherKind: Kind = prefer == .absolute ? .deviation : .absolute
+        if let o = other { return Reading(value: o, kind: otherKind) }
         return nil
     }
 

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SkinTempDisplay.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SkinTempDisplay.swift
@@ -42,6 +42,42 @@ public enum SkinTempDisplay {
         values.last.map(kind(of:))
     }
 
+    /// A resolved reading: the number to show and the scale it is on.
+    public struct Reading: Sendable, Equatable {
+        public let value: Double
+        public let kind: Kind
+        public init(value: Double, kind: Kind) { self.value = value; self.kind = kind }
+    }
+
+    /// Which of a night's two skin-temp numbers a surface should LEAD with (#1844), the pure form of the
+    /// rule the Health tile has applied since #1665.
+    ///
+    /// The absolute wins whenever the night measured one, because a deviation with no anchor cannot be
+    /// read — "+0.9" is a fever or a warm bedroom and nothing on a card says which. The deviation is the
+    /// fallback, not the default, and keeps its Δ unit so it is never mistaken for a wrist temperature
+    /// (#622).
+    ///
+    /// Two shapes make this more than a preference, both real rows:
+    ///  - a night scored before `skinTempC` shipped (2026-08-27) has only a deviation, and keeps exactly
+    ///    the display that shipped before until a scoring pass refills it;
+    ///  - a CALIBRATING night is the reverse — the deviation is nil until the baseline is usable
+    ///    (~4 nights) while the absolute is measured from night one, so those wearers otherwise see an
+    ///    empty card with a real temperature sitting behind it.
+    ///
+    /// Both values must come from the SAME row; see `DailyMetric.lastSkinTempReadingDay`. Twin of the
+    /// Kotlin `SkinTempDisplay.leadReading`.
+    public static func leadReading(absC: Double?, devC: Double?) -> Reading? {
+        if let a = absC { return Reading(value: a, kind: .absolute) }
+        if let d = devC { return Reading(value: d, kind: .deviation) }
+        return nil
+    }
+
+    /// Formats whichever number `leadReading` chose, with the unit for THAT scale.
+    public static func formatReading(_ reading: Reading, fahrenheit: Bool, decimals: Int = 1) -> String {
+        let n = numberString(reading.value, kind: reading.kind, fahrenheit: fahrenheit, decimals: decimals)
+        return "\(n) \(unitSymbol(kind: reading.kind, fahrenheit: fahrenheit))"
+    }
+
     /// Trailing unit chip: `"°C"` / `"°F"` for absolute, `"Δ°C"` / `"Δ°F"` for deviation.
     public static func unitSymbol(kind: Kind, fahrenheit: Bool) -> String {
         let base = fahrenheit ? "°F" : "°C"

--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -153,6 +153,19 @@ public struct DailyMetric: Equatable, Codable {
         days.last(where: { $0.skinTempDevC != nil && $0.day < todayKey })
     }
 
+    /// The freshest strictly-prior row carrying EITHER skin-temp number (#1844), so a surface can lead
+    /// with the absolute and fall back to the deviation from ONE night rather than mixing two.
+    ///
+    /// The OR here is deliberate and is NOT the #1842 defect. That bug read field X off a row selected on
+    /// (X or Y), so a row holding only Y blanked X. This selects a row for a value that is "whichever of
+    /// the two this night has", and the caller reads both fields off THAT row and lets
+    /// `SkinTempDisplay.leadReading` pick — so the chosen row always supplies the number shown, and an
+    /// absolute is never paired with another night's deviation. `lastSkinTempDay` stays as-is for the
+    /// deviation-only surfaces. Byte-twin of the Android `lastSkinTempReadingRow`.
+    public nonisolated static func lastSkinTempReadingDay(days: [DailyMetric], todayKey: String) -> DailyMetric? {
+        days.last(where: { ($0.skinTempC != nil || $0.skinTempDevC != nil) && $0.day < todayKey })
+    }
+
     /// PER-FIELD HRV carry — the twin of `lastSpo2Day` for a field `lastVitalsDay` DOES check, which is
     /// precisely why it needs one. That predicate is an OR across HRV / resting-HR / respiratory, so it
     /// resolves the freshest row carrying ANY of the three — including a respiratory-only row whose

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/DailyMetricLastVitalsDayTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/DailyMetricLastVitalsDayTests.swift
@@ -194,4 +194,42 @@ final class DailyMetricLastVitalsDayTests: XCTestCase {
         XCTAssertNil(DailyMetric.lastRestingHrDay(days: days, todayKey: "2026-09-03"))
     }
 
+
+    // MARK: skin-temp reading row — EITHER number, one night (#1844)
+
+    private func skinDay(_ key: String, abs: Double? = nil, dev: Double? = nil) -> DailyMetric {
+        DailyMetric(day: key, totalSleepMin: nil, efficiency: nil, deepMin: nil, remMin: nil,
+                    lightMin: nil, disturbances: nil, restingHr: nil, avgHrv: nil, recovery: nil,
+                    strain: nil, exerciseCount: nil, spo2Pct: nil, skinTempDevC: dev,
+                    respRateBpm: nil, skinTempC: abs)
+    }
+
+    /// The calibrating night the deviation-only selector skipped: a real temperature, no deviation yet.
+    func testFindsANightWithOnlyAnAbsolute() {
+        let days = [skinDay("2026-09-01", dev: -0.3), skinDay("2026-09-02", abs: 34.1)]
+        XCTAssertEqual(DailyMetric.lastSkinTempReadingDay(days: days, todayKey: "2026-09-03")?.day, "2026-09-02")
+        // The deviation-only row reaches back past it, which is what left the card empty.
+        XCTAssertEqual(DailyMetric.lastSkinTempDay(days: days, todayKey: "2026-09-03")?.day, "2026-09-01")
+    }
+
+    /// Both numbers come off ONE row, so an absolute is never paired with another night's deviation.
+    func testBothSkinNumbersComeFromOneNight() {
+        let days = [skinDay("2026-09-01", abs: 33.0, dev: -0.9), skinDay("2026-09-02", abs: 34.1, dev: 0.2)]
+        let row = DailyMetric.lastSkinTempReadingDay(days: days, todayKey: "2026-09-03")
+        XCTAssertEqual(row?.skinTempC, 34.1)
+        XCTAssertEqual(row?.skinTempDevC, 0.2)
+    }
+
+    /// Same future-clock bound as every sibling carry.
+    func testSkinReadingRowNeverCarriesTodayOrLater() {
+        let days = [skinDay("2026-09-03", abs: 34.0), skinDay("2026-09-04", abs: 34.2)]
+        XCTAssertNil(DailyMetric.lastSkinTempReadingDay(days: days, todayKey: "2026-09-03"))
+    }
+
+    /// A row with neither number is not a reading.
+    func testSkinRowsWithNeitherNumberAreSkipped() {
+        let days = [skinDay("2026-09-01", abs: 33.5), skinDay("2026-09-02")]
+        XCTAssertEqual(DailyMetric.lastSkinTempReadingDay(days: days, todayKey: "2026-09-03")?.day, "2026-09-01")
+    }
+
 }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -608,6 +608,12 @@ final class Repository: ObservableObject {
         DailyMetric.lastSkinTempDay(days: days, todayKey: todayKey)
     }
 
+    /// The freshest strictly-prior row with EITHER skin-temp number (#1844), for the surfaces that lead
+    /// with the absolute. See `DailyMetric.lastSkinTempReadingDay`.
+    nonisolated static func lastSkinTempReadingDay(days: [DailyMetric], todayKey: String) -> DailyMetric? {
+        DailyMetric.lastSkinTempReadingDay(days: days, todayKey: todayKey)
+    }
+
     /// PER-FIELD HRV carry — twin of the above, for a field `lastVitalsDay`'s OR predicate DOES check but
     /// can still resolve nil on (#1842). See `DailyMetric.lastHrvDay`.
     nonisolated static func lastHrvDay(days: [DailyMetric], todayKey: String) -> DailyMetric? {

--- a/Strand/Data/Units.swift
+++ b/Strand/Data/Units.swift
@@ -85,6 +85,11 @@ enum UnitPrefs {
     static let systemKey = "units.system"
     /// Temperature override. Empty string = "match the length/mass system" (the default).
     static let temperatureKey = "units.temperature"
+
+    /// #1846: which skin-temp number the cards lead with — absent/`""` = a temperature (the default), or
+    /// `SkinTempDisplay.Kind.deviation.rawValue` to lead with the ±baseline move. Display-only; nothing
+    /// stored ever changes. Same key string as the Android `units.skinTempDisplay` pref.
+    static let skinTempDisplayKey = "units.skinTempDisplay"
     /// Effort display scale (#268). Stored raw is an `EffortScale` rawValue; an unset/unknown value
     /// resolves to `.hundred` (NOOP's native axis). Mirrored on Android by NoopPrefs("effort.scale").
     static let effortScaleKey = "effort.scale"

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -116,6 +116,7 @@ struct LiquidTodayView: View {
     @State private var cachedRespDay: DailyMetric?
     @State private var cachedHrvDay: DailyMetric?
     @State private var cachedRestingHrDay: DailyMetric?
+    @State private var cachedSkinTempReadingDay: DailyMetric?
     /// The Charge hero's resolved state (#543 carry + the honest label), resolved ONCE in load() alongside
     /// the other caches. It composes `TodayView.lastScoredRecoveryDay`, which is O(days) — exactly the scan
     /// this cache exists to keep out of body. Never resolved in body.
@@ -188,6 +189,16 @@ struct LiquidTodayView: View {
     private var hrvDay: DailyMetric? { cachedHrvDay }
 
     private var restingHrDay: DailyMetric? { cachedRestingHrDay }
+
+    /// The skin-temp reading these cards LEAD with (#1844): today's row if it holds either number, else the
+    /// vitals carry, else the freshest prior row with either. Both numbers come off the SAME row, so an
+    /// absolute is never paired with another night's deviation. Twin of `TodayView.skinTempLeadReading`.
+    private var skinTempLeadReading: SkinTempDisplay.Reading? {
+        let row = [displayDay, vitalsDay, cachedSkinTempReadingDay]
+            .compactMap { $0 }
+            .first { $0.skinTempC != nil || $0.skinTempDevC != nil }
+        return SkinTempDisplay.leadReading(absC: row?.skinTempC, devC: row?.skinTempDevC)
+    }
     /// The Charge hero's resolved state (see `cachedChargeDisplay`), read O(1) from the cache.
     private var chargeDisplay: ChargeDisplay { cachedChargeDisplay }
 
@@ -941,7 +952,8 @@ struct LiquidTodayView: View {
             //
             // frac stays nil deliberately. A signed deviation has no natural 0–100 fill, and a ring drawn
             // from one would imply a magnitude the number does not carry.
-            let skin = displayDay?.skinTempDevC ?? vitalsDay?.skinTempDevC
+            // #1844: lead with the night's measured ABSOLUTE when it has one; deviation nights unchanged.
+            let skin = skinTempLeadReading
             cardLink(.metric("skin_temp"), title: card.title, sub: card.subtitle,
                      value: TodayView.skinTempCardValue(skin, fahrenheit: temperatureUnit == .fahrenheit),
                      tint: StrandPalette.metricAmber, frac: nil)
@@ -1245,10 +1257,9 @@ struct LiquidTodayView: View {
             // and the SAME `SkinTempDisplay` formatter every other skin-temp surface uses so a deviation
             // reads "+0.1 Δ°C" here exactly as it does on "Your Cards"/the Deep Timeline, never the plain
             // `%+.1f°` that read a fabricated absolute value for a signed deviation (#622).
-            let skinValue = displayDay?.skinTempDevC ?? vitalsDay?.skinTempDevC
-            let skinText = skinValue.map {
-                SkinTempDisplay.format($0, fahrenheit: temperatureUnit == .fahrenheit)
-            } ?? "—"
+            // #1844: same lead-with-the-absolute resolution as "Your Cards" above, so the two agree.
+            let skinText = TodayView.skinTempCardValue(skinTempLeadReading,
+                                                       fahrenheit: temperatureUnit == .fahrenheit)
             // The card's own unit is deliberately empty — the value carries "°C"/"Δ°F" itself, same as
             // the classic TodayView Skin Temp card.
             ktile(String(localized: "Skin Temp"), icon: keyMetricIcon(metric), skinText, "", StrandPalette.metricAmber, nil, key: "skin_temp")
@@ -1447,6 +1458,7 @@ struct LiquidTodayView: View {
         cachedRespDay = (selectedDayOffset == 0) ? Repository.lastRespDay(days: repo.days, todayKey: tkey) : nil
         cachedHrvDay = (selectedDayOffset == 0) ? Repository.lastHrvDay(days: repo.days, todayKey: tkey) : nil
         cachedRestingHrDay = (selectedDayOffset == 0) ? Repository.lastRestingHrDay(days: repo.days, todayKey: tkey) : nil
+        cachedSkinTempReadingDay = (selectedDayOffset == 0) ? Repository.lastSkinTempReadingDay(days: repo.days, todayKey: tkey) : nil
         // Charge carry (#543) + the honest label, resolved here for the same reason as the two above: the
         // selector below scans repo.days. Calibration nights come from the SAME `RecoveryScorer` helper the
         // classic Today reads, so the two screens agree on when a wearer is genuinely mid-calibration

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -955,7 +955,7 @@ struct LiquidTodayView: View {
             // #1844: lead with the night's measured ABSOLUTE when it has one; deviation nights unchanged.
             let skin = skinTempLeadReading
             cardLink(.metric("skin_temp"), title: card.title, sub: card.subtitle,
-                     value: TodayView.skinTempCardValue(skin, fahrenheit: temperatureUnit == .fahrenheit),
+                     value: TodayView.skinTempCardValue(reading: skin, fahrenheit: temperatureUnit == .fahrenheit),
                      tint: StrandPalette.metricAmber, frac: nil)
         case .calories:
             // #616: show the resolved imported-first value and route to the matching detail source, like
@@ -1258,7 +1258,7 @@ struct LiquidTodayView: View {
             // reads "+0.1 Δ°C" here exactly as it does on "Your Cards"/the Deep Timeline, never the plain
             // `%+.1f°` that read a fabricated absolute value for a signed deviation (#622).
             // #1844: same lead-with-the-absolute resolution as "Your Cards" above, so the two agree.
-            let skinText = TodayView.skinTempCardValue(skinTempLeadReading,
+            let skinText = TodayView.skinTempCardValue(reading: skinTempLeadReading,
                                                        fahrenheit: temperatureUnit == .fahrenheit)
             // The card's own unit is deliberately empty — the value carries "°C"/"Δ°F" itself, same as
             // the classic TodayView Skin Temp card.

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -197,7 +197,8 @@ struct LiquidTodayView: View {
         let row = [displayDay, vitalsDay, cachedSkinTempReadingDay]
             .compactMap { $0 }
             .first { $0.skinTempC != nil || $0.skinTempDevC != nil }
-        return SkinTempDisplay.leadReading(absC: row?.skinTempC, devC: row?.skinTempDevC)
+        return SkinTempDisplay.leadReading(absC: row?.skinTempC, devC: row?.skinTempDevC,
+                                           prefer: SkinTempDisplay.Kind(rawValue: skinTempDisplayRaw) ?? .absolute)
     }
     /// The Charge hero's resolved state (see `cachedChargeDisplay`), read O(1) from the cache.
     private var chargeDisplay: ChargeDisplay { cachedChargeDisplay }
@@ -1779,6 +1780,7 @@ struct LiquidTodayView: View {
     @AppStorage(UnitPrefs.systemKey) private var unitSystemRaw = UnitSystem.metric.rawValue
     private var unitSystem: UnitSystem { UnitSystem(rawValue: unitSystemRaw) ?? .metric }
     @AppStorage(UnitPrefs.temperatureKey) private var temperatureRaw = ""
+    @AppStorage(UnitPrefs.skinTempDisplayKey) private var skinTempDisplayRaw = ""   // #1846
     private var temperatureUnit: TemperatureUnit {
         UnitPrefs.resolveTemperature(system: unitSystem, override: temperatureRaw)
     }

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -156400,6 +156400,64 @@
         }
       }
     },
+    "Skin temperature display": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hauttemperatur-Anzeige"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visualización de temperatura cutánea"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Affichage de la température cutanée"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visualizzazione temperatura cutanea"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyświetlanie temperatury skóry"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apresentação da temperatura da pele"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отображение температуры кожи"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "皮肤温度显示"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "皮膚溫度顯示"
+          }
+        }
+      }
+    },
     "Temperature unit": {
       "localizations": {
         "de": {

--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -1236,6 +1236,7 @@ private struct VitalsSection: View {
     // Temperature display preference (D#103). Skin temp is stored in °C (absolute or a ±deviation); the
     // toggle re-labels it to °F. Display-only — banding still runs on the stored °C value.
     @AppStorage(UnitPrefs.systemKey) private var unitSystemRaw = UnitSystem.metric.rawValue
+    @AppStorage(UnitPrefs.skinTempDisplayKey) private var skinTempDisplayRaw = ""   // #1846
     @AppStorage(UnitPrefs.temperatureKey) private var temperatureRaw = ""
     private var temperatureUnit: TemperatureUnit {
         let system = UnitSystem(rawValue: unitSystemRaw) ?? .metric
@@ -1253,7 +1254,8 @@ private struct VitalsSection: View {
             sourceRows: repo.vitalMetricRows,
             temperatureUnit: temperatureUnit,
             spo2CandidateByDay: spo2CandidateByDay,
-            hrvOverCountByDay: hrvOverCountByDay
+            hrvOverCountByDay: hrvOverCountByDay,
+            skinTempPreferred: SkinTempDisplay.Kind(rawValue: skinTempDisplayRaw) ?? .absolute   // #1846
         )
         VStack(alignment: .leading, spacing: NoopMetrics.gap) {
             SectionHeader("Vital Signs", overline: "Latest", trailing: BodyVitalSigns.latestDayLabel(readings))

--- a/Strand/Screens/SettingsView.swift
+++ b/Strand/Screens/SettingsView.swift
@@ -182,6 +182,7 @@ struct SettingsView: View {
     private var clockFormatRaw = ClockFormatPreference.system.rawValue
     @AppStorage(UnitPrefs.systemKey) private var unitSystemRaw = UnitSystem.metric.rawValue
     @AppStorage(UnitPrefs.temperatureKey) private var temperatureRaw = ""
+    @AppStorage(UnitPrefs.skinTempDisplayKey) private var skinTempDisplayRaw = ""   // #1846
     // Effort display scale (#268). Display-only — Effort stays stored 0–100, this only chooses whether
     // it's shown on NOOP's 0–100 axis or WHOOP's 0–21 Day Strain axis.
     @AppStorage(UnitPrefs.effortScaleKey) private var effortScaleRaw = EffortScale.hundred.rawValue
@@ -993,6 +994,20 @@ struct SettingsView: View {
                     .pickerStyle(.menu)
                     .tint(StrandPalette.accent)
                     .accessibilityLabel("Temperature unit")
+                }
+                rowDivider
+                FormRow(label: "Skin temperature") {
+                    // #1846: lead with a temperature ("33.5 °C") or with the move from your own baseline
+                    // ("-0.1 Δ°C"). Only a PREFERENCE — a night that measured just one of the two still
+                    // shows that one, so the choice can never blank a card.
+                    Picker("Skin temperature", selection: $skinTempDisplayRaw) {
+                        Text("Temperature").tag("")
+                        Text("vs baseline").tag(SkinTempDisplay.Kind.deviation.rawValue)
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .tint(StrandPalette.accent)
+                    .accessibilityLabel("Skin temperature display")
                 }
                 rowDivider
                 // Effort scale (#268) — show NOOP's native 0–100 Effort or WHOOP's 0–21 Day Strain axis.

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -227,6 +227,7 @@ struct TodayView: View {
     /// `MetricExplorerView`, Liquid Today): the explicit override when set, else derived from the unit
     /// system. This screen used to print a bare `%+.1f°` and was the last one ignoring the preference.
     @AppStorage(UnitPrefs.temperatureKey) private var temperatureRaw = ""
+    @AppStorage(UnitPrefs.skinTempDisplayKey) private var skinTempDisplayRaw = ""   // #1846
     private var temperatureUnit: TemperatureUnit {
         UnitPrefs.resolveTemperature(system: unitSystem, override: temperatureRaw)
     }
@@ -619,7 +620,14 @@ struct TodayView: View {
         let row = [displayDay, lastVitalsDay, lastSkinTempReadingDay]
             .compactMap { $0 }
             .first { $0.skinTempC != nil || $0.skinTempDevC != nil }
-        return SkinTempDisplay.leadReading(absC: row?.skinTempC, devC: row?.skinTempDevC)
+        return SkinTempDisplay.leadReading(absC: row?.skinTempC, devC: row?.skinTempDevC,
+                                           prefer: skinTempPreferred)
+    }
+
+    /// The user's Settings choice (#1846), resolved from the stored raw. Absent/unrecognised reads as
+    /// `.absolute`, so an install that never opens Settings behaves exactly as before the setting existed.
+    private var skinTempPreferred: SkinTempDisplay.Kind {
+        SkinTempDisplay.Kind(rawValue: skinTempDisplayRaw) ?? .absolute
     }
 
     /// PER-FIELD respiratory carry, and the only one of these that is STALENESS-BOUNDED

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -2652,7 +2652,7 @@ struct TodayView: View {
             // Same per-field carry as Blood Oxygen; both are sparse enough that an old reading is honest.
             // #1844: lead with the night's measured ABSOLUTE when it has one (the #1665 rule, applied
             // here too) — a deviation with no anchor cannot be read. Deviation-only nights are unchanged.
-            return Self.skinTempCardValue(skinTempLeadReading, fahrenheit: temperatureUnit == .fahrenheit)
+            return Self.skinTempCardValue(reading: skinTempLeadReading, fahrenheit: temperatureUnit == .fahrenheit)
         case .sleep:
             return sleepValue(d)
         case .steps:
@@ -3898,7 +3898,7 @@ struct TodayView: View {
             let skinTempValue = skinTempLeadReading
             StatTile(
                 label: "Skin Temp",
-                value: Self.skinTempCardValue(skinTempValue, fahrenheit: temperatureUnit == .fahrenheit),
+                value: Self.skinTempCardValue(reading: skinTempValue, fahrenheit: temperatureUnit == .fahrenheit),
                 caption: skinTempValue == nil ? Self.needsStrapCaption : "",
                 accent: skinTempValue == nil ? StrandPalette.textPrimary : StrandPalette.metricAmber,
                 sparkline: sparks["skin_temp"],
@@ -5010,7 +5010,7 @@ struct TodayView: View {
     /// numbers and `SkinTempDisplay.leadReading` picks, so a night that measured a real temperature shows
     /// one and only a night without falls back to the signed deviation. Nil (neither number anywhere in the
     /// carry chain) reads as an em-dash. The `Double?` sibling below stays for the deviation-only callers.
-    static func skinTempCardValue(_ reading: SkinTempDisplay.Reading?, fahrenheit: Bool) -> String {
+    static func skinTempCardValue(reading: SkinTempDisplay.Reading?, fahrenheit: Bool) -> String {
         guard let reading else { return "—" }
         return SkinTempDisplay.formatReading(reading, fahrenheit: fahrenheit)
     }

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -604,10 +604,22 @@ struct TodayView: View {
         return Repository.lastRestingHrDay(days: repo.days, todayKey: displayDay?.day ?? selectedDayKey)
     }
 
-    /// PER-FIELD skin-temperature-deviation carry — twin of `lastSpo2Day`; mirrors the Android `lastSkinTempRow`.
-    private var lastSkinTempDay: DailyMetric? {
+    /// The carry for the surfaces that LEAD WITH THE ABSOLUTE (#1844): the freshest strictly-prior row
+    /// holding EITHER skin-temp number, so a calibrating night — real temperature, no deviation yet — is
+    /// found instead of being skipped for an older deviation. Mirrors the Android `lastSkinTempReadingRow`.
+    private var lastSkinTempReadingDay: DailyMetric? {
         guard selectedDayOffset == 0 else { return nil }
-        return Repository.lastSkinTempDay(days: repo.days, todayKey: displayDay?.day ?? selectedDayKey)
+        return Repository.lastSkinTempReadingDay(days: repo.days, todayKey: displayDay?.day ?? selectedDayKey)
+    }
+
+    /// The skin-temp reading a Today surface leads with: today's row if it has either number, else the
+    /// carry. Both numbers always come off the SAME row, so an absolute is never paired with another
+    /// night's deviation.
+    private var skinTempLeadReading: SkinTempDisplay.Reading? {
+        let row = [displayDay, lastVitalsDay, lastSkinTempReadingDay]
+            .compactMap { $0 }
+            .first { $0.skinTempC != nil || $0.skinTempDevC != nil }
+        return SkinTempDisplay.leadReading(absC: row?.skinTempC, devC: row?.skinTempDevC)
     }
 
     /// PER-FIELD respiratory carry, and the only one of these that is STALENESS-BOUNDED
@@ -2638,9 +2650,9 @@ struct TodayView: View {
             // deviation, and converts a DELTA by the scale factor alone rather than the absolute formula.
             // The card's own unit is deliberately empty — the value carries "°C" / "Δ°F" itself.
             // Same per-field carry as Blood Oxygen; both are sparse enough that an old reading is honest.
-            return Self.skinTempCardValue(
-                d?.skinTempDevC ?? lastVitalsDay?.skinTempDevC ?? lastSkinTempDay?.skinTempDevC,
-                fahrenheit: temperatureUnit == .fahrenheit)
+            // #1844: lead with the night's measured ABSOLUTE when it has one (the #1665 rule, applied
+            // here too) — a deviation with no anchor cannot be read. Deviation-only nights are unchanged.
+            return Self.skinTempCardValue(skinTempLeadReading, fahrenheit: temperatureUnit == .fahrenheit)
         case .sleep:
             return sleepValue(d)
         case .steps:
@@ -3883,7 +3895,7 @@ struct TodayView: View {
             // already a "Your Cards" tile (`DashboardCard.skinTemp`), never a Key Metrics one. Reuses the
             // SAME value chain and `skinTempCardValue` formatter the "Your Cards" case above already
             // uses, so the two tiles can never disagree.
-            let skinTempValue = d?.skinTempDevC ?? lastVitalsDay?.skinTempDevC ?? lastSkinTempDay?.skinTempDevC
+            let skinTempValue = skinTempLeadReading
             StatTile(
                 label: "Skin Temp",
                 value: Self.skinTempCardValue(skinTempValue, fahrenheit: temperatureUnit == .fahrenheit),
@@ -4994,6 +5006,15 @@ struct TodayView: View {
 
     /// The Skin Temp card's value, extracted so the bimodal-column decision can be unit-tested without a
     /// live view. Nil (no reading anywhere in the carry chain) reads as an em-dash rather than a number.
+    /// The Skin Temp card's value when the surface LEADS WITH THE ABSOLUTE (#1844) — the row supplies both
+    /// numbers and `SkinTempDisplay.leadReading` picks, so a night that measured a real temperature shows
+    /// one and only a night without falls back to the signed deviation. Nil (neither number anywhere in the
+    /// carry chain) reads as an em-dash. The `Double?` sibling below stays for the deviation-only callers.
+    static func skinTempCardValue(_ reading: SkinTempDisplay.Reading?, fahrenheit: Bool) -> String {
+        guard let reading else { return "—" }
+        return SkinTempDisplay.formatReading(reading, fahrenheit: fahrenheit)
+    }
+
     static func skinTempCardValue(_ value: Double?, fahrenheit: Bool) -> String {
         guard let value else { return "—" }
         return SkinTempDisplay.format(value, fahrenheit: fahrenheit)

--- a/Strand/Screens/VitalSignsSummary.swift
+++ b/Strand/Screens/VitalSignsSummary.swift
@@ -133,7 +133,10 @@ enum BodyVitalSigns {
                          temperatureUnit: TemperatureUnit,
                          now: Date = Date(),
                          spo2CandidateByDay: [String: Double] = [:],
-                         hrvOverCountByDay: [String: Double] = [:]) -> [BodyVitalReading] {
+                         hrvOverCountByDay: [String: Double] = [:],
+                         // #1846: the Settings lead-with choice, so this tile agrees with Today and the
+                         // detail screen. A setting that reaches two of three surfaces is worse than none.
+                         skinTempPreferred: SkinTempDisplay.Kind = .absolute) -> [BodyVitalReading] {
         let logicalDay = logicalDayKey(now)
 
         // Resolve one metric to a per-day series, taking the FIRST source (by precedence) that carries
@@ -238,8 +241,14 @@ enum BodyVitalSigns {
         // sitting unshown behind it).
         let skinAbsCandidate = latest(skinAbsPoints)
         let skinRowDay: String? = [skinRowDeviation?.day, skinAbsCandidate?.day].compactMap { $0 }.max()
-        let skinAbsRow = skinAbsCandidate.flatMap { $0.day == skinRowDay ? $0 : nil }
-        let skinRow = skinAbsRow ?? skinRowDeviation
+        let skinAbsCandidateOnDay = skinAbsCandidate.flatMap { $0.day == skinRowDay ? $0 : nil }
+        // #1846: the same `leadReading` rule the other surfaces use — the preference picks which number is
+        // tried first, the other stays the fallback, so choosing one never empties the tile.
+        let skinLeadsAbsolute = SkinTempDisplay.leadReading(absC: skinAbsCandidateOnDay?.value,
+                                                            devC: skinRowDeviation?.value,
+                                                            prefer: skinTempPreferred)?.kind == .absolute
+        let skinAbsRow = skinLeadsAbsolute ? skinAbsCandidateOnDay : nil
+        let skinRow = skinAbsRow ?? skinRowDeviation ?? skinAbsCandidateOnDay
         let skin = skinRow?.value
         let skinIsAbsolute = skinAbsRow != nil || (skin.map(VitalBands.isAbsoluteSkinTemp) ?? true)
         // The series the tile is actually showing — banding and the sparkline must both read from it, or

--- a/android/app/src/main/java/com/noop/analytics/SkinTempDisplay.kt
+++ b/android/app/src/main/java/com/noop/analytics/SkinTempDisplay.kt
@@ -43,6 +43,35 @@ object SkinTempDisplay {
     fun kind(value: Double): Kind =
         if (VitalBands.isAbsoluteSkinTemp(value)) Kind.ABSOLUTE else Kind.DEVIATION
 
+    /** A resolved reading: the number to show and the scale it is on. */
+    data class Reading(val value: Double, val kind: Kind)
+
+    /**
+     * Which of a night's two skin-temp numbers a surface should LEAD with (#1844), the pure form of the
+     * rule `HealthVitalsLogic.skinTempLeadsWithAbsolute` has applied since #1665.
+     *
+     * The absolute wins whenever the night measured one, because a deviation with no anchor cannot be
+     * read — "+0.9" is a fever or a warm bedroom and nothing on a card says which. The deviation is the
+     * fallback, not the default, and it still carries its Δ unit so it is never mistaken for a wrist
+     * temperature (#622).
+     *
+     * Two shapes make this more than a preference, and both are real rows rather than hypotheticals:
+     *  - a night scored before `skinTempC` shipped (2026-08-27) has only a deviation, and keeps exactly
+     *    the display that shipped before until a scoring pass refills it;
+     *  - a CALIBRATING night is the reverse — `recomputeSkinTempDev` returns null until the baseline is
+     *    usable (~4 nights) while the absolute is measured from night one, so those wearers otherwise see
+     *    an empty card with a real temperature sitting behind it.
+     *
+     * Both values must come from the SAME row; see `lastSkinTempReadingRow`. Twin of the Swift
+     * `SkinTempDisplay.leadReading`.
+     */
+    fun leadReading(absC: Double?, devC: Double?): Reading? =
+        absC?.let { Reading(it, Kind.ABSOLUTE) } ?: devC?.let { Reading(it, Kind.DEVIATION) }
+
+    /** Formats whichever number [leadReading] chose, with the unit for THAT scale. */
+    fun formatReading(reading: Reading, fahrenheit: Boolean, decimals: Int = 1): String =
+        "${numberString(reading.value, reading.kind, fahrenheit, decimals)} ${unitSymbol(reading.kind, fahrenheit)}"
+
     /** Trailing unit chip: `"°C"` / `"°F"` for absolute, `"Δ°C"` / `"Δ°F"` for deviation. */
     fun unitSymbol(kind: Kind, fahrenheit: Boolean): String {
         val base = if (fahrenheit) "°F" else "°C"

--- a/android/app/src/main/java/com/noop/analytics/SkinTempDisplay.kt
+++ b/android/app/src/main/java/com/noop/analytics/SkinTempDisplay.kt
@@ -12,11 +12,22 @@ package com.noop.analytics
  */
 object SkinTempDisplay {
 
-    enum class Kind {
+    /**
+     * [raw] is the PERSISTED form of the #1846 setting and is byte-identical to the Swift `Kind.rawValue`
+     * — lower-case, so `name` ("DEVIATION") must never be written to prefs. Same reasoning as
+     * `KeyMetric.raw`: two independent implementations must not drift on how they spell a stored token,
+     * and this one shares the `units.skinTempDisplay` key with Apple.
+     */
+    enum class Kind(val raw: String) {
         /** Absolute wrist temperature (°C scale, typically ~30–35 worn). */
-        ABSOLUTE,
+        ABSOLUTE("absolute"),
         /** Signed deviation from the personal nightly baseline (±°C). */
-        DEVIATION,
+        DEVIATION("deviation"),
+        ;
+
+        companion object {
+            fun fromRaw(raw: String?): Kind? = entries.firstOrNull { it.raw == raw }
+        }
     }
 
     /**
@@ -62,11 +73,21 @@ object SkinTempDisplay {
      *    usable (~4 nights) while the absolute is measured from night one, so those wearers otherwise see
      *    an empty card with a real temperature sitting behind it.
      *
+     * [prefer] is the user's Settings choice (#1846): ABSOLUTE — the default, a temperature — or DEVIATION
+     * for wearers who read the ±baseline move, which is the more sensitive illness signal. It picks which
+     * number is tried FIRST; the other is still the fallback, so choosing one never blanks a card whose
+     * night only measured the other, and the unit always names the scale actually shown.
+     *
      * Both values must come from the SAME row; see `lastSkinTempReadingRow`. Twin of the Swift
      * `SkinTempDisplay.leadReading`.
      */
-    fun leadReading(absC: Double?, devC: Double?): Reading? =
-        absC?.let { Reading(it, Kind.ABSOLUTE) } ?: devC?.let { Reading(it, Kind.DEVIATION) }
+    fun leadReading(absC: Double?, devC: Double?, prefer: Kind = Kind.ABSOLUTE): Reading? {
+        val first = if (prefer == Kind.ABSOLUTE) absC else devC
+        first?.let { return Reading(it, prefer) }
+        val other = if (prefer == Kind.ABSOLUTE) devC else absC
+        val otherKind = if (prefer == Kind.ABSOLUTE) Kind.DEVIATION else Kind.ABSOLUTE
+        return other?.let { Reading(it, otherKind) }
+    }
 
     /** Formats whichever number [leadReading] chose, with the unit for THAT scale. */
     fun formatReading(reading: Reading, fahrenheit: Boolean, decimals: Int = 1): String =

--- a/android/app/src/main/java/com/noop/data/BackupSettings.kt
+++ b/android/app/src/main/java/com/noop/data/BackupSettings.kt
@@ -55,6 +55,7 @@ object BackupSettingsCodec {
         "profile.hrZoneThresholds" to Kind.STRING,
         "units.system" to Kind.STRING,
         "units.temperature" to Kind.STRING,
+        "units.skinTempDisplay" to Kind.STRING,   // #1846, carried like the other display units
         "effort.scale" to Kind.STRING,
         // The ONE layout pref carried (#today-hosted-cards): the Trends/Sleep cards the user chose to host
         // in Today, a JSON [String] of ids. Unlike section order, this is a deliberate composition the user
@@ -145,6 +146,11 @@ object BackupSettingsBridge {
         if (noop.contains(NoopPrefs.KEY_TEMPERATURE_UNIT)) {
             noop.getString(NoopPrefs.KEY_TEMPERATURE_UNIT, null)?.let { values["units.temperature"] = it }
         }
+        // #1846: carried like the other display units. The whitelist entry alone does NOTHING — export and
+        // import are both explicit per key here, so a whitelisted-but-unwired pref silently never restores.
+        if (noop.contains(NoopPrefs.KEY_SKIN_TEMP_DISPLAY)) {
+            noop.getString(NoopPrefs.KEY_SKIN_TEMP_DISPLAY, null)?.let { values["units.skinTempDisplay"] = it }
+        }
         if (noop.contains(UnitPrefs.KEY_EFFORT_SCALE)) {
             noop.getString(UnitPrefs.KEY_EFFORT_SCALE, null)?.let { values["effort.scale"] = it }
         }
@@ -184,6 +190,12 @@ object BackupSettingsBridge {
             // "" is the Apple side's "match the length/mass system"; here that state is key-absent.
             if (raw.isEmpty()) editor.remove(NoopPrefs.KEY_TEMPERATURE_UNIT)
             else editor.putString(NoopPrefs.KEY_TEMPERATURE_UNIT, raw)
+        }
+        (values["units.skinTempDisplay"] as? String)?.let { raw ->
+            // Absent/"" is "lead with a temperature", stored as key-absent — same convention as the
+            // temperature override above, and what an older backup without this key restores to.
+            if (raw.isEmpty()) editor.remove(NoopPrefs.KEY_SKIN_TEMP_DISPLAY)
+            else editor.putString(NoopPrefs.KEY_SKIN_TEMP_DISPLAY, raw)
         }
         (values["effort.scale"] as? String)?.let { editor.putString(UnitPrefs.KEY_EFFORT_SCALE, it) }
         (values[HostedCardPrefs.KEY_SELECTION] as? String)?.let { editor.putString(HostedCardPrefs.KEY_SELECTION, it) }

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1219,8 +1219,13 @@ fun VitalSignsScreen(vm: AppViewModel, onVitalClick: (String) -> Unit = {}) {
     // Read the toggle here in the composable body, NOT inside remember{} — LocalContext.current is a
     // @Composable read and is illegal inside the calculation lambda; pass the resolved value in + key on it.
     val spo2CandidateDisplay = NoopPrefs.spo2CandidateDisplay(LocalContext.current)
-    val vitals = remember(selectedMetric, days, tempUnit, spo2CandidateByDay, spo2CandidateDisplay, hrvOverCountByDay) {
-        selectedMetric?.let { vitalsFor(it, days, tempUnit, spo2CandidateByDay, spo2CandidateDisplay, hrvOverCountByDay) }.orEmpty()
+    val skinTempPreferred = UnitPrefs.skinTempPreferred(LocalContext.current)   // #1846, same rule
+    val vitals = remember(selectedMetric, days, tempUnit, spo2CandidateByDay, spo2CandidateDisplay,
+                          hrvOverCountByDay, skinTempPreferred) {
+        selectedMetric?.let {
+            vitalsFor(it, days, tempUnit, spo2CandidateByDay, spo2CandidateDisplay, hrvOverCountByDay,
+                      skinTempPreferred)   // #1846
+        }.orEmpty()
     }
 
     ScreenScaffold(

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1898,9 +1898,12 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
             seriesLoaded = true
         }
     }
+    // #1846: read the preference OUTSIDE remember (a Composable call is not allowed in its calculation)
+    // and make it a KEY, so flipping the setting rebuilds the model instead of serving a cached one.
+    val skinTempPreferred = UnitPrefs.skinTempPreferred(LocalContext.current)
     val detail = if (isSeriesBacked) seriesDetail
-    else remember(days, key, tempUnit, effortScale, spo2CandidateByDay) {
-        buildVitalDetail(days, key, tempUnit, effortScale, spo2CandidateByDay)
+    else remember(days, key, tempUnit, effortScale, spo2CandidateByDay, skinTempPreferred) {
+        buildVitalDetail(days, key, tempUnit, effortScale, spo2CandidateByDay, skinTempPreferred)
     }
     var range by remember { mutableStateOf(VitalDetailRange.MONTH) }
 
@@ -2226,6 +2229,9 @@ private fun buildVitalDetail(
     tempUnit: TemperatureUnit,
     effortScale: EffortScale = EffortScale.HUNDRED,
     spo2CandidateByDay: Map<String, Double> = emptyMap(),
+    // #1846: travels like tempUnit — read from prefs by the caller, never defaulted quietly here, so the
+    // setting cannot look wired while doing nothing.
+    skinTempPreferred: SkinTempDisplay.Kind = SkinTempDisplay.Kind.ABSOLUTE,
 ): VitalDetailModel? {
     return when (key) {
     // The Today Key-Metrics Recovery tile's drill-in: the Recovery (Charge) trend timeline, matching the
@@ -2299,7 +2305,8 @@ private fun buildVitalDetail(
         // arithmetic on two scales, so the readings come from the matching column only.
         val newest = days.asReversed().asSequence()
             .firstOrNull { it.skinTempC != null || it.skinTempDevC != null } ?: return null
-        val lead = SkinTempDisplay.leadReading(newest.skinTempC, newest.skinTempDevC) ?: return null
+        val lead = SkinTempDisplay.leadReading(newest.skinTempC, newest.skinTempDevC, skinTempPreferred)
+            ?: return null
         val leadsAbsolute = lead.kind == SkinTempDisplay.Kind.ABSOLUTE && newest.skinTempC != null
         // Deviation-led keeps the #622 bimodal read: a CSV import writes an absolute INTO skinTempDevC, so
         // the kind is re-derived from the value and the series partitioned to it.

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2292,9 +2292,18 @@ private fun buildVitalDetail(
         format = { it.roundToInt().toString() },
     )
     "skin" -> {
-        val latest = days.asReversed().asSequence().mapNotNull { it.skinTempDevC }.firstOrNull() ?: return null
-        val kind = SkinTempDisplay.kind(latest)
         val fahrenheit = tempUnit == TemperatureUnit.FAHRENHEIT
+        // #1844: the newest reading decides the whole screen — title, unit, chart and every row — and it
+        // leads with the measured ABSOLUTE when that night has one (the #1665 rule, applied here too).
+        // The series must follow the same choice: an absolute plotted against a history of deviations is
+        // arithmetic on two scales, so the readings come from the matching column only.
+        val newest = days.asReversed().asSequence()
+            .firstOrNull { it.skinTempC != null || it.skinTempDevC != null } ?: return null
+        val lead = SkinTempDisplay.leadReading(newest.skinTempC, newest.skinTempDevC) ?: return null
+        val leadsAbsolute = lead.kind == SkinTempDisplay.Kind.ABSOLUTE && newest.skinTempC != null
+        // Deviation-led keeps the #622 bimodal read: a CSV import writes an absolute INTO skinTempDevC, so
+        // the kind is re-derived from the value and the series partitioned to it.
+        val kind = if (leadsAbsolute) SkinTempDisplay.Kind.ABSOLUTE else SkinTempDisplay.kind(lead.value)
         val unit = SkinTempDisplay.unitSymbol(kind, fahrenheit)
         val title = if (kind == SkinTempDisplay.Kind.ABSOLUTE) {
             uiString(R.string.l10n_health_screen_skin_temperature_f59127f6)
@@ -2306,10 +2315,14 @@ private fun buildVitalDetail(
             title = title,
             unit = unit,
             color = Palette.metricAmber,
-            readings = days.mapNotNull { row ->
-                row.skinTempDevC
-                    ?.takeIf { VitalBands.isAbsoluteSkinTemp(it) == (kind == SkinTempDisplay.Kind.ABSOLUTE) }
-                    ?.let { value -> VitalReading(row.day, value, row.deviceId) }
+            readings = if (leadsAbsolute) {
+                days.mapNotNull { row -> row.skinTempC?.let { VitalReading(row.day, it, row.deviceId) } }
+            } else {
+                days.mapNotNull { row ->
+                    row.skinTempDevC
+                        ?.takeIf { VitalBands.isAbsoluteSkinTemp(it) == (kind == SkinTempDisplay.Kind.ABSOLUTE) }
+                        ?.let { value -> VitalReading(row.day, value, row.deviceId) }
+                }
             },
             format = { c -> SkinTempDisplay.numberString(c, kind, fahrenheit, decimals = 1) },
         )

--- a/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
@@ -114,7 +114,11 @@ internal data class Vital(
  *
  * Twin of the Swift tile's `skinAbsRow != nil` branch.
  */
-internal fun skinTempLeadsWithAbsolute(absC: Double?): Boolean = absC != null
+internal fun skinTempLeadsWithAbsolute(
+    absC: Double?,
+    devC: Double? = null,
+    prefer: SkinTempDisplay.Kind = SkinTempDisplay.Kind.ABSOLUTE,
+): Boolean = SkinTempDisplay.leadReading(absC, devC, prefer)?.kind == SkinTempDisplay.Kind.ABSOLUTE
 
 /**
  * The deviation note shown beneath an absolute skin temperature — "+0.2 Δ°F" (#1636).
@@ -170,6 +174,9 @@ internal fun vitalsFor(
     spo2CandidateByDay: Map<String, Double> = emptyMap(),
     spo2ToggleOn: Boolean = false,
     hrvOverCountByDay: Map<String, Double> = emptyMap(),   // #1118
+    // #1846: the Settings lead-with choice. Travels like tempUnit so the Health tile agrees with Today
+    // and the detail screen — a setting that reaches two of three surfaces is worse than none.
+    skinTempPreferred: SkinTempDisplay.Kind = SkinTempDisplay.Kind.ABSOLUTE,
 ): List<Vital> {
     val todayKey = d?.day
     // History strictly before the displayed day, oldest→newest (recentDays is already
@@ -208,7 +215,7 @@ internal fun vitalsFor(
     // display that shipped before, unchanged. `leadsAbsolute` also decides which SERIES backs the
     // banding and the trail below — an absolute scored against a history of deviations would be
     // nonsense, so the two must move together.
-    val leadsAbsolute = skinTempLeadsWithAbsolute(d?.skinTempC)
+    val leadsAbsolute = skinTempLeadsWithAbsolute(d?.skinTempC, d?.skinTempDevC, skinTempPreferred)
     val skin = if (leadsAbsolute) d?.skinTempC else d?.skinTempDevC
     // Track which kind the value is so the temperature converter picks the right rule: an ABSOLUTE
     // reading uses the full C→F formula (×9/5 + 32); a ±DEVIATION must omit the offset.
@@ -385,8 +392,12 @@ internal fun latestVitals(
     spo2CandidateByDay: Map<String, Double> = emptyMap(),
     spo2ToggleOn: Boolean = false,
     hrvOverCountByDay: Map<String, Double> = emptyMap(),   // #1118
+    // #1846: the Settings lead-with choice. Travels like tempUnit so the Health tile agrees with Today
+    // and the detail screen — a setting that reaches two of three surfaces is worse than none.
+    skinTempPreferred: SkinTempDisplay.Kind = SkinTempDisplay.Kind.ABSOLUTE,
 ): List<Vital> {
-    val emptyByKey = vitalsFor(null, days, tempUnit, spo2CandidateByDay, spo2ToggleOn, hrvOverCountByDay).associateBy { it.key }
+    val emptyByKey = vitalsFor(null, days, tempUnit, spo2CandidateByDay, spo2ToggleOn, hrvOverCountByDay,
+                               skinTempPreferred).associateBy { it.key }
     return listOf(
         latestVital("resp", days, tempUnit, emptyByKey, spo2CandidateByDay, spo2ToggleOn) { it.respRateBpm != null },
         latestVital("spo2", days, tempUnit, emptyByKey, spo2CandidateByDay, spo2ToggleOn) {
@@ -395,7 +406,12 @@ internal fun latestVitals(
         latestVital("spo2raw", days, tempUnit, emptyByKey, spo2CandidateByDay, spo2ToggleOn) { it.spo2Red != null && it.spo2Ir != null },
         latestVital("rhr", days, tempUnit, emptyByKey, spo2CandidateByDay, spo2ToggleOn) { it.restingHr != null },
         latestVital("hrv", days, tempUnit, emptyByKey, hrvOverCountByDay = hrvOverCountByDay) { it.avgHrv != null },
-        latestVital("skin", days, tempUnit, emptyByKey) { it.skinTempDevC != null },
+        // #1846: pass the preference (the other keys' rows don't read it). The predicate takes EITHER
+        // number for the same reason `lastSkinTempReadingRow` does — a calibrating night has a measured
+        // absolute and no deviation yet, and a deviation-only test walks straight past it.
+        latestVital("skin", days, tempUnit, emptyByKey, skinTempPreferred = skinTempPreferred) {
+            it.skinTempC != null || it.skinTempDevC != null
+        },
     )
 }
 
@@ -416,6 +432,7 @@ private fun latestVital(
     spo2ToggleOn: Boolean = false,
     hrvOverCountByDay: Map<String, Double> = emptyMap(),   // #1118
     todayKey: String = logicalDayKeyNow(),
+    skinTempPreferred: SkinTempDisplay.Kind = SkinTempDisplay.Kind.ABSOLUTE,   // #1846
     hasValue: (DailyMetric) -> Boolean,
 ): Vital {
     val row = Baselines.freshestCarried(
@@ -423,7 +440,10 @@ private fun latestVital(
         todayKey,
     )?.second
     return row
-        ?.let { latestRow -> vitalsFor(latestRow, days, tempUnit, spo2CandidateByDay, spo2ToggleOn, hrvOverCountByDay).firstOrNull { it.key == key } }
+        ?.let { latestRow ->
+            vitalsFor(latestRow, days, tempUnit, spo2CandidateByDay, spo2ToggleOn, hrvOverCountByDay,
+                      skinTempPreferred).firstOrNull { it.key == key }
+        }
         ?.copy(asOfLabel = asOfLabel(row.day))
         ?: emptyByKey.getValue(key)
 }

--- a/android/app/src/main/java/com/noop/ui/LogicalDay.kt
+++ b/android/app/src/main/java/com/noop/ui/LogicalDay.kt
@@ -130,6 +130,22 @@ internal fun lastHrvRow(days: List<DailyMetric>, todayKey: String): DailyMetric?
 internal fun lastRestingHrRow(days: List<DailyMetric>, todayKey: String): DailyMetric? =
     days.lastOrNull { it.restingHr != null && it.day < todayKey }
 
+/**
+ * The freshest strictly-prior row carrying EITHER skin-temp number (#1844), so a surface can lead with
+ * the absolute and fall back to the deviation from ONE night rather than mixing two.
+ *
+ * The OR here is deliberate and is NOT the #1842 defect. That bug read field X off a row selected on
+ * (X or Y), so a row holding only Y blanked X. This selects a row for a value that is "whichever of the
+ * two this night has", and the caller reads both fields off THAT row and lets
+ * [com.noop.analytics.SkinTempDisplay.leadReading] pick — so the chosen row always supplies the number
+ * shown, and the absolute and its deviation note always describe the same night.
+ *
+ * [lastSkinTempRow] stays as-is for the deviation-only surfaces. Twin of the Swift
+ * `DailyMetric.lastSkinTempReadingDay`.
+ */
+internal fun lastSkinTempReadingRow(days: List<DailyMetric>, todayKey: String): DailyMetric? =
+    days.lastOrNull { (it.skinTempC != null || it.skinTempDevC != null) && it.day < todayKey }
+
 /** PER-FIELD twin of [lastVitalsRow] for skin temperature deviation. See [lastSpo2Row]. */
 internal fun lastSkinTempRow(days: List<DailyMetric>, todayKey: String): DailyMetric? =
     days.lastOrNull { it.skinTempDevC != null && it.day < todayKey }

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -719,11 +719,25 @@ object NoopPrefs {
     const val KEY_UNIT_SYSTEM = "units.system"
     const val KEY_TEMPERATURE_UNIT = "units.temperature"
 
+    /** #1846: which skin-temp number the cards lead with — "" / absent = a temperature (default), or the
+     *  DEVIATION raw to lead with the ±baseline move. Display-only; nothing stored ever changes. */
+    const val KEY_SKIN_TEMP_DISPLAY = "units.skinTempDisplay"
+
     fun setUnitSystem(context: Context, system: UnitSystem) {
         of(context).edit().putString(KEY_UNIT_SYSTEM, system.raw).apply()
     }
 
     /** Persist the temperature override, or pass null to clear it back to "match the system". */
+    fun setSkinTempDisplay(context: Context, kind: com.noop.analytics.SkinTempDisplay.Kind?) {
+        of(context).edit().apply {
+            if (kind == null || kind == com.noop.analytics.SkinTempDisplay.Kind.ABSOLUTE) {
+                remove(KEY_SKIN_TEMP_DISPLAY)
+            } else {
+                putString(KEY_SKIN_TEMP_DISPLAY, kind.raw)
+            }
+        }.apply()
+    }
+
     fun setTemperatureUnit(context: Context, unit: TemperatureUnit?) {
         of(context).edit().apply {
             if (unit == null) remove(KEY_TEMPERATURE_UNIT) else putString(KEY_TEMPERATURE_UNIT, unit.raw)

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -671,6 +671,9 @@ fun SettingsScreen(
     var temperatureRaw by remember {
         mutableStateOf(NoopPrefs.of(context).getString(NoopPrefs.KEY_TEMPERATURE_UNIT, "") ?: "")
     }
+    // #1846: which skin-temp number the cards lead with. Display-only, like the row above — the stored
+    // value never changes, so flipping it just re-reads the same night on the other scale.
+    var skinTempKind by remember { mutableStateOf(UnitPrefs.skinTempPreferred(context)) }
     // Effort display scale (#268) — show NOOP's native 0–100 Effort or WHOOP's 0–21 Day Strain axis.
     // Display-only; the stored value never changes. Mirrors into local state like the toggles above.
     var effortScale by remember { mutableStateOf(UnitPrefs.effortScale(context)) }
@@ -1214,6 +1217,30 @@ fun SettingsScreen(
                         onSelect = {
                             temperatureRaw = it
                             NoopPrefs.setTemperatureUnit(context, TemperatureUnit.fromRaw(it))
+                        },
+                    )
+                }
+                SettingsRowDivider()
+                SettingsFormRow(label = uiString(R.string.l10n_settings_screen_skin_temperature_fc103030)) {
+                    // #1846: lead with a temperature ("33.5 °C") or with the move from your own baseline
+                    // ("-0.1 Δ°C"). Only a PREFERENCE — a night that measured just one of the two still
+                    // shows that one, so the choice can never blank a card.
+                    SegmentedPillControl(
+                        items = listOf(
+                            com.noop.analytics.SkinTempDisplay.Kind.ABSOLUTE,
+                            com.noop.analytics.SkinTempDisplay.Kind.DEVIATION,
+                        ),
+                        selection = skinTempKind,
+                        label = {
+                            if (it == com.noop.analytics.SkinTempDisplay.Kind.ABSOLUTE) {
+                                uiString(R.string.l10n_settings_screen_temperature_0a9062a9)
+                            } else {
+                                uiString(R.string.skin_temp_vs_baseline)
+                            }
+                        },
+                        onSelect = {
+                            skinTempKind = it
+                            NoopPrefs.setSkinTempDisplay(context, it)
                         },
                     )
                 }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3616,8 +3616,11 @@ private fun dashboardCardValue(
                 // bedroom). Both numbers come off the SAME row so the scale shown is that night's own.
                 // #622 still applies to the fallback: a deviation keeps its Δ unit so "−0.1 °C" is never
                 // read as a wrist temperature.
-                val row = vd?.takeIf { it.skinTempC != null || it.skinTempDevC != null } ?: skinTempDay
-                com.noop.analytics.SkinTempDisplay.leadReading(row?.skinTempC, row?.skinTempDevC)
+                // Same resolver as the Key Metrics tile, so the two can never disagree — the claim the iOS
+                // twin already made in a comment and that now actually holds on both platforms. It also puts
+                // today's own reading FIRST: `vd` is `carriedDay ?: day`, so a live carry hid a temperature
+                // measured today, which `todaysOwnReadingWinsOverEitherCarry` has asserted all along.
+                resolveSkinTempReading(day, carriedDay, skinTempDay)
                     ?.let { com.noop.analytics.SkinTempDisplay.formatReading(it, fahrenheit = fahrenheit) }
                     ?: NO_DATA
             }
@@ -4937,7 +4940,8 @@ private fun RecordingStatusChip(state: RecordingState, onConnect: () -> Unit) {
  * [com.noop.analytics.SkinTempDisplay.leadReading].
  *
  * Both numbers are read off the SAME row, so an absolute is never paired with another night's deviation.
- * [resolveSkinTempDevC] stays for the deviation-only call sites.
+ * Replaces `resolveSkinTempDevC`, which had no caller left once both Today surfaces moved onto
+ * this one; its carry-order tests were repinned here rather than dropped.
  */
 internal fun resolveSkinTempReading(
     d: DailyMetric?,
@@ -4947,18 +4951,6 @@ internal fun resolveSkinTempReading(
     listOfNotNull(d, carriedDay, skinTempCarryDay)
         .firstOrNull { it.skinTempC != null || it.skinTempDevC != null }
         ?.let { com.noop.analytics.SkinTempDisplay.leadReading(it.skinTempC, it.skinTempDevC) }
-
-/**
- * The Key Metrics Skin Temp tile's 3-way fallback: today's row, then the whole-row recovery carry,
- * then the per-field skin-temp carry (mirrors spo2CarryDay/respCarryDay's reasoning — carriedDay can
- * land on a row with null skinTempDevC even when a genuine reading exists further back). Extracted so
- * the carry regression ryanbr's PR #1589 review flagged is testable without Compose/Robolectric.
- */
-internal fun resolveSkinTempDevC(
-    d: DailyMetric?,
-    carriedDay: DailyMetric?,
-    skinTempCarryDay: DailyMetric?,
-): Double? = d?.skinTempDevC ?: carriedDay?.skinTempDevC ?: skinTempCarryDay?.skinTempDevC
 
 /**
  * The full 14-day metric grid, mirroring the macOS LazyVGrid order:

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1018,8 +1018,11 @@ fun TodayScreen(
     val lastSpo2Day: DailyMetric? = remember(days, carryOverTodayKey, selectedDayOffset, displayMetric) {
         if (selectedDayOffset == 0) lastSpo2Row(days, maxOf(displayMetric?.day ?: "", carryOverTodayKey)) else null
     }
+    // #1844: the carry must find a night with EITHER number now that these surfaces lead with the
+    // absolute — a calibrating night has a real temperature and no deviation yet, and lastSkinTempRow
+    // (deviation-only) would skip straight past it. Both Today consumers below want that row.
     val lastSkinTempDay: DailyMetric? = remember(days, carryOverTodayKey, selectedDayOffset, displayMetric) {
-        if (selectedDayOffset == 0) lastSkinTempRow(days, maxOf(displayMetric?.day ?: "", carryOverTodayKey)) else null
+        if (selectedDayOffset == 0) lastSkinTempReadingRow(days, maxOf(displayMetric?.day ?: "", carryOverTodayKey)) else null
     }
     // #1842: per-field HRV / resting-HR carries, the twins of the SpO₂ and skin-temp rows above. Same
     // shape, same future-clock bound; see lastHrvRow for why the shared lastVitalsRow is not enough.
@@ -3607,13 +3610,17 @@ private fun dashboardCardValue(
             (vd?.spo2Pct ?: spo2Day?.spo2Pct)?.let { String.format(Locale.getDefault(), "%.0f%%", it) }
                 ?: (vd?.day ?: day?.day)?.let { spo2CandidateByDay[it] }?.let { String.format(Locale.getDefault(), "%.0f%%", it) }
                 ?: NO_DATA
-        DashboardCard.SKIN_TEMP -> {
-            // #622: bimodal field — absolute °C (import) vs signed Δ°C vs baseline (live).
-            // Always label the scale; bare "−0.1°" next to a 34° deep-timeline chart looked broken.
-            val v = vd?.skinTempDevC ?: skinTempDay?.skinTempDevC
-            if (v == null) NO_DATA
-            else com.noop.analytics.SkinTempDisplay.format(v, fahrenheit = fahrenheit)
-        }
+            DashboardCard.SKIN_TEMP -> {
+                // #1844: LEAD WITH THE ABSOLUTE when the night measured one, the rule the Health tile has
+                // used since #1665 — a deviation with no anchor cannot be read ("+0.9" is a fever or a warm
+                // bedroom). Both numbers come off the SAME row so the scale shown is that night's own.
+                // #622 still applies to the fallback: a deviation keeps its Δ unit so "−0.1 °C" is never
+                // read as a wrist temperature.
+                val row = vd?.takeIf { it.skinTempC != null || it.skinTempDevC != null } ?: skinTempDay
+                com.noop.analytics.SkinTempDisplay.leadReading(row?.skinTempC, row?.skinTempDevC)
+                    ?.let { com.noop.analytics.SkinTempDisplay.formatReading(it, fahrenheit = fahrenheit) }
+                    ?: NO_DATA
+            }
         DashboardCard.SLEEP -> sleepValue(vd)
         DashboardCard.STEPS -> {
             val real = day?.steps?.let { intStringGrouped(it.toDouble()) }
@@ -4925,6 +4932,23 @@ private fun RecordingStatusChip(state: RecordingState, onConnect: () -> Unit) {
 // `provenanceBadgeLabel` By-Day mappers are kept (Intelligence/Trends + tests still use that vocabulary).
 
 /**
+ * The skin-temp reading a Today surface should LEAD with (#1844): the first of today / the recovery carry
+ * / the per-field carry that holds EITHER number, resolved to absolute-or-deviation by
+ * [com.noop.analytics.SkinTempDisplay.leadReading].
+ *
+ * Both numbers are read off the SAME row, so an absolute is never paired with another night's deviation.
+ * [resolveSkinTempDevC] stays for the deviation-only call sites.
+ */
+internal fun resolveSkinTempReading(
+    d: DailyMetric?,
+    carriedDay: DailyMetric?,
+    skinTempCarryDay: DailyMetric?,
+): com.noop.analytics.SkinTempDisplay.Reading? =
+    listOfNotNull(d, carriedDay, skinTempCarryDay)
+        .firstOrNull { it.skinTempC != null || it.skinTempDevC != null }
+        ?.let { com.noop.analytics.SkinTempDisplay.leadReading(it.skinTempC, it.skinTempDevC) }
+
+/**
  * The Key Metrics Skin Temp tile's 3-way fallback: today's row, then the whole-row recovery carry,
  * then the per-field skin-temp carry (mirrors spo2CarryDay/respCarryDay's reasoning — carriedDay can
  * land on a row with null skinTempDevC even when a genuine reading exists further back). Extracted so
@@ -5171,13 +5195,13 @@ private fun MetricGrid(
             // `d ?: carriedDay` idiom every other simple tile above uses (HRV/RESTING_HR), and the SAME
             // `SkinTempDisplay` formatter the DashboardCard.SKIN_TEMP branch uses so a deviation reads
             // "+0.1 Δ°C" identically on both surfaces (#622: bimodal absolute-vs-deviation field).
-            val v = resolveSkinTempDevC(d, carriedDay, skinTempCarryDay)
+            val reading = resolveSkinTempReading(d, carriedDay, skinTempCarryDay)
             val fahrenheit = UnitPrefs.temperature(LocalContext.current) == TemperatureUnit.FAHRENHEIT
             KeyTileData(
                 label = uiString(R.string.today_card_skin_temp),
                 // The value carries its own "°C"/"Δ°F" (SkinTempDisplay.format), so unit stays empty —
                 // same as the DashboardCard.SKIN_TEMP card and the classic TodayView Skin Temp tile.
-                value = v?.let { com.noop.analytics.SkinTempDisplay.format(it, fahrenheit = fahrenheit) } ?: NO_DATA,
+                value = reading?.let { com.noop.analytics.SkinTempDisplay.formatReading(it, fahrenheit = fahrenheit) } ?: NO_DATA,
                 unit = "",
                 tint = Palette.metricAmber,
                 frac = null,

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3356,6 +3356,9 @@ private fun YourCardsSection(
                         rhrDay = rhrDay,
                         respDay = respDay,
                         fahrenheit = fahrenheit,
+                        // #1846: the user's lead-with choice. Read at the call site, not defaulted inside —
+                        // a defaulted parameter no caller passes is a setting that silently does nothing.
+                        skinTempPreferred = com.noop.ui.UnitPrefs.skinTempPreferred(LocalContext.current),
                         stress = stress,
                         fitnessAge = fitnessAge,
                         vo2max = vo2max,
@@ -3573,6 +3576,8 @@ private fun dashboardCardValue(
     hydrationGoalMl: Int,
     spo2CandidateByDay: Map<String, Double> = emptyMap(),
     fahrenheit: Boolean = false,
+    skinTempPreferred: com.noop.analytics.SkinTempDisplay.Kind =
+        com.noop.analytics.SkinTempDisplay.Kind.ABSOLUTE,
 ): String {
     fun withUnit(s: String): String =
         if (s == NO_DATA) NO_DATA else if (card.unit.isEmpty()) s else "$s ${card.unit}"
@@ -3620,7 +3625,7 @@ private fun dashboardCardValue(
                 // twin already made in a comment and that now actually holds on both platforms. It also puts
                 // today's own reading FIRST: `vd` is `carriedDay ?: day`, so a live carry hid a temperature
                 // measured today, which `todaysOwnReadingWinsOverEitherCarry` has asserted all along.
-                resolveSkinTempReading(day, carriedDay, skinTempDay)
+                resolveSkinTempReading(day, carriedDay, skinTempDay, skinTempPreferred)
                     ?.let { com.noop.analytics.SkinTempDisplay.formatReading(it, fahrenheit = fahrenheit) }
                     ?: NO_DATA
             }
@@ -4947,10 +4952,11 @@ internal fun resolveSkinTempReading(
     d: DailyMetric?,
     carriedDay: DailyMetric?,
     skinTempCarryDay: DailyMetric?,
+    prefer: com.noop.analytics.SkinTempDisplay.Kind = com.noop.analytics.SkinTempDisplay.Kind.ABSOLUTE,
 ): com.noop.analytics.SkinTempDisplay.Reading? =
     listOfNotNull(d, carriedDay, skinTempCarryDay)
         .firstOrNull { it.skinTempC != null || it.skinTempDevC != null }
-        ?.let { com.noop.analytics.SkinTempDisplay.leadReading(it.skinTempC, it.skinTempDevC) }
+        ?.let { com.noop.analytics.SkinTempDisplay.leadReading(it.skinTempC, it.skinTempDevC, prefer) }
 
 /**
  * The full 14-day metric grid, mirroring the macOS LazyVGrid order:
@@ -5187,7 +5193,10 @@ private fun MetricGrid(
             // `d ?: carriedDay` idiom every other simple tile above uses (HRV/RESTING_HR), and the SAME
             // `SkinTempDisplay` formatter the DashboardCard.SKIN_TEMP branch uses so a deviation reads
             // "+0.1 Δ°C" identically on both surfaces (#622: bimodal absolute-vs-deviation field).
-            val reading = resolveSkinTempReading(d, carriedDay, skinTempCarryDay)
+            val reading = resolveSkinTempReading(
+                d, carriedDay, skinTempCarryDay,
+                com.noop.ui.UnitPrefs.skinTempPreferred(LocalContext.current),
+            )
             val fahrenheit = UnitPrefs.temperature(LocalContext.current) == TemperatureUnit.FAHRENHEIT
             KeyTileData(
                 label = uiString(R.string.today_card_skin_temp),

--- a/android/app/src/main/java/com/noop/ui/Units.kt
+++ b/android/app/src/main/java/com/noop/ui/Units.kt
@@ -157,6 +157,17 @@ object UnitPrefs {
     fun system(context: Context): UnitSystem =
         UnitSystem.fromRaw(NoopPrefs.of(context).getString(NoopPrefs.KEY_UNIT_SYSTEM, null))
 
+    /**
+     * Which skin-temp number the cards LEAD with (#1846). Absolute by default — a temperature is what a
+     * temperature reading should say — with DEVIATION for wearers who track the ±baseline move. Only a
+     * preference: [com.noop.analytics.SkinTempDisplay.leadReading] still falls back to the other number,
+     * so a night that measured only one is never blanked by this choice.
+     */
+    fun skinTempPreferred(context: Context): com.noop.analytics.SkinTempDisplay.Kind =
+        com.noop.analytics.SkinTempDisplay.Kind.fromRaw(
+            NoopPrefs.of(context).getString(NoopPrefs.KEY_SKIN_TEMP_DISPLAY, null),
+        ) ?: com.noop.analytics.SkinTempDisplay.Kind.ABSOLUTE
+
     /** The resolved temperature unit, applying the "match the length/mass system" default. */
     fun temperature(context: Context): TemperatureUnit {
         val override = TemperatureUnit.fromRaw(

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2680,4 +2680,5 @@
     <string name="vo2max_method_change_caption">Die Linie bricht dort ab, wo sich die Schätzmethode geändert hat oder nicht erfasst wurde.</string>
     <string name="l10n_app_changelog_a_whoop_5_that_stays_connected_7b490eee">Eine WHOOP 5, die verbunden bleibt, deine innere Uhr im Schlaf-Screen und ein Journal, das Nein von gar nichts unterscheidet</string>
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Wähle dein Zeitformat, Schlaf von Straps ohne Bewegungsdaten und ein Strap-Log, das nicht mehr rät</string>
+    <string name="l10n_settings_screen_skin_temperature_fc103030">Hauttemperatur</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2667,4 +2667,5 @@
     <string name="vo2max_method_change_caption">La línea se interrumpe donde el método de estimación cambió o no se registró.</string>
     <string name="l10n_app_changelog_a_whoop_5_that_stays_connected_7b490eee">Una WHOOP 5 que no se desconecta, tu reloj interno en la pantalla de Sueño y un diario que distingue No de nada</string>
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Elige el reloj de 12 horas, sueño desde correas que no registran movimiento y un registro que deja de suponer</string>
+    <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura cutánea</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2666,4 +2666,5 @@
     <string name="vo2max_method_change_caption">La courbe est interrompue là où la méthode d’estimation a changé ou n’a pas été enregistrée.</string>
     <string name="l10n_app_changelog_a_whoop_5_that_stays_connected_7b490eee">Une WHOOP 5 qui reste connectée, votre horloge interne sur l\'écran Sommeil, et un journal qui distingue Non de rien</string>
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Choisissez l\'horloge 12 heures, le sommeil depuis des bracelets sans données de mouvement, et un journal qui cesse de deviner</string>
+    <string name="l10n_settings_screen_skin_temperature_fc103030">Température cutanée</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2671,4 +2671,5 @@
     <string name="vo2max_method_change_caption">Linia jest przerwana tam, gdzie metoda szacowania zmieniła się lub nie została zapisana.</string>
     <string name="l10n_app_changelog_a_whoop_5_that_stays_connected_7b490eee">WHOOP 5, który nie traci połączenia, zegar biologiczny na ekranie snu i dziennik odróżniający Nie od braku wpisu</string>
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Wybierz zegar 12-godzinny, sen z opasek bez danych o ruchu i dziennik, który przestaje zgadywać</string>
+    <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura skóry</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2659,4 +2659,5 @@
     <string name="vo2max_method_change_caption">A linha é interrompida onde o método de estimativa mudou ou não foi registado.</string>
     <string name="l10n_app_changelog_a_whoop_5_that_stays_connected_7b490eee">Uma WHOOP 5 que se mantém ligada, o seu relógio interno no ecrã de Sono e um diário que distingue Não de nada</string>
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Escolha o relógio de 12 horas, sono a partir de pulseiras sem dados de movimento e um registo que deixa de adivinhar</string>
+    <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura da pele</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2580,4 +2580,5 @@
     <string name="vo2max_method_change_caption">线条在估算方法发生变化或未记录之处中断。</string>
     <string name="l10n_app_changelog_a_whoop_5_that_stays_connected_7b490eee">不再频繁掉线的 WHOOP 5、睡眠页上的生物钟，以及能分清「否」与「未记录」的日志</string>
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">自选 12 小时制、从无运动数据的手环读取睡眠，以及不再靠猜测的手环日志</string>
+    <string name="l10n_settings_screen_skin_temperature_fc103030">皮肤温度</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2693,4 +2693,5 @@
     <string name="vo2max_method_change_caption">The line breaks where the estimation method changed or was not recorded.</string>
     <string name="l10n_app_changelog_a_whoop_5_that_stays_connected_7b490eee">A WHOOP 5 that stays connected, your body clock on the Sleep screen, and a Journal that knows No from nothing</string>
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Choose a 12-hour clock, sleep from straps that bank no motion, and a strap log that stops guessing</string>
+    <string name="l10n_settings_screen_skin_temperature_fc103030">Skin temperature</string>
 </resources>

--- a/android/app/src/test/java/com/noop/analytics/SkinTempLeadReadingTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SkinTempLeadReadingTest.kt
@@ -1,0 +1,63 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #1844: which of a night's two skin-temp numbers a surface leads with, and how it reads once formatted.
+ *
+ * The rule the Health tile has used since #1665, made pure so Today and the detail screen can share it:
+ * a deviation with no anchor cannot be read, so a measured absolute wins whenever the night has one.
+ */
+class SkinTempLeadReadingTest {
+
+    /** The everyday case: the night measured a real temperature, so that is what shows. */
+    @Test
+    fun absoluteWinsWhenTheNightMeasuredOne() {
+        val r = SkinTempDisplay.leadReading(absC = 33.8, devC = -0.1)!!
+        assertEquals(SkinTempDisplay.Kind.ABSOLUTE, r.kind)
+        assertEquals(33.8, r.value, 1e-9)
+        assertEquals("33.8 °C", SkinTempDisplay.formatReading(r, fahrenheit = false))
+    }
+
+    /** A night scored before skinTempC shipped (2026-08-27) keeps EXACTLY the display that shipped before. */
+    @Test
+    fun deviationLedNightIsUnchanged() {
+        val r = SkinTempDisplay.leadReading(absC = null, devC = -0.1)!!
+        assertEquals(SkinTempDisplay.Kind.DEVIATION, r.kind)
+        assertEquals("-0.1 Δ°C", SkinTempDisplay.formatReading(r, fahrenheit = false))
+    }
+
+    /** A CALIBRATING night is the reverse — measured absolute, no usable baseline yet, so no deviation.
+     *  This is the case that previously showed an empty card with a real temperature behind it. */
+    @Test
+    fun calibratingNightStillShowsItsTemperature() {
+        val r = SkinTempDisplay.leadReading(absC = 34.1, devC = null)!!
+        assertEquals(SkinTempDisplay.Kind.ABSOLUTE, r.kind)
+        assertEquals("34.1 °C", SkinTempDisplay.formatReading(r, fahrenheit = false))
+    }
+
+    /** Nothing measured stays nothing: the carry must never invent a reading. */
+    @Test
+    fun noNumbersCarryNothing() {
+        assertNull(SkinTempDisplay.leadReading(absC = null, devC = null))
+    }
+
+    /** °F uses the full conversion for an absolute and the offset-free one for a deviation — the whole
+     *  reason the kind has to travel with the value rather than being re-guessed at the format call. */
+    @Test
+    fun fahrenheitConvertsEachKindByItsOwnRule() {
+        val abs = SkinTempDisplay.leadReading(absC = 35.0, devC = null)!!
+        assertEquals("95.0 °F", SkinTempDisplay.formatReading(abs, fahrenheit = true))
+        val dev = SkinTempDisplay.leadReading(absC = null, devC = 1.0)!!
+        assertEquals("+1.8 Δ°F", SkinTempDisplay.formatReading(dev, fahrenheit = true))
+    }
+
+    /** #1842 still holds through the new path: a deviation that rounds to zero drops its sign. */
+    @Test
+    fun signedZeroStaysFixedThroughLeadReading() {
+        val r = SkinTempDisplay.leadReading(absC = null, devC = -0.02)!!
+        assertEquals("0.0 Δ°C", SkinTempDisplay.formatReading(r, fahrenheit = false))
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/SkinTempLeadReadingTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SkinTempLeadReadingTest.kt
@@ -60,4 +60,61 @@ class SkinTempLeadReadingTest {
         val r = SkinTempDisplay.leadReading(absC = null, devC = -0.02)!!
         assertEquals("0.0 Δ°C", SkinTempDisplay.formatReading(r, fahrenheit = false))
     }
+
+    // MARK: the Settings choice (#1846)
+
+    /** Choosing the deviation leads with it even on a night that measured a real temperature. */
+    @Test
+    fun deviationPreferenceLeadsWithTheDelta() {
+        val r = SkinTempDisplay.leadReading(absC = 33.8, devC = -0.1,
+                                            prefer = SkinTempDisplay.Kind.DEVIATION)!!
+        assertEquals(SkinTempDisplay.Kind.DEVIATION, r.kind)
+        assertEquals("-0.1 Δ°C", SkinTempDisplay.formatReading(r, fahrenheit = false))
+    }
+
+    /** The choice is a PREFERENCE, not a filter: a night with only the other number still shows it,
+     *  so flipping the setting can never blank a card. Both directions. */
+    @Test
+    fun eitherPreferenceFallsBackToTheNumberTheNightHas() {
+        val devOnly = SkinTempDisplay.leadReading(absC = null, devC = -0.4,
+                                                   prefer = SkinTempDisplay.Kind.ABSOLUTE)!!
+        assertEquals("-0.4 Δ°C", SkinTempDisplay.formatReading(devOnly, fahrenheit = false))
+
+        val absOnly = SkinTempDisplay.leadReading(absC = 34.2, devC = null,
+                                                   prefer = SkinTempDisplay.Kind.DEVIATION)!!
+        assertEquals("34.2 °C", SkinTempDisplay.formatReading(absOnly, fahrenheit = false))
+    }
+
+    /** The unit always names the scale ACTUALLY shown, never the one that was asked for — otherwise a
+     *  fallback would print a temperature under a Δ label, or a delta as a wrist temperature. */
+    @Test
+    fun theUnitFollowsTheValueNotThePreference() {
+        val r = SkinTempDisplay.leadReading(absC = 34.2, devC = null,
+                                            prefer = SkinTempDisplay.Kind.DEVIATION)!!
+        assertEquals(SkinTempDisplay.Kind.ABSOLUTE, r.kind)
+        assertEquals("°C", SkinTempDisplay.unitSymbol(r.kind, fahrenheit = false))
+    }
+
+    /** Default is unchanged, so an install that never opens Settings behaves exactly as #1844 shipped. */
+    @Test
+    fun defaultIsAbsolute() {
+        assertEquals(SkinTempDisplay.Kind.ABSOLUTE,
+                     SkinTempDisplay.leadReading(absC = 33.0, devC = 0.5)!!.kind)
+    }
+
+
+    /** The PERSISTED token, byte-identical to the Swift `Kind.rawValue` — both platforms share the
+     *  `units.skinTempDisplay` key, so a drift here (e.g. writing `Kind.name`) would make one platform
+     *  unable to read the other's stored choice. Same contract `KeyMetric.raw` already pins. */
+    @Test
+    fun rawTokensMatchTheSwiftRawValues() {
+        assertEquals("absolute", SkinTempDisplay.Kind.ABSOLUTE.raw)
+        assertEquals("deviation", SkinTempDisplay.Kind.DEVIATION.raw)
+        assertEquals(SkinTempDisplay.Kind.DEVIATION, SkinTempDisplay.Kind.fromRaw("deviation"))
+        assertEquals(SkinTempDisplay.Kind.ABSOLUTE, SkinTempDisplay.Kind.fromRaw("absolute"))
+        // Anything unrecognised (including the old uppercase spelling) falls back at the read site.
+        assertNull(SkinTempDisplay.Kind.fromRaw("DEVIATION"))
+        assertNull(SkinTempDisplay.Kind.fromRaw(null))
+    }
+
 }

--- a/android/app/src/test/java/com/noop/ui/KeyMetricSkinTempTest.kt
+++ b/android/app/src/test/java/com/noop/ui/KeyMetricSkinTempTest.kt
@@ -42,17 +42,24 @@ class KeyMetricSkinTempTest {
     private fun day(skinTempDevC: Double?) =
         DailyMetric(deviceId = "my-whoop-noop", day = "2026-08-25", skinTempDevC = skinTempDevC)
 
+    private fun value(d: DailyMetric?, carriedDay: DailyMetric?, skinTempCarryDay: DailyMetric?) =
+        resolveSkinTempReading(d, carriedDay, skinTempCarryDay)?.value
+
     /**
      * Regression for ryanbr's PR #1589 review: carriedDay (lastScoredRecoveryDay) is a whole-row
      * carry that lands on a row with null skinTempDevC even when a genuine reading exists further
      * back, so the tile must fall through to the per-field skinTempCarryDay — exactly like
-     * spo2CarryDay/respCarryDay, and matching iOS TodayView's lastSkinTempDay chain.
+     * spo2CarryDay/respCarryDay, and matching the iOS `skinTempLeadReading` chain.
+     *
+     * Repinned onto `resolveSkinTempReading` (#1844) when both Today surfaces moved onto it: same carry
+     * ORDER, same fixtures, now reading `.value` off the resolved reading. The order is the part worth
+     * guarding, and it did not change.
      */
     @Test fun nullSkinTempDevCFallsThroughToPerFieldCarry() {
         val perFieldCarry = day(skinTempDevC = 0.4)
         assertEquals(
             0.4,
-            resolveSkinTempDevC(d = null, carriedDay = day(skinTempDevC = null), skinTempCarryDay = perFieldCarry)!!,
+            value(d = null, carriedDay = day(skinTempDevC = null), skinTempCarryDay = perFieldCarry)!!,
             0.0,
         )
     }
@@ -60,7 +67,7 @@ class KeyMetricSkinTempTest {
     @Test fun todaysOwnReadingWinsOverEitherCarry() {
         assertEquals(
             0.2,
-            resolveSkinTempDevC(
+            value(
                 d = day(skinTempDevC = 0.2),
                 carriedDay = day(skinTempDevC = -0.1),
                 skinTempCarryDay = day(skinTempDevC = 0.4),
@@ -72,7 +79,7 @@ class KeyMetricSkinTempTest {
     @Test fun wholeRowCarryWinsOverPerFieldCarryWhenBothPresent() {
         assertEquals(
             -0.1,
-            resolveSkinTempDevC(
+            value(
                 d = null,
                 carriedDay = day(skinTempDevC = -0.1),
                 skinTempCarryDay = day(skinTempDevC = 0.4),
@@ -82,6 +89,6 @@ class KeyMetricSkinTempTest {
     }
 
     @Test fun noRowAnywhereYieldsNull() {
-        assertNull(resolveSkinTempDevC(d = null, carriedDay = null, skinTempCarryDay = null))
+        assertNull(value(d = null, carriedDay = null, skinTempCarryDay = null))
     }
 }

--- a/android/app/src/test/java/com/noop/ui/LastSkinTempReadingRowTest.kt
+++ b/android/app/src/test/java/com/noop/ui/LastSkinTempReadingRowTest.kt
@@ -1,0 +1,45 @@
+package com.noop.ui
+
+import com.noop.data.DailyMetric
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** #1844: the carry must find a night holding EITHER skin-temp number, and read both off that ONE row. */
+class LastSkinTempReadingRowTest {
+
+    private fun day(d: String, abs: Double? = null, dev: Double? = null) =
+        DailyMetric(deviceId = "my-whoop", day = d, skinTempC = abs, skinTempDevC = dev)
+
+    /** The calibrating night the deviation-only selector skipped: real temperature, no deviation yet. */
+    @Test
+    fun findsANightWithOnlyAnAbsolute() {
+        val days = listOf(day("2026-09-01", dev = -0.3), day("2026-09-02", abs = 34.1))
+        assertEquals("2026-09-02", lastSkinTempReadingRow(days, todayKey = "2026-09-03")?.day)
+        // The old deviation-only row would reach back past it to the older night.
+        assertEquals("2026-09-01", lastSkinTempRow(days, todayKey = "2026-09-03")?.day)
+    }
+
+    /** Both numbers come off the SAME row, so an absolute is never paired with another night's deviation. */
+    @Test
+    fun bothNumbersComeFromOneNight() {
+        val days = listOf(day("2026-09-01", abs = 33.0, dev = -0.9), day("2026-09-02", abs = 34.1, dev = 0.2))
+        val row = lastSkinTempReadingRow(days, todayKey = "2026-09-03")!!
+        assertEquals(34.1, row.skinTempC!!, 1e-9)
+        assertEquals(0.2, row.skinTempDevC!!, 1e-9)
+    }
+
+    /** Same future-clock bound as every sibling carry. */
+    @Test
+    fun neverCarriesTodayOrLater() {
+        val days = listOf(day("2026-09-03", abs = 34.0), day("2026-09-04", abs = 34.2))
+        assertNull(lastSkinTempReadingRow(days, todayKey = "2026-09-03"))
+    }
+
+    /** A row with neither number is not a reading. */
+    @Test
+    fun rowsWithNeitherNumberAreSkipped() {
+        val days = listOf(day("2026-09-01", abs = 33.5), day("2026-09-02"))
+        assertEquals("2026-09-01", lastSkinTempReadingRow(days, todayKey = "2026-09-03")?.day)
+    }
+}


### PR DESCRIPTION
Two changes to how skin temperature reads. Reported on #1842 → #1844, with the Settings choice as #1846.

## Lead with the temperature, not the delta

The Today card and the detail screen showed `0.0 Δ°C` — a deviation against a baseline neither screen names. The Health tile already solved this, and the rule is the whole argument:

> A deviation with no anchor cannot be read — "+0.9" is a fever or a warm bedroom and nothing on the tile says which — so the absolute leads and the deviation becomes the context beneath it.

#1663 stored the nightly absolute (`dailyMetric.skinTempC`); #1665 applied it to the Health tile. Three surfaces never came onto that pattern and still read `skinTempDevC` only — Today's "Your Cards" row, the Key Metrics tile, and the `HealthScreen` detail (title, unit, chart and every readings row). Apple's two Today layouts had the same gap.

`TodayView.dashboardValue` was worse than the Android card that was reported: `.hrv`, `.restingHr` and `.skinTemp` had no carry at all while their neighbours carried, so a straight port of the Android change would have left it broken.

`Δ°C` is **not** the defect and stays wherever a deviation is genuinely what is shown (#622 added it so `-0.1 °C` is not read as a broken thermometer).

### The carry had to change with it

`lastSkinTempRow` selects on `skinTempDevC`, so it walks past a CALIBRATING night: the deviation is null until the baseline is usable (~4 nights), while the absolute is measured from night one. Those wearers saw an empty card with a real temperature sitting behind it.

`lastSkinTempReadingRow` takes a row holding EITHER number. **That OR predicate is deliberate and is not the #1842 defect**, and both selectors say so in their docs: #1842 read field X off a row chosen on `(X or Y)`, so a row holding only Y blanked X. Here the value *is* "whichever of the two this night has", and the caller reads both fields off **that** row — so an absolute is never paired with another night's deviation.

## The setting (#1846)

Absolute is the right default but not the right answer for everyone — the ±baseline move is the more sensitive illness signal. **Settings → Units → Skin temperature: Temperature (default) or "vs baseline"**, both platforms.

It is a PREFERENCE, not a filter: `leadReading` gains `prefer`, which picks the number tried FIRST; the other stays the fallback, so a choice can never blank a card whose night measured only the other. The unit always names the scale ACTUALLY shown, never the one asked for.

Wired at the call sites, not defaulted inside — `dashboardCardValue`, `buildVitalDetail` and `BodyVitalSigns.readings` take the resolved preference the way they already take `tempUnit`, and on the detail screen it is also a `remember` key so flipping it rebuilds rather than serving a cached model.

Caught before shipping: Kotlin persisted `Kind.name` (`"DEVIATION"`) while Swift persisted `rawValue` (`"deviation"`) under the same `units.skinTempDisplay` key. Kotlin's `Kind` gains a `raw` matching Swift byte for byte plus `fromRaw`, with a test pinning the tokens — the drift `KeyMetricSkinTempTest` exists to catch.

## What the re-review changed

- The **Health tile ignored the setting on both platforms**; it now goes through the same `leadReading` rule. A setting reaching two of three surfaces reads as broken rather than absent.
- Six `latestVital(...)` calls took the new parameter's default; **zero passed it**.
- That row's predicate was `skinTempDevC != null`, so it walked past a calibrating night — the same bug as the carry, one layer down.
- `units.skinTempDisplay` was whitelisted for backup but **export and import are explicit per key**, so it would never have restored. Both halves wired, `""` = key-absent like `units.temperature`.
- `resolveSkinTempDevC` had no caller left; deleted, and its four carry-order cases repinned onto the new resolver.
- The two Kotlin Today surfaces **did not agree** while the iOS twin's comment claimed they could never disagree — Your Cards read `vd` (`carriedDay ?: day`), so a live carry hid a temperature measured today, which `todaysOwnReadingWinsOverEitherCarry` has asserted against all along.

## Verification

- Kotlin: full suite **5113 / 0**, 19 new cases.
- Swift: `WhoopStore` XCTest for the new selector. `StrandAnalytics` will not build on Linux (GRDB's CSQLite), so `leadReading`/`formatReading` were run by extracting them **verbatim** into an isolated harness against the Kotlin's own fixtures — all pass, including that #1842's signed zero still holds.
- i18n and doc-comment gates clean. One new Android string in all 6 locales; one Apple a11y label spliced across all 9 (58 insertions, 0 deletions — no JSON round-trip). Segment labels reuse existing translated keys.

## Note for testing

`skinTempC` landed 2026-08-27 and refills on the next scoring pass, re-derived from raw `skinTempSample` rows still on disk — `analyzeRecent` re-scores a 21-night window per post-sync pass. **On an install whose newest reading predates 27 Aug this is correctly invisible until then**, and nights whose raw samples were already pruned stay deviation-only for good.