### PR TITLE
health: say when skin temp could not honour the Settings choice (#1847)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2327,6 +2327,15 @@ private fun buildVitalDetail(
         // the kind is re-derived from the value and the series partitioned to it.
         val kind = if (leadsAbsolute) SkinTempDisplay.Kind.ABSOLUTE else SkinTempDisplay.kind(lead.value)
         val unit = SkinTempDisplay.unitSymbol(kind, fahrenheit)
+        val skinReadings = if (leadsAbsolute) {
+            days.mapNotNull { row -> row.skinTempC?.let { VitalReading(row.day, it, row.deviceId) } }
+        } else {
+            days.mapNotNull { row ->
+                row.skinTempDevC
+                    ?.takeIf { VitalBands.isAbsoluteSkinTemp(it) == (kind == SkinTempDisplay.Kind.ABSOLUTE) }
+                    ?.let { value -> VitalReading(row.day, value, row.deviceId) }
+            }
+        }
         val title = if (kind == SkinTempDisplay.Kind.ABSOLUTE) {
             uiString(R.string.l10n_health_screen_skin_temperature_f59127f6)
         } else {
@@ -2337,23 +2346,21 @@ private fun buildVitalDetail(
             title = title,
             unit = unit,
             color = Palette.metricAmber,
-            readings = if (leadsAbsolute) {
-                days.mapNotNull { row -> row.skinTempC?.let { VitalReading(row.day, it, row.deviceId) } }
-            } else {
-                days.mapNotNull { row ->
-                    row.skinTempDevC
-                        ?.takeIf { VitalBands.isAbsoluteSkinTemp(it) == (kind == SkinTempDisplay.Kind.ABSOLUTE) }
-                        ?.let { value -> VitalReading(row.day, value, row.deviceId) }
-                }
-            },
+            readings = skinReadings,
             format = { c -> SkinTempDisplay.numberString(c, kind, fahrenheit, decimals = 1) },
             // #1847: Settings asked for a temperature and none of these nights has one, so the screen shows
             // the deviation instead. Say so — silently falling back is why the setting reads as broken.
             // Nights scored before skinTempC shipped kept only the deviation; a scoring pass refills them.
-            fallbackNote = if (shouldExplainSkinTempFallback(skinTempPreferred, leadsAbsolute)) {
-                uiString(R.string.l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae)
-            } else {
-                null
+            fallbackNote = when {
+                shouldExplainSkinTempFallback(skinTempPreferred, leadsAbsolute) ->
+                    uiString(R.string.l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae)
+                // Leading with the absolute drops deviation-only nights from the series, so the reading
+                // count falls. Say why rather than letting history look like it vanished.
+                shouldExplainShortenedSkinTempSeries(
+                    shownReadings = skinReadings.size,
+                    rowsWithEitherNumber = days.count { it.skinTempC != null || it.skinTempDevC != null },
+                ) -> uiString(R.string.l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da)
+                else -> null
             },
         )
     }

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -1747,6 +1747,8 @@ private data class VitalDetailModel(
     val color: Color,
     val readings: List<VitalReading>,
     val format: (Double) -> String,
+    /** #1847: why the screen is not showing what Settings asked for. Null when it is. */
+    val fallbackNote: String? = null,
 ) {
     /** (day, value) projection the trend chart + range helpers consume — SAME order as [readings], so the
      *  chart, the header count, and the table can never drift apart. */
@@ -2059,6 +2061,14 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                             style = NoopType.footnote,
                             color = Palette.textTertiary,
                         )
+                        detail.fallbackNote?.let { note ->
+                            Text(
+                                text = note,
+                                style = NoopType.footnote,
+                                color = Palette.textTertiary,
+                                modifier = Modifier.padding(top = 6.dp),
+                            )
+                        }
                     }
                 }
                 SegmentedPillControl(
@@ -2337,6 +2347,14 @@ private fun buildVitalDetail(
                 }
             },
             format = { c -> SkinTempDisplay.numberString(c, kind, fahrenheit, decimals = 1) },
