### PR TITLE
health: apply the skin-temp preference across the window, not just the newest night

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2314,18 +2314,26 @@ private fun buildVitalDetail(
     )
     "skin" -> {
         val fahrenheit = tempUnit == TemperatureUnit.FAHRENHEIT
-        // #1844: the newest reading decides the whole screen — title, unit, chart and every row — and it
-        // leads with the measured ABSOLUTE when that night has one (the #1665 rule, applied here too).
-        // The series must follow the same choice: an absolute plotted against a history of deviations is
-        // arithmetic on two scales, so the readings come from the matching column only.
-        val newest = days.asReversed().asSequence()
-            .firstOrNull { it.skinTempC != null || it.skinTempDevC != null } ?: return null
-        val lead = SkinTempDisplay.leadReading(newest.skinTempC, newest.skinTempDevC, skinTempPreferred)
-            ?: return null
-        val leadsAbsolute = lead.kind == SkinTempDisplay.Kind.ABSOLUTE && newest.skinTempC != null
-        // Deviation-led keeps the #622 bimodal read: a CSV import writes an absolute INTO skinTempDevC, so
-        // the kind is re-derived from the value and the series partitioned to it.
-        val kind = if (leadsAbsolute) SkinTempDisplay.Kind.ABSOLUTE else SkinTempDisplay.kind(lead.value)
+        // #1850: the preference applies across the WINDOW, not just the newest row. Keying the whole
+        // screen off the newest night meant a wearer with twenty stored temperatures and one recent night
+        // without saw twenty-three deltas — the setting says Temperature and the app HAS temperatures.
+        // `leadReading`'s rule lifted to the window: the chosen kind wins whenever any night carries it,
+        // the other is still the fallback, so a choice can never empty the screen.
+        //
+        // An absolute may live in EITHER column (#622: a WHOOP CSV import writes absolute °C into
+        // skinTempDevC), so both count here and in the series below.
+        val anyAbsolute = days.any { row ->
+            row.skinTempC != null || row.skinTempDevC?.let { VitalBands.isAbsoluteSkinTemp(it) } == true
+        }
+        val anyDeviation = days.any { row ->
+            row.skinTempDevC?.let { !VitalBands.isAbsoluteSkinTemp(it) } == true
+        }
+        if (!anyAbsolute && !anyDeviation) return null
+        val leadsAbsolute = when (skinTempPreferred) {
+            SkinTempDisplay.Kind.ABSOLUTE -> anyAbsolute
+            SkinTempDisplay.Kind.DEVIATION -> !anyDeviation && anyAbsolute
+        }
+        val kind = if (leadsAbsolute) SkinTempDisplay.Kind.ABSOLUTE else SkinTempDisplay.Kind.DEVIATION
         val unit = SkinTempDisplay.unitSymbol(kind, fahrenheit)
         val skinReadings = if (leadsAbsolute) {
             // An absolute-led series takes EVERY absolute reading, whichever column holds it. A WHOOP CSV
@@ -2338,9 +2346,11 @@ private fun buildVitalDetail(
                     ?.let { VitalReading(row.day, it, row.deviceId) }
             }
         } else {
+            // Genuine deviations only — an imported absolute sitting in this column belongs to the other
+            // scale and is excluded, exactly as before.
             days.mapNotNull { row ->
                 row.skinTempDevC
-                    ?.takeIf { VitalBands.isAbsoluteSkinTemp(it) == (kind == SkinTempDisplay.Kind.ABSOLUTE) }
+                    ?.takeIf { !VitalBands.isAbsoluteSkinTemp(it) }
                     ?.let { value -> VitalReading(row.day, value, row.deviceId) }
             }
         }
@@ -2361,24 +2371,16 @@ private fun buildVitalDetail(
             // Nights scored before skinTempC shipped kept only the deviation; a scoring pass refills them.
             fallbackNote = when {
                 shouldExplainSkinTempFallback(
-                    skinTempPreferred, leadsAbsolute,
-                    anyAbsoluteInWindow = days.any { it.skinTempC != null },
+                    skinTempPreferred, leadsAbsolute, anyAbsolute,
                 ) ->
                     uiString(R.string.l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae)
-                // #1850: the newest night has none but an older one does — the shape a partial refill
-                // leaves behind, and the one that showed NOTHING before this.
-                shouldExplainNewestNightHasNoTemperature(
-                    skinTempPreferred, leadsAbsolute,
-                    anyAbsoluteInWindow = days.any { it.skinTempC != null },
-                ) ->
-                    uiString(R.string.l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b)
-                // Leading with the absolute drops deviation-only nights from the series, so the reading
-                // count falls. Say why rather than letting history look like it vanished.
+                // Leading with the absolute drops deviation-only nights from the series — which can now
+                // include the most recent one. Say why rather than letting history look like it vanished.
                 shouldExplainShortenedSkinTempSeries(
                     leadsAbsolute = leadsAbsolute,
                     shownReadings = skinReadings.size,
                     rowsWithEitherNumber = days.count { it.skinTempC != null || it.skinTempDevC != null },
-                ) -> uiString(R.string.l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da)
+                ) -> uiString(R.string.l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b)
                 else -> null
             },
         )

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2365,6 +2365,13 @@ private fun buildVitalDetail(
                     anyAbsoluteInWindow = days.any { it.skinTempC != null },
                 ) ->
                     uiString(R.string.l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae)
