### PR TITLE
docs(ios): name the on-device AltStore Error Log shape, not just the desktop one

### DIFF
--- a/docs/IOS.md
+++ b/docs/IOS.md
@@ -27,6 +27,27 @@ ID**. Nothing about this touches NOOP's identity or Apple's servers on our side.
    and installs NOOP. First launch may need **Settings → General → VPN & Device Management → trust
    your Apple ID**.
 
+### If AltStore's Error Log says "Install NOOP Failed"
+
+The same failure also shows up **on the phone**, in AltStore's own Error Log, where it names NOOP and so
+looks like NOOP's fault:
+
+> **Install NOOP Failed** — `NSCocoaErrorDomain 3840`
+> *The data couldn't be read because it isn't in the correct format.*
+
+**Read the whole log before concluding anything.** If it also contains:
+
+> **Refresh AltStore Failed** — `NSCocoaErrorDomain 3840`
+
+then AltStore could not refresh **its own app**, which nothing about NOOP's `.ipa` or NOOP's source can
+cause. Every "… Failed" line is the same decode failure hitting whatever AltStore happened to be doing at
+that minute — installing NOOP, refreshing NOOP, refreshing itself. The NOOP-named lines are the symptom,
+not the cause.
+
+`NSCocoaErrorDomain 3840` is a parse error: AltStore expected structured data and got something else back
+(usually an HTML page). See the section below — it is the same underlying problem as the desktop sign-in
+failure, just reported from the phone instead of AltServer.
+
 ### If AltServer can't sign in with your Apple ID
 
 A failure at **step 1** — before NOOP is involved at all — looks like this:


### PR DESCRIPTION
Another report of the same upstream AltStore failure, arriving in a form the docs did not cover.

The existing note describes **AltServer's desktop sign-in dialog**. This user was looking at AltStore's **Error Log on the phone**, whose first line reads:

> **Install NOOP Failed** — `NSCocoaErrorDomain 3840`
> *The data couldn't be read because it isn't in the correct format.*

Nothing under a heading about *Apple ID sign-in* leads someone there, so the doc read as if this were a different problem — a NOOP one.

## The log carries its own disproof

Alongside the NOOP lines sits:

> **Refresh AltStore Failed** — `NSCocoaErrorDomain 3840`

AltStore could not refresh **its own app**. No `.ipa` and no source JSON of ours can cause that. Every line is the same decode failure hitting whatever AltStore happened to be doing that minute — installing NOOP, refreshing NOOP, refreshing itself. The NOOP-named lines are the symptom, not the cause.

So the new section leads with that tell, because it is the one thing in the screenshot that settles attribution without needing to trust us.

## Deliberately unchanged

The existing balance stays: local network filtering *can* produce an identical-looking error, and the note already says so while making clear it is **not** the usual cause. That wording is the correction from the last time this was misattributed to a user's DNS/VPN, and it is worth not re-breaking.

Docs only — no code, no strings.