### PR TITLE
sleep: drag the filled hypnogram to read the clock time under your finger

### DIFF
--- a/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageBreakdownUi.kt
@@ -1,8 +1,9 @@
 package com.noop.ui
 
+import android.text.format.DateFormat
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,10 +12,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -23,11 +28,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
-import android.text.format.DateFormat
-import java.util.TimeZone
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -35,6 +39,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.noop.R
 import java.util.Locale
+import java.util.TimeZone
 import kotlin.math.roundToInt
 
 /**
@@ -242,12 +247,44 @@ internal fun FilledHypnogram(
     // left the hypnogram axis in 24h while the sleep card above it changed - the setting half-applied.
     val is24h = ClockPrefs.uses24Hour(LocalContext.current)
     val axisTicks = if (showsAxis) hypnogramAxisTicks(onsetTs!!, wakeTs!!, maxAxisLabels, is24h) else emptyList()
+    var scrub by remember(intervals) { mutableStateOf<ScrubHit?>(null) }
+    // The crosshair tracks the FINGER. Snapping it to the resolved segment would put the line up to
+    // half a segment from the touch while the readout named the time where the finger actually was.
+    var scrubX by remember(intervals) { mutableStateOf(0f) }
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.space6)) {
         Canvas(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(Metrics.compactChartHeight)
-                .semantics { contentDescription = axSummary },
+                .semantics { contentDescription = axSummary }
+                .then(
+                    // #1855: drag to read the clock time under your finger. Offered only when the
+                    // night supplies a clock window, because without one there is no real time to
+                    // report and a number would have to be invented.
+                    if (showsAxis) {
+                        Modifier.pointerInput(intervals, originSec, spanSec) {
+                            fun hit(x: Float) = scrubHitAt(
+                                xPx = x,
+                                widthPx = size.width.toFloat(),
+                                intervals = intervals,
+                                originSec = originSec,
+                                spanSec = spanSec,
+                            )
+                            detectHorizontalDragGestures(
+                                onDragStart = { scrubX = it.x; scrub = hit(it.x) },
+                                onDragEnd = { scrub = null },
+                                onDragCancel = { scrub = null },
+                                onHorizontalDrag = { change, _ ->
+                                    scrubX = change.position.x
+                                    scrub = hit(change.position.x)
+                                    change.consume()
+                                },
+                            )
+                        }
+                    } else {
+                        Modifier
+                    },
+                ),
         ) {
             val w = size.width
             val h = size.height
@@ -319,8 +356,48 @@ internal fun FilledHypnogram(
                     strokeWidth = 1f,
                 )
             }
+
+            // Scrub crosshair LAST, so it sits over the filled staircase. In FILLED mode every stage
+            // paints from its level down to the baseline, so a crosshair drawn earlier is covered by
+            // the next rect and effectively invisible across most of the chart.
+            if (scrub != null) {
+                val cx = scrubX.coerceIn(0f, w)
+                drawLine(
+                    color = Palette.textPrimary,
+                    start = Offset(cx, 0f),
+                    end = Offset(cx, h),
+                    strokeWidth = 2f,
+                )
+            }
         }
-        if (axisTicks.isNotEmpty()) {
+        val hit = scrub
+        if (hit != null) {
+            // Replaces the time axis rather than adding a layer, so the chart does not change height
+            // mid-drag. Two Texts with spacing, not one string joined by a literal separator: that
+            // separator would be new hardcoded copy, and building it outside the Text() call to dodge
+            // extraction is the pattern #557 / #922 track. Stage names and clockTimeLabel are both
+            // existing, so this adds no new strings.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(
+                    Metrics.space6,
+                    Alignment.CenterHorizontally,
+                ),
+            ) {
+                Text(
+                    hit.stage.uppercase(),
+                    style = NoopType.footnote,
+                    color = Palette.textSecondary,
+                    maxLines = 1,
+                )
+                Text(
+                    clockTimeLabel(hit.timestamp, is24h),
+                    style = NoopType.footnote,
+                    color = Palette.textPrimary,
+                    maxLines = 1,
+                )
+            }
+        } else if (axisTicks.isNotEmpty()) {
             HypnogramTimeAxis(axisTicks)
         }
     }

--- a/android/app/src/main/java/com/noop/ui/SleepStageTimelineLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepStageTimelineLogic.kt
@@ -40,6 +40,36 @@ internal data class StageInterval(val stage: String, val startSec: Double, val e
     val durationSec: Double get() = endSec - startSec
 }
 
+/** What the hypnogram scrub is pointing at: the stage under the finger and its clock time. */
+internal data class ScrubHit(val stage: String, val timestamp: Long)
+
+/**
+ * Resolve a scrub x on the FILLED hypnogram into a stage and a real clock time (#1855).
+ *
+ * Valid here in a way it would NOT be on the proportional strip. `FilledHypnogram` positions every
+ * segment by `xOf(sec) = w * (sec / spanSec)` — linear in real time — from persisted per-epoch
+ * segments that carry their own start and end. So inverting x gives a timestamp the night actually
+ * had. The proportional strip is a different thing: it arranges stage TOTALS in a fixed
+ * light/deep/light/rem/light/awake order that is not the chronology, so a clock time read off it
+ * would be invented. That is why the scrub lives here and not there.
+ *
+ * The stage comes from containment on the real intervals rather than from the x fraction, so a gap
+ * the stager left unlabelled reports no stage instead of borrowing its neighbour's.
+ */
+internal fun scrubHitAt(
+    xPx: Float,
+    widthPx: Float,
+    intervals: List<StageInterval>,
+    originSec: Double,
+    spanSec: Double,
+): ScrubHit? {
+    if (widthPx <= 0f || spanSec <= 0.0 || intervals.isEmpty()) return null
+    val frac = (xPx / widthPx).coerceIn(0f, 1f).toDouble()
+    val sec = frac * spanSec
+    val stage = intervals.firstOrNull { sec >= it.startSec && sec <= it.endSec }?.stage.orEmpty()
+    return ScrubHit(stage = stage, timestamp = (originSec + sec).toLong())
+}
+
 /**
  * Reconstruct absolute (stage, startSec, endSec) intervals from the hero's ordered
  * `realSegments` weight pairs (name, minutes) by walking cumulative fractions across [spanSec]

--- a/android/app/src/test/java/com/noop/ui/HypnogramScrubTest.kt
+++ b/android/app/src/test/java/com/noop/ui/HypnogramScrubTest.kt
@@ -1,0 +1,63 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the hypnogram scrub (#1855): dragging the FILLED hypnogram reports the real clock time and
+ * the stage under the finger.
+ *
+ * The component matters as much as the maths here. `FilledHypnogram` draws persisted per-epoch
+ * segments positioned by `xOf(sec) = w * (sec / spanSec)` — linear in real time — so inverting x
+ * yields a timestamp the night actually had. The PROPORTIONAL strip is a different thing: it
+ * arranges stage TOTALS in a fixed light/deep/light/rem/light/awake order that is not the
+ * chronology, so a clock time read off that would be invented. These tests pin the honest one.
+ */
+class HypnogramScrubTest {
+
+    private val origin = 1_700_000_000.0          // unix seconds
+    private val span = 8 * 3600.0                 // an 8-hour window
+
+    /** deep 0–2h, rem 2–3h, then a deliberate unlabelled gap 3–4h, light 4–8h. */
+    private val intervals = listOf(
+        StageInterval("deep", 0.0, 2 * 3600.0),
+        StageInterval("rem", 2 * 3600.0, 3 * 3600.0),
+        StageInterval("light", 4 * 3600.0, 8 * 3600.0),
+    )
+
+    @Test fun timeIsTheRealClockTimeAtThatFractionOfTheNight() {
+        val hit = scrubHitAt(xPx = 100f, widthPx = 400f, intervals, origin, span)!!
+        assertEquals((origin + 2 * 3600.0).toLong(), hit.timestamp)   // a quarter in = 2 h
+    }
+
+    @Test fun theStageComesFromContainmentOnRealIntervals() {
+        assertEquals("deep", scrubHitAt(50f, 400f, intervals, origin, span)!!.stage)
+        assertEquals("rem", scrubHitAt(125f, 400f, intervals, origin, span)!!.stage)
+        assertEquals("light", scrubHitAt(300f, 400f, intervals, origin, span)!!.stage)
+    }
+
+    @Test fun anUnlabelledGapReportsNoStageRatherThanBorrowingANeighbour() {
+        // 3.5 h in lands in the gap the stager left unlabelled. The time is still real, but naming a
+        // stage there would be asserting something the night never recorded.
+        val hit = scrubHitAt(xPx = 175f, widthPx = 400f, intervals, origin, span)!!
+        assertEquals("", hit.stage)
+        assertEquals((origin + 3.5 * 3600.0).toLong(), hit.timestamp)
+    }
+
+    @Test fun theEndsClampToTheWindow() {
+        assertEquals(origin.toLong(), scrubHitAt(0f, 400f, intervals, origin, span)!!.timestamp)
+        assertEquals((origin + span).toLong(), scrubHitAt(400f, 400f, intervals, origin, span)!!.timestamp)
+    }
+
+    @Test fun pastEitherEdgeClampsRatherThanExtrapolating() {
+        assertEquals(origin.toLong(), scrubHitAt(-99f, 400f, intervals, origin, span)!!.timestamp)
+        assertEquals((origin + span).toLong(), scrubHitAt(9999f, 400f, intervals, origin, span)!!.timestamp)
+    }
+
+    @Test fun degenerateInputsReportNothingRatherThanGuessing() {
+        assertNull("no width", scrubHitAt(10f, 0f, intervals, origin, span))
+        assertNull("no span", scrubHitAt(10f, 400f, intervals, origin, 0.0))
+        assertNull("no intervals", scrubHitAt(10f, 400f, emptyList(), origin, span))
+    }
+}


