### PR TITLE
ble: re-arm a WHOOP 5/MG realtime stream that has lapsed (#1865)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7154,7 +7154,12 @@ class WhoopBleClient(
                     // Only republish when the value actually changed: a same-HR frame's it.copy() allocates a
                     // whole throwaway LiveState that StateFlow drops as equal anyway — pure GC churn at ~1 Hz,
                     // every frame. Matches the Swift FrameRouter guard (`state.heartRate != hr`).
-                    if (hr in 30..220) noteLiveHr()
+                    // #1865: only a LIVE sample restarts the stall clock. Replayed offload frames reach
+                    // this branch too (handleFrame carries `replayedOffload`, and stopUnexpectedRealtimeImu
+                    // gates on it for exactly that reason), so counting them would let a history sync mask
+                    // a dead realtime stream — which is the very shape of the bug this recovers from:
+                    // healthy-looking traffic hiding the absence of HR.
+                    if (hr in 30..220 && !replayedOffload) noteLiveHr()
                     if (hr in 30..220 && _state.value.heartRate != hr) _state.update { it.copy(heartRate = hr) }
                 }
                 // The realtime stream usually reports rr_count=0; only update R-R when this frame

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1080,6 +1080,17 @@ class WhoopBleClient(
         /** Stream gone quiet this long (but not yet stall) ⇒ re-subscribe in case a CCCD silently dropped. */
         private const val KEEPALIVE_QUIET_MS = 45_000L
 
+        /**
+         * #1865: how long live HR may be absent, while we believe the stream is armed, before a 5/MG gets
+         * one re-arm.
+         *
+         * Sits between the 45 s quiet threshold and the 600 s bounce fuse on purpose. The 0x2A37 profile
+         * genuinely lulls at rest — that lull is why #1414 widened the fuse to 10 minutes — so a shorter
+         * value would re-arm a perfectly healthy stream, while waiting for the fuse means never recovering
+         * at all: the fuse watches ANY inbound data, and a strap answering battery polls never trips it.
+         */
+        private const val REALTIME_HR_STALL_MS = 300_000L
+
         /** A CCCD write can transiently return BUSY if the stack slot hasn't freed yet; retry the same
          *  subscribe a few times (short backoff) before giving up, rather than dropping the stream. */
         private const val CCCD_RETRY_DELAY_MS = 60L
@@ -1238,6 +1249,28 @@ class WhoopBleClient(
             201 -> "status=ERROR_GATT_WRITE_REQUEST_BUSY(201)"
             else -> "status=$status"
         }
+
+        /**
+         * #1865: whether a 5/MG's realtime stream looks LAPSED and should get its one re-arm.
+         *
+         * Pure so the decision is testable — `keepAliveFire` itself needs a live GATT link, which is why
+         * the drop-recovery decision next door was extracted the same way.
+         *
+         * Every clause earns its place:
+         *  - `wantsRealtime`: never arm a stream nobody asked for.
+         *  - `realtimeArmed`: if we do NOT believe it is armed, `reconcileRealtime` has a real edge and
+         *    sends the toggle itself. This path exists only for the case it cannot see.
+         *  - `!reArmedSinceHr`: one write per stall episode, not one per 30 s tick.
+         *  - the threshold: the 0x2A37 profile legitimately lulls at rest, so this must sit well past a
+         *    normal quiet spell.
+         */
+        fun shouldReArmLapsedRealtime(
+            wantsRealtime: Boolean,
+            realtimeArmed: Boolean,
+            reArmedSinceHr: Boolean,
+            hrSilentMs: Long,
+            stallMs: Long = REALTIME_HR_STALL_MS,
+        ): Boolean = wantsRealtime && realtimeArmed && !reArmedSinceHr && hrSilentMs > stallMs
 
         fun shouldReArmRealtimeAfterDrop(droppedCmd: CommandNumber?): Boolean =
             droppedCmd == CommandNumber.TOGGLE_REALTIME_HR
@@ -3269,6 +3302,21 @@ class WhoopBleClient(
     @Volatile private var realtimeArmed = false
     /** Wall-clock of the last inbound notification — drives the keep-alive liveness watchdog. */
     @Volatile private var lastDataAtMs = 0L
+
+    /**
+     * #1865: when a LIVE HR sample last arrived — distinct from [lastDataAtMs], which any inbound frame
+     * refreshes.
+     *
+     * That distinction is the whole bug. A 5/MG whose realtime stream has lapsed still answers battery
+     * polls and still serves history, so [lastDataAtMs] keeps the link looking perfectly healthy and the
+     * stall bounce never fires. Only an HR-specific clock can see "the stream is dead while the link is
+     * fine", which is exactly the state reported: bonded, worn, history synced just now, no bpm.
+     */
+    @Volatile private var lastLiveHrAtMs = 0L
+
+    /** #1865: one re-arm per stall episode, cleared when live HR resumes. Same shape as
+     *  [resubscribedSinceData] — recovering costs one write, repeating it every tick would not. */
+    @Volatile private var realtimeReArmedSinceHr = false
     /** True once we've re-subscribed during the CURRENT quiet episode, so the keep-alive re-subscribes
      *  at most once between data arrivals instead of flooding descriptor writes every 30s tick (#77).
      *  Reset to false in [onInbound] when fresh data lands. */
@@ -7106,6 +7154,7 @@ class WhoopBleClient(
                     // Only republish when the value actually changed: a same-HR frame's it.copy() allocates a
                     // whole throwaway LiveState that StateFlow drops as equal anyway — pure GC churn at ~1 Hz,
                     // every frame. Matches the Swift FrameRouter guard (`state.heartRate != hr`).
+                    if (hr in 30..220) noteLiveHr()
                     if (hr in 30..220 && _state.value.heartRate != hr) _state.update { it.copy(heartRate = hr) }
                 }
                 // The realtime stream usually reports rr_count=0; only update R-R when this frame
@@ -7538,6 +7587,7 @@ class WhoopBleClient(
             // Skip the redundant it.copy() when HR is unchanged — StateFlow drops an equal state anyway, so
             // this only avoids the per-frame throwaway LiveState allocation (matches FrameRouter). The bonded
             // transition below stays UNCONDITIONAL: it must still fire once even while HR sits steady.
+            noteLiveHr()
             if (_state.value.heartRate != hr) _state.update { it.copy(heartRate = hr) }
             // EXPERIMENTAL WHOOP 5.0/MG: there is no confirmed-write bond for a 5/MG strap, so once
             // live HR actually streams over the standard profile we treat the link as established —
@@ -7632,6 +7682,12 @@ class WhoopBleClient(
     // MARK: Live-stream keep-alive  (port of BLEManager.startKeepAlive / keepAliveFire)
     // ====================================================================================
 
+    /** #1865: a live HR sample arrived — restart the stall clock and re-arm the one-shot recovery. */
+    private fun noteLiveHr() {
+        lastLiveHrAtMs = System.currentTimeMillis()
+        realtimeReArmedSinceHr = false
+    }
+
     /**
      * How long this family's live link may go silent before the app stops calling it healthy.
      *
@@ -7639,6 +7695,9 @@ class WhoopBleClient(
      * says "a reconnect would achieve nothing", and the only honest measure of that is the same one the
      * watchdog uses to decide a reconnect IS needed. Two numbers here could disagree, and the way they
      * would fail is a Connect button that declines to act on a link the watchdog has already given up on.
+     *
+     * Note it measures ANY inbound data, not live HR — which is why #1865 needed its own clock: a strap
+     * answering battery polls keeps this fuse from ever tripping while the HR stream is dead.
      */
     private fun liveLinkStallFuseMs(): Long =
         if (connectedFamily == DeviceFamily.WHOOP5) KEEPALIVE_STALL_5MG_EMPTY_MS else KEEPALIVE_STALL_MS
@@ -7648,6 +7707,10 @@ class WhoopBleClient(
         handler.removeCallbacks(keepAliveRunnable)
         keepAliveTick = 0
         lastDataAtMs = System.currentTimeMillis()   // arm the watchdog from "now", not 1970
+        // #1865: same reasoning for the HR clock — a fresh link has not missed anything yet, so the stall
+        // check must not fire on the first tick just because no sample has landed in the first 30 seconds.
+        lastLiveHrAtMs = System.currentTimeMillis()
+        realtimeReArmedSinceHr = false
         handler.postDelayed(keepAliveRunnable, KEEPALIVE_INTERVAL_MS)
     }
 
@@ -7738,14 +7801,44 @@ class WhoopBleClient(
                     if (wantsRealtime) { realtimeArmed = true; realtimeArmedThisLink = true; send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(1)) }
                     // #battery: ~60 s normally, ~30 s while charging (see [batteryPollDue]).
                     if (batteryPollDue(keepAliveTick, s.charging == true)) send(CommandNumber.GET_BATTERY_LEVEL)
-                } else if (connectedFamily == DeviceFamily.WHOOP5 &&
-                    batteryPollDue(keepAliveTick, s.charging == true)
-                ) {
+                } else if (connectedFamily == DeviceFamily.WHOOP5) {
+                    // #1865: re-arm a LAPSED realtime stream. The WHOOP4 branch above re-sends
+                    // TOGGLE_REALTIME_HR every tick precisely because "the firmware lets the realtime HR
+                    // stream lapse if it isn't re-armed" — a 5/MG got none of that, on the reasoning that it
+                    // "rejects WHOOP4-framed commands". That premise no longer holds for this command:
+                    // `reconcileRealtime` above sends the toggle to BOTH families because send() routes the
+                    // 5/MG one with puffin framing.
+                    //
+                    // Nothing else recovers it. reconcileRealtime is edge-triggered, so while we believe the
+                    // stream is armed it sends nothing; the one-shot re-subscribe fixes a dropped CCCD, not a
+                    // lapsed stream; and the stall bounce keys on [lastDataAtMs], which battery polls and
+                    // history offload keep fresh. Reported exactly that way: bonded, worn, "history synced
+                    // just now", and no bpm — every other signal healthy, which is what kept the one path
+                    // that could have helped from firing.
+                    //
+                    // Gated on an HR-SPECIFIC stall rather than sent every tick: a healthy 5/MG stream costs
+                    // nothing, and the 0x2A37 profile legitimately lulls at rest (why #1414 widened the bounce
+                    // fuse to 10 min), so the threshold sits well past a normal lull. One re-arm per stall
+                    // episode, cleared when a sample lands.
+                    val hrSilentMs = System.currentTimeMillis() - lastLiveHrAtMs
+                    if (shouldReArmLapsedRealtime(
+                            wantsRealtime = wantsRealtime,
+                            realtimeArmed = realtimeArmed,
+                            reArmedSinceHr = realtimeReArmedSinceHr,
+                            hrSilentMs = hrSilentMs,
+                        )
+                    ) {
+                        realtimeReArmedSinceHr = true
+                        log("No live HR for ${hrSilentMs / 1000}s while armed — re-arming the 5/MG realtime stream (#1865)")
+                        send(CommandNumber.TOGGLE_REALTIME_HR, byteArrayOf(1))
+                    }
+                    if (batteryPollDue(keepAliveTick, s.charging == true)) {
                     // 5/MG battery comes only from a 0x2A19 read and the strap sends no unsolicited battery
                     // notification, so poll it here (about every 60s) rather than only while the Live screen
                     // is open. The ring then stays current on any screen without a manual sync, and the read
                     // keeps the link warm.
-                    refreshBattery()
+                        refreshBattery()
+                    }
                 }
             }
         }

--- a/android/app/src/test/java/com/noop/ble/LapsedRealtimeReArmTest.kt
+++ b/android/app/src/test/java/com/noop/ble/LapsedRealtimeReArmTest.kt
@@ -95,4 +95,22 @@ class LapsedRealtimeReArmTest {
             ),
         )
     }
