### PR TITLE
alarm: log what the smart-alarm detector actually saw

### DIFF
--- a/android/app/src/main/java/com/noop/alarm/SleepWindowWatcher.kt
+++ b/android/app/src/main/java/com/noop/alarm/SleepWindowWatcher.kt
@@ -30,6 +30,23 @@ class SleepWindowWatcher(
     /** Set once we've advanced the alarm so we don't keep re-advancing every sample. */
     private var fired: Boolean = false
 
+    /**
+     * The trough established so far, or null while no reading has qualified as a candidate. READ-ONLY
+     * diagnostics (#1858) — the detector's own decisions do not consult it.
+     *
+     * Null is the interesting value: it means no reading has ever been BELOW [troughCeilingBpm], which
+     * is what happens when the user is awake for the whole window, and it is the state [shouldWake]
+     * treats as "no reference yet" and refuses to fire on.
+     */
+    val trough: Int? get() = if (troughBpm == Int.MAX_VALUE) null else troughBpm
+
+    /** Readings folded in since [reset]. READ-ONLY diagnostics: distinguishes "no live HR" from
+     *  "HR arrived but the heuristic never fired". */
+    val samples: Int get() = sampleCount
+
+    /** Whether the alarm has already been advanced this window. READ-ONLY diagnostics. */
+    val hasFired: Boolean get() = fired
+
     /** Reset for a fresh night (called when the watcher (re)enters a window). */
     fun reset() {
         troughBpm = Int.MAX_VALUE

--- a/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
@@ -206,6 +206,10 @@ class WhoopConnectionService : Service() {
      *  The detector is reset each time we (re)enter a window. */
     private val sleepWatcher = SleepWindowWatcher()
     private var inAlarmWindow = false
+    /** Whether this window has already logged a live-HR reading (#1858). The window-open line is worth
+     *  one line a night, and it must report a REAL reading: `heartRate ?: 0` means the collector also
+     *  runs when nothing is streaming, which is the very case the line exists to rule out. */
+    private var loggedAlarmWindowHr = false
 
     /** The smart-alarm HR collector, alive for the life of the service. */
     private var alarmJob: Job? = null
@@ -518,15 +522,71 @@ class WhoopConnectionService : Service() {
                 .conflate()
                 .collect { hr ->
                     if (!store.enabled || store.scheduledDeadlineMs <= 0L) {
+                        // Disarmed while we were inside the window. SmartAlarmReceiver zeroes the
+                        // edges before re-arming, and an explicit disable zeroes them for good, so
+                        // without this the end-of-window line is simply lost — and a window line with
+                        // no end line is documented to mean the HR stream stopped, which would be the
+                        // wrong reading. Log it here so every opened window closes with a line.
+                        if (inAlarmWindow) {
+                            ble.externalLog(
+                                "Smart alarm: wake window ended (alarm no longer armed), detector " +
+                                    "${if (sleepWatcher.hasFired) "fired" else "never fired"} - " +
+                                    "${sleepWatcher.trough?.let { "trough $it bpm" } ?: "trough never established"} " +
+                                    "from ${sleepWatcher.samples} readings",
+                            )
+                        }
                         inAlarmWindow = false
                         return@collect
                     }
                     val now = System.currentTimeMillis()
                     val inWindow = now in store.scheduledWindowStartMs until store.scheduledDeadlineMs
-                    if (inWindow && !inAlarmWindow) sleepWatcher.reset()   // fresh night
+                    if (inWindow && !inAlarmWindow) {
+                        sleepWatcher.reset()   // fresh night
+                        loggedAlarmWindowHr = false
+                    }
+                    // #1858: the alarm package had no logging at all, so "the smart alarm never works"
+                    // could not be told apart from "nothing was streaming all night" — the two need
+                    // opposite fixes. These lines are diagnostics ONLY; every decision below is
+                    // unchanged.
+                    //
+                    // Reading an exported log. It takes BOTH the window line and the end line, because
+                    // the end line carries the sample count and only that separates a detector that
+                    // declined to fire from a stream that stopped underneath it:
+                    //
+                    //   window + advance                  -> worked
+                    //   window + end (no fire, samples n) -> HR flowed all window and it still never
+                    //                                        fired: the detector's own defect
+                    //   window, NO end line               -> the stream stopped before the window ended
+                    //                                        (no post-deadline sample to log on)
+                    //   no window + end (samples 0)       -> nothing streamed inside the window at all
+                    //   neither line                      -> the collector never ran in-window: the
+                    //                                        service was down, or the alarm was off
+                    if (!inWindow && inAlarmWindow) {
+                        ble.externalLog(
+                            "Smart alarm: wake window ended, detector ${if (sleepWatcher.hasFired) "fired" else "never fired"} " +
+                                "- ${sleepWatcher.trough?.let { "trough $it bpm" } ?: "trough never established"} " +
+                                "from ${sleepWatcher.samples} readings",
+                        )
+                    }
                     inAlarmWindow = inWindow
                     if (!inWindow) return@collect
+                    if (hr > 0 && !loggedAlarmWindowHr) {
+                        loggedAlarmWindowHr = true
+                        val mins = (store.scheduledDeadlineMs - now) / 60_000L
+                        ble.externalLog("Smart alarm: in wake window with live HR $hr bpm, deadline in $mins min")
+                    }
                     if (sleepWatcher.shouldWake(hr)) {
+                        // advanceTo() returns silently when the OS will not honour an exact alarm (the
+                        // API 31+ permission can be revoked AFTER the alarm was armed, leaving a
+                        // deadline that can never be moved). Claiming "advancing" would then assert
+                        // something this line cannot attribute - and that is precisely the case someone
+                        // reading the log would be hunting. State the request and the permission apart.
+                        val permitted = SmartAlarmScheduler.canScheduleExact(this@WhoopConnectionService)
+                        ble.externalLog(
+                            "Smart alarm: detector fired, asking to advance the wake - HR $hr bpm vs " +
+                                "trough ${sleepWatcher.trough} after ${sleepWatcher.samples} readings" +
+                                if (permitted) "" else " - IGNORED, exact alarms are not permitted",
+                        )
                         SmartAlarmScheduler.advanceTo(this@WhoopConnectionService, store, now)
                     }
                 }

--- a/android/app/src/test/java/com/noop/alarm/SleepWindowWatcherTest.kt
+++ b/android/app/src/test/java/com/noop/alarm/SleepWindowWatcherTest.kt
@@ -2,6 +2,7 @@ package com.noop.alarm
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -55,6 +56,30 @@ class SleepWindowWatcherTest {
         assertFalse(w.shouldWake(120))
         repeat(6) { assertFalse(w.shouldWake(48)) }
         assertTrue(w.shouldWake(55))   // 55 is +7 over the real trough of 48
+    }
+
+    @Test fun diagnosticsReportWhatTheDetectorActuallySaw() {
+        // #1858: these accessors exist so an exported strap log can tell "no live HR all night" apart
+        // from "HR arrived and the heuristic still never fired". They must REPORT state, never change
+        // a decision — so the assertions here pin the reported values against a known feed.
+        val w = watcher()
+        assertNull(w.trough)
+        assertEquals(0, w.samples)
+        assertFalse(w.hasFired)
+
+        // The reported failure shape: awake for the whole window, every reading above the ceiling.
+        // No trough is ever established, which is exactly what shouldWake refuses to fire on.
+        repeat(6) { assertFalse(w.shouldWake(110)) }
+        assertNull(w.trough)
+        assertEquals(6, w.samples)      // HR WAS arriving - the log must be able to say so
+        assertFalse(w.hasFired)
+
+        // A sleeping feed establishes a trough and fires; the accessors follow.
+        val w2 = watcher()
+        repeat(6) { w2.shouldWake(50) }
+        assertEquals(50, w2.trough)
+        assertTrue(w2.shouldWake(58))
+        assertTrue(w2.hasFired)
     }
 
     @Test fun resetClearsState() {


### PR DESCRIPTION
The alarm package has **no logging at all**, so a report of "the smart alarm never works" cannot be told apart from "nothing was streaming all night" — and those two need opposite fixes. Three lines, all diagnostics.

```
Smart alarm: in wake window with live HR 54 bpm, deadline in 28 min
Smart alarm: detector fired, asking to advance the wake - HR 61 bpm vs trough 52 after 44 readings
Smart alarm: wake window ended, detector never fired - trough never established from 61 readings
```

Each line asserts only what it can attribute. `advanceTo()` returns **silently** when the OS will not honour an exact alarm — the API 31+ permission can be revoked *after* the alarm was armed, leaving a deadline that can never be moved — so the line names the **request**, and appends `- IGNORED, exact alarms are not permitted` when the OS will refuse it. That is exactly the case someone reading the log would be hunting, and a line claiming "advancing" would have hidden it. For the same reason the end-of-window line reports what the **detector** did rather than that the alarm moved: `hasFired` knows the first and not the second.

How to read an exported log. It takes **both** the window line and the end line — the end line carries the sample count, and only that separates a detector that declined to fire from a stream that stopped underneath it:

| what appears | what it means |
|---|---|
| window + advance | worked; the trough and sample count say on what evidence |
| window + end (no fire, samples n) | HR flowed all window and it **still** never fired — the detector's own defect |
| window, **no** end line | the stream stopped before the window ended (no post-deadline sample to log on) |
| no window + end (samples 0) | nothing streamed inside the window at all |
| neither line | the collector never ran in-window — service down, or the alarm off |

Every window that opens also closes with a line. `SmartAlarmReceiver` zeroes the scheduled edges *before* re-arming, and an explicit disable zeroes them for good, so the disarmed path emits the end line too — otherwise it would vanish silently and leave the window line looking like a stream that stopped, which is a different fault with a different fix.

*(An earlier revision of this PR claimed "window line, no advance line = the detector's own defect". That was wrong: it is also exactly what a stream dying mid-window looks like. Caught on re-review; the table above and the source comment now state the rule correctly.)*

The window line requires `hr > 0` and fires once per window. The collector maps `heartRate ?: 0`, so it also runs when nothing is streaming — precisely the case this line exists to rule out, and it would cheerfully report "live HR 0" if left ungated.

`SleepWindowWatcher` gains `trough` / `samples` / `hasFired` as read-only accessors over state it already held. A **null trough** is the interesting one: it means no reading was ever below `troughCeilingBpm`, which is what happens when the user is awake for the whole window, and it is the state `shouldWake` refuses to fire on.

## No behaviour change, and that is checked rather than asserted

Verified by stripping the added log lines from the patched file and diffing the result against the shipped one. Every decision statement is identical — `inWindow`, the `reset()` on window entry, `inAlarmWindow = inWindow`, the `!inWindow` return, `shouldWake`, `advanceTo`. The only structural edit is a single-statement `if` becoming a braced block.

This matters here more than usual: the previous attempt at this issue calibrated the detector from my estimates instead of data, and was worse than the bug it targeted. These lines are what a corrected margin should be fitted to.

## Verification

- `:app:testFullDebugUnitTest --tests "com.noop.alarm.*"` — **SleepWindowWatcherTest 8 tests, 0 failures** (1 new, the 7 existing untouched), **PhoneAlarmWeekdayTest 22, 0 failures**. Test names checked in the XML so the filter is not a zero-match pass.
- The new test pins the reported shape: awake for the whole window leaves `trough == null` while `samples == 6`, so the log can prove HR was arriving even though nothing fired.
- `Tools/doc_comment_lint.py` OK.
- Android only — there is no Swift twin of this detector, and Apple has no wake window at all.

Analysis this supports is on #1858. It improves nothing for the reporter on its own; it makes the next report answerable.