### PR DESCRIPTION
Asked for by @AussieFries in #1855: a line showing the time when you slide over the stage chart, so a wake or onset the strap mis-registered can be pinpointed. macOS answers this with hover; touch needs a drag, so this follows the `Charts.kt` scrub pattern.

## It goes on the filled hypnogram, not the proportional strip

That is the whole design decision, and the first attempt got it wrong.

`HypnogramWithAxis` looks like the right place and is not. It is fed by `stageSegments()`:

```kotlin
add("light", s.light * 0.4);  add("deep", s.deep);   add("light", s.light * 0.3)
add("rem",   s.rem);          add("light", s.light * 0.3);  add("awake", s.awake)
```

A fixed order of stage **totals** — a picture of *how much* of each stage there was, not *when*. Reading a clock time off it would have shown an **invented timestamp with a crosshair pointing at it**, which is exactly what *"NOOP never makes up a number"* rules out. **The proportional strip is untouched by this change.**

`FilledHypnogram` is the honest home: it draws persisted per-epoch segments positioned by `xOf(sec) = w * (sec / spanSec)` — linear in real time — so inverting x yields a timestamp the night actually had.

## What it reports

- **Time** from the linear inverse, valid because the draw is linear in real seconds.
- **Stage** by *containment* on the real intervals, not from the x fraction. A gap the stager left unlabelled reports **no stage** rather than borrowing its neighbour's — the time there is still real, the stage genuinely is not known.
- **Crosshair drawn last**, after the staircase. Drawn earlier — as the first version did — every stage's filled rect paints over it, leaving the line invisible across most of the chart in FILLED mode.
- **Crosshair at the finger**, not the resolved segment. Snapping would put the line up to half a segment from the touch while the readout named the time where the finger actually was; the line and the number have to agree.