+            // #1847: Settings asked for a temperature and none of these nights has one, so the screen shows
+            // the deviation instead. Say so — silently falling back is why the setting reads as broken.
+            // Nights scored before skinTempC shipped kept only the deviation; a scoring pass refills them.
+            fallbackNote = if (shouldExplainSkinTempFallback(skinTempPreferred, leadsAbsolute)) {
+                uiString(R.string.l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae)
+            } else {
+                null
+            },
         )
     }
     else -> null

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2328,7 +2328,15 @@ private fun buildVitalDetail(
         val kind = if (leadsAbsolute) SkinTempDisplay.Kind.ABSOLUTE else SkinTempDisplay.kind(lead.value)
         val unit = SkinTempDisplay.unitSymbol(kind, fahrenheit)
         val skinReadings = if (leadsAbsolute) {
-            days.mapNotNull { row -> row.skinTempC?.let { VitalReading(row.day, it, row.deviceId) } }
+            // An absolute-led series takes EVERY absolute reading, whichever column holds it. A WHOOP CSV
+            // import writes absolute °C straight into skinTempDevC (`skin_temp_celsius`, #622 bimodal), so
+            // reading skinTempC alone hid a wearer's imported temperatures from a temperature chart — and
+            // made the shortened-series note call them "a baseline difference only", which they are not.
+            // Mixing is only unsound ACROSS scales; these are the same scale.
+            days.mapNotNull { row ->
+                (row.skinTempC ?: row.skinTempDevC?.takeIf { VitalBands.isAbsoluteSkinTemp(it) })
+                    ?.let { VitalReading(row.day, it, row.deviceId) }
+            }
         } else {
             days.mapNotNull { row ->
                 row.skinTempDevC

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2352,11 +2352,15 @@ private fun buildVitalDetail(
             // the deviation instead. Say so — silently falling back is why the setting reads as broken.
             // Nights scored before skinTempC shipped kept only the deviation; a scoring pass refills them.
             fallbackNote = when {
-                shouldExplainSkinTempFallback(skinTempPreferred, leadsAbsolute) ->
+                shouldExplainSkinTempFallback(
+                    skinTempPreferred, leadsAbsolute,
+                    anyAbsoluteInWindow = days.any { it.skinTempC != null },
+                ) ->
                     uiString(R.string.l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae)
                 // Leading with the absolute drops deviation-only nights from the series, so the reading
                 // count falls. Say why rather than letting history look like it vanished.
                 shouldExplainShortenedSkinTempSeries(
+                    leadsAbsolute = leadsAbsolute,
                     shownReadings = skinReadings.size,
                     rowsWithEitherNumber = days.count { it.skinTempC != null || it.skinTempDevC != null },
                 ) -> uiString(R.string.l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da)

--- a/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
@@ -99,6 +99,21 @@ internal data class Vital(
 }
 
 /**
+ * Whether the skin-temp screen must explain a SHORTENED series (#1847).
+ *
+ * Leading with the absolute means the chart and table must read the absolute column, because an absolute
+ * plotted against a history of deviations is arithmetic on two scales. Nights that only ever recorded a
+ * deviation therefore drop out — and after a sync refills the 21-night `analyzeRecent` window on an install
+ * with older history, the reading count visibly falls with nothing on screen saying why.
+ *
+ * True only when rows were actually dropped, so a complete series stays silent.
+ */
+internal fun shouldExplainShortenedSkinTempSeries(
+    shownReadings: Int,
+    rowsWithEitherNumber: Int,
+): Boolean = shownReadings < rowsWithEitherNumber
+
+/**
  * Whether the skin-temp screen must EXPLAIN itself (#1847).
  *
  * `leadReading` deliberately falls back: asking for a temperature on a night that only ever recorded a

--- a/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
@@ -106,27 +106,38 @@ internal data class Vital(
  * deviation therefore drop out — and after a sync refills the 21-night `analyzeRecent` window on an install
  * with older history, the reading count visibly falls with nothing on screen saying why.
  *
+ * ONLY when leading with the absolute. The deviation-led branch also drops rows — calibrating nights that
+ * have only an absolute, and the #622 bimodal partition — but they are the OPPOSITE kind, so this note's
+ * sentence would be precisely backwards there. Gated inside the rule rather than at the call site, because
+ * the function name promises the whole rule.
+ *
  * True only when rows were actually dropped, so a complete series stays silent.
  */
 internal fun shouldExplainShortenedSkinTempSeries(
+    leadsAbsolute: Boolean,
     shownReadings: Int,
     rowsWithEitherNumber: Int,
-): Boolean = shownReadings < rowsWithEitherNumber
+): Boolean = leadsAbsolute && shownReadings < rowsWithEitherNumber
 
 /**
  * Whether the skin-temp screen must EXPLAIN itself (#1847).
  *
  * `leadReading` deliberately falls back: asking for a temperature on a night that only ever recorded a
  * deviation shows the deviation rather than blanking. That is right, but silent — the setting then looks
- * broken, because both choices render the same Δ°C. True exactly when the user asked for a temperature and
- * no night in the window has one.
+ * broken, because both choices render the same Δ°C.
+ *
+ * Requires that NO night in the window has an absolute, not merely that the newest lacks one. When the
+ * newest night has no absolute but an older one does, the sentence "no measured temperature for these
+ * nights" is false for those older nights — so that case shows nothing. Saying nothing is a gap; saying
+ * something untrue about the user's own data is worse.
  *
  * Pure so the decision is testable without Compose.
  */
 internal fun shouldExplainSkinTempFallback(
     prefer: SkinTempDisplay.Kind,
     leadsAbsolute: Boolean,
-): Boolean = prefer == SkinTempDisplay.Kind.ABSOLUTE && !leadsAbsolute
+    anyAbsoluteInWindow: Boolean,
+): Boolean = prefer == SkinTempDisplay.Kind.ABSOLUTE && !leadsAbsolute && !anyAbsoluteInWindow
 
 /**
  * Whether the skin-temp tile leads with the night's ABSOLUTE (#1636).

--- a/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
@@ -99,6 +99,21 @@ internal data class Vital(
 }
 
 /**
+ * Whether the skin-temp screen must EXPLAIN itself (#1847).
+ *
+ * `leadReading` deliberately falls back: asking for a temperature on a night that only ever recorded a
+ * deviation shows the deviation rather than blanking. That is right, but silent — the setting then looks
+ * broken, because both choices render the same Δ°C. True exactly when the user asked for a temperature and
+ * no night in the window has one.
+ *
+ * Pure so the decision is testable without Compose.
+ */
+internal fun shouldExplainSkinTempFallback(
+    prefer: SkinTempDisplay.Kind,
+    leadsAbsolute: Boolean,
+): Boolean = prefer == SkinTempDisplay.Kind.ABSOLUTE && !leadsAbsolute
+
+/**
  * Whether the skin-temp tile leads with the night's ABSOLUTE (#1636).
  *
  * True whenever the displayed night measured one. A deviation with no anchor cannot be read — "+0.9" is

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2682,4 +2682,5 @@
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Wähle dein Zeitformat, Schlaf von Straps ohne Bewegungsdaten und ein Strap-Log, das nicht mehr rät</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Hauttemperatur</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Für diese Nächte liegt keine gemessene Temperatur vor — angezeigt wird die Abweichung von deinem Basiswert. Eine Synchronisierung bewertet die letzten Nächte neu und ergänzt sie.</string>
+    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Es werden nur Nächte mit gemessener Temperatur angezeigt. Für frühere Nächte wurde nur eine Abweichung vom Basiswert erfasst.</string>
 </resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2681,4 +2681,5 @@
     <string name="l10n_app_changelog_a_whoop_5_that_stays_connected_7b490eee">Eine WHOOP 5, die verbunden bleibt, deine innere Uhr im Schlaf-Screen und ein Journal, das Nein von gar nichts unterscheidet</string>
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Wähle dein Zeitformat, Schlaf von Straps ohne Bewegungsdaten und ein Strap-Log, das nicht mehr rät</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Hauttemperatur</string>
+    <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Für diese Nächte liegt keine gemessene Temperatur vor — angezeigt wird die Abweichung von deinem Basiswert. Eine Synchronisierung bewertet die letzten Nächte neu und ergänzt sie.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2669,4 +2669,5 @@
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Elige el reloj de 12 horas, sueño desde correas que no registran movimiento y un registro que deja de suponer</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura cutánea</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">No hay temperatura medida para estas noches: se muestra la diferencia respecto a tu referencia. Una sincronización vuelve a analizar las noches recientes y la completa.</string>
+    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Solo se muestran las noches con temperatura medida. En las noches anteriores solo se registró la diferencia respecto a la referencia.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2668,4 +2668,5 @@
     <string name="l10n_app_changelog_a_whoop_5_that_stays_connected_7b490eee">Una WHOOP 5 que no se desconecta, tu reloj interno en la pantalla de Sueño y un diario que distingue No de nada</string>
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Elige el reloj de 12 horas, sueño desde correas que no registran movimiento y un registro que deja de suponer</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura cutánea</string>
+    <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">No hay temperatura medida para estas noches: se muestra la diferencia respecto a tu referencia. Una sincronización vuelve a analizar las noches recientes y la completa.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2667,4 +2667,5 @@
     <string name="l10n_app_changelog_a_whoop_5_that_stays_connected_7b490eee">Une WHOOP 5 qui reste connectée, votre horloge interne sur l\'écran Sommeil, et un journal qui distingue Non de rien</string>
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Choisissez l\'horloge 12 heures, le sommeil depuis des bracelets sans données de mouvement, et un journal qui cesse de deviner</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Température cutanée</string>
+    <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Aucune température mesurée pour ces nuits — l\'écart par rapport à votre référence est affiché. Une synchronisation réévalue les nuits récentes et le complète.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2668,4 +2668,5 @@
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Choisissez l\'horloge 12 heures, le sommeil depuis des bracelets sans données de mouvement, et un journal qui cesse de deviner</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Température cutanée</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Aucune température mesurée pour ces nuits — l\'écart par rapport à votre référence est affiché. Une synchronisation réévalue les nuits récentes et le complète.</string>
+    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Seules les nuits avec une température mesurée sont affichées. Les nuits précédentes n\'ont enregistré qu\'un écart par rapport à la référence.</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2672,4 +2672,5 @@
     <string name="l10n_app_changelog_a_whoop_5_that_stays_connected_7b490eee">WHOOP 5, który nie traci połączenia, zegar biologiczny na ekranie snu i dziennik odróżniający Nie od braku wpisu</string>
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Wybierz zegar 12-godzinny, sen z opasek bez danych o ruchu i dziennik, który przestaje zgadywać</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura skóry</string>
+    <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Brak zmierzonej temperatury dla tych nocy — pokazano różnicę względem Twojej wartości bazowej. Synchronizacja ponownie przelicza ostatnie noce i ją uzupełnia.</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2673,4 +2673,5 @@
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Wybierz zegar 12-godzinny, sen z opasek bez danych o ruchu i dziennik, który przestaje zgadywać</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura skóry</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Brak zmierzonej temperatury dla tych nocy — pokazano różnicę względem Twojej wartości bazowej. Synchronizacja ponownie przelicza ostatnie noce i ją uzupełnia.</string>
+    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Pokazywane są tylko noce ze zmierzoną temperaturą. We wcześniejszych nocach zapisano jedynie różnicę względem wartości bazowej.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2660,4 +2660,5 @@
     <string name="l10n_app_changelog_a_whoop_5_that_stays_connected_7b490eee">Uma WHOOP 5 que se mantém ligada, o seu relógio interno no ecrã de Sono e um diário que distingue Não de nada</string>
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Escolha o relógio de 12 horas, sono a partir de pulseiras sem dados de movimento e um registo que deixa de adivinhar</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura da pele</string>
+    <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Sem temperatura medida para estas noites — a mostrar a diferença em relação à sua referência. Uma sincronização reavalia as noites recentes e preenche-a.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2661,4 +2661,5 @@
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Escolha o relógio de 12 horas, sono a partir de pulseiras sem dados de movimento e um registo que deixa de adivinhar</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura da pele</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Sem temperatura medida para estas noites — a mostrar a diferença em relação à sua referência. Uma sincronização reavalia as noites recentes e preenche-a.</string>
+    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Só são mostradas as noites com temperatura medida. As noites anteriores registaram apenas a diferença em relação à referência.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2581,4 +2581,5 @@
     <string name="l10n_app_changelog_a_whoop_5_that_stays_connected_7b490eee">不再频繁掉线的 WHOOP 5、睡眠页上的生物钟，以及能分清「否」与「未记录」的日志</string>
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">自选 12 小时制、从无运动数据的手环读取睡眠，以及不再靠猜测的手环日志</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">皮肤温度</string>
+    <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">这些夜晚没有实测温度，显示的是与基线的差值。同步后会重新计算近期夜晚并补上。</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2582,4 +2582,5 @@
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">自选 12 小时制、从无运动数据的手环读取睡眠，以及不再靠猜测的手环日志</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">皮肤温度</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">这些夜晚没有实测温度，显示的是与基线的差值。同步后会重新计算近期夜晚并补上。</string>
+    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">仅显示有实测温度的夜晚。更早的夜晚只记录了与基线的差值。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2695,4 +2695,5 @@
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Choose a 12-hour clock, sleep from straps that bank no motion, and a strap log that stops guessing</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Skin temperature</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">No measured temperature for these nights — showing the difference from your baseline. A sync re-scores recent nights and fills it in.</string>
+    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Only nights with a measured temperature are shown. Earlier nights recorded a baseline difference only.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2694,4 +2694,5 @@
     <string name="l10n_app_changelog_a_whoop_5_that_stays_connected_7b490eee">A WHOOP 5 that stays connected, your body clock on the Sleep screen, and a Journal that knows No from nothing</string>
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Choose a 12-hour clock, sleep from straps that bank no motion, and a strap log that stops guessing</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Skin temperature</string>
+    <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">No measured temperature for these nights — showing the difference from your baseline. A sync re-scores recent nights and fills it in.</string>
 </resources>

--- a/android/app/src/test/java/com/noop/ui/SkinTempFallbackNoteTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SkinTempFallbackNoteTest.kt
@@ -16,19 +16,22 @@ class SkinTempFallbackNoteTest {
     /** Asked for a temperature, no night has one — the reported case, and the only one that explains. */
     @Test
     fun explainsWhenTemperatureWasAskedForAndNoneExists() {
-        assertTrue(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.ABSOLUTE, leadsAbsolute = false))
+        assertTrue(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.ABSOLUTE, leadsAbsolute = false,
+                                                  anyAbsoluteInWindow = false))
     }
 
     /** Asked for a temperature and got one: nothing to explain. */
     @Test
     fun silentWhenTheChoiceWasHonoured() {
-        assertFalse(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.ABSOLUTE, leadsAbsolute = true))
+        assertFalse(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.ABSOLUTE, leadsAbsolute = true,
+                                                   anyAbsoluteInWindow = true))
     }
 
     /** Asked for the baseline delta and got it. */
     @Test
     fun silentWhenTheDeviationWasChosen() {
-        assertFalse(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.DEVIATION, leadsAbsolute = false))
+        assertFalse(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.DEVIATION, leadsAbsolute = false,
+                                                   anyAbsoluteInWindow = false))
     }
 
     /** Chose the delta but only an absolute exists: the reverse fallback. It shows a temperature under a
@@ -36,7 +39,8 @@ class SkinTempFallbackNoteTest {
      *  deliberate rather than an oversight. */
     @Test
     fun silentOnTheReverseFallback() {
-        assertFalse(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.DEVIATION, leadsAbsolute = true))
+        assertFalse(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.DEVIATION, leadsAbsolute = true,
+                                                   anyAbsoluteInWindow = true))
     }
 
     // MARK: the shortened series (#1847, found in re-review)
