### PR TITLE
coupled: show the optimal strain band as a tube on Android, matching Apple

### DIFF
--- a/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
@@ -497,11 +497,52 @@ private fun StrainCard(dayStrain21: Double?, recovery: Double?, calories: Double
                 verticalArrangement = Arrangement.spacedBy(14.dp),
             ) {
                 HeroStat("Day Strain", dayStrain21?.let { String.format(Locale.US, "%.1f", it) } ?: COUPLED_NO_DATA, Palette.effortColor)
-                HeroStat("Optimal", optimalStrainRangeText(recovery), Palette.chargeColor)
+                OptimalStat("Optimal", recovery)
                 HeroStat("Calories", calories?.let { "${it.roundToInt()} kcal" } ?: COUPLED_NO_DATA, Palette.metricAmber)
                 HeroStat("Workouts", workouts.toString(), Palette.textPrimary)
             }
         }
+    }
+}
+
+/**
+ * The OPTIMAL strain band stat: the heroStat idiom plus a liquid tube visualising where the suggested band
+ * sits on the 0-21 axis. Twin of Swift CoupledView.optimalStat, which has had the tube since the coupled
+ * layout shipped while Android printed the range alone - the band was the one coupled stat with a shape to
+ * show and no shape shown.
+ *
+ * Not folded into [HeroStat]: Swift keeps optimalStat separate for the same reasons (4dp spacing rather
+ * than 2, and the tube), and every other stat here is a bare number with nothing to plot.
+ *
+ * A calibrating / unscored day shows the no-data token over an EMPTY tube, never a guessed band.
+ */
+@Composable
+private fun OptimalStat(title: String, recovery: Double?) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        // Takes the title as a parameter and uppercases it here, exactly as [HeroStat] does, rather than
+        // inlining "OPTIMAL". Not cosmetic: the four stat titles on this screen are unlocalized literals
+        // that the i18n gate cannot see as HeroStat arguments, and inlining one into a Text() makes that
+        // ONE of the four visible and fails the gate. Localising a single stat title while its three
+        // siblings stay hardcoded would be the wrong fix for a parity PR; the four of them are one
+        // pre-existing gap and belong to one change.
+        Text(title.uppercase(), style = NoopType.overline, color = Palette.textSecondary)
+        // Deliberately the same bare Text as [HeroStat]'s value, with no maxLines. Swift shrinks this
+        // (lineLimit(1).minimumScaleFactor(0.6)) but so does its heroStat, and Android's HeroStat does
+        // neither - so that divergence belongs to all four coupled stats, not to this one. Adding a
+        // maxLines here alone would truncate where the siblings wrap and where Swift shrinks: different
+        // from both.
+        Text(optimalStrainRangeText(recovery), style = NoopType.number(20f), color = Palette.chargeColor)
+        // animated = false matches the Swift call: the stat stack is a read-out, not an instrument, and a
+        // posed tube costs nothing per frame.
+        LiquidTube(
+            frac = optimalUpperFraction(recovery),
+            tint = Palette.chargeColor,
+            height = 8.dp,
+            animated = false,
+        )
     }
 }
 
@@ -666,6 +707,19 @@ internal fun optimalStrainRange(recovery: Double?): OptimalStrainRange? {
         r >= 34 -> OptimalStrainRange(10, 14)
         else -> OptimalStrainRange(4, 10)
     }
+}
+
+/**
+ * The optimal band's UPPER bound as a 0..1 fraction of the 0-21 axis, for the tube fill. 0 (an empty tube)
+ * when recovery is unknown, so the tube never fabricates a band the text is refusing to name.
+ *
+ * Twin of Swift CoupledView.optimalUpperFraction. Reads the upper bound rather than the midpoint because
+ * the tube shows how far up the axis the suggested band REACHES, which is what pairs with "14 to 18"
+ * printed above it.
+ */
+internal fun optimalUpperFraction(recovery: Double?): Double {
+    val band = optimalStrainRange(recovery) ?: return 0.0
+    return (band.high.toDouble() / 21.0).coerceIn(0.0, 1.0)
 }
 
 /** The optimal band as display text ("14 to 18" / the no-data token). Byte-identical to the Swift twin. */