## No new copy

While scrubbing, the time axis is **replaced** by the stage and clock time rather than a layer being added, so the chart does not change height mid-drag. Stage names are existing tokens, and the time goes through `clockTimeLabel`, which already honours the 12/24h preference (#1821).

The readout is two `Text`s with spacing, not one string joined by a literal separator — that separator is new hardcoded copy, and building it outside the `Text()` call to dodge extraction is the pattern #557 and #922 track.

Scrub is offered only when the night supplies a clock window.

## Verification

- `testFullDebugUnitTest --tests "com.noop.ui.*"` — **130 classes, 0 failures**, including 6 new `HypnogramScrubTest` cases.
- `compileFullDebugKotlin` clean, `i18n_audit.py --ci` clean, `doc_comment_lint.py` OK.

**Not verified: nobody has dragged it.** The mapping is tested; the feel — crosshair weight, whether replacing the axis reads well mid-drag — wants a device.

## Related, investigated

Both platforms floor short bands when drawing and hit-test with an unfloored linear inverse, so both share the same small skew.

- `Hypnogram.swift:398` — `let width = max(2, x1 - x0)`
- `FilledHypnogram` — `val segW = (x1 - x0).coerceAtLeast(1.5f)...`

A band narrower than the floor is painted wider than its true time span and overlaps its neighbour's pixels, so the stage under those pixels can resolve to the neighbour. On a 3x phone with a ~360dp chart the floor bites below roughly 40s of an 8h night, and WHOOP stages are 30s epochs — so single-epoch bands do reach it. The resulting skew is at most the floor itself: 1.5px here, 2pt on Apple. The crosshair stroke is 2px and touch slop is an order of magnitude wider, so it sits below the interaction resolution.

Left alone deliberately. Making the hit-test floor-aware would make time non-linear in x, and the readout's clock time would stop agreeing with the axis labels it replaces — a worse trade than a sub-crosshair stage skew on 30s bands.

One deliberate divergence from Apple: on a gap between intervals `intervalIndex(atX:)` snaps to the nearest band by centre time, always naming a stage. `scrubHitAt` reports no stage and still shows the correct clock time, rather than attributing unclassified time to a stage. Pinned by test. Hover/scrub is UI, so this is outside the parity contract.