+                // #1850: the newest night has none but an older one does — the shape a partial refill
+                // leaves behind, and the one that showed NOTHING before this.
+                shouldExplainNewestNightHasNoTemperature(
+                    skinTempPreferred, leadsAbsolute,
+                    anyAbsoluteInWindow = days.any { it.skinTempC != null },
+                ) ->
+                    uiString(R.string.l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b)
                 // Leading with the absolute drops deviation-only nights from the series, so the reading
                 // count falls. Say why rather than letting history look like it vanished.
                 shouldExplainShortenedSkinTempSeries(

--- a/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
@@ -120,32 +120,15 @@ internal fun shouldExplainShortenedSkinTempSeries(
 ): Boolean = leadsAbsolute && shownReadings < rowsWithEitherNumber
 
 /**
- * The MIXED case (#1850): a temperature was asked for, the newest night has none, but an older night does.
- *
- * Re-review pass 2 on #1847 silenced this rather than print "no measured temperature for these nights",
- * which is false for the nights that have one. Silence turned out to be the wrong trade: it is the COMMON
- * shape, not a rarity, because a scoring pass only refills the nights whose raw skinTempSample rows
- * survived pruning — so a wearer sets Temperature, sees deltas, and is told nothing at all.
- *
- * It gets its own sentence instead, which is accurate about both halves.
- */
-internal fun shouldExplainNewestNightHasNoTemperature(
-    prefer: SkinTempDisplay.Kind,
-    leadsAbsolute: Boolean,
-    anyAbsoluteInWindow: Boolean,
-): Boolean = prefer == SkinTempDisplay.Kind.ABSOLUTE && !leadsAbsolute && anyAbsoluteInWindow
-
-/**
  * Whether the skin-temp screen must EXPLAIN itself (#1847).
  *
  * `leadReading` deliberately falls back: asking for a temperature on a night that only ever recorded a
  * deviation shows the deviation rather than blanking. That is right, but silent — the setting then looks
  * broken, because both choices render the same Δ°C.
  *
- * Requires that NO night in the window has an absolute, not merely that the newest lacks one. When the
- * newest night has no absolute but an older one does, the sentence "no measured temperature for these
- * nights" is false for those older nights — so that case shows nothing. Saying nothing is a gap; saying
- * something untrue about the user's own data is worse.
+ * Requires that NO night in the window carries a temperature. #1850 removed the other case entirely:
+ * the preference now applies across the window, so a single stored temperature anywhere means the screen
+ * leads with temperatures rather than falling back and needing to explain itself.
  *
  * Pure so the decision is testable without Compose.
  */

--- a/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalsLogic.kt
@@ -120,6 +120,22 @@ internal fun shouldExplainShortenedSkinTempSeries(
 ): Boolean = leadsAbsolute && shownReadings < rowsWithEitherNumber
 
 /**
+ * The MIXED case (#1850): a temperature was asked for, the newest night has none, but an older night does.
+ *
+ * Re-review pass 2 on #1847 silenced this rather than print "no measured temperature for these nights",
+ * which is false for the nights that have one. Silence turned out to be the wrong trade: it is the COMMON
+ * shape, not a rarity, because a scoring pass only refills the nights whose raw skinTempSample rows
+ * survived pruning — so a wearer sets Temperature, sees deltas, and is told nothing at all.
+ *
+ * It gets its own sentence instead, which is accurate about both halves.
+ */
+internal fun shouldExplainNewestNightHasNoTemperature(
+    prefer: SkinTempDisplay.Kind,
+    leadsAbsolute: Boolean,
+    anyAbsoluteInWindow: Boolean,
+): Boolean = prefer == SkinTempDisplay.Kind.ABSOLUTE && !leadsAbsolute && anyAbsoluteInWindow
+
+/**
  * Whether the skin-temp screen must EXPLAIN itself (#1847).
  *
  * `leadReading` deliberately falls back: asking for a temperature on a night that only ever recorded a

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2682,6 +2682,5 @@
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Wähle dein Zeitformat, Schlaf von Straps ohne Bewegungsdaten und ein Strap-Log, das nicht mehr rät</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Hauttemperatur</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Für diese Nächte liegt keine gemessene Temperatur vor — angezeigt wird die Abweichung von deinem Basiswert. Eine Synchronisierung bewertet die letzten Nächte neu und ergänzt sie.</string>
-    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Es werden nur Nächte mit gemessener Temperatur angezeigt. Für frühere Nächte wurde nur eine Abweichung vom Basiswert erfasst.</string>
-    <string name="l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b">Für die letzte Nacht liegt keine gemessene Temperatur vor, daher wird der gesamte Verlauf als Abweichung von deinem Basiswert angezeigt.</string>
+    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Es werden nur Nächte mit gemessener Temperatur angezeigt; für die übrigen wurde nur eine Abweichung vom Basiswert erfasst.</string>
 </resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2683,4 +2683,5 @@
     <string name="l10n_settings_screen_skin_temperature_fc103030">Hauttemperatur</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Für diese Nächte liegt keine gemessene Temperatur vor — angezeigt wird die Abweichung von deinem Basiswert. Eine Synchronisierung bewertet die letzten Nächte neu und ergänzt sie.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Es werden nur Nächte mit gemessener Temperatur angezeigt. Für frühere Nächte wurde nur eine Abweichung vom Basiswert erfasst.</string>
+    <string name="l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b">Für die letzte Nacht liegt keine gemessene Temperatur vor, daher wird der gesamte Verlauf als Abweichung von deinem Basiswert angezeigt.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2670,4 +2670,5 @@
     <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura cutánea</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">No hay temperatura medida para estas noches: se muestra la diferencia respecto a tu referencia. Una sincronización vuelve a analizar las noches recientes y la completa.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Solo se muestran las noches con temperatura medida. En las noches anteriores solo se registró la diferencia respecto a la referencia.</string>
+    <string name="l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b">La noche más reciente no tiene temperatura medida, por lo que toda la tendencia se muestra como la diferencia respecto a tu referencia.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2669,6 +2669,5 @@
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Elige el reloj de 12 horas, sueño desde correas que no registran movimiento y un registro que deja de suponer</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura cutánea</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">No hay temperatura medida para estas noches: se muestra la diferencia respecto a tu referencia. Una sincronización vuelve a analizar las noches recientes y la completa.</string>
-    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Solo se muestran las noches con temperatura medida. En las noches anteriores solo se registró la diferencia respecto a la referencia.</string>
-    <string name="l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b">La noche más reciente no tiene temperatura medida, por lo que toda la tendencia se muestra como la diferencia respecto a tu referencia.</string>
+    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Solo se muestran las noches con temperatura medida; en las demás solo se registró la diferencia respecto a la referencia.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2668,6 +2668,5 @@
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Choisissez l\'horloge 12 heures, le sommeil depuis des bracelets sans données de mouvement, et un journal qui cesse de deviner</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Température cutanée</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Aucune température mesurée pour ces nuits — l\'écart par rapport à votre référence est affiché. Une synchronisation réévalue les nuits récentes et le complète.</string>
-    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Seules les nuits avec une température mesurée sont affichées. Les nuits précédentes n\'ont enregistré qu\'un écart par rapport à la référence.</string>
-    <string name="l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b">La nuit la plus récente n\'a pas de température mesurée : toute la tendance est donc affichée comme l\'écart par rapport à votre référence.</string>
+    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Seules les nuits avec une température mesurée sont affichées ; les autres n\'ont enregistré qu\'un écart par rapport à la référence.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2669,4 +2669,5 @@
     <string name="l10n_settings_screen_skin_temperature_fc103030">Température cutanée</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Aucune température mesurée pour ces nuits — l\'écart par rapport à votre référence est affiché. Une synchronisation réévalue les nuits récentes et le complète.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Seules les nuits avec une température mesurée sont affichées. Les nuits précédentes n\'ont enregistré qu\'un écart par rapport à la référence.</string>
+    <string name="l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b">La nuit la plus récente n\'a pas de température mesurée : toute la tendance est donc affichée comme l\'écart par rapport à votre référence.</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2674,4 +2674,5 @@
     <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura skóry</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Brak zmierzonej temperatury dla tych nocy — pokazano różnicę względem Twojej wartości bazowej. Synchronizacja ponownie przelicza ostatnie noce i ją uzupełnia.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Pokazywane są tylko noce ze zmierzoną temperaturą. We wcześniejszych nocach zapisano jedynie różnicę względem wartości bazowej.</string>
+    <string name="l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b">Ostatnia noc nie ma zmierzonej temperatury, więc cały trend jest pokazany jako różnica względem Twojej wartości bazowej.</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2673,6 +2673,5 @@
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Wybierz zegar 12-godzinny, sen z opasek bez danych o ruchu i dziennik, który przestaje zgadywać</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura skóry</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Brak zmierzonej temperatury dla tych nocy — pokazano różnicę względem Twojej wartości bazowej. Synchronizacja ponownie przelicza ostatnie noce i ją uzupełnia.</string>
-    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Pokazywane są tylko noce ze zmierzoną temperaturą. We wcześniejszych nocach zapisano jedynie różnicę względem wartości bazowej.</string>
-    <string name="l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b">Ostatnia noc nie ma zmierzonej temperatury, więc cały trend jest pokazany jako różnica względem Twojej wartości bazowej.</string>
+    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Pokazywane są tylko noce ze zmierzoną temperaturą; w pozostałych zapisano jedynie różnicę względem wartości bazowej.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2662,4 +2662,5 @@
     <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura da pele</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Sem temperatura medida para estas noites — a mostrar a diferença em relação à sua referência. Uma sincronização reavalia as noites recentes e preenche-a.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Só são mostradas as noites com temperatura medida. As noites anteriores registaram apenas a diferença em relação à referência.</string>
+    <string name="l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b">A noite mais recente não tem temperatura medida, pelo que toda a tendência é mostrada como a diferença em relação à sua referência.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2661,6 +2661,5 @@
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Escolha o relógio de 12 horas, sono a partir de pulseiras sem dados de movimento e um registo que deixa de adivinhar</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura da pele</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Sem temperatura medida para estas noites — a mostrar a diferença em relação à sua referência. Uma sincronização reavalia as noites recentes e preenche-a.</string>
-    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Só são mostradas as noites com temperatura medida. As noites anteriores registaram apenas a diferença em relação à referência.</string>
-    <string name="l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b">A noite mais recente não tem temperatura medida, pelo que toda a tendência é mostrada como a diferença em relação à sua referência.</string>
+    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Só são mostradas as noites com temperatura medida; as restantes registaram apenas a diferença em relação à referência.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2582,6 +2582,5 @@
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">自选 12 小时制、从无运动数据的手环读取睡眠，以及不再靠猜测的手环日志</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">皮肤温度</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">这些夜晚没有实测温度，显示的是与基线的差值。同步后会重新计算近期夜晚并补上。</string>
-    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">仅显示有实测温度的夜晚。更早的夜晚只记录了与基线的差值。</string>
-    <string name="l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b">最近一晚没有实测温度，因此整个趋势以与基线的差值显示。</string>
+    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">仅显示有实测温度的夜晚；其余夜晚只记录了与基线的差值。</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2583,4 +2583,5 @@
     <string name="l10n_settings_screen_skin_temperature_fc103030">皮肤温度</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">这些夜晚没有实测温度，显示的是与基线的差值。同步后会重新计算近期夜晚并补上。</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">仅显示有实测温度的夜晚。更早的夜晚只记录了与基线的差值。</string>
+    <string name="l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b">最近一晚没有实测温度，因此整个趋势以与基线的差值显示。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2696,4 +2696,5 @@
     <string name="l10n_settings_screen_skin_temperature_fc103030">Skin temperature</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">No measured temperature for these nights — showing the difference from your baseline. A sync re-scores recent nights and fills it in.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Only nights with a measured temperature are shown. Earlier nights recorded a baseline difference only.</string>
+    <string name="l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b">The most recent night has no measured temperature, so the whole trend is shown as the difference from your baseline.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2695,6 +2695,5 @@
     <string name="l10n_app_changelog_choose_a_12_hour_clock_sleep_8a19db5c">Choose a 12-hour clock, sleep from straps that bank no motion, and a strap log that stops guessing</string>
     <string name="l10n_settings_screen_skin_temperature_fc103030">Skin temperature</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">No measured temperature for these nights — showing the difference from your baseline. A sync re-scores recent nights and fills it in.</string>
-    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_earlier_ni_a45140da">Only nights with a measured temperature are shown. Earlier nights recorded a baseline difference only.</string>
-    <string name="l10n_health_screen_the_most_recent_night_has_no_measured_temperature_so_the_who_16ddbd6b">The most recent night has no measured temperature, so the whole trend is shown as the difference from your baseline.</string>
+    <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Only nights with a measured temperature are shown; the others recorded a baseline difference only.</string>
 </resources>

--- a/android/app/src/test/java/com/noop/ui/SkinTempFallbackNoteTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SkinTempFallbackNoteTest.kt
@@ -2,6 +2,7 @@ package com.noop.ui
 
 import com.noop.analytics.SkinTempDisplay
 import com.noop.analytics.VitalBands
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -121,46 +122,38 @@ class SkinTempFallbackNoteTest {
     }
 
 
-    // MARK: #1850 — the case re-review pass 2 silenced, which turned out to be the common one
+    // MARK: #1850 — the preference now applies across the WINDOW
 
     /**
-     * Reported from a real install: Temperature selected, deltas on screen, and NO note. The only path
-     * producing both is "newest night has no absolute, an older one does" — silenced in #1847 because the
-     * all-or-nothing sentence would have been false for the nights that do have one. It now has its own.
+     * The reported install: Temperature selected, deltas on screen, no explanation. The cause was not the
+     * missing sentence I first added — it was that the whole screen keyed off the NEWEST row, so twenty
+     * stored temperatures lost to one recent night without. The window-wide rule is what fixes it, and
+     * the fallback note is now reserved for a window that genuinely holds none.
      */
     @Test
-    fun explainsWhenOnlyTheNewestNightLacksATemperature() {
-        assertTrue(shouldExplainNewestNightHasNoTemperature(SkinTempDisplay.Kind.ABSOLUTE,
-                                                            leadsAbsolute = false,
-                                                            anyAbsoluteInWindow = true))
+    fun oneStoredTemperatureAnywhereMeansNoFallbackNote() {
+        assertFalse(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.ABSOLUTE, leadsAbsolute = true,
+                                                  anyAbsoluteInWindow = true))
     }
 
-    /** The three ABSOLUTE-preference cases are mutually exclusive and together total: nothing anywhere,
-     *  newest-only missing, or honoured. No combination can leave the screen silent again. */
+    /** Only a window with NO temperature at all still explains itself. */
     @Test
-    fun everyAbsolutePreferenceCaseIsCovered() {
+    fun anEmptyWindowStillExplains() {
+        assertTrue(shouldExplainSkinTempFallback(SkinTempDisplay.Kind.ABSOLUTE, leadsAbsolute = false,
+                                                 anyAbsoluteInWindow = false))
+    }
+
+    /**
+     * The whole grid for the ABSOLUTE preference, so no quadrant can fall silent again. With the
+     * window-wide rule, `leadsAbsolute == anyAbsolute`, and the only speaking case is neither.
+     */
+    @Test
+    fun everyAbsolutePreferenceCaseIsAccountedFor() {
         for (anyAbsolute in listOf(false, true)) {
-            for (leads in listOf(false, true)) {
-                val nothingAnywhere = shouldExplainSkinTempFallback(
-                    SkinTempDisplay.Kind.ABSOLUTE, leads, anyAbsolute)
-                val newestOnly = shouldExplainNewestNightHasNoTemperature(
-                    SkinTempDisplay.Kind.ABSOLUTE, leads, anyAbsolute)
-                // Never both at once.
-                assertFalse("both fired for leads=$leads any=$anyAbsolute", nothingAnywhere && newestOnly)
-                // When the choice was NOT honoured, exactly one of them must speak.
-                if (!leads) {
-                    assertTrue("silent for leads=false any=$anyAbsolute", nothingAnywhere || newestOnly)
-                }
-            }
+            val leads = anyAbsolute      // the window-wide rule, stated as the test's own model
+            val explains = shouldExplainSkinTempFallback(SkinTempDisplay.Kind.ABSOLUTE, leads, anyAbsolute)
+            assertEquals("leads=$leads any=$anyAbsolute", !anyAbsolute, explains)
         }
-    }
-
-    /** Choosing the delta never triggers the temperature explanations. */
-    @Test
-    fun deviationPreferenceStaysSilentInTheMixedCase() {
-        assertFalse(shouldExplainNewestNightHasNoTemperature(SkinTempDisplay.Kind.DEVIATION,
-                                                             leadsAbsolute = false,
-                                                             anyAbsoluteInWindow = true))
     }
 
 }

--- a/android/app/src/test/java/com/noop/ui/SkinTempFallbackNoteTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SkinTempFallbackNoteTest.kt
@@ -120,4 +120,47 @@ class SkinTempFallbackNoteTest {
                                                          rowsWithEitherNumber = 12))
     }
 
