### PR TITLE
android(backup): clear the busy flag in a finally, as the Apple twin does

### DIFF
--- a/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
@@ -87,8 +87,10 @@ fun BackupSyncScreen() {
         busy = true
         scope.launch {
             // Clear in a `finally` so it clears on ANY exit — the twin of the Apple `defer` in
-            // `BackupSyncView.runRestore`. Every control here is gated on `!busy`, so a flag left set
-            // disables the whole screen, the way out of it included.
+            // `BackupSyncView.runRestore`. All five controls in the screen body are gated on `!busy`
+            // — folder picker, auto toggle, keep-count, Back up now, Restore — so a flag left set is a
+            // dead end rather than one stuck button. (The restore sheet and confirm dialog are not
+            // gated, but they are transient overlays, not the way back to a working screen.)
             //
             // The NeedsRestart branch never reaches the `finally`: it exits the process first. That is
             // the wanted behaviour — the screen stays disabled through the restart rather than briefly

--- a/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
@@ -86,37 +86,47 @@ fun BackupSyncScreen() {
     fun runRestore(uri: Uri) {
         busy = true
         scope.launch {
-            val r = withContext(Dispatchers.IO) { DataBackup.importFrom(context, uri) }
-            busy = false
-            when (r) {
-                is DataBackup.ImportResult.NeedsRestart -> {
-                    // #57: the restore CLOSED and swapped the database file. The long-lived WhoopRepository +
-                    // BLE client still hold a DAO on the OLD (now-closed) connection, so any strap sync would
-                    // fail with "connection pool has been closed" — and, worse, empty/metadata history ENDs
-                    // would still ack and trim the strap PAST records we can't store, discarding real history.
-                    // Relaunching the process re-opens Room against the restored file. Do it automatically
-                    // rather than trust the user to read a toast (which is exactly how #57 happened).
-                    Toast.makeText(context, "Backup restored — restarting NOOP…", Toast.LENGTH_LONG).show()
-                    // NonCancellable: this coroutine runs in the screen's scope, which is cancelled the
-                    // instant the user navigates away. The restart is a data-safety guarantee (the DB is
-                    // already swapped), so it must complete even if the composition leaves — otherwise the
-                    // user could keep syncing into the closed DB, the very bug we're fixing.
-                    withContext(NonCancellable) {
-                        delay(800)   // let the toast render before the process dies
-                        val ctx = context.applicationContext
-                        ctx.packageManager.getLaunchIntentForPackage(ctx.packageName)
-                            ?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                            ?.let { ctx.startActivity(it) }
-                        Runtime.getRuntime().exit(0)
+            // Clear in a `finally` so it clears on ANY exit — the twin of the Apple `defer` in
+            // `BackupSyncView.runRestore`. Every control here is gated on `!busy`, so a flag left set
+            // disables the whole screen, the way out of it included.
+            //
+            // The NeedsRestart branch never reaches the `finally`: it exits the process first. That is
+            // the wanted behaviour — the screen stays disabled through the restart rather than briefly
+            // accepting taps against a database that has already been swapped underneath it.
+            try {
+                val r = withContext(Dispatchers.IO) { DataBackup.importFrom(context, uri) }
+                when (r) {
+                    is DataBackup.ImportResult.NeedsRestart -> {
+                        // #57: the restore CLOSED and swapped the database file. The long-lived WhoopRepository +
+                        // BLE client still hold a DAO on the OLD (now-closed) connection, so any strap sync would
+                        // fail with "connection pool has been closed" — and, worse, empty/metadata history ENDs
+                        // would still ack and trim the strap PAST records we can't store, discarding real history.
+                        // Relaunching the process re-opens Room against the restored file. Do it automatically
+                        // rather than trust the user to read a toast (which is exactly how #57 happened).
+                        Toast.makeText(context, "Backup restored — restarting NOOP…", Toast.LENGTH_LONG).show()
+                        // NonCancellable: this coroutine runs in the screen's scope, which is cancelled the
+                        // instant the user navigates away. The restart is a data-safety guarantee (the DB is
+                        // already swapped), so it must complete even if the composition leaves — otherwise the
+                        // user could keep syncing into the closed DB, the very bug we're fixing.
+                        withContext(NonCancellable) {
+                            delay(800)   // let the toast render before the process dies
+                            val ctx = context.applicationContext
+                            ctx.packageManager.getLaunchIntentForPackage(ctx.packageName)
+                                ?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                                ?.let { ctx.startActivity(it) }
+                            Runtime.getRuntime().exit(0)
+                        }
                     }
+                    is DataBackup.ImportResult.Failed ->
+                        Toast.makeText(context, r.message, Toast.LENGTH_LONG).show()
+                    // #1807: recoverable, but not from here — this screen restores a folder snapshot
+                    // directly and has no confirm step to hang the override on. Settings → Backup & restore
+                    // → Import does, and shows the same sentence with a way through.
+                    is DataBackup.ImportResult.TooLarge ->
+                        Toast.makeText(context, r.message, Toast.LENGTH_LONG).show()
                 }
-                is DataBackup.ImportResult.Failed ->
-                    Toast.makeText(context, r.message, Toast.LENGTH_LONG).show()
-                // #1807: recoverable, but not from here — this screen restores a folder snapshot
-                // directly and has no confirm step to hang the override on. Settings → Backup & restore
-                // → Import does, and shows the same sentence with a way through.
-                is DataBackup.ImportResult.TooLarge ->
-                    Toast.makeText(context, r.message, Toast.LENGTH_LONG).show()
+            } finally {
+                busy = false
             }
         }
     }
@@ -334,18 +344,24 @@ fun BackupSyncScreen() {
                         onClick = {
                             busy = true
                             scope.launch {
-                                val ok = withContext(Dispatchers.IO) { BackupSync.backupNow(context) }
-                                lastMs = BackupSyncPrefs.lastBackupMs(context)
-                                busy = false
-                                Toast.makeText(
-                                    context,
-                                    if (ok) {
-                                        "Backed up to your folder."
-                                    } else {
-                                        "Backup failed - re-pick the folder and try again."
-                                    },
-                                    Toast.LENGTH_LONG,
-                                ).show()
+                                // Clear in a `finally` so it clears on ANY exit — the twin of the Apple `defer` in
+                                // `BackupSyncView.backupNow`. The flag now clears after the toast rather than before it,
+                                // which is the point: the screen stays disabled until the work is genuinely finished.
+                                try {
+                                    val ok = withContext(Dispatchers.IO) { BackupSync.backupNow(context) }
+                                    lastMs = BackupSyncPrefs.lastBackupMs(context)
+                                    Toast.makeText(
+                                        context,
+                                        if (ok) {
+                                            "Backed up to your folder."
+                                        } else {
+                                            "Backup failed - re-pick the folder and try again."
+                                        },
+                                        Toast.LENGTH_LONG,
+                                    ).show()
+                                } finally {
+                                    busy = false
+                                }
                             }
                         },
                     )


### PR DESCRIPTION
Every control on Backup & Sync is gated on `!busy`, so a flag left set disables the whole screen — including the way out of it. The Apple twin clears it in a `defer` with a comment saying exactly that. The Android screen cleared it as a plain statement partway through the coroutine, so any throw after that point skipped it.

```kotlin
busy = true
scope.launch {
    val ok = withContext(Dispatchers.IO) { BackupSync.backupNow(context) }
    lastMs = ...
    busy = false          // skipped entirely if anything above throws
    Toast...
}
```

Both call sites now clear it in a `finally`.

## What this is not

**This is not a repair for the reported stuck button.** I went looking for a cause and this is the structural gap I found, but the wedge it protects against is narrow and I could not show it is reachable:

- `writeSnapshot` wraps `createDocument`, `exportTo` and the integrity check in `runCatching`, so `backupNow` returns `false` rather than throwing.
- `scope` is a `rememberCoroutineScope()` with no handler, so an escaping throw would crash the app rather than wedge the screen.
- `busy` lives in a plain `remember`, so if the screen leaves composition mid-work the state is discarded — cancellation cannot leave a stuck flag behind either.

The narrow window that remains is a throw *after* the IO call while the screen is still composed — `lastMs = BackupSyncPrefs.lastBackupMs(context)`, or `Toast.show()` against a bad window token. Worth stating the invariant in code rather than relying on the callee never throwing, but I would not want this merged under the impression that it answers the report.

## Ordering consequences, both deliberate

- **Back up now** clears the flag *after* the toast instead of before, so the screen stays disabled until the work is genuinely finished.
- **runRestore's `NeedsRestart` branch never reaches the `finally`** — it exits the process first. That is wanted: the screen stays disabled through the restart rather than briefly accepting taps against a database that has already been swapped underneath it.

## Review aid

`git diff -w` is the honest view: **18 insertions, 2 deletions**, and every one of them is the `try`/`finally` plus its comment. The 98-line raw diff is re-indentation.

## Verification

- `compileFullDebugKotlin --no-build-cache` clean.
- `syncRoomSchemaSnapshot` in its own invocation, then `testFullDebugUnitTest --rerun-tasks` over `BackupSyncTest`, `BackupSyncFileIoTest`, `DataBackupIntegrityTest` — **29 tests, 0 failures**. My first filtered run exited 0 having matched nothing; the counts above are from result XMLs, not the exit code.
- `i18n_audit.py --ci` and `doc_comment_lint.py` clean. Longest line unchanged at 157, so no new style outlier.

**No test covers the change.** It lives in a Composable's `onClick` lambda, and the Compose test dependencies here are `androidTestImplementation` only — instrumented, device-required, and not run in CI. An honest test would need infrastructure this repo does not have.

## Same shape elsewhere, not touched

`DataSourcesScreen.kt` (2 sites, **9** controls gated on `busy`) and `OnboardingScreen.kt` (1 site) have the identical pattern. Both wrap their IO in `runCatching`, so they are contained the same way this one was — but DataSourcesScreen would be the worst place to get it wrong. Left alone deliberately; happy to follow up.