+
+    /**
+     * The threshold is the only thing standing between "recovers a dead stream" and "writes to a healthy
+     * one every five minutes", so it is pinned rather than left to a constant nobody re-reads.
+     *
+     * It must sit ABOVE the 45 s quiet threshold (an ordinary gap between samples) and BELOW the 600 s
+     * bounce fuse — not because the fuse would rescue this case (it cannot; it watches any inbound data,
+     * which is the bug) but because a threshold beyond it would mean the app had given up on the link
+     * before it ever tried the cheaper fix.
+     */
+    @Test
+    fun theThresholdSitsBetweenTheQuietMarkAndTheBounceFuse() {
+        val quietMs = 45_000L
+        val bounceFuse5mgMs = 600_000L
+        assertTrue("must not fire during an ordinary quiet spell", stall > quietMs)
+        assertTrue("must act before the app would give up on the link", stall < bounceFuse5mgMs)
+    }
+
 }

--- a/android/app/src/test/java/com/noop/ble/LapsedRealtimeReArmTest.kt
+++ b/android/app/src/test/java/com/noop/ble/LapsedRealtimeReArmTest.kt
@@ -1,0 +1,98 @@
+package com.noop.ble
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1865: recovering a WHOOP 5/MG realtime stream that lapsed while the link stayed healthy.
+ *
+ * Reported as "Live doesn't work — initially it shows real data but now it doesn't", on a strap showing
+ * Bonded / FULL BOND, worn, battery fine, "history synced just now", and no bpm.
+ *
+ * That combination is the bug. A WHOOP 4.0 re-sends TOGGLE_REALTIME_HR on every 30 s keep-alive tick,
+ * documented as being because "the firmware lets the realtime HR stream lapse if it isn't re-armed". A
+ * 5/MG got none of it, and none of the other recovery paths can see this state:
+ *
+ *  - `reconcileRealtime` is edge-triggered, so while we believe the stream is armed it sends nothing;
+ *  - the one-shot re-subscribe recovers a dropped CCCD, not a stream the firmware let lapse;
+ *  - the stall bounce keys on ANY inbound data, and a strap answering battery polls and serving history
+ *    never trips it.
+ */
+class LapsedRealtimeReArmTest {
+
+    private val stall = 300_000L
+
+    /** The reported state: we think it is armed, someone wants it, and no sample has arrived in ages. */
+    @Test
+    fun aLongHrSilenceWhileArmedEarnsOneReArm() {
+        assertTrue(
+            WhoopBleClient.shouldReArmLapsedRealtime(
+                wantsRealtime = true, realtimeArmed = true, reArmedSinceHr = false,
+                hrSilentMs = stall + 1, stallMs = stall,
+            ),
+        )
+    }
+
+    /**
+     * A resting wearer's 0x2A37 stream legitimately lulls — that lull is why #1414 widened the bounce fuse
+     * to ten minutes. A normal quiet spell must not provoke a write.
+     */
+    @Test
+    fun anOrdinaryLullDoesNotReArm() {
+        assertFalse(
+            WhoopBleClient.shouldReArmLapsedRealtime(
+                wantsRealtime = true, realtimeArmed = true, reArmedSinceHr = false,
+                hrSilentMs = 60_000, stallMs = stall,
+            ),
+        )
+    }
+
+    /** One write per stall episode, not one per 30 s tick — the same discipline the re-subscribe uses. */
+    @Test
+    fun itOnlyReArmsOncePerEpisode() {
+        assertFalse(
+            WhoopBleClient.shouldReArmLapsedRealtime(
+                wantsRealtime = true, realtimeArmed = true, reArmedSinceHr = true,
+                hrSilentMs = stall * 10, stallMs = stall,
+            ),
+        )
+    }
+
+    /** Nobody wants the stream: arming it would cost battery for a screen that is closed. */
+    @Test
+    fun anUnwantedStreamIsNeverArmed() {
+        assertFalse(
+            WhoopBleClient.shouldReArmLapsedRealtime(
+                wantsRealtime = false, realtimeArmed = true, reArmedSinceHr = false,
+                hrSilentMs = stall * 10, stallMs = stall,
+            ),
+        )
+    }
+
+    /**
+     * If we do NOT believe it is armed, `reconcileRealtime` has a genuine false→true edge and sends the
+     * toggle itself. This path exists only for the state that reconciler cannot see, so it must stay out
+     * of the way rather than racing it with a second write.
+     */
+    @Test
+    fun anUnarmedStreamIsLeftToTheReconciler() {
+        assertFalse(
+            WhoopBleClient.shouldReArmLapsedRealtime(
+                wantsRealtime = true, realtimeArmed = false, reArmedSinceHr = false,
+                hrSilentMs = stall * 10, stallMs = stall,
+            ),
+        )
+    }
+
+    /** The threshold is exclusive, so exactly-at-the-boundary waits one more tick rather than firing early. */
+    @Test
+    fun theThresholdIsExclusive() {
+        assertFalse(
+            WhoopBleClient.shouldReArmLapsedRealtime(
+                wantsRealtime = true, realtimeArmed = true, reArmedSinceHr = false,
+                hrSilentMs = stall, stallMs = stall,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Reported as *"Live doesn't work — initially it shows real data but now it doesn't"*, on a strap reading **Bonded / FULL BOND**, worn, battery 33%, *"History synced just now"* — and no bpm.

**That combination is the bug, not a confusing coincidence.**

## Why it never recovers

The WHOOP 4.0 keep-alive branch re-sends `TOGGLE_REALTIME_HR` every 30 s tick, and states why: *"re-arm realtime HR so the firmware can't let it lapse"*. A 5/MG is skipped because it *"rejects WHOOP4-framed commands"* — **a premise that no longer holds for this command**, since `reconcileRealtime()` twenty lines above sends the toggle to both families precisely because `send()` routes the 5/MG one with puffin framing.

Nothing else can see the state:

| Path | Why it does not fire |
|---|---|
| `reconcileRealtime` | edge-triggered; while `realtimeArmed` is true there is no edge |
| one-shot re-subscribe | recovers a dropped CCCD, not a lapsed stream |
| stall bounce | keys on `lastDataAtMs`, refreshed by **any** inbound frame — battery polls and history offload keep it fresh, and #1414 widened the 5/MG fuse to 10 min because HR lulls are a family trait |

So every other signal being healthy is exactly what stops the one path that could help. **That is why this needed its own HR-specific clock** rather than reusing `lastDataAtMs` — the existing clock cannot distinguish "link fine, stream dead", which is the entire failure.

## The change

- `lastLiveHrAtMs` + `realtimeReArmedSinceHr`, stamped wherever a live WHOOP HR sample lands, armed on connect so the first tick cannot fire spuriously.
- In the 5/MG keep-alive branch: one re-arm per stall episode after **5 minutes** of HR silence while we believe the stream is armed.
- Threshold sits above a normal at-rest lull (the 45 s quiet threshold, and the reason #1414 went to 10 min) and below the fuse that will never fire here anyway.
- Decision extracted as pure `shouldReArmLapsedRealtime`, following the `shouldReArmRealtimeAfterDrop` precedent next door — `keepAliveFire` needs a live GATT link, so extraction is the only way this gets a test.

**The WHOOP 4.0 branch is untouched**, and the 5/MG battery poll it now shares a branch with is preserved (checked in the diff, not assumed).

## Verification, and its limits

Full suite **5148 / 0**, 6 new cases: the reported state re-arms; an ordinary lull does not; once per episode; never when unwanted; never when unarmed (that is `reconcileRealtime`'s job and racing it with a second write would be wrong); threshold exclusive. Doc-comment and i18n gates clean.

**Not hardware-validated.** BLE cannot be CI- or Linux-tested. This needs a 5/MG with Live open past the threshold, and the mechanism is inferred from the code paths plus the reported state rather than observed. Two assumptions are worth naming: that the 5/MG firmware lapses the way the 4.0's is documented to, and that `realtimeArmed` was still true on the reporting device. If either is wrong the re-arm is harmless but is not the cure.

**Apple unchanged.** `BLEManager` has the identical `guard selectedModel.deviceFamily == .whoop4 else { return }`, so the gap is there too — left alone rather than fixed blind, since an unvalidated BLE change on the platform with no reporter doubles the untested surface. Tracked on #1865.

## Possibly related

#1858's *"the smart alarm basically never works"*: the smart-wake detector needs live HR **inside the wake window**, so a lapsed 5/MG stream would produce exactly that — the guaranteed deadline fires, the early move never can. Worth re-checking that report once this is on a device.