--- a/android/app/src/test/java/com/noop/ui/CoupledScreenTest.kt
+++ b/android/app/src/test/java/com/noop/ui/CoupledScreenTest.kt
@@ -1,6 +1,7 @@
 package com.noop.ui
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -61,5 +62,37 @@ class CoupledScreenTest {
         assertEquals("7h 50m", hoursMinutes(470.0))
         assertEquals("0h 5m", hoursMinutes(5.0))
         assertEquals("8h 0m", hoursMinutes(480.0))
+    }
+
+    /**
+     * The tube fill beside the OPTIMAL range (#43). Twin of Swift CoupledView.optimalUpperFraction, which
+     * is `max(0, min(1, Double(band.upperBound) / 21))` - so these expectations are the Swift expression
+     * evaluated on the approved bands, not values read back off the Kotlin.
+     */
+    @Test
+    fun optimalUpperFractionMatchesTheSwiftTwin() {
+        assertEquals(18.0 / 21.0, optimalUpperFraction(90.0), 1e-12)
+        assertEquals(18.0 / 21.0, optimalUpperFraction(67.0), 1e-12)   // green, inclusive lower edge
+        assertEquals(14.0 / 21.0, optimalUpperFraction(66.9), 1e-12)
+        assertEquals(14.0 / 21.0, optimalUpperFraction(34.0), 1e-12)   // yellow, inclusive lower edge
+        assertEquals(10.0 / 21.0, optimalUpperFraction(33.9), 1e-12)
+        assertEquals(10.0 / 21.0, optimalUpperFraction(0.0), 1e-12)
+    }
+
+    @Test
+    fun optimalUpperFractionIsEmptyWhenRecoveryIsUnknown() {
+        // A calibrating / unscored day prints the no-data token, so the tube must be EMPTY rather than
+        // fabricate a band the text alongside it is refusing to name.
+        assertEquals(0.0, optimalUpperFraction(null), 1e-12)
+    }
+
+    @Test
+    fun optimalUpperFractionNeverLeavesTheAxis() {
+        // Every approved band is inside 0..21, so the clamp is defensive - but it is the reason a future
+        // band change cannot push the tube past full.
+        for (r in listOf(null, -50.0, 0.0, 33.9, 34.0, 66.9, 67.0, 100.0, 1000.0)) {
+            val f = optimalUpperFraction(r)
+            assertTrue("fraction out of range for recovery=$r: $f", f in 0.0..1.0)
+        }
     }
 }


### PR DESCRIPTION
Apple has drawn the #43 optimal band as a liquid tube beside the OPTIMAL stat since the coupled layout shipped. Android printed `14 to 18` and nothing else — the one coupled stat with a shape to show and no shape shown. A range is the only value in that stack that occupies part of an axis rather than sitting at a point on it.

| | Apple | Android before | Android after |
|---|---|---|---|
| range text | `14 to 18` | `14 to 18` | `14 to 18` |
| band on the axis | `LiquidTube` | — | `LiquidTube` |

## Nothing new is computed

`optimalStrainRange` is already present and already byte-identical to the Swift twin. This adds `optimalUpperFraction` over it — `band.high / 21`, clamped — which is Swift's `max(0, min(1, Double(band.upperBound) / 21))`, plus an `OptimalStat` composable mirroring Swift's `optimalStat` (4dp spacing rather than `HeroStat`'s 2, the range text, then the tube).

Android's `LiquidTube` already existed and already mirrors the iOS one, so the tube is a call rather than a new primitive. `animated = false` matches the Swift call site: the stat stack is a read-out, not an instrument, and a posed tube costs nothing per frame.

The range text is the same bare `Text` as `HeroStat`'s value, with no `maxLines`. Swift shrinks it (`lineLimit(1).minimumScaleFactor(0.6)`) — but so does *its* `heroStat`, while Android's `HeroStat` does neither. That divergence belongs to all four coupled stats rather than to this one, so it is left alone here instead of half-fixed on a single stat, which would truncate where the siblings wrap and where Swift shrinks: different from both.

An unknown recovery gives `0.0`, so a calibrating or unscored day shows the no-data token over an **empty** tube. The tube must never fabricate a band the text beside it is refusing to name — the same honesty rule the range text already follows.

## What this is not

Asked for by a user as *"a simple mark of the optimal strain zone on the strain circle itself"*. This is not that.

**There is no strain circle in the app.** Strain is a `LiquidVessel` on both platforms; the circular `StrainGauge` exists in both codebases but is unreferenced except by Swift previews, and the surrounding comments call it "the old StrainGauge" — the vessel idiom replaced it. Marking the band on the vessel is the real request, and it is a larger change needing a design call on how a band reads against a liquid fill.

This closes the parity gap underneath that: Android could not overlay a band it had no way to draw.

## Verification

- `:app:testFullDebugUnitTest --tests "com.noop.ui.CoupledScreenTest"` — **10 tests, 0 failures** (3 new; the 7 existing untouched). Test names checked in the XML so the filter is not a zero-match pass.
- The new expectations are the **Swift expression evaluated on the approved bands** (`18/21`, `14/21`, `10/21`), not values read back off the Kotlin — including both inclusive band edges (67, 34) and the unknown-recovery case.
- `compileFullDebugKotlin` clean, `Tools/doc_comment_lint.py` OK.
- No new strings — the stat title was already a literal, so the i18n gate is untouched.

One thing the tube does **not** do, on either platform: it fills to the band's *upper* bound, so it draws a ceiling rather than a zone — the band's lower edge is nowhere on the axis. Matching Apple is the whole point of this PR so that is left as-is, but it is worth naming, because the original request was to mark the *zone*, and after this neither platform does.

Not verifiable here: this is a visual change, and nobody has seen it rendered. It wants an eye on the Coupled screen before it is trusted to look right beside the existing stats.