@@ -45,19 +49,47 @@ class SkinTempFallbackNoteTest {
      *  drops the deviation-only nights and the reading count visibly falls. Say why. */
     @Test
     fun explainsWhenNightsWereDroppedFromTheSeries() {
-        assertTrue(shouldExplainShortenedSkinTempSeries(shownReadings = 21, rowsWithEitherNumber = 40))
+        assertTrue(shouldExplainShortenedSkinTempSeries(leadsAbsolute = true, shownReadings = 21,
+                                                        rowsWithEitherNumber = 40))
     }
 
     /** A complete series says nothing — the note must not appear on a healthy screen. */
     @Test
     fun silentWhenEveryNightIsShown() {
-        assertFalse(shouldExplainShortenedSkinTempSeries(shownReadings = 23, rowsWithEitherNumber = 23))
+        assertFalse(shouldExplainShortenedSkinTempSeries(leadsAbsolute = true, shownReadings = 23,
+                                                         rowsWithEitherNumber = 23))
     }
 
     /** No data at all is the empty state's job, not this note's. */
     @Test
     fun silentWhenThereIsNothingToShow() {
-        assertFalse(shouldExplainShortenedSkinTempSeries(shownReadings = 0, rowsWithEitherNumber = 0))
+        assertFalse(shouldExplainShortenedSkinTempSeries(leadsAbsolute = true, shownReadings = 0,
+                                                         rowsWithEitherNumber = 0))
+    }
+
+
+    // MARK: what the second re-review caught — the note must never say the opposite of what happened
+
+    /**
+     * The deviation-led branch ALSO drops rows: calibrating nights that have only an absolute, and the #622
+     * bimodal partition. Those are the OPPOSITE kind, so "only nights with a measured temperature are
+     * shown" would be precisely backwards. Ungated, this fired the moment a wearer picked "vs baseline"
+     * with any calibrating night in the window.
+     */
+    @Test
+    fun neverExplainsAShortenedSeriesWhenLeadingWithTheDeviation() {
+        assertFalse(shouldExplainShortenedSkinTempSeries(leadsAbsolute = false, shownReadings = 21,
+                                                         rowsWithEitherNumber = 40))
+    }
+
+    /**
+     * The newest night has no absolute but an older one does. "No measured temperature for these nights" is
+     * false for those older nights, so the screen says nothing rather than something untrue.
+     */
+    @Test
+    fun silentWhenSomeOlderNightDoesHaveATemperature() {
+        assertFalse(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.ABSOLUTE, leadsAbsolute = false,
+                                                  anyAbsoluteInWindow = true))
     }
 
 }

