### PR TITLE
fix(oura): break the resume-cursor ↔ time-anchor deadlock that re-serves the same history forever

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraDriver.swift
@@ -246,17 +246,34 @@ public final class OuraDriver {
         return Int(seconds)
     }
 
+    /// How far the ring's clock may run AHEAD of `lowerBoundTicks` and still be recognised. The bound is a
+    /// stale resume cursor or the oldest ring-time a drain has seen, either of which can trail the ring's
+    /// clock by the ring's whole banked depth (~14 days) plus however long the cursor has been stuck — the
+    /// original 7-day window silently excluded exactly that case: in the 2026-09-02/03 iOS captures an
+    /// 8.2-day-stale cursor could never be re-anchored, so it could never advance, so the staleness only
+    /// grew — one full re-serve of the same window per launch, forever. Widening costs no
+    /// honesty: both readings fit the window only when `window >= 9 × lowerBound`, i.e. a ring under ~5
+    /// days of clock — and that case still resolves to nil below, exactly as before.
+    public static let syncTimeAnchorWindowTicks: Int64 = 38_880_000   // 45 days of 100 ms ticks
+
     /// Resolve the 0x13 SyncTime-response device timestamp into ring TICKS, or nil when no unambiguous
     /// reading exists. ringverse BLE.md labels the field "seconds" but the ring's record clock runs in
     /// 100 ms ticks, so both readings are tried: the raw value (already ticks) and value×10 (seconds→
-    /// ticks). The ring's clock at connect must sit shortly AFTER where the last drain ended, so a
-    /// candidate is plausible iff it falls in `[historyCursor, historyCursor + 7 days]`; exactly one
-    /// must fit (ambiguity or a fresh/reset cursor → nil → the caller logs raw instead of guessing).
+    /// ticks). The ring's clock at connect must sit AFTER any ring-time we already know about, so a
+    /// candidate is plausible iff it falls in `[lowerBoundTicks, lowerBoundTicks +
+    /// syncTimeAnchorWindowTicks]`; exactly one must fit (ambiguity or no reference at all → nil → the
+    /// caller logs raw instead of guessing).
+    ///
+    /// `lowerBoundTicks` is any ring-time known to precede the ring's clock NOW: the persisted resume
+    /// cursor at connect, or — when that is 0 (fresh pair / post-reboot reset) or too stale — the largest
+    /// envelope ring-time the drain has actually seen (`OuraHistoryDrain.maxSeenRingTime`), which needs no
+    /// anchor to read and so breaks the cursor↔anchor deadlock (2026-09-02/03 captures).
+    ///
     /// Pure and testable; the honest-data invariant is "no anchor beats a wrong anchor".
