### PR TITLE
alarm: learn the smart-alarm trough across the night, not just the wake window

### DIFF
--- a/android/app/src/main/java/com/noop/alarm/SleepWindowWatcher.kt
+++ b/android/app/src/main/java/com/noop/alarm/SleepWindowWatcher.kt
@@ -5,17 +5,28 @@ package com.noop.alarm
  *
  * It never touches AlarmManager itself; it only DECIDES whether the current overnight HR pattern
  * looks like a lighter sleep phase (or an arousal) within the wake window. The caller (the BLE
- * foreground service) feeds it the live heart rate once it's inside the window and, if [shouldWake]
- * returns true, asks [SmartAlarmScheduler.advanceTo] to move the guaranteed alarm EARLIER. The
- * scheduler clamps that to the window and can never push the wake later or drop it, so this detector
- * is advisory only — the hard deadline remains the floor of safety.
+ * foreground service) feeds it the live heart rate and, if [shouldWake] returns true, asks
+ * [SmartAlarmScheduler.advanceTo] to move the guaranteed alarm EARLIER. The scheduler clamps that to
+ * the window and can never push the wake later or drop it, so this detector is advisory only — the
+ * hard deadline remains the floor of safety.
  *
  * HONEST signal, no over-claiming: during deep sleep heart rate sits near its nightly trough and is
  * steady; in lighter sleep / on an arousal it lifts above that trough. We track the lowest smoothed
  * HR seen overnight (the trough proxy) and fire when the current HR rises a meaningful margin above