--- a/android/app/src/test/java/com/noop/ui/SkinTempFallbackNoteTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SkinTempFallbackNoteTest.kt
@@ -1,0 +1,41 @@
+package com.noop.ui
+
+import com.noop.analytics.SkinTempDisplay
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1847: the skin-temp screen has to say when it could not honour the Settings choice.
+ *
+ * `leadReading` falls back rather than blanking, which is right but invisible — both settings then render
+ * the same Δ°C and the toggle reads as broken. The note fires in exactly one case.
+ */
+class SkinTempFallbackNoteTest {
+
+    /** Asked for a temperature, no night has one — the reported case, and the only one that explains. */
+    @Test
+    fun explainsWhenTemperatureWasAskedForAndNoneExists() {
+        assertTrue(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.ABSOLUTE, leadsAbsolute = false))
+    }
+
+    /** Asked for a temperature and got one: nothing to explain. */
+    @Test
+    fun silentWhenTheChoiceWasHonoured() {
+        assertFalse(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.ABSOLUTE, leadsAbsolute = true))
+    }
+
+    /** Asked for the baseline delta and got it. */
+    @Test
+    fun silentWhenTheDeviationWasChosen() {
+        assertFalse(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.DEVIATION, leadsAbsolute = false))
+    }
+
+    /** Chose the delta but only an absolute exists: the reverse fallback. It shows a temperature under a
+     *  plain °C unit, which is self-describing, so it does not need a sentence. Pinned so the asymmetry is
+     *  deliberate rather than an oversight. */
+    @Test
+    fun silentOnTheReverseFallback() {
+        assertFalse(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.DEVIATION, leadsAbsolute = true))
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/SkinTempFallbackNoteTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SkinTempFallbackNoteTest.kt
@@ -1,6 +1,7 @@
 package com.noop.ui
 
 import com.noop.analytics.SkinTempDisplay