-    public static func syncTimeAnchorCandidate(responseValue: UInt32, historyCursor: UInt32) -> UInt32? {
-        guard historyCursor > 0 else { return nil }
-        let lower = Int64(historyCursor)
-        let upper = lower + 6_048_000   // 7 days of 100 ms ticks
+    public static func syncTimeAnchorCandidate(responseValue: UInt32, lowerBoundTicks: UInt32) -> UInt32? {
+        guard lowerBoundTicks > 0 else { return nil }
+        let lower = Int64(lowerBoundTicks)
+        let upper = lower + syncTimeAnchorWindowTicks
         let readings = [Int64(responseValue), Int64(responseValue) * 10]
         let fits = readings.filter { $0 >= lower && $0 <= upper && $0 <= Int64(UInt32.max) }
         guard fits.count == 1 else { return nil }

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/FramingTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/FramingTests.swift
@@ -219,22 +219,54 @@ final class FramingTests: XCTestCase {
     // MARK: - 0x13 -> anchor tick disambiguation (OuraDriver.syncTimeAnchorCandidate)
 
     func testSyncTimeAnchorCandidateResolvesUnit() {
-        // The 2026-07-13 shape: cursor banked at 4_413_933 (last night's log end); ~11 h later the
-        // ring's clock is ~4.81M ticks. A raw-ticks response fits the [cursor, cursor+7d] window and
+        // The 2026-07-13 shape: floor banked at 4_413_933 (last night's log end); ~11 h later the
+        // ring's clock is ~4.81M ticks. A raw-ticks response fits the [floor, floor+45d] window and
         // the seconds x10 reading does not -> unambiguous ticks.
-        XCTAssertEqual(OuraDriver.syncTimeAnchorCandidate(responseValue: 4_810_000, historyCursor: 4_413_933),
+        XCTAssertEqual(OuraDriver.syncTimeAnchorCandidate(responseValue: 4_810_000, lowerBoundTicks: 4_413_933),
                        4_810_000)
         // A seconds-unit response (481_000 s = 4.81M ticks) only fits when multiplied x10.
-        XCTAssertEqual(OuraDriver.syncTimeAnchorCandidate(responseValue: 481_000, historyCursor: 4_413_933),
+        XCTAssertEqual(OuraDriver.syncTimeAnchorCandidate(responseValue: 481_000, lowerBoundTicks: 4_413_933),
                        4_810_000)
-        // Below the cursor in both readings (ring reboot / stale value) -> nil.
-        XCTAssertNil(OuraDriver.syncTimeAnchorCandidate(responseValue: 100_000, historyCursor: 4_413_933))
-        // Beyond cursor+7d in both readings -> nil.
-        XCTAssertNil(OuraDriver.syncTimeAnchorCandidate(responseValue: 40_000_000, historyCursor: 4_413_933))
-        // A fresh/reset cursor gives no reference -> nil (never guess on a full pull).
-        XCTAssertNil(OuraDriver.syncTimeAnchorCandidate(responseValue: 4_810_000, historyCursor: 0))
-        // Ambiguity guard: BOTH readings inside the window -> nil.
-        XCTAssertNil(OuraDriver.syncTimeAnchorCandidate(responseValue: 150_000, historyCursor: 140_000))
+        // Below the floor in both readings (ring reboot / stale value) -> nil.
+        XCTAssertNil(OuraDriver.syncTimeAnchorCandidate(responseValue: 100_000, lowerBoundTicks: 4_413_933))
+        // Beyond floor+45d in both readings -> nil.
+        XCTAssertNil(OuraDriver.syncTimeAnchorCandidate(responseValue: 50_000_000, lowerBoundTicks: 4_413_933))
+        // No reference at all -> nil (never guess).
+        XCTAssertNil(OuraDriver.syncTimeAnchorCandidate(responseValue: 4_810_000, lowerBoundTicks: 0))
+        // Ambiguity guard: BOTH readings inside the window -> nil. Reachable only while the floor is
+        // under window/9 (~5 days of ring clock), i.e. a barely-run ring.
+        XCTAssertNil(OuraDriver.syncTimeAnchorCandidate(responseValue: 150_000, lowerBoundTicks: 140_000))
+    }
+
+    /// Regression from the 2026-09-02/03 iOS captures. The ring's 0x13 reply reads 0x0218767f =
+    /// 35_157_631 ticks while the persisted resume cursor sits at 28_073_725 — 8.20 days behind. Under the
+    /// old 7-day window neither reading fit, so no anchor was adopted; with no anchor the drain-end commit
+    /// could not advance the cursor (`resumeCursorAtDrainEnd(resolvesUnderAnchor: false)` returns it
+    /// unchanged), so the cursor stayed stale and the gap only grew — a permanent loop, one full re-serve
+    /// of the same window per launch. The widened window resolves it, unambiguously.
+    func testSyncTimeAnchorCandidateAcceptsAStaleCursorFromTheCaptures() {
+        let staleCursor: UInt32 = 28_073_725          // banked 2026-08-26 02:49:56 by the 300 s guard
+        for reply: UInt32 in [0x0218767f, 0x02187ce8, 0x02189fce] {   // the three 09-03 launches
+            XCTAssertEqual(OuraDriver.syncTimeAnchorCandidate(responseValue: reply,
+                                                              lowerBoundTicks: staleCursor),
+                           reply, "0x\(String(reply, radix: 16)) must resolve as raw ticks")
+        }
+        // The old 7-day window is what excluded it: 28_073_725 + 6_048_000 = 34_121_725 < 35_157_631.
+        XCTAssertGreaterThan(OuraDriver.syncTimeAnchorWindowTicks, 35_157_631 - Int64(staleCursor),
+                             "the window must cover the observed 8.2-day staleness")
+    }
+
+    /// The other half of the deadlock: on a fresh pair / post-reboot reset the cursor is 0, so it
+    /// can never be the reference. The drain's `maxSeenRingTime` can — it counts EVERY history record's
+    /// envelope time and needs no anchor to read — so the caller retries the parked reply against it.
+    func testSyncTimeAnchorCandidateResolvesAgainstSeenRingTimeWhenCursorIsZero() {
+        let reply: UInt32 = 0x0211dbd0                // 34_724_816 — the 2026-09-02 capture, cursor 0
+        XCTAssertNil(OuraDriver.syncTimeAnchorCandidate(responseValue: reply, lowerBoundTicks: 0))
+        // First batch of a full pull lands the ring's OLDEST banked record (~14 days back).
+        let oldestBanked: UInt32 = 34_724_816 - 12_096_000
+        XCTAssertEqual(OuraDriver.syncTimeAnchorCandidate(responseValue: reply,
+                                                          lowerBoundTicks: oldestBanked),
+                       reply)
     }
 
     func testAdoptSyncTimeAnchorResolvesHistoryTimes() {

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -245,6 +245,13 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     private var loggedFirstTemp = false
     /// Logs the FIRST SpO2 sample decoded this session only. Twin of `loggedFirstTemp`.
     private var loggedFirstSpo2 = false
+    /// The 0x13 SyncTime reply parked because nothing yet available could disambiguate its unit (ticks vs
+    /// seconds x10): the resume cursor was 0 (fresh pair / post-reboot full pull) or so stale the ring's
+    /// clock had run past the window. Retried against the drain's `maxSeenRingTime` as the first batch
+    /// lands (2026-09-02/03 captures). The ORIGINAL receipt wall-clock is carried along, because THAT is the instant the
+    /// ring's counter pairs with - re-stamping at retry time would skew the anchor by the drain's latency.
+    private var pendingSyncTime: (deviceTimestamp: UInt32, status: UInt8, receivedAt: Int64)?
+
     /// Logs the FIRST ring-time -> UTC anchor of this session only (s5.5); reset on stop/disconnect.
     private var loggedAnchor = false
     /// Tier-B (UNVERIFIED) kinds ("activity" / "real_steps" / "sleep_summary" / "spo2_smoothed") already
@@ -1328,6 +1335,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         loggedFirstTemp = false
         loggedFirstSpo2 = false
         loggedAnchor = false
+        pendingSyncTime = nil
         loggedTierBKinds.removeAll()
         loggedFeatureStatuses.removeAll()
         loggedProductInfo.removeAll()
@@ -1565,6 +1573,10 @@ public final class OuraLiveSource: NSObject, ObservableObject {
                 drain.noteSeenRingTime(rt)
             }
         }
+        // The drain now has a ring-time reference that needs no anchor, so a 0x13 reply parked at connect
+        // may be resolvable. Retry BEFORE `ingest`, so this batch anchors straight away instead of parking
+        // into `pendingAnchorEvents` and being drained a moment later (2026-09-02/03 captures).
+        retryPendingSyncTimeAnchor()
         if pendingContinuation { restartBatchQuietTimer() }
         ingest(events)
     }
@@ -2277,6 +2289,7 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         loggedFirstTemp = false
         loggedFirstSpo2 = false
         loggedAnchor = false
+        pendingSyncTime = nil
         loggedTierBKinds.removeAll()
         loggedFeatureStatuses.removeAll()
         loggedProductInfo.removeAll()
@@ -2362,6 +2375,7 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         loggedFirstTemp = false
         loggedFirstSpo2 = false
         loggedAnchor = false
+        pendingSyncTime = nil
         loggedTierBKinds.removeAll()
         loggedFeatureStatuses.removeAll()
         loggedProductInfo.removeAll()
@@ -2547,28 +2561,56 @@ extension OuraLiveSource: @preconcurrency CBPeripheralDelegate {
         ingestHistory(driver.ingest(notification: bytes, reassembler: reassembler))
     }
 
+    /// The ring-time floor the 0x13 unit test disambiguates against: the persisted resume cursor, or the
+    /// largest envelope ring-time this drain has seen when that is further along. `maxSeenRingTime` is the
+    /// half that breaks the deadlock (2026-09-02/03 captures) — it counts EVERY history record, anchored or not, so it is
+    /// readable with no anchor, whereas the cursor can only advance once an anchor exists.
+    private var syncTimeAnchorLowerBound: UInt32 {
+        max(historyCursor, drain.maxSeenRingTime)
+    }
+
+    /// Try to turn a 0x13 SyncTime reply into this session's UTC anchor, returning whether it stuck.
+    /// `receivedAt` is the host wall-clock at the moment the reply ARRIVED (not now), since that is the
+    /// instant the ring's counter pairs with. Shared by the at-connect attempt and the retry.
+    private func adoptSyncTimeAnchor(deviceTimestamp: UInt32, status: UInt8, receivedAt: Int64, source: String) -> Bool {
+        guard let driver else { return false }
+        guard let rt = OuraDriver.syncTimeAnchorCandidate(responseValue: deviceTimestamp,
+                                                          lowerBoundTicks: syncTimeAnchorLowerBound),
+              driver.adoptSyncTimeAnchor(ringTimestamp: rt, unixSeconds: receivedAt) else { return false }
+        let unit = rt == deviceTimestamp ? "ticks" : "seconds x10"
+        let raw = String(format: "0x%08x", deviceTimestamp)
+        if !loggedAnchor {
+            loggedAnchor = true
+            log("Oura: UTC anchor from SyncTime response (0x13) \(source) - device rt \(rt) [\(unit), raw \(raw), status \(status)] = its receipt time; no 0x42 needed this session")
+        }
+        drainPendingAnchorEvents()
+        drainPendingHypnogramBursts()
+        return true
+    }
+
     /// Anchor from the 0x13 SyncTime response (ringverse BLE.md `13 05 <device_ts:4LE> <status:1>`):
     /// the ring's clock counter at the moment it processed our SyncTime, paired with the host wall-clock
-    /// at receipt. The tick unit is disambiguated against the persisted resume cursor
-    /// (OuraDriver.syncTimeAnchorCandidate — raw ticks vs seconds×10, exactly one must be plausible);
-    /// no unambiguous reading → log the raw value for investigation and adopt NOTHING (an honest missing
-    /// anchor beats a guessed one). On success everything parked while unanchored resolves immediately.
+    /// at receipt. The tick unit is disambiguated against a known-earlier ring-time
+    /// (OuraDriver.syncTimeAnchorCandidate — raw ticks vs seconds×10, exactly one must be plausible).
+    /// At connect the only reference is the resume cursor, which is 0 on a fresh pair and may be far
+    /// staler than the ring's clock; rather than discard the reply, PARK it and retry once history starts
+    /// landing (2026-09-02/03 captures). Still adopts NOTHING on ambiguity — an honest missing anchor beats a guessed one.
     private func handleSyncTimeResponse(_ resp: (deviceTimestamp: UInt32, status: UInt8)) {
-        guard let driver else { return }
         let now = Int64(Date().timeIntervalSince1970)
+        if adoptSyncTimeAnchor(deviceTimestamp: resp.deviceTimestamp, status: resp.status,
+                               receivedAt: now, source: "at connect") { return }
+        pendingSyncTime = (resp.deviceTimestamp, resp.status, now)
         let raw = String(format: "0x%08x", resp.deviceTimestamp)
-        if let rt = OuraDriver.syncTimeAnchorCandidate(responseValue: resp.deviceTimestamp,
-                                                       historyCursor: historyCursor),
-           driver.adoptSyncTimeAnchor(ringTimestamp: rt, unixSeconds: now) {
-            let unit = rt == resp.deviceTimestamp ? "ticks" : "seconds x10"
-            if !loggedAnchor {
-                loggedAnchor = true
-                log("Oura: UTC anchor from SyncTime response (0x13) - device rt \(rt) [\(unit), raw \(raw), status \(resp.status)] = now; no 0x42 needed this session")
-            }
-            drainPendingAnchorEvents()
-            drainPendingHypnogramBursts()
-        } else {
-            log("Oura: SyncTime response (0x13) raw \(raw) status \(resp.status) - no unambiguous tick reading vs cursor \(historyCursor); anchor NOT adopted (investigation)")
+        log("Oura: SyncTime response (0x13) raw \(raw) status \(resp.status) - no unambiguous tick reading vs ring-time floor \(syncTimeAnchorLowerBound); parked, retrying as history lands (investigation)")
+    }
+
+    /// Retry a parked 0x13 reply now that the drain has seen real ring-times. Silent on failure (the
+    /// parked reply simply waits for a better floor); one line on success, from `adoptSyncTimeAnchor`.
+    private func retryPendingSyncTimeAnchor() {
+        guard let parked = pendingSyncTime, drain.maxSeenRingTime > 0 else { return }
+        if adoptSyncTimeAnchor(deviceTimestamp: parked.deviceTimestamp, status: parked.status,
+                               receivedAt: parked.receivedAt, source: "resolved against history") {
+            pendingSyncTime = nil
         }
     }
 

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -311,6 +311,14 @@ class OuraLiveSource(
     private var loggedFirstTemp = false
     /** Logs the FIRST SpO2 sample decoded this session only. Twin of [loggedFirstTemp]. */
     private var loggedFirstSpo2 = false
+    /** The 0x13 SyncTime reply parked because nothing yet available could disambiguate its unit (ticks vs
+     *  seconds x10): the resume cursor was 0 (fresh pair / post-reboot full pull) or so stale the ring's
+     *  clock had run past the window. Retried against the drain's maxSeenRingTime as the first batch lands
+     *  (2026-09-02/03 captures). The ORIGINAL receipt wall-clock is carried along, because THAT is the instant the ring's
+     *  counter pairs with - re-stamping at retry time would skew the anchor by the drain's latency.
+     *  Twin of Swift's pendingSyncTime. */
+    private var pendingSyncTime: Triple<Long, Int, Long>? = null
+
     /** Logs the FIRST ring-time -> UTC anchor of this session only (s5.5); reset on stop/disconnect. */
     private var loggedAnchor = false
     /** Tier-B (UNVERIFIED) kinds ("activity" / "real_steps" / "sleep_summary" / "spo2_smoothed") already
@@ -835,27 +843,71 @@ class OuraLiveSource(
     }
 
     /**
+     * The ring-time floor the 0x13 unit test disambiguates against: the persisted resume cursor, or the
+     * largest envelope ring-time this drain has seen when that is further along. maxSeenRingTime is the
+     * half that breaks the deadlock (2026-09-02/03 captures) — it counts EVERY history record, anchored or not, so it is
+     * readable with no anchor, whereas the cursor can only advance once an anchor exists.
+     * Twin of Swift's syncTimeAnchorLowerBound.
+     */
+    private val syncTimeAnchorLowerBound: Long
+        get() = maxOf(historyCursor, drain.maxSeenRingTime)
+
+    /**
+     * Try to turn a 0x13 SyncTime reply into this session's UTC anchor, returning whether it stuck.
+     * [receivedAt] is the host wall-clock at the moment the reply ARRIVED (not now), since that is the
+     * instant the ring's counter pairs with. Shared by the at-connect attempt and the retry.
+     * Twin of Swift's adoptSyncTimeAnchor.
+     */
+    private fun adoptSyncTimeAnchor(
+        d: OuraDriver,
+        deviceTimestamp: Long,
+        status: Int,
+        receivedAt: Long,
+        source: String,
+    ): Boolean {
+        val rt = OuraDriver.syncTimeAnchorCandidate(deviceTimestamp, syncTimeAnchorLowerBound)
+            ?: return false
+        if (!d.adoptSyncTimeAnchor(ringTimestamp = rt, unixSeconds = receivedAt)) return false
+        val unit = if (rt == deviceTimestamp) "ticks" else "seconds x10"
+        val raw = "0x%08x".format(deviceTimestamp)
+        if (!loggedAnchor) {
+            loggedAnchor = true
+            log("Oura: UTC anchor from SyncTime response (0x13) $source - device rt $rt [$unit, " +
+                "raw $raw, status $status] = its receipt time; no 0x42 needed this session")
+        }
+        drainPendingAnchorEvents()
+        drainPendingHypnogramBursts()
+        return true
+    }
+
+    /**
      * Anchor from the 0x13 SyncTime response (ringverse: the ring's clock counter when it processed
-     * our SyncTime, paired with host wall-clock at receipt). The tick unit is disambiguated against
-     * the persisted resume cursor; no unambiguous reading → log the raw value and adopt NOTHING (an
-     * honest missing anchor beats a guessed one). Kotlin twin of Swift's handleSyncTimeResponse.
+     * our SyncTime, paired with host wall-clock at receipt). The tick unit is disambiguated against a
+     * known-earlier ring-time. At connect the only reference is the resume cursor, which is 0 on a fresh
+     * pair and may be far staler than the ring's clock; rather than discard the reply, PARK it and retry
+     * once history starts landing (2026-09-02/03 captures). Still adopts NOTHING on ambiguity — an honest missing anchor
+     * beats a guessed one. Kotlin twin of Swift's handleSyncTimeResponse.
      */
     private fun handleSyncTimeResponse(d: OuraDriver, resp: com.noop.oura.SyncTimeResponse) {
         val now = System.currentTimeMillis() / 1000L
+        if (adoptSyncTimeAnchor(d, resp.deviceTimestamp, resp.status, now, "at connect")) return
+        pendingSyncTime = Triple(resp.deviceTimestamp, resp.status, now)
         val raw = "0x%08x".format(resp.deviceTimestamp)
-        val rt = OuraDriver.syncTimeAnchorCandidate(resp.deviceTimestamp, historyCursor)
-        if (rt != null && d.adoptSyncTimeAnchor(ringTimestamp = rt, unixSeconds = now)) {
-            val unit = if (rt == resp.deviceTimestamp) "ticks" else "seconds x10"
-            if (!loggedAnchor) {
-                loggedAnchor = true
-                log("Oura: UTC anchor from SyncTime response (0x13) - device rt $rt [$unit, raw $raw, " +
-                    "status ${resp.status}] = now; no 0x42 needed this session")
-            }
-            drainPendingAnchorEvents()
-            drainPendingHypnogramBursts()
-        } else {
-            log("Oura: SyncTime response (0x13) raw $raw status ${resp.status} - no unambiguous tick " +
-                "reading vs cursor $historyCursor; anchor NOT adopted (investigation)")
+        log("Oura: SyncTime response (0x13) raw $raw status ${resp.status} - no unambiguous tick " +
+            "reading vs ring-time floor $syncTimeAnchorLowerBound; parked, retrying as history lands " +
+            "(investigation)")
+    }
+
+    /**
+     * Retry a parked 0x13 reply now that the drain has seen real ring-times. Silent on failure (the
+     * parked reply simply waits for a better floor); one line on success, from [adoptSyncTimeAnchor].
+     * Twin of Swift's retryPendingSyncTimeAnchor.
+     */
+    private fun retryPendingSyncTimeAnchor(d: OuraDriver) {
+        val parked = pendingSyncTime ?: return
+        if (drain.maxSeenRingTime <= 0) return
+        if (adoptSyncTimeAnchor(d, parked.first, parked.second, parked.third, "resolved against history")) {
+            pendingSyncTime = null
         }
     }
 
@@ -954,6 +1006,7 @@ class OuraLiveSource(
         loggedFirstTemp = false
         loggedFirstSpo2 = false
         loggedAnchor = false
+        pendingSyncTime = null
         loggedTierBKinds.clear()
         loggedFeatureStatuses.clear()
         loggedProductInfo.clear()
@@ -1046,6 +1099,7 @@ class OuraLiveSource(
         loggedFirstTemp = false
         loggedFirstSpo2 = false
         loggedAnchor = false
+        pendingSyncTime = null
         loggedTierBKinds.clear()
         loggedFeatureStatuses.clear()
         loggedProductInfo.clear()
@@ -1191,6 +1245,7 @@ class OuraLiveSource(
                     loggedFirstTemp = false
                     loggedFirstSpo2 = false
                     loggedAnchor = false
+                    pendingSyncTime = null
                     loggedTierBKinds.clear()
         loggedFeatureStatuses.clear()
         loggedProductInfo.clear()
@@ -1574,6 +1629,10 @@ class OuraLiveSource(
                 for (e in events) {
                     e.envelopeRingTimestamp?.let { drain.noteSeenRingTime(it) }
                 }
+                // The drain now has a ring-time reference that needs no anchor, so a 0x13 reply parked at
+                // connect may be resolvable. Retry BEFORE emit, so this batch anchors straight away
+                // instead of parking into pendingAnchorEvents and being drained a moment later (2026-09-02/03 captures).
+                retryPendingSyncTimeAnchor(d)
                 if (pendingContinuation && events.isNotEmpty()) {
                     handler.removeCallbacks(batchQuietRunnable)
                     handler.postDelayed(batchQuietRunnable, batchQuietMs)

--- a/android/app/src/main/java/com/noop/oura/OuraDriver.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraDriver.kt
@@ -649,18 +649,38 @@ class OuraDriver(
         private const val SAMPLE_FUTURE_TOLERANCE_SECONDS = 300L
 
         /**
+         * How far the ring's clock may run AHEAD of [lowerBoundTicks] and still be recognised. The bound
+         * is a stale resume cursor or the oldest ring-time a drain has seen, either of which can trail
+         * the ring's clock by the ring's whole banked depth (~14 days) plus however long the cursor has
+         * been stuck — the original 7-day window silently excluded exactly that case: in the 2026-09-02/03
+         * iOS captures an 8.2-day-stale cursor could never be re-anchored, so it could never advance, so
+         * the staleness only grew — one full re-serve of the same window per launch, forever. Widening
+         * costs no honesty: both readings fit the window only when
+         * `window >= 9 × lowerBound`, i.e. a ring under ~5 days of clock — and that case still resolves
+         * to null below, exactly as before. Byte-identical twin of Swift's syncTimeAnchorWindowTicks.
+         */
+        const val SYNC_TIME_ANCHOR_WINDOW_TICKS = 38_880_000L   // 45 days of 100 ms ticks
+
+        /**
          * Resolve the 0x13 SyncTime-response device timestamp into ring TICKS, or null when no
          * unambiguous reading exists. ringverse BLE.md labels the field "seconds" but the ring's record
          * clock runs in 100 ms ticks, so both readings are tried: the raw value (already ticks) and
-         * value×10 (seconds→ticks). The ring's clock at connect must sit shortly AFTER where the last
-         * drain ended, so a candidate is plausible iff it falls in `[historyCursor, historyCursor +
-         * 7 days]`; exactly one must fit (ambiguity or a fresh/reset cursor → null → the caller logs
-         * raw instead of guessing). Pure. Byte-identical twin of Swift's syncTimeAnchorCandidate.
+         * value×10 (seconds→ticks). The ring's clock at connect must sit AFTER any ring-time we already
+         * know about, so a candidate is plausible iff it falls in `[lowerBoundTicks, lowerBoundTicks +
+         * SYNC_TIME_ANCHOR_WINDOW_TICKS]`; exactly one must fit (ambiguity or no reference at all → null
+         * → the caller logs raw instead of guessing).
+         *
+         * [lowerBoundTicks] is any ring-time known to precede the ring's clock NOW: the persisted resume
+         * cursor at connect, or — when that is 0 (fresh pair / post-reboot reset) or too stale — the
+         * largest envelope ring-time the drain has actually seen ([OuraHistoryDrain.maxSeenRingTime]),
+         * which needs no anchor to read and so breaks the cursor↔anchor deadlock (2026-09-02/03 captures).
+         *
+         * Pure. Byte-identical twin of Swift's syncTimeAnchorCandidate.
          */
-        fun syncTimeAnchorCandidate(responseValue: Long, historyCursor: Long): Long? {
-            if (historyCursor <= 0) return null
-            val lower = historyCursor
-            val upper = lower + 6_048_000L   // 7 days of 100 ms ticks
+        fun syncTimeAnchorCandidate(responseValue: Long, lowerBoundTicks: Long): Long? {
+            if (lowerBoundTicks <= 0) return null
+            val lower = lowerBoundTicks
+            val upper = lower + SYNC_TIME_ANCHOR_WINDOW_TICKS
             val readings = listOf(responseValue, responseValue * 10)
             val fits = readings.filter { it in lower..upper && it <= 0xFFFF_FFFFL }
             if (fits.size != 1) return null

--- a/android/app/src/test/java/com/noop/oura/FramingTest.kt
+++ b/android/app/src/test/java/com/noop/oura/FramingTest.kt
@@ -100,21 +100,82 @@ class FramingTest {
         assertNull(OuraFraming.parseSyncTimeResponse(bytes("4beda900")))
     }
 
+    /**
+     * Parity oracle for [OuraDriver.syncTimeAnchorCandidate] (2026-09-02/03 captures). Expected values are the VERBATIM
+     * stdout of the shipped Swift twin compiled standalone (`swiftc -O twin.swift main.swift`), one
+     * `responseValue / lowerBoundTicks / result` row per line — not values read off the Kotlin. The
+     * spread covers the shipped unit cases, the 2026-09-02/03 capture values behind this fix, both halves
+     * of the cursor↔anchor deadlock, the exact window edges, the ambiguity band around the 9× boundary,
+     * and the UInt32 ceiling. Guards the Kotlin direction only; the Swift test in FramingTests.swift is
+     * what stops Swift drifting.
+     */
     @Test
-    fun testSyncTimeAnchorCandidateResolvesUnit() {
-        // The 2026-07-13 shape: cursor banked at 4_413_933; ~11 h later the ring's clock is ~4.81M
-        // ticks. A raw-ticks response fits [cursor, cursor+7d] and the seconds x10 reading does not.
-        assertEquals(4_810_000L, OuraDriver.syncTimeAnchorCandidate(4_810_000L, 4_413_933L))
-        // A seconds-unit response (481_000 s = 4.81M ticks) only fits when multiplied x10.
-        assertEquals(4_810_000L, OuraDriver.syncTimeAnchorCandidate(481_000L, 4_413_933L))
-        // Below the cursor in both readings (ring reboot / stale value) -> null.
-        assertNull(OuraDriver.syncTimeAnchorCandidate(100_000L, 4_413_933L))
-        // Beyond cursor+7d in both readings -> null.
-        assertNull(OuraDriver.syncTimeAnchorCandidate(40_000_000L, 4_413_933L))
-        // A fresh/reset cursor gives no reference -> null (never guess on a full pull).
-        assertNull(OuraDriver.syncTimeAnchorCandidate(4_810_000L, 0L))
-        // Ambiguity guard: BOTH readings inside the window -> null.
-        assertNull(OuraDriver.syncTimeAnchorCandidate(150_000L, 140_000L))
+    fun testSyncTimeAnchorCandidateMatchesTheSwiftOracle() {
+        // responseValue, lowerBoundTicks, expected (null = no unambiguous reading)
+        val oracle: List<Triple<Long, Long, Long?>> = listOf(
+            Triple(4_810_000L, 4_413_933L, 4_810_000L),
+            Triple(481_000L, 4_413_933L, 4_810_000L),
+            Triple(100_000L, 4_413_933L, null),
+            Triple(50_000_000L, 4_413_933L, null),
+            Triple(4_810_000L, 0L, null),
+            Triple(150_000L, 140_000L, null),
+            Triple(35_157_631L, 28_073_725L, 35_157_631L),
+            Triple(35_159_272L, 28_073_725L, 35_159_272L),
+            Triple(35_168_206L, 28_073_725L, 35_168_206L),
+            Triple(34_724_816L, 0L, null),
+            Triple(34_749_048L, 0L, null),
+            Triple(34_776_653L, 0L, null),
+            Triple(34_724_816L, 22_628_816L, 34_724_816L),
+            Triple(34_749_048L, 22_628_816L, 34_749_048L),
+            Triple(34_776_653L, 22_628_816L, 34_776_653L),
+            Triple(28_073_725L, 28_073_725L, 28_073_725L),
+            Triple(66_953_725L, 28_073_725L, 66_953_725L),
+            Triple(66_953_726L, 28_073_725L, null),
+            Triple(28_073_724L, 28_073_725L, null),
+            Triple(500_000L, 400_000L, null),
+            Triple(4_320_000L, 4_320_000L, null),
+            Triple(4_320_001L, 4_320_001L, 4_320_001L),
+            Triple(4_294_967_295L, 4_294_000_000L, 4_294_967_295L),
+            Triple(500_000_000L, 100_000_000L, null),
+        )
+        for ((value, lowerBound, expected) in oracle) {
+            assertEquals(
+                "syncTimeAnchorCandidate($value, $lowerBound)",
+                expected,
+                OuraDriver.syncTimeAnchorCandidate(value, lowerBound),
+            )
+        }
+    }
+
+    /**
+     * Stated as the behaviour rather than the table: the 2026-09-03 capture's 0x13 reply
+     * (0x0218767f = 35_157_631) against the frozen resume cursor 28_073_725, which trails it by 8.20
+     * days. Under the old 7-day window neither reading fit, so no anchor was adopted; with no anchor the
+     * drain-end commit could not advance the cursor, so the cursor stayed stale and the gap only grew —
+     * a permanent loop, one full re-serve of the same window per launch.
+     */
+    @Test
+    fun testSyncTimeAnchorCandidateAcceptsAStaleCursor() {
+        val staleCursor = 28_073_725L
+        assertEquals(35_157_631L, OuraDriver.syncTimeAnchorCandidate(0x0218767fL, staleCursor))
+        // The old 7-day window is what excluded it: 28_073_725 + 6_048_000 = 34_121_725 < 35_157_631.
+        assertTrue(
+            "the window must cover the observed 8.2-day staleness",
+            OuraDriver.SYNC_TIME_ANCHOR_WINDOW_TICKS > 35_157_631L - staleCursor,
+        )
+    }
+
+    /**
+     * The other half of the deadlock: on a fresh pair / post-reboot reset the cursor is 0, so it
+     * can never be the reference. The drain's maxSeenRingTime can — it counts EVERY history record's
+     * envelope time and needs no anchor to read — so the caller retries the parked reply against it.
+     */
+    @Test
+    fun testSyncTimeAnchorCandidateResolvesAgainstSeenRingTimeWhenCursorIsZero() {
+        val reply = 0x0211dbd0L                 // 34_724_816 — the 2026-09-02 capture, cursor 0
+        assertNull(OuraDriver.syncTimeAnchorCandidate(reply, 0L))
+        // First batch of a full pull lands the ring's OLDEST banked record (~14 days back).
+        assertEquals(reply, OuraDriver.syncTimeAnchorCandidate(reply, 34_724_816L - 12_096_000L))
     }
 
     @Test


### PR DESCRIPTION
## What

Two gates in the Oura `0x13` SyncTime path could leave a ring **permanently** unable to advance its persisted `GetEvents` cursor. With the cursor frozen, every launch re-drains the same window of banked history and commits nothing — indefinitely.

## Evidence

Two iOS diagnostic snapshots from the same device (iPhone18,1, iOS 26.6.1, app 11.0.0 @ `70c267a6`), taken ~11 h apart. Every launch in the 09-03 bundle starts from the identical cursor:

```
[07:50:20] Oura: fetching history from cursor 28073725 … [cursor-fix]
[07:53:04] Oura: fetching history from cursor 28073725 … [cursor-fix]
[08:07:57] Oura: fetching history from cursor 28073725 … [cursor-fix]
```

— although the 07:50 session had already drained to **28228514**. In the 09-02 bundle all three launches start from cursor **0**: a full re-pull of the ring's entire backlog, three times in 90 minutes. Every session in both bundles logs `[no anchor yet]`, and `Oura: UTC anchor from SyncTime response (0x13)` appears **zero** times.

## Root cause

- `commitResumeCursor` only persists a cursor that resolves under the *current* anchor — `OuraHistoryDrain.resumeCursorAtDrainEnd(resolvesUnderAnchor: false)` returns the cursor unchanged.
- The anchor comes from `OuraDriver.syncTimeAnchorCandidate`, which disambiguated the reply's unit (raw ticks vs seconds×10) against `[cursor, cursor + 7 days]`.

So **no anchor → no cursor advance → the cursor falls further behind → still no anchor.** Self-sustaining; it never heals on its own.

Both entry points into that state were reachable:

| | cursor | 0x13 reply | window upper | outcome |
|---|---|---|---|---|
| 09-03 | 28,073,725 | `0x0218767f` = 35,157,631 | 34,121,725 | **8.20 d** past the window → no fit |
| 09-02 | `0` | `0x0211dbd0` = 34,724,816 | — | `guard historyCursor > 0` → rejected outright |

The stale cursor got there honestly: the 300 s deadline guard banked it at a point already 8 days old, which landed straight outside the 7-day window. Cursor 0 is every fresh pair and every post-reboot (`sawPreResumeData`) reset.

## The fix

Both halves are required — neither is sufficient alone.

1. **Widen the window to 45 days** (`syncTimeAnchorWindowTicks` / `SYNC_TIME_ANCHOR_WINDOW_TICKS`). The bound can trail the ring's clock by the whole banked depth (~14 d) plus however long the cursor has been stuck. This costs no honesty: both readings fit only when `window ≥ 9 × lowerBound`, i.e. a ring under ~5 days of clock — and that case still resolves to nil/null exactly as before.
2. **Park a reply that cannot yet be disambiguated** instead of discarding it, and retry it against `OuraHistoryDrain.maxSeenRingTime` as the first batch lands. That counter tracks *every* history record's envelope time and needs **no anchor** to read — so it is a reference the cursor cannot be. The original receipt wall-clock is carried along; re-stamping at retry time would skew the anchor by the drain's latency.

The gate stays honest throughout: ambiguity and "no reference at all" still adopt **NOTHING**. The at-connect log line now says the reply was parked and will be retried, rather than claiming it was rejected outright — a diagnostic that asserts only what it can attribute.

## Verification

- **`swift test` (Packages):** OuraProtocol 209 · WhoopProtocol 654 · StrandAnalytics 1728 · WhoopStore 477 · StrandImport 249 — **0 failures**.
- **macOS app target:** `xcodebuild -scheme Strand -destination 'platform=macOS' build` succeeded, and `… test` ran **StrandTests: 1482 tests, 0 failures**. (`app-build.yml` is disabled by default, so app-target Swift is not covered by CI — this was run locally.)
- **Android:** `compileFullDebugKotlin` clean. `testFullDebugUnitTest`: 5100 tests, 2 failures — both `RecoveryDriversTest` float-rounding, **proven pre-existing** by running the same suite in a worktree at the base commit (5098 tests, the same 2 failures). This branch adds 2 tests and 0 failures.
- **`Tools/doc_comment_lint.py`:** OK, no new detached doc comments.
- **Cross-platform parity by oracle, not by eye:** the Kotlin expected values are the **verbatim stdout** of the shipped Swift twin compiled standalone (`swiftc -O twin.swift main.swift`) — 24 rows covering the capture values, both deadlock halves, the exact window edges, the ambiguity band around the 9× boundary, and the `UInt32` ceiling. Not values read back off the Kotlin. A matching Swift test guards the other direction.

## Not done — needs a real ring

This is a **BLE-path change**, so compile-success proves nothing about connection behaviour. It still needs hardware confirmation that (a) the anchor is adopted (`UTC anchor from SyncTime response (0x13) resolved against history`) and (b) `fetching history from cursor …` moves forward across consecutive launches.

An affected device also carries ~8 days of backlog that the drain must still work through at 300 s/pass; progress now banks between passes instead of being discarded, but the first few sessions will still be catching up. Clearing `com.noop.oura.historyCursor.<deviceId>` in `UserDefaults` is not needed and would force a full re-pull — the fix recovers without it.

## Scope

One concern: the anchor gate and its two call sites. No schema change, no migration, no UI, no new strings.