### PR TITLE
alarm: per-day wake times for the phone alarm (#1858)

### DIFF
--- a/android/app/src/main/java/com/noop/alarm/SmartAlarmBootReceiver.kt
+++ b/android/app/src/main/java/com/noop/alarm/SmartAlarmBootReceiver.kt
@@ -27,8 +27,12 @@ class SmartAlarmBootReceiver : BroadcastReceiver() {
                 runCatching {
                     val wind = WindDownStore.from(context)
                     if (wind.enabled) {
-                        val wake = SmartAlarmStore.from(context).targetMinutes
-                        WindDownScheduler.schedule(context, wind, wake)
+                        val alarm = SmartAlarmStore.from(context)
+                        // #1858: the per-day overrides go through here too. This is the ONE call site that
+                        // reschedules without a user action, so dropping them here does not fail loudly —
+                        // it quietly collapses seven weekday nudges back to one daily nudge on the default
+                        // wake time, and stays that way until the user next edits a setting.
+                        WindDownScheduler.schedule(context, wind, alarm.targetMinutes, alarm.targetOverrides)
                     }
                 }
             }

--- a/android/app/src/main/java/com/noop/alarm/SmartAlarmScheduler.kt
+++ b/android/app/src/main/java/com/noop/alarm/SmartAlarmScheduler.kt
@@ -50,29 +50,16 @@ object SmartAlarmScheduler {
     fun arm(context: Context, store: SmartAlarmStore, afterFire: Boolean = false): Long? {
         if (!canScheduleExact(context)) return null
 
-        val deadlineMin = (store.targetMinutes + store.windowMinutes)
-        // The window's hard edge can roll past midnight (e.g. 23:50 + 30). Compute the next wall-clock
-        // occurrence of that absolute minute-of-day, then derive the window-start from it so the two
-        // edges stay on the same night even across the midnight boundary.
+        // #1858: the deadline minute is per-day now, so the DAY is chosen first and its own target read
+        // from it. The window start is still derived from the deadline, so the two edges stay on the same
+        // night even when the window opens the previous evening.
         val weekdays = store.weekdays
-        val deadline = nextOccurrence(deadlineMin % SmartAlarmStore.MINUTES_PER_DAY, weekdays)
-        // Re-arm after a fire (audit): when the smart alarm fires EARLY on a light-sleep phase (e.g. 06:35
-        // for a 07:00 deadline), the deadline's next occurrence is still TODAY 07:00 — so a plain re-arm
-        // scheduled a second guaranteed wake the SAME morning, waking the user again. We just woke them
-        // today, so the next wake must be tomorrow: push a same-day deadline forward one day.
-        if (afterFire) {
-            val now = Calendar.getInstance()
-            val sameDay = deadline.get(Calendar.YEAR) == now.get(Calendar.YEAR) &&
-                deadline.get(Calendar.DAY_OF_YEAR) == now.get(Calendar.DAY_OF_YEAR)
-            if (sameDay) {
-                deadline.add(Calendar.DAY_OF_YEAR, 1)
-                // …and that push can land on a day the alarm is switched off, so re-apply the weekday
-                // filter. Without this, re-arming after a Saturday fire would schedule Sunday even with
-                // Sunday deselected — the one path that reaches a disabled day, because it moves the
-                // deadline AFTER nextOccurrence already filtered it.
-                advanceToEnabledDay(deadline, weekdays)
-            }
-        }
+        val deadline = nextDeadline(
+            now = Calendar.getInstance(),
+            weekdays = weekdays,
+            windowMinutes = store.windowMinutes,
+            afterFire = afterFire,
+        ) { store.targetFor(it) } ?: return null
         val windowStartMs = deadline.timeInMillis - store.windowMinutes.toLong() * 60_000L
 
         scheduleExact(context, deadline.timeInMillis)
@@ -155,35 +142,54 @@ object SmartAlarmScheduler {
         )
     }
 
-    /** The next wall-clock occurrence (today or tomorrow) of an absolute minute-of-day. */
-    private fun nextOccurrence(minuteOfDay: Int, weekdays: Set<Int> = emptySet()): Calendar =
-        Calendar.getInstance().apply {
-            set(Calendar.HOUR_OF_DAY, minuteOfDay / 60)
-            set(Calendar.MINUTE, minuteOfDay % 60)
-            set(Calendar.SECOND, 0)
-            set(Calendar.MILLISECOND, 0)
-            if (timeInMillis <= System.currentTimeMillis()) add(Calendar.DAY_OF_YEAR, 1)
-            advanceToEnabledDay(this, weekdays)
-        }
-
     /**
-     * Roll `cal` forward until it lands on a day the alarm is allowed to fire on.
+     * The next hard-deadline instant, honouring PER-DAY wake times (#1858).
      *
-     * EMPTY [weekdays] means every day, so this is a no-op — that is the pre-weekday behaviour and the
-     * default for every existing install, which is why the whole feature can ship without a migration.
+     * Replaces the old "find the next occurrence of one minute-of-day, then roll to an enabled day":
+     * with per-day targets the deadline minute is no longer a single number, so the day must be chosen
+     * FIRST and its own target read from it.
      *
-     * The 7-iteration bound is a guard, not an expectation: [SmartAlarmStore.weekdays] already filters
-     * to 1..7, so a non-empty set always contains a reachable day and the loop exits in at most six
-     * steps. If a future caller ever passes an unreachable set, this returns the unshifted day rather
-     * than spinning — a wrong-day alarm is recoverable, a hung scheduler on the safety-critical path is
-     * not. Kept `internal` so the day-selection can be unit-tested without an AlarmManager.
+     * Walks candidate days forward from today. For each day the alarm is allowed to fire on, the deadline
+     * is that day's own `target + window`, and the first such instant strictly in the future wins. The
+     * weekday tested is therefore still the day the DEADLINE lands on — the morning you are actually
+     * woken — which is what [SmartAlarmStore.weekdays] has always meant and what a person means by
+     * "Monday at 04:45".
+     *
+     * `target + window` can roll past midnight (23:50 + 30). Taking it modulo the day places the deadline
+     * on the enabled day itself and lets the WINDOW START fall on the previous evening, which is the same
+     * relationship the single-time version produced.
+     *
+     * [afterFire] skips today outright. When the smart logic fires early — 04:35 for an 04:45 deadline —
+     * today's deadline is still ahead, and re-arming onto it would wake the user a second time the same
+     * morning. Skipping the day is a cleaner statement of that than adjusting a date afterwards, and it
+     * cannot land on a disabled day because the loop only ever considers enabled ones.
+     *
+     * Pure but for the clock passed in, so every one of those cases is unit-testable without an
+     * AlarmManager. Returns null only if no day is reachable, which [SmartAlarmStore.weekdays]'s 1..7
+     * filter already prevents.
      */
-    internal fun advanceToEnabledDay(cal: Calendar, weekdays: Set<Int>) {
-        if (weekdays.isEmpty()) return
-        var guard = 0
-        while (cal.get(Calendar.DAY_OF_WEEK) !in weekdays && guard < 7) {
-            cal.add(Calendar.DAY_OF_YEAR, 1)
-            guard++
+    internal fun nextDeadline(
+        now: Calendar,
+        weekdays: Set<Int>,
+        windowMinutes: Int,
+        afterFire: Boolean = false,
+        targetForDay: (Int) -> Int,
+    ): Calendar? {
+        for (offset in 0..7) {
+            if (afterFire && offset == 0) continue
+            val candidate = (now.clone() as Calendar).apply {
+                add(Calendar.DAY_OF_YEAR, offset)
+            }
+            val dow = candidate.get(Calendar.DAY_OF_WEEK)
+            if (weekdays.isNotEmpty() && dow !in weekdays) continue
+            val deadlineMin =
+                (targetForDay(dow) + windowMinutes) % SmartAlarmStore.MINUTES_PER_DAY
+            candidate.set(Calendar.HOUR_OF_DAY, deadlineMin / 60)
+            candidate.set(Calendar.MINUTE, deadlineMin % 60)
+            candidate.set(Calendar.SECOND, 0)
+            candidate.set(Calendar.MILLISECOND, 0)
+            if (candidate.timeInMillis > now.timeInMillis) return candidate
         }
+        return null
     }
 }

--- a/android/app/src/main/java/com/noop/alarm/SmartAlarmScheduler.kt
+++ b/android/app/src/main/java/com/noop/alarm/SmartAlarmScheduler.kt
@@ -143,6 +143,32 @@ object SmartAlarmScheduler {
     }
 
     /**
+     * The EARLIEST-wake minute of the next scheduled window (#1858) — what the guarantee card names.
+     *
+     * The card promises a specific time ("a backup alarm is set for 04:45"), so once wake times vary by
+     * day it has to show the next one rather than the default; on a moved day the default is simply the
+     * wrong number. DERIVED from [nextDeadline] rather than recomputed, so the card and the alarm cannot
+     * disagree — two independent time computations drifting apart is the failure this change already had
+     * to fix in two other places.
+     *
+     * Falls back to [defaultTarget] when no day is reachable, so the card degrades to the previous
+     * behaviour rather than blanking. Pure but for the clock, so it is testable without Compose.
+     */
+    internal fun nextWindowStartMinutes(
+        now: Calendar,
+        weekdays: Set<Int>,
+        windowMinutes: Int,
+        defaultTarget: Int,
+        targetForDay: (Int) -> Int,
+    ): Int {
+        val deadline = nextDeadline(now, weekdays, windowMinutes, afterFire = false, targetForDay)
+            ?: return defaultTarget
+        val deadlineMin = deadline.get(Calendar.HOUR_OF_DAY) * 60 + deadline.get(Calendar.MINUTE)
+        return (deadlineMin - windowMinutes + SmartAlarmStore.MINUTES_PER_DAY) %
+            SmartAlarmStore.MINUTES_PER_DAY
+    }
+
+    /**
      * The next hard-deadline instant, honouring PER-DAY wake times (#1858).
      *
      * Replaces the old "find the next occurrence of one minute-of-day, then roll to an enabled day":

--- a/android/app/src/main/java/com/noop/alarm/SmartAlarmScheduler.kt
+++ b/android/app/src/main/java/com/noop/alarm/SmartAlarmScheduler.kt
@@ -59,7 +59,21 @@ object SmartAlarmScheduler {
             weekdays = weekdays,
             windowMinutes = store.windowMinutes,
             afterFire = afterFire,
-        ) { store.targetFor(it) } ?: return null
+        ) { store.targetFor(it) } ?: run {
+            // No day is reachable, so there IS no next wake — clear the persisted edges rather than
+            // leaving the previous ones behind. The watcher reads exactly those two fields to decide it is
+            // inside a wake window, so a stale pair is a phantom window: it would keep feeding HR to the
+            // detector and could advance an alarm that no longer exists.
+            //
+            // Deliberately NOT the same as the `canScheduleExact` bail above. There the intent still
+            // stands and the OS is only refusing right now, so the stored edges must survive for
+            // `rearmPersisted` to retry. Here there is nothing to retry.
+            //
+            // `SmartAlarmStore.weekdays` filters to 1..7, so this is unreachable through the store today;
+            // the guard is for the caller that forgets, on a path where the failure is silent.
+            cancel(context, store)
+            return null
+        }
         val windowStartMs = deadline.timeInMillis - store.windowMinutes.toLong() * 60_000L
 
         scheduleExact(context, deadline.timeInMillis)

--- a/android/app/src/main/java/com/noop/alarm/SmartAlarmStore.kt
+++ b/android/app/src/main/java/com/noop/alarm/SmartAlarmStore.kt
@@ -56,6 +56,46 @@ class SmartAlarmStore(private val prefs: SharedPreferences) {
             .putStringSet(KEY_WEEKDAYS, v.filter { it in 1..7 }.map { it.toString() }.toSet())
             .apply()
 
+    /**
+     * PER-DAY wake times (#1858): `Calendar.DAY_OF_WEEK` → earliest-wake minutes, for the days that
+     * differ from [targetMinutes].
+     *
+     * A sparse OVERRIDE map, not a full schedule: absent days fall back to [targetMinutes], so an install
+     * that never sets one behaves exactly as before and there is nothing to migrate. Reported as
+     * "04:45 three days a week and 03:30 on two others" — a shape the single-time model could not express
+     * at all, so the honest answer to that user was "the app cannot do this", not "you set it up wrong".
+     *
+     * Keyed on the day the HARD DEADLINE lands on — the morning you are actually woken — matching
+     * [weekdays] and what a person means by "Monday at 04:45". Stored as `day:minutes` strings so the
+     * whole map lives in one SharedPreferences key with no serialiser; entries outside 1..7 or outside a
+     * valid minute-of-day are dropped on read, so a corrupted value can never schedule a bogus time.
+     */
+    var targetOverrides: Map<Int, Int>
+        get() = prefs.getStringSet(KEY_TARGET_OVERRIDES, emptySet())
+            .orEmpty()
+            .mapNotNull { entry ->
+                val parts = entry.split(':')
+                val day = parts.getOrNull(0)?.toIntOrNull()
+                val minutes = parts.getOrNull(1)?.toIntOrNull()
+                if (day != null && minutes != null && day in 1..7 && minutes in 0 until MINUTES_PER_DAY) {
+                    day to minutes
+                } else {
+                    null
+                }
+            }
+            .toMap()
+        set(v) = prefs.edit()
+            .putStringSet(
+                KEY_TARGET_OVERRIDES,
+                v.filter { (d, m) -> d in 1..7 && m in 0 until MINUTES_PER_DAY }
+                    .map { (d, m) -> "$d:$m" }
+                    .toSet(),
+            )
+            .apply()
+
+    /** The earliest-wake minute for [dayOfWeek] — its override, else the single [targetMinutes]. */
+    fun targetFor(dayOfWeek: Int): Int = targetOverrides[dayOfWeek] ?: targetMinutes
+
     /** The wall-clock epoch (ms) of the currently-scheduled HARD deadline, or 0 if none. Persisted so
      *  the boot receiver can re-arm the exact alarm after a restart without recomputing intent. */
     var scheduledDeadlineMs: Long
@@ -73,6 +113,7 @@ class SmartAlarmStore(private val prefs: SharedPreferences) {
         private const val KEY_TARGET = "alarm.targetMinutes"
         private const val KEY_WINDOW = "alarm.windowMinutes"
         private const val KEY_WEEKDAYS = "alarm.weekdays"
+        private const val KEY_TARGET_OVERRIDES = "alarm.targetOverrides"
         private const val KEY_DEADLINE_MS = "alarm.scheduledDeadlineMs"
         private const val KEY_WINDOW_START_MS = "alarm.scheduledWindowStartMs"
 

--- a/android/app/src/main/java/com/noop/alarm/WindDownScheduler.kt
+++ b/android/app/src/main/java/com/noop/alarm/WindDownScheduler.kt
@@ -35,24 +35,56 @@ object WindDownScheduler {
      * prior schedule first so a settings change doesn't stack two nudges. No-op'd by the caller when
      * the nudge is disabled (it calls [cancel] instead).
      */
-    fun schedule(context: Context, store: WindDownStore, wakeMinutes: Int) {
+    fun schedule(
+        context: Context,
+        store: WindDownStore,
+        wakeMinutes: Int,
+        perDayWake: Map<Int, Int> = emptyMap(),
+    ) {
         val am = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        val pi = nudgePendingIntent(context)
-        am.cancel(pi)
-        val minuteOfDay = store.nudgeMinuteOfDay(wakeMinutes)
-        val first = nextOccurrence(minuteOfDay)
-        // Inexact, repeating, NOT wakeup — a wind-down reminder doesn't need to punch through Doze.
-        am.setInexactRepeating(
-            AlarmManager.RTC,
-            first.timeInMillis,
-            AlarmManager.INTERVAL_DAY,
-            pi,
-        )
+        // Cancel BOTH shapes first. Switching between them changes how many alarms exist, so cancelling
+        // only the one about to be re-scheduled would strand the other's — seven weekly nudges left
+        // running after a switch back to daily, or a stale daily one firing beside the seven.
+        cancel(context)
+
+        if (perDayWake.isEmpty()) {
+            val first = nextOccurrence(store.nudgeMinuteOfDay(wakeMinutes))
+            // Inexact, repeating, NOT wakeup — a wind-down reminder doesn't need to punch through Doze.
+            am.setInexactRepeating(
+                AlarmManager.RTC,
+                first.timeInMillis,
+                AlarmManager.INTERVAL_DAY,
+                nudgePendingIntent(context),
+            )
+            return
+        }
+
+        // #1858 (Apple parity): with per-day wake times set, fan out to seven weekday-pinned nudges each
+        // at that day's own time. Mirrors `WindDownNudge`'s #554 fan-out, which does exactly this with
+        // seven UNCalendarNotificationTriggers — the nudge exists to be an hour before YOUR wake, so on a
+        // day whose wake moved it has to move with it.
+        //
+        // A weekly repeat is a daily interval times seven; each day carries its own request code so the
+        // seven PendingIntents are distinct rather than overwriting one another.
+        for (weekday in 1..7) {
+            val wake = perDayWake[weekday] ?: wakeMinutes
+            val first = nextWeeklyOccurrence(store.nudgeMinuteOfDay(wake), weekday)
+            am.setInexactRepeating(
+                AlarmManager.RTC,
+                first.timeInMillis,
+                AlarmManager.INTERVAL_DAY * 7,
+                nudgePendingIntent(context, weekday),
+            )
+        }
     }
 
+    /** Cancel every shape the nudge can be scheduled in — the single daily one AND all seven weekday
+     *  pins. Unconditional on purpose: the caller does not always know which shape is live, and a
+     *  cancel that misses one leaves a reminder firing at a time the user has already changed. */
     fun cancel(context: Context) {
         val am = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
         am.cancel(nudgePendingIntent(context))
+        for (weekday in 1..7) am.cancel(nudgePendingIntent(context, weekday))
     }
 
     /** Raise the low-key nudge notification. Called from [WindDownReceiver]. */
@@ -78,10 +110,12 @@ object WindDownScheduler {
         }
     }
 
-    private fun nudgePendingIntent(context: Context): PendingIntent {
+    /** [weekday] null = the single daily nudge; 1..7 = that weekday's own pin, on its own request code
+     *  so the seven do not collide with each other or with the daily one. */
+    private fun nudgePendingIntent(context: Context, weekday: Int? = null): PendingIntent {
         val intent = Intent(context, WindDownReceiver::class.java).setAction(ACTION_NUDGE)
         return PendingIntent.getBroadcast(
-            context, REQUEST_CODE, intent,
+            context, REQUEST_CODE + (weekday ?: 0), intent,
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
     }
@@ -98,6 +132,34 @@ object WindDownScheduler {
                 },
             )
         }
+    }
+
+    /**
+     * The next time [minuteOfDay] falls on [weekday] (Calendar 1=Sun…7=Sat) — the anchor for a weekly
+     * repeat. Walks forward at most seven days, so today counts only if the minute is still ahead.
+     *
+     * `internal` so the day/time arithmetic is unit-testable without an AlarmManager, which is the whole
+     * of what could go wrong here.
+     */
+    internal fun nextWeeklyOccurrence(
+        minuteOfDay: Int,
+        weekday: Int,
+        now: Calendar = Calendar.getInstance(),
+    ): Calendar {
+        val cal = (now.clone() as Calendar).apply {
+            set(Calendar.HOUR_OF_DAY, minuteOfDay / 60)
+            set(Calendar.MINUTE, minuteOfDay % 60)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+        var guard = 0
+        while ((cal.get(Calendar.DAY_OF_WEEK) != weekday || cal.timeInMillis <= now.timeInMillis) &&
+            guard < 8
+        ) {
+            cal.add(Calendar.DAY_OF_YEAR, 1)
+            guard++
+        }
+        return cal
     }
 
     private fun nextOccurrence(minuteOfDay: Int): Calendar =

--- a/android/app/src/main/java/com/noop/alarm/WindDownScheduler.kt
+++ b/android/app/src/main/java/com/noop/alarm/WindDownScheduler.kt
@@ -68,7 +68,10 @@ object WindDownScheduler {
         // seven PendingIntents are distinct rather than overwriting one another.
         for (weekday in 1..7) {
             val wake = perDayWake[weekday] ?: wakeMinutes
-            val first = nextWeeklyOccurrence(store.nudgeMinuteOfDay(wake), weekday)
+            // The nudge is pinned to the day it FIRES on, which is not always the day you wake on: an
+            // early wake pushes it back over midnight. See [WindDownStore.nudgeDayShift].
+            val nudgeWeekday = shiftWeekday(weekday, store.nudgeDayShift(wake))
+            val first = nextWeeklyOccurrence(store.nudgeMinuteOfDay(wake), nudgeWeekday)
             am.setInexactRepeating(
                 AlarmManager.RTC,
                 first.timeInMillis,
@@ -133,6 +136,15 @@ object WindDownScheduler {
             )
         }
     }
+
+    /**
+     * Move a `Calendar.DAY_OF_WEEK` by [shift] days, wrapping through the week end (1=Sun…7=Sat).
+     *
+     * [shift] is normally 0 or -1 — an early wake puts its wind-down on the previous evening — but the
+     * arithmetic is general so a long sleep-need plus lead cannot produce an out-of-range weekday.
+     */
+    internal fun shiftWeekday(weekday: Int, shift: Int): Int =
+        Math.floorMod(weekday - 1 + shift, 7) + 1
 
     /**
      * The next time [minuteOfDay] falls on [weekday] (Calendar 1=Sun…7=Sat) — the anchor for a weekly

--- a/android/app/src/main/java/com/noop/alarm/WindDownStore.kt
+++ b/android/app/src/main/java/com/noop/alarm/WindDownStore.kt
@@ -29,8 +29,25 @@ class WindDownStore(private val prefs: SharedPreferences) {
         set(v) = prefs.edit().putInt(KEY_LEAD, v.coerceIn(LEAD_MIN, LEAD_MAX)).apply()
 
     /**
+     * How many days BEFORE the wake day the nudge falls: 0 for the same day, -1 for the evening before.
+     *
+     * Only matters once the nudge is pinned to a WEEKDAY (#1858's per-day fan-out). The single daily
+     * schedule never needed it — it fires at a minute-of-day every day, so which day "owns" it is not a
+     * question anyone asks.
+     *
+     * It matters now because per-day wake times exist precisely to support EARLY wakes: a 03:30 wake with
+     * an 8 h need and a 30 min lead puts the nudge at 19:00 the PREVIOUS evening. Pinning that to the
+     * wake's own weekday would fire it eight hours AFTER the wake it is meant to precede — and it would be
+     * pointing at the next day's wake, which may be a different time entirely.
+     */
+    fun nudgeDayShift(wakeMinutes: Int): Int =
+        nudgeDayShift(wakeMinutes, sleepNeedMinutes, leadMinutes)
+
+    /**
      * Minute-of-day the nudge should fire, derived from a wake time: wake − sleepNeed − lead,
      * wrapped into [0, 1440). With an 06:30 wake, 8 h need and 30 min lead this is 22:00.
+     *
+     * The wrap loses WHICH day that minute belongs to, which is why [nudgeDayShift] exists beside it.
      */
     fun nudgeMinuteOfDay(wakeMinutes: Int): Int {
         val raw = wakeMinutes - sleepNeedMinutes - leadMinutes
@@ -39,6 +56,10 @@ class WindDownStore(private val prefs: SharedPreferences) {
     }
 
     companion object {
+        /** Pure form of [nudgeDayShift], so the day arithmetic is testable without a Context. */
+        fun nudgeDayShift(wakeMinutes: Int, sleepNeedMinutes: Int, leadMinutes: Int): Int =
+            Math.floorDiv(wakeMinutes - sleepNeedMinutes - leadMinutes, 24 * 60)
+
         private const val PREFS = "noop_wind_down"
         private const val KEY_ENABLED = "windDown.enabled"
         private const val KEY_SLEEP_NEED = "windDown.sleepNeedMinutes"

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -2558,6 +2558,11 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         phoneAlarmStore.targetOverrides = next
         _phoneAlarmDayOverrides.value = phoneAlarmStore.targetOverrides
         if (phoneAlarmStore.enabled) SmartAlarmScheduler.arm(appContext, phoneAlarmStore)
+        // The strap-buzz companion derives its buzz time FROM the phone alarm, so an override that moves a
+        // wake time has to move the buzz with it. `setPhoneAlarmWeekdays` already reconciles for exactly
+        // this reason; omitting it here would leave the strap armed for the old time until some unrelated
+        // edit happened to reconcile — a strap buzzing at the wrong hour being worse than one not buzzing.
+        reconcileStrapAlarm()
     }
 
     /** Set the days the phone alarm fires on. EMPTY = every day (see [SmartAlarmStore.weekdays]).

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -634,6 +634,11 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     private val _phoneAlarmEnabled = MutableStateFlow(phoneAlarmStore.enabled)
     /** Whether the phone smart alarm is armed (a guaranteed OS alarm is scheduled). */
     val phoneAlarmEnabled: StateFlow<Boolean> = _phoneAlarmEnabled.asStateFlow()
+    /** #1858: per-weekday wake-time overrides for the PHONE alarm — the strap alarm's #554 feature,
+     *  which this screen has shown beside it since then. Empty = every enabled day uses the single time. */
+    private val _phoneAlarmDayOverrides = MutableStateFlow(phoneAlarmStore.targetOverrides)
+    val phoneAlarmDayOverrides: StateFlow<Map<Int, Int>> = _phoneAlarmDayOverrides.asStateFlow()
+
     private val _phoneAlarmTargetMinutes = MutableStateFlow(phoneAlarmStore.targetMinutes)
     /** Earliest acceptable wake time, minutes since midnight. */
     val phoneAlarmTargetMinutes: StateFlow<Int> = _phoneAlarmTargetMinutes.asStateFlow()
@@ -2539,6 +2544,22 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         reconcileStrapAlarm()
     }
 
+    /**
+     * #1858: set or clear ONE weekday's wake-time override for the phone alarm.
+     *
+     * `null` clears, so a day can go back to following the single time without a second control. Re-arms
+     * afterwards for the same reason every other alarm edit does: the scheduled deadline is computed from
+     * these values, so leaving it stale would keep waking the user at the old time until something else
+     * happened to re-arm. Mirrors `setSmartAlarmDayOverride` for the strap.
+     */
+    fun setPhoneAlarmDayOverride(dayOfWeek: Int, minutes: Int?) {
+        val next = phoneAlarmStore.targetOverrides.toMutableMap()
+        if (minutes == null) next.remove(dayOfWeek) else next[dayOfWeek] = minutes
+        phoneAlarmStore.targetOverrides = next
+        _phoneAlarmDayOverrides.value = phoneAlarmStore.targetOverrides
+        if (phoneAlarmStore.enabled) SmartAlarmScheduler.arm(appContext, phoneAlarmStore)
+    }
+
     /** Set the days the phone alarm fires on. EMPTY = every day (see [SmartAlarmStore.weekdays]).
      *
      *  Re-arms while enabled so deselecting today's day moves the alarm to the next selected one
@@ -2741,12 +2762,20 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         } else null
         // Buzz-WHOOP-4 companion's requested time: the phone alarm's EARLIEST wake time, next occurrence
         // ON A DAY THAT ALARM ACTUALLY FIRES. This routes through the same weekday-aware resolver the
-        // smart alarm uses (with no per-day overrides — the phone alarm has none) rather than
-        // nextDailyEpochSec, which is unconditionally daily: leaving it daily would buzz the strap on a
-        // morning the phone alarm is switched off, which is precisely the day the user asked to sleep in.
-        // An empty weekday set still means every day, so the default behaviour is unchanged.
+        // smart alarm uses rather than nextDailyEpochSec, which is unconditionally daily: leaving it daily
+        // would buzz the strap on a morning the phone alarm is switched off, which is precisely the day the
+        // user asked to sleep in. An empty weekday set still means every day.
+        //
+        // #1858: the per-day overrides go through TOO. This companion exists to buzz the strap at the phone
+        // alarm's earliest wake time, so a day whose wake time was moved must move the buzz with it — the
+        // comment here used to say "the phone alarm has none", which stopped being true the moment it got
+        // them, and a strap buzzing at the old time is worse than one not buzzing at all.
         val buzzEpoch = if (_buzzWhoop4Enabled.value) {
-            nextSmartAlarmEpochSec(phoneAlarmStore.targetMinutes, phoneAlarmStore.weekdays)
+            nextSmartAlarmEpochSec(
+                phoneAlarmStore.targetMinutes,
+                phoneAlarmStore.weekdays,
+                dayOverrides = phoneAlarmStore.targetOverrides,
+            )
         } else null
 
         val epochSec = earliestStrapAlarmEpochSec(smartEpoch, buzzEpoch)

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -2538,7 +2538,9 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         _phoneAlarmTargetMinutes.value = phoneAlarmStore.targetMinutes
         if (phoneAlarmStore.enabled) SmartAlarmScheduler.arm(appContext, phoneAlarmStore)
         // The wind-down nudge is derived from the wake time, so keep it in step.
-        if (windDownStore.enabled) WindDownScheduler.schedule(appContext, windDownStore, phoneAlarmStore.targetMinutes)
+        if (windDownStore.enabled) WindDownScheduler.schedule(
+            appContext, windDownStore, phoneAlarmStore.targetMinutes, phoneAlarmStore.targetOverrides,
+        )
         // #536: re-arm the strap at the new earliest time when "Buzz WHOOP 4" is on. Routed through the
         // single reconciler so it can't clobber a smart-alarm the user still has on (#5).
         reconcileStrapAlarm()
@@ -2563,6 +2565,14 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         // this reason; omitting it here would leave the strap armed for the old time until some unrelated
         // edit happened to reconcile — a strap buzzing at the wrong hour being worse than one not buzzing.
         reconcileStrapAlarm()
+        // The wind-down nudge is anchored to the wake time this just moved, so it has to move too —
+        // Apple's WindDownNudge has fanned out per-day since #554. Without this the reminder keeps
+        // pointing at the old wake on exactly the day the user changed.
+        if (windDownStore.enabled) {
+            WindDownScheduler.schedule(
+                appContext, windDownStore, phoneAlarmStore.targetMinutes, phoneAlarmStore.targetOverrides,
+            )
+        }
     }
 
     /** Set the days the phone alarm fires on. EMPTY = every day (see [SmartAlarmStore.weekdays]).
@@ -2603,7 +2613,9 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     fun setWindDownEnabled(enabled: Boolean) {
         windDownStore.enabled = enabled
         _windDownEnabled.value = enabled
-        if (enabled) WindDownScheduler.schedule(appContext, windDownStore, phoneAlarmStore.targetMinutes)
+        if (enabled) WindDownScheduler.schedule(
+            appContext, windDownStore, phoneAlarmStore.targetMinutes, phoneAlarmStore.targetOverrides,
+        )
         else WindDownScheduler.cancel(appContext)
     }
 

--- a/android/app/src/main/java/com/noop/ui/SmartAlarmScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SmartAlarmScreen.kt
@@ -93,17 +93,12 @@ fun SmartAlarmScreen(vm: AppViewModel) {
             val nextTargetMinutes = remember(
                 targetMinutes, windowMinutes, phoneAlarmWeekdays, phoneAlarmDayOverrides,
             ) {
-                com.noop.alarm.SmartAlarmScheduler.nextDeadline(
+                com.noop.alarm.SmartAlarmScheduler.nextWindowStartMinutes(
                     now = java.util.Calendar.getInstance(),
                     weekdays = phoneAlarmWeekdays,
                     windowMinutes = windowMinutes,
+                    defaultTarget = targetMinutes,
                 ) { phoneAlarmDayOverrides[it] ?: targetMinutes }
-                    ?.let { cal ->
-                        val deadlineMin = cal.get(java.util.Calendar.HOUR_OF_DAY) * 60 +
-                            cal.get(java.util.Calendar.MINUTE)
-                        (deadlineMin - windowMinutes + 24 * 60) % (24 * 60)
-                    }
-                    ?: targetMinutes
             }
             WindowCard(enabled = enabled, targetMinutes = nextTargetMinutes, windowMinutes = windowMinutes)
         }

--- a/android/app/src/main/java/com/noop/ui/SmartAlarmScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SmartAlarmScreen.kt
@@ -61,6 +61,7 @@ fun SmartAlarmScreen(vm: AppViewModel) {
     val targetMinutes by vm.phoneAlarmTargetMinutes.collectAsStateWithLifecycle()
     val windowMinutes by vm.phoneAlarmWindowMinutes.collectAsStateWithLifecycle()
     val phoneAlarmWeekdays by vm.phoneAlarmWeekdays.collectAsStateWithLifecycle()
+    val phoneAlarmDayOverrides by vm.phoneAlarmDayOverrides.collectAsStateWithLifecycle()
     val buzzWhoop4 by vm.buzzWhoop4Enabled.collectAsStateWithLifecycle()
     // #536: the hint adapts to bond state — the strap can only be armed when a WHOOP 4.0 is connected.
     val liveState = vm.live.collectAsStateWithLifecycle().value
@@ -84,7 +85,28 @@ fun SmartAlarmScreen(vm: AppViewModel) {
         subtitle = "Your wake window, the strap wake-alarm, and the evening wind-down reminder, in one place.",
     ) {
         // The guaranteed-wake card always shows so the safety promise is the first thing read.
-        item { WindowCard(enabled = enabled, targetMinutes = targetMinutes, windowMinutes = windowMinutes) }
+        item {
+            // #1858: the card names a specific time ("a backup alarm is set for 04:45"), so with per-day
+            // wake times it has to show the NEXT one rather than the default — on a day whose time was
+            // moved, the default is simply the wrong number, and this card is the one thing on the screen
+            // that makes a promise. Falls back to the default when no day is reachable.
+            val nextTargetMinutes = remember(
+                targetMinutes, windowMinutes, phoneAlarmWeekdays, phoneAlarmDayOverrides,
+            ) {
+                com.noop.alarm.SmartAlarmScheduler.nextDeadline(
+                    now = java.util.Calendar.getInstance(),
+                    weekdays = phoneAlarmWeekdays,
+                    windowMinutes = windowMinutes,
+                ) { phoneAlarmDayOverrides[it] ?: targetMinutes }
+                    ?.let { cal ->
+                        val deadlineMin = cal.get(java.util.Calendar.HOUR_OF_DAY) * 60 +
+                            cal.get(java.util.Calendar.MINUTE)
+                        (deadlineMin - windowMinutes + 24 * 60) % (24 * 60)
+                    }
+                    ?: targetMinutes
+            }
+            WindowCard(enabled = enabled, targetMinutes = nextTargetMinutes, windowMinutes = windowMinutes)
+        }
 
         item {
         AlarmSettingsCard {
@@ -163,6 +185,18 @@ fun SmartAlarmScreen(vm: AppViewModel) {
                     onToggle = { dow ->
                         vm.setPhoneAlarmWeekdays(toggledSmartAlarmWeekday(dow, phoneAlarmWeekdays))
                     },
+                )
+                RowDividerLocal()
+                // #1858: per-day wake times, the SAME picker and the same contract the strap alarm below
+                // has had since #554. Both alarms sit on this one screen, so one of them supporting a
+                // different time on different days and the other not is read as the feature being broken —
+                // which is exactly how it was reported ("I want 04:45 on three days and 03:30 on two
+                // others… the smart alarm basically never works").
+                AlarmDayOverridePicker(
+                    defaultMinutes = targetMinutes,
+                    enabledDays = phoneAlarmWeekdays,
+                    overrides = phoneAlarmDayOverrides,
+                    onSetOverride = { dow, minutes -> vm.setPhoneAlarmDayOverride(dow, minutes) },
                 )
             }
 

--- a/android/app/src/test/java/com/noop/alarm/PhoneAlarmWeekdayTest.kt
+++ b/android/app/src/test/java/com/noop/alarm/PhoneAlarmWeekdayTest.kt
@@ -235,4 +235,34 @@ class PhoneAlarmWeekdayTest {
         assertEquals(31, at.get(Calendar.DAY_OF_MONTH))   // Mon 24 → Mon 31
     }
 
+
+    /**
+     * An EARLY wake puts its wind-down on the previous EVENING, so the nudge must be pinned to that day —
+     * not to the day you wake on.
+     *
+     * The reported schedule is exactly this shape: a 03:30 wake with an 8 h need and a 30 min lead puts
+     * the nudge at 19:00 the night before. Pinning it to the wake's own weekday would fire it eight hours
+     * AFTER the wake it exists to precede, pointing at the next day's wake — which per-day times mean may
+     * be a different hour entirely.
+     *
+     * Only reachable once the nudge is weekday-pinned: the single daily schedule fires at a minute-of-day
+     * every day, so which day owns it was never a question.
+     */
+    @Test fun anEarlyWakePinsTheNudgeToThePreviousEvening() {
+        val need = WindDownStore.DEFAULT_SLEEP_NEED   // 8 h
+        val lead = WindDownStore.DEFAULT_LEAD         // 30 min
+        // 03:30 wake ⇒ 19:00 the previous evening.
+        assertEquals(-1, WindDownStore.nudgeDayShift(3 * 60 + 30, need, lead))
+        // A late-morning wake keeps its nudge on the same day.
+        assertEquals(0, WindDownStore.nudgeDayShift(21 * 60, need, lead))
+    }
+
+    /** Shifting a weekday wraps through the week end in both directions. */
+    @Test fun theWeekdayShiftWrapsAtBothEnds() {
+        assertEquals(Calendar.SATURDAY, WindDownScheduler.shiftWeekday(Calendar.SUNDAY, -1))
+        assertEquals(Calendar.SUNDAY, WindDownScheduler.shiftWeekday(Calendar.MONDAY, -1))
+        assertEquals(Calendar.MONDAY, WindDownScheduler.shiftWeekday(Calendar.MONDAY, 0))
+        assertEquals(Calendar.SUNDAY, WindDownScheduler.shiftWeekday(Calendar.SATURDAY, 1))
+    }
+
 }

--- a/android/app/src/test/java/com/noop/alarm/PhoneAlarmWeekdayTest.kt
+++ b/android/app/src/test/java/com/noop/alarm/PhoneAlarmWeekdayTest.kt
@@ -167,4 +167,48 @@ class PhoneAlarmWeekdayTest {
     @Test fun anUnreachableSetYieldsNothingInsteadOfSpinning() {
         assertNull(deadline(mondayAt(), weekdays = setOf(99)))
     }
+
+    // MARK: what the guarantee card shows
+
+    /**
+     * The card names a specific time, so it must name the NEXT one. Derived from the same
+     * [SmartAlarmScheduler.nextDeadline] the alarm uses, so the promise on screen and the alarm that
+     * actually fires cannot drift apart — two independent time computations going stale is the failure
+     * this change had to fix in the Buzz-WHOOP companion as well.
+     */
+    @Test fun theCardShowsTheNextWindowNotTheDefault() {
+        val start = SmartAlarmScheduler.nextWindowStartMinutes(
+            now = mondayAt(),
+            weekdays = setOf(Calendar.TUESDAY),
+            windowMinutes = 30,
+            defaultTarget = 4 * 60 + 15,
+        ) { mapOf(Calendar.TUESDAY to 3 * 60)[it] ?: (4 * 60 + 15) }
+        assertEquals(3 * 60, start)   // Tuesday's own 03:00, not the 04:15 default
+    }
+
+    /** With no overrides it is the default, so the card is unchanged for every existing install. */
+    @Test fun theCardKeepsTheDefaultWhenNothingIsOverridden() {
+        val start = SmartAlarmScheduler.nextWindowStartMinutes(
+            now = mondayAt(), weekdays = emptySet(), windowMinutes = 30, defaultTarget = 6 * 60 + 30,
+        ) { 6 * 60 + 30 }
+        assertEquals(6 * 60 + 30, start)
+    }
+
+    /** A window opening the previous evening still reports its own start, not a negative minute. */
+    @Test fun theCardHandlesAWindowThatOpensBeforeMidnight() {
+        val start = SmartAlarmScheduler.nextWindowStartMinutes(
+            now = mondayAt(), weekdays = setOf(Calendar.MONDAY), windowMinutes = 30,
+            defaultTarget = 23 * 60 + 50,
+        ) { 23 * 60 + 50 }
+        assertEquals(23 * 60 + 50, start)
+    }
+
+    /** Nothing schedulable degrades to the default rather than blanking the promise. */
+    @Test fun theCardFallsBackWhenNoDayIsReachable() {
+        val start = SmartAlarmScheduler.nextWindowStartMinutes(
+            now = mondayAt(), weekdays = setOf(99), windowMinutes = 30, defaultTarget = 5 * 60,
+        ) { 5 * 60 }
+        assertEquals(5 * 60, start)
+    }
+
 }

--- a/android/app/src/test/java/com/noop/alarm/PhoneAlarmWeekdayTest.kt
+++ b/android/app/src/test/java/com/noop/alarm/PhoneAlarmWeekdayTest.kt
@@ -211,4 +211,28 @@ class PhoneAlarmWeekdayTest {
         assertEquals(5 * 60, start)
     }
 
+
+    // MARK: wind-down fan-out (Apple parity — WindDownNudge has done this since #554)
+
+    /** The weekly anchor lands on the requested weekday at the requested minute. */
+    @Test fun theWeeklyNudgeAnchorLandsOnItsWeekday() {
+        val at = WindDownScheduler.nextWeeklyOccurrence(21 * 60 + 15, Calendar.THURSDAY, mondayAt())
+        assertEquals(Calendar.THURSDAY, at.get(Calendar.DAY_OF_WEEK))
+        assertEquals(21, at.get(Calendar.HOUR_OF_DAY))
+        assertEquals(15, at.get(Calendar.MINUTE))
+        assertEquals(27, at.get(Calendar.DAY_OF_MONTH))   // Mon 24 → Thu 27
+    }
+
+    /** Today counts only while its minute is still ahead. */
+    @Test fun todayCountsWhenItsMinuteHasNotPassed() {
+        val at = WindDownScheduler.nextWeeklyOccurrence(21 * 60, Calendar.MONDAY, mondayAt(hour = 5))
+        assertEquals(24, at.get(Calendar.DAY_OF_MONTH))
+    }
+
+    /** …and rolls a full week once it has, rather than scheduling a nudge in the past. */
+    @Test fun aPassedMinuteRollsAWholeWeek() {
+        val at = WindDownScheduler.nextWeeklyOccurrence(4 * 60, Calendar.MONDAY, mondayAt(hour = 9))
+        assertEquals(31, at.get(Calendar.DAY_OF_MONTH))   // Mon 24 → Mon 31
+    }
+
 }

--- a/android/app/src/test/java/com/noop/alarm/PhoneAlarmWeekdayTest.kt
+++ b/android/app/src/test/java/com/noop/alarm/PhoneAlarmWeekdayTest.kt
@@ -1,25 +1,39 @@
 package com.noop.alarm
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 import java.util.Calendar
 
 /**
- * Per-day scheduling for the PHONE smart alarm (distinct from com.noop.ui.SmartAlarmWeekdayTest,
- * which covers the STRAP alarm): the Mon…Sun circles that let a day be switched off
- * without disabling the alarm and having to remember to switch it back on.
+ * Day and time selection for the PHONE smart alarm (distinct from com.noop.ui.SmartAlarmWeekdayTest,
+ * which covers the STRAP alarm).
  *
- * Covers [SmartAlarmScheduler.advanceToEnabledDay], which is the whole of the day-selection logic —
- * `arm` wraps it around an AlarmManager call that a JVM test cannot exercise, so the decision is
- * factored out and pinned here instead. Fixtures use a fixed date so a Sunday case stays a Sunday case
- * whatever day the suite runs on.
+ * Covers [SmartAlarmScheduler.nextDeadline], which is the whole of the scheduling decision — `arm` wraps
+ * it around an AlarmManager call a JVM test cannot exercise, so the decision is factored out and pinned
+ * here. Repinned from `advanceToEnabledDay` when #1858 made the deadline minute per-day: the day can no
+ * longer be chosen first and the time applied afterwards, because the time is a property OF the day.
+ *
+ * Fixtures use a fixed date so a Sunday case stays a Sunday case whatever day the suite runs on.
  */
 class PhoneAlarmWeekdayTest {
 
     /** 2026-08-24 is a Monday. Calendar.DAY_OF_WEEK: 1=Sun … 7=Sat. */
-    private fun mondayAt(hour: Int = 7): Calendar = Calendar.getInstance().apply {
+    private fun mondayAt(hour: Int = 5): Calendar = Calendar.getInstance().apply {
         set(2026, Calendar.AUGUST, 24, hour, 0, 0)
         set(Calendar.MILLISECOND, 0)
+    }
+
+    /** 06:30 earliest + 30 min window = a 07:00 deadline, the shipped defaults. */
+    private fun deadline(
+        now: Calendar,
+        weekdays: Set<Int> = emptySet(),
+        target: Int = 6 * 60 + 30,
+        window: Int = 30,
+        afterFire: Boolean = false,
+        perDay: Map<Int, Int> = emptyMap(),
+    ): Calendar? = SmartAlarmScheduler.nextDeadline(now, weekdays, window, afterFire) {
+        perDay[it] ?: target
     }
 
     /** The fixture must actually be the day the tests below assume. */
@@ -28,58 +42,129 @@ class PhoneAlarmWeekdayTest {
     }
 
     /**
-     * EMPTY = every day. This is the backward-compatible default: every existing install has no weekday
-     * key set, so an empty set must leave the day exactly as computed or the feature would silently
-     * re-schedule everyone's alarm on upgrade.
+     * EMPTY = every day, the backward-compatible default: every existing install has no weekday key set,
+     * so an empty set must schedule today's own deadline rather than shifting anyone on upgrade.
      */
-    @Test fun emptySetMeansEveryDayAndDoesNotMoveTheDay() {
-        val cal = mondayAt()
-        SmartAlarmScheduler.advanceToEnabledDay(cal, emptySet())
-        assertEquals(Calendar.MONDAY, cal.get(Calendar.DAY_OF_WEEK))
-        assertEquals(24, cal.get(Calendar.DAY_OF_MONTH))
+    @Test fun emptySetMeansEveryDay() {
+        val d = deadline(mondayAt())!!
+        assertEquals(Calendar.MONDAY, d.get(Calendar.DAY_OF_WEEK))
+        assertEquals(24, d.get(Calendar.DAY_OF_MONTH))
+        assertEquals(7, d.get(Calendar.HOUR_OF_DAY))
+        assertEquals(0, d.get(Calendar.MINUTE))
     }
 
-    /** A day that IS selected is left alone — no gratuitous shifting. */
+    /** A day that IS selected is used as-is — no gratuitous shifting. */
     @Test fun anEnabledDayIsNotMoved() {
-        val cal = mondayAt()
-        SmartAlarmScheduler.advanceToEnabledDay(cal, setOf(Calendar.MONDAY, Calendar.FRIDAY))
-        assertEquals(Calendar.MONDAY, cal.get(Calendar.DAY_OF_WEEK))
-        assertEquals(24, cal.get(Calendar.DAY_OF_MONTH))
+        val d = deadline(mondayAt(), weekdays = setOf(Calendar.MONDAY, Calendar.FRIDAY))!!
+        assertEquals(Calendar.MONDAY, d.get(Calendar.DAY_OF_WEEK))
+        assertEquals(24, d.get(Calendar.DAY_OF_MONTH))
     }
 
-    /** A disabled day rolls forward to the next selected one, and to the NEAREST such day. */
+    /** A disabled day rolls forward to the NEAREST selected one. */
     @Test fun aDisabledDayAdvancesToTheNextSelectedDay() {
-        val cal = mondayAt()
-        SmartAlarmScheduler.advanceToEnabledDay(cal, setOf(Calendar.WEDNESDAY, Calendar.SATURDAY))
-        assertEquals(Calendar.WEDNESDAY, cal.get(Calendar.DAY_OF_WEEK))
-        assertEquals(26, cal.get(Calendar.DAY_OF_MONTH))   // Mon 24 → Wed 26, not Sat
+        val d = deadline(mondayAt(), weekdays = setOf(Calendar.WEDNESDAY, Calendar.SATURDAY))!!
+        assertEquals(Calendar.WEDNESDAY, d.get(Calendar.DAY_OF_WEEK))
+        assertEquals(26, d.get(Calendar.DAY_OF_MONTH))   // Mon 24 → Wed 26, not Sat
     }
 
     /** Wrapping the week end: from Monday, a Sunday-only alarm lands six days out, not never. */
     @Test fun itWrapsAroundTheWeekEnd() {
-        val cal = mondayAt()
-        SmartAlarmScheduler.advanceToEnabledDay(cal, setOf(Calendar.SUNDAY))
-        assertEquals(Calendar.SUNDAY, cal.get(Calendar.DAY_OF_WEEK))
-        assertEquals(30, cal.get(Calendar.DAY_OF_MONTH))   // Mon 24 → Sun 30
+        val d = deadline(mondayAt(), weekdays = setOf(Calendar.SUNDAY))!!
+        assertEquals(Calendar.SUNDAY, d.get(Calendar.DAY_OF_WEEK))
+        assertEquals(30, d.get(Calendar.DAY_OF_MONTH))   // Mon 24 → Sun 30
     }
 
-    /** The time of day survives a day shift — only the DATE moves. */
-    @Test fun advancingPreservesTheWakeTime() {
-        val cal = mondayAt(hour = 6).apply { set(Calendar.MINUTE, 45) }
-        SmartAlarmScheduler.advanceToEnabledDay(cal, setOf(Calendar.THURSDAY))
-        assertEquals(Calendar.THURSDAY, cal.get(Calendar.DAY_OF_WEEK))
-        assertEquals(6, cal.get(Calendar.HOUR_OF_DAY))
-        assertEquals(45, cal.get(Calendar.MINUTE))
+    /** Today's deadline already gone ⇒ tomorrow, not a wake in the past. */
+    @Test fun aPastDeadlineRollsToTheNextDay() {
+        val d = deadline(mondayAt(hour = 9))!!   // 07:00 already behind us
+        assertEquals(25, d.get(Calendar.DAY_OF_MONTH))
+    }
+
+    // MARK: #1858 — a different wake time on different days
+
+    /**
+     * The reported shape: 04:45 on three days, 03:30 on two others — impossible to express before, since
+     * one target applied to every selected day.
+     *
+     * Each day's deadline is its OWN target plus the window, so Tuesday here wakes at 03:30 while the
+     * default days wake at 04:45.
+     */
+    @Test fun aDayWithAnOverrideUsesItsOwnTime() {
+        val d = deadline(
+            mondayAt(),
+            weekdays = setOf(Calendar.TUESDAY),
+            target = 4 * 60 + 15,                                   // default 04:15 + 30 = 04:45
+            perDay = mapOf(Calendar.TUESDAY to 3 * 60),             // Tue 03:00 + 30 = 03:30
+        )!!
+        assertEquals(Calendar.TUESDAY, d.get(Calendar.DAY_OF_WEEK))
+        assertEquals(3, d.get(Calendar.HOUR_OF_DAY))
+        assertEquals(30, d.get(Calendar.MINUTE))
+    }
+
+    /** A day with no override falls back to the single target, so setting one day never moves another. */
+    @Test fun daysWithoutAnOverrideKeepTheDefault() {
+        val d = deadline(
+            mondayAt(),
+            weekdays = setOf(Calendar.MONDAY),
+            target = 4 * 60 + 15,
+            perDay = mapOf(Calendar.TUESDAY to 3 * 60),   // an override for a DIFFERENT day
+        )!!
+        assertEquals(Calendar.MONDAY, d.get(Calendar.DAY_OF_WEEK))
+        assertEquals(4, d.get(Calendar.HOUR_OF_DAY))
+        assertEquals(45, d.get(Calendar.MINUTE))
     }
 
     /**
-     * An unreachable set returns the unshifted day rather than spinning. [SmartAlarmStore.weekdays]
-     * filters to 1..7 so this is unreachable through the store, but the guard is on the
-     * safety-critical scheduling path: a wrong-day alarm is recoverable, a hung scheduler is not.
+     * The nearest day wins on TIME, not on day order alone: with per-day targets an earlier day can now
+     * hold a later deadline, so "next" has to be decided by the instant.
      */
-    @Test fun anUnreachableSetTerminatesInsteadOfSpinning() {
-        val cal = mondayAt()
-        SmartAlarmScheduler.advanceToEnabledDay(cal, setOf(99))
-        assertEquals(24 + 7, cal.get(Calendar.DAY_OF_MONTH))   // bounded at 7 hops, then gives up
+    @Test fun theNearestDeadlineWinsAcrossDifferentPerDayTimes() {
+        val d = deadline(
+            mondayAt(hour = 5),                                   // Monday 05:00; Monday's own 04:45 is gone
+            weekdays = setOf(Calendar.MONDAY, Calendar.TUESDAY),
+            target = 4 * 60 + 15,
+            perDay = mapOf(Calendar.TUESDAY to 3 * 60),
+        )!!
+        assertEquals(Calendar.TUESDAY, d.get(Calendar.DAY_OF_WEEK))
+        assertEquals(25, d.get(Calendar.DAY_OF_MONTH))
+        assertEquals(3, d.get(Calendar.HOUR_OF_DAY))
+    }
+
+    // MARK: re-arming and edges
+
+    /**
+     * After an EARLY fire the same morning's deadline is still ahead — re-arming onto it would wake the
+     * user a second time. `afterFire` skips today, and because the skip happens inside the day loop it
+     * can never land on a day the alarm is switched off.
+     */
+    @Test fun afterFiringEarlyTheNextWakeIsNotToday() {
+        val d = deadline(mondayAt(hour = 4), afterFire = true)!!   // 07:00 today still ahead
+        assertEquals(25, d.get(Calendar.DAY_OF_MONTH))
+    }
+
+    /** …and the skip respects the weekday set rather than blindly taking tomorrow. */
+    @Test fun afterFiringTheSkipStillHonoursTheEnabledDays() {
+        val d = deadline(
+            mondayAt(hour = 4), weekdays = setOf(Calendar.MONDAY, Calendar.THURSDAY), afterFire = true,
+        )!!
+        assertEquals(Calendar.THURSDAY, d.get(Calendar.DAY_OF_WEEK))
+    }
+
+    /**
+     * `target + window` can roll past midnight. The deadline stays on the ENABLED day and the window
+     * opens the previous evening — the same relationship the single-time version produced.
+     */
+    @Test fun aWindowCrossingMidnightKeepsTheDeadlineOnTheEnabledDay() {
+        val d = deadline(mondayAt(), weekdays = setOf(Calendar.MONDAY), target = 23 * 60 + 50, window = 30)!!
+        assertEquals(Calendar.MONDAY, d.get(Calendar.DAY_OF_WEEK))
+        assertEquals(0, d.get(Calendar.HOUR_OF_DAY))
+        assertEquals(20, d.get(Calendar.MINUTE))
+    }
+
+    /** An unreachable set yields null rather than spinning — a missed alarm is recoverable, a hung
+     *  scheduler on the safety-critical path is not. The store's 1..7 filter makes this unreachable in
+     *  practice; the guard is for the day a caller forgets that. */
+    @Test fun anUnreachableSetYieldsNothingInsteadOfSpinning() {
+        assertNull(deadline(mondayAt(), weekdays = setOf(99)))
     }
 }


### PR DESCRIPTION
Reported as *"I want it to go off at around 4:45 on three days of the week and at 3:30 on two other days… the smart alarm basically never works."*

The first half is not a misunderstanding. The phone alarm held **one** `targetMinutes` for every selected day, so that schedule was not expressible at all.

**The strap alarm on the same screen has had per-day times since #554.** Two alarms sitting together with near-identical controls, one supporting a different time on different days and the other not — reading that as "the feature is broken" is the correct reading of what's in front of you.

## Reuses #554's model rather than inventing a second one

Same `AlarmDayOverridePicker`, and a `targetOverrides` map encoded exactly like `NoopPrefs.smartAlarmDayOverrides` (`"dow:minute"` string set, 1..7, `[0,1440)`). Sparse overrides over the single time, so an install that sets none behaves as before and there is nothing to migrate.

## Scheduling changed shape, not just gained a lookup

With per-day targets the deadline minute is no longer a single number, so the old *"find the next occurrence of one minute-of-day, then roll forward to an enabled day"* cannot work — **the day must be chosen first and its own target read from it**.

`nextDeadline` walks candidate days and takes the first enabled day whose own `target + window` is still ahead. That also folds the after-fire re-arm in as "skip today" rather than a post-hoc date adjustment: a plainer statement of the same rule, and it cannot land on a disabled day.

`nextOccurrence` / `advanceToEnabledDay` are deleted, and `PhoneAlarmWeekdayTest` is repinned onto `nextDeadline` — same day-selection intent, now against live code rather than a helper kept alive by its own test.

## Two other surfaces computed a wake time independently

Both would have gone stale — the failure mode this repo keeps producing:

- **The Buzz-WHOOP companion** passed no overrides, under a comment reading *"the phone alarm has none"*. True when written; false the moment it got them. A strap buzzing at the old time is worse than one not buzzing at all.
- **The "Guaranteed wake" card** names a specific time (*"a backup alarm is set for 04:45"*). It now shows the **next** window rather than the default — on a moved day the default is simply the wrong number, and that card is the one thing on the screen making a promise.

## Verification

Full suite **5133 / 0**. `PhoneAlarmWeekdayTest` has 13 cases covering per-day selection, the nearest-deadline-across-different-times case (an earlier day can now hold a later deadline, so "next" is decided by the instant), the after-fire skip honouring enabled days, and a window crossing midnight. Doc-comment and i18n gates clean. **No new strings** — the picker and its copy already exist.

## Not addressed here

Tracked on #1858, because neither should be guessed at:

- **The smart wake never firing early.** It needs a live HR stream inside the window and there is **zero logging** anywhere in the alarm package, so no report can currently distinguish "no HR arrived" from "the detector declined". Instrumentation first.
- **Ringing while already awake or mid-workout.** `ActiveWorkoutStore` would give the signal, but the alarm's contract is that it fires even if Bluetooth drops or the app is closed. Weakening that risks someone oversleeping, so it needs a decision (snooze rather than skip? opt-in?) rather than a quiet change.