+import com.noop.analytics.VitalBands
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -90,6 +91,33 @@ class SkinTempFallbackNoteTest {
     fun silentWhenSomeOlderNightDoesHaveATemperature() {
         assertFalse(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.ABSOLUTE, leadsAbsolute = false,
                                                   anyAbsoluteInWindow = true))
+    }
+
+
+    // MARK: third re-review — an absolute is an absolute, whichever column holds it
+
+    /**
+     * A WHOOP CSV import writes absolute °C into skinTempDevC (`skin_temp_celsius`, the #622 bimodal
+     * field). Those nights belong in an absolute-led series — same scale — and counting them as dropped
+     * made the note describe real temperatures as "a baseline difference only".
+     *
+     * Pins the discriminator the series selection leans on, so a change to the 20.0 threshold surfaces
+     * here rather than as a mislabelled chart.
+     */
+    @Test
+    fun anImportedAbsoluteIsRecognisedAsAbsolute() {
+        assertTrue(VitalBands.isAbsoluteSkinTemp(34.0))    // WHOOP export, stored in skinTempDevC
+        assertTrue(VitalBands.isAbsoluteSkinTemp(20.0))    // boundary is inclusive
+        assertFalse(VitalBands.isAbsoluteSkinTemp(0.5))    // a real deviation
+        assertFalse(VitalBands.isAbsoluteSkinTemp(-0.6))
+    }
+
+    /** With imported absolutes now IN the series, only genuine deviations count as dropped — so a window
+     *  holding nothing but absolutes (however stored) shows no note. */
+    @Test
+    fun silentWhenEveryDroppedRowWasActuallyAnAbsolute() {
+        assertFalse(shouldExplainShortenedSkinTempSeries(leadsAbsolute = true, shownReadings = 12,
+                                                         rowsWithEitherNumber = 12))
     }
 
 }