- * it AND is itself not at the floor. This is a coarse "you're stirring" heuristic — it is NOT a sleep
- * stage classifier and makes no clinical claim. If the strap streams nothing (BLE down, not worn),
- * the detector simply never fires and the hard deadline wakes the user.
+ * it. This is a coarse "you're stirring" heuristic — it is NOT a sleep stage classifier and makes no
+ * clinical claim. If the strap streams nothing (BLE down, not worn), the detector simply never fires
+ * and the hard deadline wakes the user.
+ *
+ * #1858 — the trough is learned across the WHOLE night via [note], not just inside the wake window.
+ * It used to be both learned and tested inside the window, which inverted the whole feature: the
+ * trough could only come from the same 30 minutes we were judging, so a user already AWAKE when the
+ * window opened had no sleeping trough to rise above and the smart advance could never fire. Worse,
+ * [troughCeilingBpm] rejects readings above it as trough candidates — sound when the night supplies
+ * the trough, fatal when the window is the only source, because anyone up and moving (a workout is
+ * the reported case) sat entirely above the ceiling and left the trough UNSET, which the fire gate
+ * reads as "no reference yet". The feature failed exactly when it was most obvious the user was
+ * awake, and always rang at the hard deadline instead. Learning across the night makes being awake
+ * the STRONGEST rise above the trough rather than the one case that cannot be detected.
  */
 class SleepWindowWatcher(
     /** How far above the nightly trough (bpm) counts as "lighter / stirring". */
@@ -24,13 +35,26 @@ class SleepWindowWatcher(
     private val minSamples: Int = 30,
     /** Ignore obviously-awake-high HR as a trough candidate (e.g. the user got up briefly). */
     private val troughCeilingBpm: Int = 90,
+    /**
+     * Ignore implausibly LOW readings as trough candidates. Only matters now that the trough is
+     * learned across hours rather than one 30-minute window: a single dropout artefact would
+     * otherwise set the trough for the whole night, and since the fire gate is `trough + riseBpm`, a
+     * too-low trough lowers the bar — it would advance the alarm the instant the window opened.
+     */
+    private val troughFloorBpm: Int = 25,
 ) {
     private var troughBpm: Int = Int.MAX_VALUE
     private var sampleCount: Int = 0
     /** Set once we've advanced the alarm so we don't keep re-advancing every sample. */
     private var fired: Boolean = false
 
-    /** Reset for a fresh night (called when the watcher (re)enters a window). */
+    /** The trough learned so far, or null while no plausible candidate has been seen. Diagnostics only. */
+    val trough: Int? get() = if (troughBpm == Int.MAX_VALUE) null else troughBpm
+
+    /** Usable readings folded in since [reset]. Diagnostics only. */
+    val samples: Int get() = sampleCount
+
+    /** Reset for a fresh night (called when the alarm is armed for a new deadline). */
     fun reset() {
         troughBpm = Int.MAX_VALUE
         sampleCount = 0
@@ -38,14 +62,24 @@ class SleepWindowWatcher(
     }
 
     /**
-     * Feed one smoothed HR reading. Returns true exactly once — when the reading first looks like a
-     * lighter phase inside the window — so the caller advances the alarm a single time. All later
-     * calls return false until [reset]. A non-positive HR (no live data) is ignored.
+     * Fold one reading into the nightly trough WITHOUT deciding anything. This is what runs for the
+     * hours before the wake window opens, so that by the time the window matters there is a real
+     * sleeping trough to judge against. A non-positive HR (no live data) is ignored.
+     */
+    fun note(bpm: Int) {
+        if (bpm <= 0) return
+        sampleCount++
+        if (bpm in troughFloorBpm..troughCeilingBpm && bpm < troughBpm) troughBpm = bpm
+    }
+
+    /**
+     * Feed one smoothed HR reading from INSIDE the wake window. Returns true exactly once — when the
+     * reading first looks like a lighter phase — so the caller advances the alarm a single time. All
+     * later calls return false until [reset]. A non-positive HR (no live data) is ignored.
      */
     fun shouldWake(bpm: Int): Boolean {
         if (bpm <= 0) return false
-        sampleCount++
-        if (bpm <= troughCeilingBpm && bpm < troughBpm) troughBpm = bpm
+        note(bpm)
         if (fired) return false
         if (sampleCount < minSamples || troughBpm == Int.MAX_VALUE) return false
         // Rise of >= riseBpm above the trough, and the current reading itself is off the floor.

--- a/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
@@ -203,9 +203,13 @@ class WhoopConnectionService : Service() {
      *  and, on a lighter-phase reading, advances the GUARANTEED alarm earlier. It can only ever move
      *  the alarm earlier within the window — the hard deadline scheduled via AlarmManager is the floor
      *  of safety, so if BLE drops or no light sleep is found the user is still woken at the window end.
-     *  The detector is reset each time we (re)enter a window. */
+     *  The detector is reset once per armed deadline (#1858), NOT on window entry — the trough it
+ *  judges against is learned over the hours BEFORE the window, so resetting as the window opens
+ *  would discard exactly the reference the decision needs. */
     private val sleepWatcher = SleepWindowWatcher()
     private var inAlarmWindow = false
+    /** The deadline [sleepWatcher] is currently learning a trough for; a change means a new night. */
+    private var watchedDeadlineMs = 0L
 
     /** The smart-alarm HR collector, alive for the life of the service. */
     private var alarmJob: Job? = null
@@ -522,11 +526,35 @@ class WhoopConnectionService : Service() {
                         return@collect
                     }
                     val now = System.currentTimeMillis()
-                    val inWindow = now in store.scheduledWindowStartMs until store.scheduledDeadlineMs
-                    if (inWindow && !inAlarmWindow) sleepWatcher.reset()   // fresh night
-                    inAlarmWindow = inWindow
-                    if (!inWindow) return@collect
+                    val deadline = store.scheduledDeadlineMs
+                    val windowStart = store.scheduledWindowStartMs
+                    // A newly-armed deadline is what marks a fresh night, not the window opening
+                    // (#1858). Resetting on window entry meant the trough could only ever come from
+                    // the same minutes being judged, so someone already awake at window open had no
+                    // sleeping trough to rise above and the smart advance could never fire.
+                    if (deadline != watchedDeadlineMs) {
+                        watchedDeadlineMs = deadline
+                        sleepWatcher.reset()
+                        inAlarmWindow = false
+                    }
+                    if (now < windowStart - TROUGH_LEARN_LEAD_MS || now >= deadline) return@collect
+                    if (now < windowStart) {
+                        sleepWatcher.note(hr)   // learn the night's trough; decide nothing yet
+                        return@collect
+                    }
+                    if (!inAlarmWindow) {
+                        inAlarmWindow = true
+                        // The alarm package had no logging at all, so a report of "the smart alarm
+                        // never works" could not be told apart from "no live HR all night". These two
+                        // lines make the difference visible in the log the user already exports.
+                        ble.externalLog(
+                            "Smart alarm: wake window open, trough " +
+                                "${sleepWatcher.trough ?: "not established"} bpm from " +
+                                "${sleepWatcher.samples} readings",
+                        )
+                    }
                     if (sleepWatcher.shouldWake(hr)) {
+                        ble.externalLog("Smart alarm: advancing - HR $hr above trough ${sleepWatcher.trough}")
                         SmartAlarmScheduler.advanceTo(this@WhoopConnectionService, store, now)
                     }
                 }
@@ -696,6 +724,15 @@ class WhoopConnectionService : Service() {
         private const val CHANNEL_ID = "noop_strap_connection"
         private const val NOTIF_ID = 4201
         const val ACTION_STOP = "com.noop.ble.action.STOP_CONNECTION"
+
+        /**
+         * How long before the wake window opens the detector starts learning the night's HR trough
+         * (#1858). Bounded rather than "since the alarm was armed", because the next night's alarm is
+         * armed the moment this one fires: without a bound the trough would be learned across the
+         * whole waking day too, and one quiet afternoon reading would set a floor that has nothing to
+         * do with the night being judged.
+         */
+        private const val TROUGH_LEARN_LEAD_MS = 8L * 60L * 60L * 1000L
 
         /**
          * Promote the process to the foreground so the strap stays connected. Safe to call when

--- a/android/app/src/test/java/com/noop/alarm/SleepWindowWatcherTest.kt
+++ b/android/app/src/test/java/com/noop/alarm/SleepWindowWatcherTest.kt
@@ -2,6 +2,7 @@ package com.noop.alarm
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -55,6 +56,47 @@ class SleepWindowWatcherTest {
         assertFalse(w.shouldWake(120))
         repeat(6) { assertFalse(w.shouldWake(48)) }
         assertTrue(w.shouldWake(55))   // 55 is +7 over the real trough of 48
+    }
+
+    @Test fun awakeAtWindowOpenFiresOnceTheTroughCameFromTheNight() {
+        // #1858, the reported failure: the user is already awake — mid-workout, HR 95-130 — when the
+        // wake window opens. Every one of those readings is above troughCeilingBpm, so when the trough
+        // could only be learned inside the window it was never established at all and the fire gate
+        // read that as "no reference yet": the alarm always rang at the hard deadline, most reliably
+        // when the user was most obviously awake. With the trough learned overnight, being awake is
+        // simply the largest rise above it.
+        val w = watcher()
+        repeat(6) { w.note(50) }              // the night, before the window
+        assertTrue(w.shouldWake(110))         // window opens, user is up
+    }
+
+    @Test fun noteLearnsTheTroughWithoutEverFiring() {
+        val w = watcher()
+        // Learning must decide nothing on its own: a rise seen BEFORE the window is not a wake.
+        repeat(6) { w.note(50) }
+        w.note(90)
+        assertEquals(50, w.trough)
+        // Only a reading fed through shouldWake (i.e. inside the window) can advance the alarm.
+        assertTrue(w.shouldWake(58))
+    }
+
+    @Test fun aDropoutLowDoesNotBecomeTheTrough() {
+        // Learning across hours rather than one window exposes the trough to more artefacts, and a
+        // too-LOW trough is the dangerous direction: the gate is trough + riseBpm, so it would fire
+        // the instant the window opened. Readings below troughFloorBpm are not trough candidates.
+        val w = watcher()
+        w.note(3)
+        repeat(6) { w.note(48) }
+        assertEquals(48, w.trough)
+        assertFalse(w.shouldWake(52))   // +4 over the REAL trough, not +49 over the artefact
+    }
+
+    @Test fun troughIsNullUntilAPlausibleReadingArrives() {
+        val w = watcher()
+        assertNull(w.trough)
+        w.note(120)                     // above the ceiling: not a candidate
+        assertNull(w.trough)
+        assertEquals(1, w.samples)      // still counted as a sample seen
     }
 
     @Test fun resetClearsState() {


### PR DESCRIPTION
## The bug

`SleepWindowWatcher` both **learned** its trough and **tested** against it inside the wake window, so the reference could only ever come from the same 30 minutes being judged. Someone already awake when the window opened had no sleeping trough to rise above, and the smart advance could not fire — the alarm always rang at the hard deadline.

`troughCeilingBpm` turns that from a weak signal into an impossible one. Rejecting readings above it as trough candidates is correct when the night supplies the trough; when the window is the *only* source, anyone up and moving sits entirely above the ceiling, the trough is left unset, and the fire gate reads that as "no reference yet".

Simulating the reported scenarios against the shipped detector:

| scenario | before |
|---|---|
| asleep, then stirs | fires early ✓ |
| **awake in a workout (95–130 bpm)** | **never fires** — trough never established |
| **awake, sitting up (92 bpm)** | **never fires** — trough never established |
| awake, relaxed (88 bpm) | never fires — no 6 bpm rise follows |
| no live HR | never fires |

The feature failed most reliably in the case where it was most obvious the user was awake. That matches the field report exactly: *"regardless of whether I'm already awake or in the middle of a workout, the phone always rings at 4:45."*

The class doc already claimed the trough was "the lowest smoothed HR seen **overnight**". It was never that — `reset()` ran on window entry.

## The fix

The trough is learned with a new `note()` over the hours before the window and only **tested** inside it, so being awake becomes the *largest* rise above the trough rather than the one state that cannot be detected.

- Learning is bounded to **8 h** before the window. The next night's alarm is armed the moment this one fires, so an unbounded floor would be learned across the waking day, and one quiet afternoon reading would set a floor with nothing to do with the night being judged.
- The detector resets **per armed deadline**, not on window entry — resetting as the window opens discards the very reference the decision needs.
- A **trough floor** rejects dropout artefacts. The gate is `trough + riseBpm`, so a too-low trough *lowers* the bar and would advance the alarm the instant the window opened. This only matters once learning spans hours instead of one window.

Two log lines go with it. The alarm package had **no logging at all**, so "the smart alarm never works" could not be told apart from "no live HR all night". The window-open line names the trough and the sample count behind it; the advance line names the reading that moved the alarm. Both land in the strap log users already export.

## Consequence worth stating plainly

With a real trough, the alarm now fires at the **start** of the window for anyone already awake, so the effective wake can move earlier by up to the window length. That is the documented behaviour finally becoming reachable, not a new policy — `advanceTo` still clamps to the window, the hard deadline is untouched, and it remains the floor of safety.

This does not address the *other* half of the report — that there are two independent alarm configurations (strap wake-alarm and phone alarm), each with its own per-day overrides, so setting 3:30 on two days in one leaves the other at its single 4:45 target. That is a separate concern and is not touched here.

## Verification

- `:app:testFullDebugUnitTest --tests "com.noop.alarm.*"` — **SleepWindowWatcherTest 11 tests, 0 failures** (4 new; the 7 existing ones kept as-is and still pass), **PhoneAlarmWeekdayTest 22, 0 failures**. Test-name list checked in the XML so the filter is not a zero-match pass.
- `Tools/doc_comment_lint.py` OK, no new detached doc comments.
- Android only — there is no Swift twin of this detector, so no parity obligation.

**Not confirmable without hardware.** This is a live-HR path: it still needs a night on a strap to show the advance actually happening, and the two new log lines exist so that night produces evidence either way.