+
+    // MARK: #1850 — the case re-review pass 2 silenced, which turned out to be the common one
+
+    /**
+     * Reported from a real install: Temperature selected, deltas on screen, and NO note. The only path
+     * producing both is "newest night has no absolute, an older one does" — silenced in #1847 because the
+     * all-or-nothing sentence would have been false for the nights that do have one. It now has its own.
+     */
+    @Test
+    fun explainsWhenOnlyTheNewestNightLacksATemperature() {
+        assertTrue(shouldExplainNewestNightHasNoTemperature(SkinTempDisplay.Kind.ABSOLUTE,
+                                                            leadsAbsolute = false,
+                                                            anyAbsoluteInWindow = true))
+    }
+
+    /** The three ABSOLUTE-preference cases are mutually exclusive and together total: nothing anywhere,
+     *  newest-only missing, or honoured. No combination can leave the screen silent again. */
+    @Test
+    fun everyAbsolutePreferenceCaseIsCovered() {
+        for (anyAbsolute in listOf(false, true)) {
+            for (leads in listOf(false, true)) {
+                val nothingAnywhere = shouldExplainSkinTempFallback(
+                    SkinTempDisplay.Kind.ABSOLUTE, leads, anyAbsolute)
+                val newestOnly = shouldExplainNewestNightHasNoTemperature(
+                    SkinTempDisplay.Kind.ABSOLUTE, leads, anyAbsolute)
+                // Never both at once.
+                assertFalse("both fired for leads=$leads any=$anyAbsolute", nothingAnywhere && newestOnly)
+                // When the choice was NOT honoured, exactly one of them must speak.
+                if (!leads) {
+                    assertTrue("silent for leads=false any=$anyAbsolute", nothingAnywhere || newestOnly)
+                }
+            }
+        }
+    }
+
+    /** Choosing the delta never triggers the temperature explanations. */
+    @Test
+    fun deviationPreferenceStaysSilentInTheMixedCase() {
+        assertFalse(shouldExplainNewestNightHasNoTemperature(SkinTempDisplay.Kind.DEVIATION,
+                                                             leadsAbsolute = false,
+                                                             anyAbsoluteInWindow = true))
+    }
+
 }