--- a/android/app/src/test/java/com/noop/ui/SkinTempFallbackNoteTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SkinTempFallbackNoteTest.kt
@@ -38,4 +38,26 @@ class SkinTempFallbackNoteTest {
     fun silentOnTheReverseFallback() {
         assertFalse(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.DEVIATION, leadsAbsolute = true))
     }
+
+    // MARK: the shortened series (#1847, found in re-review)
+
+    /** After a sync refills the 21-night window on an install with older history, the absolute-led series
+     *  drops the deviation-only nights and the reading count visibly falls. Say why. */
+    @Test
+    fun explainsWhenNightsWereDroppedFromTheSeries() {
+        assertTrue(shouldExplainShortenedSkinTempSeries(shownReadings = 21, rowsWithEitherNumber = 40))
+    }
+
+    /** A complete series says nothing — the note must not appear on a healthy screen. */
+    @Test
+    fun silentWhenEveryNightIsShown() {
+        assertFalse(shouldExplainShortenedSkinTempSeries(shownReadings = 23, rowsWithEitherNumber = 23))
+    }
+
+    /** No data at all is the empty state's job, not this note's. */
+    @Test
+    fun silentWhenThereIsNothingToShow() {
+        assertFalse(shouldExplainShortenedSkinTempSeries(shownReadings = 0, rowsWithEitherNumber = 0))
+    }
+
 }


