### PR TITLE
ble: stop skipping the handshake once the unbonded probe has retired (#1867)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
+++ b/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
@@ -72,6 +72,12 @@ internal fun shouldProbeUnbondedOffload(
  * because TWO decisions depend on it and they were only wired to one: the probe retires itself correctly,
  * while the handshake skip that exists TO SERVE it kept applying forever.
  *
+ * What happens to a stranded strap once this is fixed, since "it starts writing helloes again" deserves an
+ * answer rather than a shrug: it resumes the ordinary handshake, a #1635 strap refuses it, and
+ * [BondRefusalGiveUp] latches `helloSuppressed` after its 5-refusal threshold — settling at the designed
+ * "Live HR, not fully paired" end state. Bounded, and strictly better than the state it replaces, which
+ * had no bond, no offload AND no probe.
+ *
  * That asymmetry strands the strap. With the hello skipped `didBond` can never become true, so the
  * ordinary offload gate can never open — and once the probe has retired there is nothing left the skip is
  * buying. A field log shows the end state plainly: the hello skipped on every connect, no probe lines at

--- a/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
+++ b/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
@@ -62,9 +62,24 @@ internal fun shouldProbeUnbondedOffload(
     // eleven weeks. Only the stable no-hello link can answer this question.
     if (helloWrittenThisLink) return false
     if (alreadyProbedThisLink) return false
-    if (previouslyRefused) return false
-    return unbondedProbeStillWorthAsking(silentLinksSoFar)
+    return !unbondedProbeRetired(previouslyRefused, silentLinksSoFar)
 }
+
+/**
+ * Has the probe stopped asking — for good, on this device?
+ *
+ * True on a latched refusal (the strap's verdict) or once the silent-link budget is spent. Extracted
+ * because TWO decisions depend on it and they were only wired to one: the probe retires itself correctly,
+ * while the handshake skip that exists TO SERVE it kept applying forever.
+ *
+ * That asymmetry strands the strap. With the hello skipped `didBond` can never become true, so the
+ * ordinary offload gate can never open — and once the probe has retired there is nothing left the skip is
+ * buying. A field log shows the end state plainly: the hello skipped on every connect, no probe lines at
+ * all, `didBond=false` and `Backfill: deferred` nine times across sixteen hours. The strap could neither
+ * bond nor sync, in service of a question that had already stopped being asked.
+ */
+internal fun unbondedProbeRetired(previouslyRefused: Boolean, silentLinksSoFar: Int): Boolean =
+    previouslyRefused || !unbondedProbeStillWorthAsking(silentLinksSoFar)
 
 /**
  * How many links may end in SILENCE before the probe retires itself.
@@ -142,7 +157,13 @@ internal fun unbondedProbeSupersedesHandshake(
     isWhoop5: Boolean,
     appLevelBonded: Boolean,
     userInitiated: Boolean,
-): Boolean = optedIn && isWhoop5 && !appLevelBonded && !userInitiated
+    /**
+     * The probe has stopped asking ([unbondedProbeRetired]) — so skipping the hello now buys nothing and
+     * costs the strap its bond and its offload. Suppressing the handshake is only defensible while
+     * something is using the link it creates.
+     */
+    probeRetired: Boolean,
+): Boolean = optedIn && isWhoop5 && !appLevelBonded && !userInitiated && !probeRetired
 
 /**
  * Said once per superseded connect, because a hello that is absent looks identical to one that failed

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -8638,7 +8638,9 @@ class WhoopBleClient(
                         appLevelBonded = didBond,
                         userInitiated = helloRetryRequested,
                         // Same retirement the probe applies to itself — read here rather than assumed, so
-                        // the skip stops the moment the thing it serves does.
+                        // the skip stops the moment the thing it serves does. The two inputs address the
+                        // same strap: `lastDevice` is set at connect, long before this runs post-discovery,
+                        // and `beginUnbondedOffloadProbe` already pairs these two sources the same way.
                         probeRetired = unbondedProbeRetired(
                             previouslyRefused = unbondedOffloadPreviouslyRefused(g.device.address),
                             silentLinksSoFar = unbondedProbeSilentLinks,

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4912,13 +4912,17 @@ class WhoopBleClient(
      * here.
      */
     @SuppressLint("MissingPermission")
+    /** #1867: the latched per-device refusal, read the same way by the probe and by the handshake skip
+     *  that serves it — two readers of one fact, so neither can drift from the other. */
+    private fun unbondedOffloadPreviouslyRefused(address: String?): Boolean = runCatching {
+        unbondedOffloadRefusedPrefKey(address)?.let {
+            context.getSharedPreferences(com.noop.ui.NoopPrefs.NAME, android.content.Context.MODE_PRIVATE)
+                .getBoolean(it, false)
+        } ?: false
+    }.getOrDefault(false)
+
     private fun beginUnbondedOffloadProbe(g: BluetoothGatt) {
-        val refused = runCatching {
-            unbondedOffloadRefusedPrefKey(g.device.address)?.let {
-                context.getSharedPreferences(com.noop.ui.NoopPrefs.NAME, android.content.Context.MODE_PRIVATE)
-                    .getBoolean(it, false)
-            } ?: false
-        }.getOrDefault(false)
+        val refused = unbondedOffloadPreviouslyRefused(g.device.address)
         if (!shouldProbeUnbondedOffload(
                 isWhoop5 = connectedFamily == DeviceFamily.WHOOP5,
                 optedIn = PuffinExperiment.from(context).unbondedOffload,
@@ -8633,6 +8637,12 @@ class WhoopBleClient(
                         isWhoop5 = true,
                         appLevelBonded = didBond,
                         userInitiated = helloRetryRequested,
+                        // Same retirement the probe applies to itself — read here rather than assumed, so
+                        // the skip stops the moment the thing it serves does.
+                        probeRetired = unbondedProbeRetired(
+                            previouslyRefused = unbondedOffloadPreviouslyRefused(g.device.address),
+                            silentLinksSoFar = unbondedProbeSilentLinks,
+                        ),
                     )
                 ) {
                     log(unbondedProbeSupersedesLine(explicitBondOptedIn = puffinExperiment.explicitBond))

--- a/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
@@ -352,11 +352,11 @@ class UnbondedOffloadProbeTest {
     @Test
     fun `opting in replaces the handshake for that connect`() {
         assertTrue(unbondedProbeSupersedesHandshake(
-            optedIn = true, isWhoop5 = true, appLevelBonded = false, userInitiated = false))
+            optedIn = true, isWhoop5 = true, appLevelBonded = false, userInitiated = false, probeRetired = false))
         assertFalse(unbondedProbeSupersedesHandshake(
-            optedIn = false, isWhoop5 = true, appLevelBonded = false, userInitiated = false))
+            optedIn = false, isWhoop5 = true, appLevelBonded = false, userInitiated = false, probeRetired = false))
         assertFalse(unbondedProbeSupersedesHandshake(
-            optedIn = true, isWhoop5 = false, appLevelBonded = false, userInitiated = false))
+            optedIn = true, isWhoop5 = false, appLevelBonded = false, userInitiated = false, probeRetired = false))
     }
 
     /**
@@ -366,13 +366,13 @@ class UnbondedOffloadProbeTest {
     @Test
     fun `pressing Connect still gets the handshake`() {
         assertFalse(unbondedProbeSupersedesHandshake(
-            optedIn = true, isWhoop5 = true, appLevelBonded = false, userInitiated = true))
+            optedIn = true, isWhoop5 = true, appLevelBonded = false, userInitiated = true, probeRetired = false))
     }
 
     @Test
     fun `a strap that already bonded has nothing to prove`() {
         assertFalse(unbondedProbeSupersedesHandshake(
-            optedIn = true, isWhoop5 = true, appLevelBonded = true, userInitiated = false))
+            optedIn = true, isWhoop5 = true, appLevelBonded = true, userInitiated = false, probeRetired = false))
     }
 
     /**
@@ -470,4 +470,60 @@ class UnbondedOffloadProbeTest {
         // actually issued a read rather than being assumed to have.
         assertFalse(unbondedProbeShouldWaitForDis(disChainInFlight = false, deferralsSoFar = 0))
     }
+
+    // MARK: #1867 — the skip must retire when the probe does
+
+    /**
+     * Found in a field log: the hello skipped on every connect, NO probe lines at all, `didBond=false` and
+     * `Backfill: deferred` nine times across sixteen hours.
+     *
+     * The probe retires itself correctly — on a latched refusal, or once the silent-link budget is spent —
+     * but the handshake skip that exists to serve it kept applying regardless. With no hello, `didBond` can
+     * never become true, so the ordinary offload gate can never open either. The strap could neither bond
+     * nor sync, in service of a question that had already stopped being asked.
+     */
+    @Test
+    fun `a retired probe stops superseding the handshake`() {
+        assertFalse(unbondedProbeSupersedesHandshake(
+            optedIn = true, isWhoop5 = true, appLevelBonded = false, userInitiated = false,
+            probeRetired = true))
+    }
+
+    /** A latched refusal is the strap's verdict — it retires the probe, so the handshake must resume. */
+    @Test
+    fun `a latched refusal retires the probe`() {
+        assertTrue(unbondedProbeRetired(previouslyRefused = true, silentLinksSoFar = 0))
+    }
+
+    /** Silence spends a budget rather than latching, so the probe stays live while it has one. */
+    @Test
+    fun `silence retires the probe only once its budget is spent`() {
+        assertFalse(unbondedProbeRetired(previouslyRefused = false, silentLinksSoFar = 0))
+        assertFalse(unbondedProbeRetired(
+            previouslyRefused = false, silentLinksSoFar = UNBONDED_PROBE_MAX_SILENT_LINKS - 1))
+        assertTrue(unbondedProbeRetired(
+            previouslyRefused = false, silentLinksSoFar = UNBONDED_PROBE_MAX_SILENT_LINKS))
+    }
+
+    /**
+     * The two gates must agree by construction, not by both being edited together. Whenever the probe
+     * declines for a RETIREMENT reason, the skip must decline too — otherwise the strap is stranded with a
+     * suppressed handshake and nothing using the link it creates.
+     */
+    @Test
+    fun `the skip and the probe retire on exactly the same conditions`() {
+        for (refused in listOf(false, true)) {
+            for (silent in 0..UNBONDED_PROBE_MAX_SILENT_LINKS + 1) {
+                val retired = unbondedProbeRetired(refused, silent)
+                val probeWouldRun = shouldProbeUnbondedOffload(
+                    isWhoop5 = true, optedIn = true, bonded = false, helloWrittenThisLink = false,
+                    alreadyProbedThisLink = false, previouslyRefused = refused, silentLinksSoFar = silent)
+                val skips = unbondedProbeSupersedesHandshake(
+                    optedIn = true, isWhoop5 = true, appLevelBonded = false, userInitiated = false,
+                    probeRetired = retired)
+                assertEquals("refused=$refused silent=$silent", probeWouldRun, skips)
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
A field strap log showed a WHOOP 5/MG that could neither bond nor sync, indefinitely: the hello skipped on **every** connect, **no probe lines at all**, `didBond=false` ×9 and `Backfill: deferred` ×9 across sixteen hours.

## The two gates were asymmetric

The probe retires itself correctly — on a latched refusal, or once `UNBONDED_PROBE_MAX_SILENT_LINKS` is spent — which is precisely what its own doc promises:

> the point of a probe is to stop being one after it has its answer

But the handshake skip that exists **to serve** that probe checked neither condition:

```kotlin
supersedes = optedIn && isWhoop5 && !appLevelBonded && !userInitiated
```

So once the probe stopped asking, the opt-in silently became a permanent *"never write CLIENT_HELLO"* switch — and with no hello, `didBond` can never become true, so the ordinary offload gate can never open either. The log's own defer line states it:

> No hello was written on this link, so `didBond` cannot become true and this gate cannot open for the rest of it.

**Suppressing a handshake is only defensible while something is using the link it creates.** Nothing was.

## Fix

`unbondedProbeRetired(previouslyRefused, silentLinksSoFar)` is now the single place that answers "has the probe stopped asking", read by **both** the probe and the skip. The latched refusal likewise moves behind one helper rather than being inlined at one call site and re-derived at the other — two readers of one fact.

## The test that would have caught it

Reasoning that the two gates agreed is what produced the bug, so the new test does not reason: it walks the entire `refused × silentLinks` space and asserts the probe's decision and the skip's decision match at every point.

## Deliberately unchanged

- **Pressing Connect still wins** — an explicit request for the handshake must never be answered with an experiment.
- A **bonded** strap still skips nothing.
- The skip still applies normally **while the probe has budget** — this only stops the case where it was buying nothing.

## Verification

Full suite **5153 / 0**; `UnbondedOffloadProbeTest` at 37 cases. Doc-comment and i18n gates clean. Blast radius checked: `unbondedProbeSupersedesHandshake` has exactly one production caller.

**Not hardware-validated** — BLE cannot be CI-tested. The behavioural effect is that a retired-probe strap resumes writing `CLIENT_HELLO`, i.e. returns to the pre-experiment path it should have been on all along, so the failure mode if I am wrong is the status quo rather than something new.