### PR DESCRIPTION
Reported from a real install on the latest testing build: **Temperature** selected, deltas on screen, no explanation.

I first shipped a missing sentence for it. The re-review found that was treating a symptom.

### The actual defect

`leadsAbsolute` keyed off the **newest row alone**. A wearer with twenty stored temperatures and one recent night without one got twenty-three deltas. The setting says Temperature and the app *has* temperatures — no sentence makes that acceptable.

`leadReading`'s rule, lifted from the row to the window: **the chosen kind wins whenever any night carries it**, the other stays the fallback, so a choice can never empty the screen. An absolute counts from either column, since a WHOOP CSV import writes absolute °C into `skinTempDevC` (#622).

That makes the mixed case I'd just written a note for **unreachable** — one stored temperature anywhere now leads with temperatures instead of explaining why it won't. Note and helper deleted. The fallback note is reserved for a window that genuinely holds none, which is its only honest use.

### Fallout handled

- The shortened-series note is **reworded**: the dropped nights can now include the most recent one, so "Earlier nights recorded a baseline difference only" would be wrong.
- Both superseded strings are **removed from all 7 locale files** rather than left as dead entries.
- `kind` no longer needs deriving from the newest value — leading absolute means absolute, and the deviation branch takes genuine deviations only.

### Why this kept slipping

Three passes treated the display rule as fixed and argued about the copy that explains it. The rule was the bug. The grid test is rewritten around the new rule (`leadsAbsolute == anyAbsolute`), asserting the note fires exactly when the window holds no temperature and never otherwise.

Full suite **5127 / 0**. Doc-comment and i18n gates clean. Android-only, same as #1847.