### PR DESCRIPTION
Setting **Skin temperature** to *Temperature* and getting the same `0.0 Δ°C` back is indistinguishable from a broken toggle.

It isn't broken. `leadReading` falls back rather than blanking, so a night that only ever recorded a deviation shows its deviation — right behaviour, completely invisible. The detail screen now says so under the reading:

> No measured temperature for these nights — showing the difference from your baseline. A sync re-scores recent nights and fills it in.

It fires in exactly one case: a temperature was asked for and no night in the window has one. **The reverse fallback stays silent on purpose**, and a test pins that asymmetry — a temperature under a plain `°C` unit is self-describing, whereas a `Δ` where a temperature was requested is not.

The decision is a pure `shouldExplainSkinTempFallback`, so it is tested without Compose.

### Why those nights have no temperature

Worth stating, because it is not obvious and it is what makes the note honest — the deviation is *derived from* the absolute:

```kotlin
val skinTempDevC: Double? = nightlySkinTempC?.let { ... }
```

So every night showing a delta **had** a real temperature at scoring time. It was computed, used to derive the delta, and discarded, because those nights were scored before #1663 added the column on 2026-08-27. A scoring pass re-derives it from the raw `skinTempSample` rows still on disk — `analyzeRecent` re-scores a 21-night window per post-sync pass — which is exactly what the note points the user at.

### Scope

Android only, and deliberately. The note lives on the vital-detail screen; Apple's twin is `MetricExplorerView`, which sources skin temp through `Repository.dailyColumn` — a shared key→column mapper returning `skinTempDevC` to every caller including Trends. Repointing that changes which series the chart plots and how the band behaves, so it is filed separately rather than folded in here.

**This also corrects #1845's body**, which claimed no Swift twin of the detail screen exists. `MetricExplorerView` is the twin; I checked for the wrong marker string.

### Verification

Full suite **5117 / 0** (4 new). Note translated across all 6 Android locales. Doc-comment and i18n gates clean.