### PR TITLE
today: say why Recovery Vitals is blank on a night with no motion

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -950,7 +950,13 @@ public enum AnalyticsEngine {
             // The ABSOLUTE this pass's deviation was derived from (#1636). Set HERE, beside
             // `skinTempDevC`, so the engine's own row is symmetric: any path that persists this
             // struct directly keeps both thermal values, not just the one.
-            skinTempC: nightlySkinTempC)
+            skinTempC: nightlySkinTempC,
+            // The SAME condition that emptied `restingHr` and `avgHrv` above: `physiologySessions` is
+            // `matched` minus the HR-only ones, so an all-HR-only night leaves it empty and both vitals
+            // nil. Recorded rather than re-derived downstream, so the explanation and the values it
+            // explains cannot disagree. Byte-identical twin of Kotlin `AnalyticsEngine`'s
+            // `sleepHrOnly = if (matched.isEmpty()) null else physiologySessions.isEmpty()`.
+            sleepHrOnly: matched.isEmpty ? nil : physiologySessions.isEmpty)
         _ = sleepStart; _ = sleepEnd  // available for callers wiring sleep_start/end columns
 
         // ── Cache rows ────────────────────────────────────────────────────────

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -883,6 +883,16 @@ extension WhoopStore {
         migrator.registerMigration("v41-drop-raw-imu-sample") { db in
             try db.drop(table: "rawImuSample")
         }
+        // Whether every sleep session that day was staged from heart rate alone (#1801). The Kotlin twin
+        // is `DailyMetric.sleepHrOnly`, added by Room MIGRATION_35_36; the shared schema oracle pins the
+        // two shapes together, so this exists here even while only Android reads it — a column present on
+        // one side and absent on the other is the drift #775 tracks, and stagingSparse set the precedent
+        // for carrying a staging-quality flag on both.
+        migrator.registerMigration("v42-daily-sleep-hr-only") { db in
+            try db.alter(table: "dailyMetric") { t in
+                t.add(column: "sleepHrOnly", .boolean)
+            }
+        }
         return migrator
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -105,13 +105,16 @@ public struct DailyMetric: Equatable, Codable {
     /// that column and `SkinTempDisplay.isAbsoluteSkinTemp` separates them by magnitude. This column is
     /// unambiguous: it is always an absolute, and only the strap pipeline writes it.
     public let skinTempC: Double?
+    /// Kotlin twin: `DailyMetric.sleepHrOnly`. Every session that night staged from heart rate alone.
+    public let sleepHrOnly: Bool?
     public init(day: String, totalSleepMin: Double?, efficiency: Double?, deepMin: Double?,
                 remMin: Double?, lightMin: Double?, disturbances: Int?, restingHr: Int?,
                 avgHrv: Double?, recovery: Double?, strain: Double?, exerciseCount: Int?,
                 spo2Pct: Double? = nil, skinTempDevC: Double? = nil, respRateBpm: Double? = nil,
                 steps: Int? = nil, activeKcalEst: Double? = nil,
                 spo2Red: Int? = nil, spo2Ir: Int? = nil, avgSdnn: Double? = nil,
-                skinTempC: Double? = nil) {
+                skinTempC: Double? = nil,
+                sleepHrOnly: Bool? = nil) {
         self.day = day; self.totalSleepMin = totalSleepMin; self.efficiency = efficiency
         self.deepMin = deepMin; self.remMin = remMin; self.lightMin = lightMin
         self.disturbances = disturbances; self.restingHr = restingHr; self.avgHrv = avgHrv
@@ -120,6 +123,7 @@ public struct DailyMetric: Equatable, Codable {
         self.steps = steps; self.activeKcalEst = activeKcalEst
         self.spo2Red = spo2Red; self.spo2Ir = spo2Ir; self.avgSdnn = avgSdnn
         self.skinTempC = skinTempC
+        self.sleepHrOnly = sleepHrOnly
     }
 
     /// The freshest STRICTLY-PRIOR day that carries at least one overnight vital (HRV / resting HR /
@@ -465,8 +469,8 @@ extension WhoopStore {
                     (deviceId, day, totalSleepMin, efficiency, deepMin, remMin, lightMin,
                      disturbances, restingHr, avgHrv, recovery, strain, exerciseCount,
                      spo2Pct, skinTempDevC, respRateBpm, steps, activeKcalEst,
-                     spo2Red, spo2Ir, avgSdnn, skinTempC)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     spo2Red, spo2Ir, avgSdnn, skinTempC, sleepHrOnly)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(deviceId, day) DO UPDATE SET
                     totalSleepMin = excluded.totalSleepMin,
                     efficiency = excluded.efficiency,
@@ -487,13 +491,14 @@ extension WhoopStore {
                     spo2Red = excluded.spo2Red,
                     spo2Ir = excluded.spo2Ir,
                     avgSdnn = excluded.avgSdnn,
-                    skinTempC = excluded.skinTempC
+                    skinTempC = excluded.skinTempC,
+                    sleepHrOnly = excluded.sleepHrOnly
                 """, arguments: [deviceId, d.day, d.totalSleepMin, d.efficiency, d.deepMin,
                                  d.remMin, d.lightMin, d.disturbances, d.restingHr, d.avgHrv,
                                  d.recovery, d.strain, d.exerciseCount,
                                  d.spo2Pct, d.skinTempDevC, d.respRateBpm,
                                  d.steps, d.activeKcalEst,
-                                 d.spo2Red, d.spo2Ir, d.avgSdnn, d.skinTempC])
+                                 d.spo2Red, d.spo2Ir, d.avgSdnn, d.skinTempC, d.sleepHrOnly])
             n += db.changesCount
         }
         return n
@@ -544,7 +549,7 @@ extension WhoopStore {
                 SELECT day, totalSleepMin, efficiency, deepMin, remMin, lightMin, disturbances,
                        restingHr, avgHrv, recovery, strain, exerciseCount,
                        spo2Pct, skinTempDevC, respRateBpm, steps, activeKcalEst,
-                       spo2Red, spo2Ir, avgSdnn, skinTempC FROM dailyMetric
+                       spo2Red, spo2Ir, avgSdnn, skinTempC, sleepHrOnly FROM dailyMetric
                 WHERE deviceId = ? AND day >= ? AND day <= ?
                 ORDER BY day ASC
                 """, arguments: [deviceId, from, to])
@@ -559,7 +564,8 @@ extension WhoopStore {
                                 respRateBpm: $0["respRateBpm"],
                                 steps: $0["steps"], activeKcalEst: $0["activeKcalEst"],
                                 spo2Red: $0["spo2Red"], spo2Ir: $0["spo2Ir"], avgSdnn: $0["avgSdnn"],
-                                skinTempC: $0["skinTempC"])
+                                skinTempC: $0["skinTempC"],
+                                sleepHrOnly: $0["sleepHrOnly"])
                 }
         }
     }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
@@ -42,7 +42,8 @@
     "v38-apple-step-hour",
     "v39-ppg-burst-index",
     "v40-daily-skin-temp-absolute",
-    "v41-drop-raw-imu-sample"
+    "v41-drop-raw-imu-sample",
+    "v42-daily-sleep-hr-only"
   ],
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android — the per-row upload flag belongs to an upload path that does not exist there — so it is dead width, not divergent data. Removing it needs a Room table rebuild.",

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 35,
+  "roomVersion": 36,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -372,6 +372,16 @@
           "affinity": "REAL",
           "notNull": false,
           "default": null
+        },
+        {
+          "name": "sleepHrOnly",
+          "affinity": "NUMERIC",
+          "notNull": false,
+          "default": null,
+          "android": {
+            "affinity": "INTEGER"
+          },
+          "divergence": "grdb-boolean-affinity"
         }
       ],
       "primaryKey": [

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -2915,7 +2915,8 @@ extension DailyMetric {
                     avgHrv: avgHrv, recovery: r, strain: strain, exerciseCount: exerciseCount,
                     spo2Pct: spo2Pct, skinTempDevC: sd, respRateBpm: respRateBpm,
                     steps: steps, activeKcalEst: activeKcalEst,
-                    spo2Red: spo2Red, spo2Ir: spo2Ir, avgSdnn: avgSdnn, skinTempC: sa)
+                    spo2Red: spo2Red, spo2Ir: spo2Ir, avgSdnn: avgSdnn, skinTempC: sa,
+                    sleepHrOnly: sleepHrOnly)
     }
 
     /// Rebuild with substituted sleep-derived fields (a user-corrected wake window), leaving every
@@ -2927,7 +2928,7 @@ extension DailyMetric {
                     strain: strain, exerciseCount: exerciseCount, spo2Pct: spo2Pct,
                     skinTempDevC: skinTempDevC, respRateBpm: respRateBpm, steps: steps,
                     activeKcalEst: activeKcalEst, spo2Red: spo2Red, spo2Ir: spo2Ir, avgSdnn: avgSdnn,
-                    skinTempC: skinTempC)
+                    skinTempC: skinTempC, sleepHrOnly: sleepHrOnly)
     }
 }
 

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -3238,7 +3238,10 @@ private extension DailyMetric {
             avgSdnn: avgSdnn ?? fallback.avgSdnn,
             // On-device only (imports never carry it), so an imported row's nil is backfilled from the
             // computed fallback — otherwise the night's absolute would be lost. (#1636)
-            skinTempC: skinTempC ?? fallback.skinTempC
+            skinTempC: skinTempC ?? fallback.skinTempC,
+            // Same shape, same reason (#1801): only a scoring pass knows how the night was staged, so an
+            // imported row's nil takes the computed answer rather than erasing it.
+            sleepHrOnly: sleepHrOnly ?? fallback.sleepHrOnly
         )
     }
 
@@ -3268,7 +3271,11 @@ private extension DailyMetric {
             spo2Red: spo2Red,   // non-sleep field: preserved as-is (#93)
             spo2Ir: spo2Ir,
             avgSdnn: avgSdnn,   // non-sleep (HRV) field: preserved as-is
-            skinTempC: skinTempC // non-sleep (thermal) field: preserved as-is (#1636)
+            skinTempC: skinTempC, // non-sleep (thermal) field: preserved as-is (#1636)
+            // MOVES with the sleep columns, unlike the others here: it describes how the very stage
+            // figures being taken were derived, so leaving `self`'s behind would caption the source's
+            // hypnogram with the import's staging — and an import's is always nil. (#1801)
+            sleepHrOnly: source.sleepHrOnly
         )
     }
 }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -403,7 +403,11 @@ final class Repository: ObservableObject {
             spo2Ir: rawSpo2FromFiller ? filler.spo2Ir : winner.spo2Ir,
             // Strap-only, like raw SpO2: an imported winner carries no absolute skin temp, so take the
             // filler's rather than let the union blank a value the strap did record (#1636).
-            skinTempC: winner.skinTempC ?? filler.skinTempC
+            skinTempC: winner.skinTempC ?? filler.skinTempC,
+            // Part of the SLEEP GROUP, not an independent column (#1801): it describes how the stage
+            // figures above were derived, so it has to come from whichever row supplied them. A plain
+            // `winner ?? filler` would caption the winner's own hypnogram with the filler's staging.
+            sleepHrOnly: sleepFromFiller ? filler.sleepHrOnly : winner.sleepHrOnly
         )
     }
 

--- a/StrandTests/DailySkinTempAbsoluteCarryTests.swift
+++ b/StrandTests/DailySkinTempAbsoluteCarryTests.swift
@@ -72,4 +72,41 @@ final class DailySkinTempAbsoluteCarryTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(scored.skinTempDevC), 0.52, accuracy: 0.001)
         XCTAssertEqual(try XCTUnwrap(scored.recovery), 0.71, accuracy: 0.001)
     }
+
+    // MARK: - The same four seams, for the HR-only staging flag (#1801)
+
+    /// `sleepHrOnly` rides the identical rebuild path as the absolute above, and the struct has no
+    /// `copy()` — every seam respells the field list, so a new column is dropped by omission rather than
+    /// by error. These four are that column's version of the tests above.
+
+    func testScoringKeepsTheStagingFlag() throws {
+        let scored = row(skinTempC: 34.6).with(recovery: 0.71, skinTempDevC: 0.52, skinTempC: 34.6)
+        XCTAssertNil(scored.sleepHrOnly, "a row that never carried the flag must not invent one")
+        let hrOnly = DailyMetric(day: "2026-09-03", sleepHrOnly: true)
+            .with(recovery: 0.71, skinTempDevC: nil, skinTempC: nil)
+        XCTAssertEqual(hrOnly.sleepHrOnly, true, "scoring must not discard how the night was staged")
+    }
+
+    func testASleepEditKeepsTheStagingFlag() {
+        let edited = DailyMetric(day: "2026-09-03", sleepHrOnly: true)
+            .with(totalSleepMin: 400, efficiency: 0.93, deepMin: 80, remMin: 100, lightMin: 220)
+        // Correcting the wake window does not change whether the strap banked any motion.
+        XCTAssertEqual(edited.sleepHrOnly, true)
+    }
+
+    func testAnImportedRowTakesTheComputedStagingFlag() {
+        let imported = DailyMetric(day: "2026-09-03")
+        let computed = DailyMetric(day: "2026-09-03", sleepHrOnly: true)
+        XCTAssertEqual(imported.fillingNilFields(from: computed).sleepHrOnly, true,
+                       "only a scoring pass knows the staging; an import's nil must not erase it")
+    }
+
+    func testTheFlagMovesWithTheSleepColumnsItDescribes() {
+        let importRow = DailyMetric(day: "2026-09-03", totalSleepMin: 300)
+        let editedComputed = DailyMetric(day: "2026-09-03", totalSleepMin: 400, sleepHrOnly: true)
+        let merged = importRow.takingSleepFields(from: editedComputed)
+        XCTAssertEqual(merged.totalSleepMin, 400)
+        // The flag describes THOSE stage figures, so it travels with them rather than staying behind.
+        XCTAssertEqual(merged.sleepHrOnly, true)
+    }
 }

--- a/StrandTests/DailySkinTempAbsoluteCarryTests.swift
+++ b/StrandTests/DailySkinTempAbsoluteCarryTests.swift
@@ -109,4 +109,18 @@ final class DailySkinTempAbsoluteCarryTests: XCTestCase {
         // The flag describes THOSE stage figures, so it travels with them rather than staying behind.
         XCTAssertEqual(merged.sleepHrOnly, true)
     }
+
+    /// The Swift twin of the Kotlin coalesce cases: the flag belongs to the sleep GROUP.
+    func testTheStagingFlagMovesWithTheSleepBlock() {
+        let winner = DailyMetric(day: "2026-09-03", restingHr: 55)
+        let filler = DailyMetric(day: "2026-09-03", totalSleepMin: 400, deepMin: 39,
+                                 remMin: 54, lightMin: 57, sleepHrOnly: true)
+        XCTAssertEqual(Repository.coalesceDay(winner, filler).sleepHrOnly, true)
+    }
+
+    func testAWinnerThatOwnsTheSleepBlockKeepsItsOwnStagingFlag() {
+        let winner = DailyMetric(day: "2026-09-03", totalSleepMin: 420, deepMin: 90, sleepHrOnly: false)
+        let filler = DailyMetric(day: "2026-09-03", totalSleepMin: 300, sleepHrOnly: true)
+        XCTAssertEqual(Repository.coalesceDay(winner, filler).sleepHrOnly, false)
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -870,6 +870,11 @@ object AnalyticsEngine {
             disturbances = if (matched.isEmpty()) null else disturbances,
             restingHr = restingHRDaily,
             avgHrv = avgHRVDaily,
+            // The SAME condition that just emptied the two fields above: `physiologySessions` is
+            // `matched` minus the HR-only ones, so an all-HR-only night leaves it empty and both vitals
+            // null. Recording it here rather than re-deriving in the UI keeps the explanation and the
+            // cause as one expression — a second definition could disagree with the values it explains.
+            sleepHrOnly = if (matched.isEmpty()) null else physiologySessions.isEmpty(),
             recovery = recovery,
             strain = strain,
             exerciseCount = workouts.size,

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -329,6 +329,15 @@ data class DailyMetric(
     // one is unambiguous: always absolute, and only the strap pipeline writes it. Nullable: nights scored
     // before v34 stay null until a re-score re-derives them from the same raw samples.
     val skinTempC: Double? = null,
+    // Whether EVERY sleep session this day was staged from heart rate alone, with no motion to work from
+    // (#1801). The two vitals below it are not missing by accident on such a night: the HR-only spine
+    // constructs its sessions with restingHR and avgHRV null on purpose, because sleep bounds inferred
+    // from heart rate are not firm enough to hang a resting HR or a nightly RMSSD on, and AnalyticsEngine
+    // then gates both on `!hrOnly`. Persisted so the card can say WHICH of those it is — a blank next to
+    // a populated respiratory rate reads as a sync failure, and a field log showed a week of exactly that
+    // misreading. Appended LAST so the column order matches the Room CREATE TABLE and the Swift row.
+    // Null on every row scored before v36 and on any day with no sleep at all.
+    val sleepHrOnly: Boolean? = null,
 )
 
 /**

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -53,7 +53,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         V18AuxSampleEntity::class,
         AppleStepHour::class,
     ],
-    version = 35,
+    version = 36,
     // #775: ON so Room's KSP processor writes the generated schema (every table's exact `CREATE TABLE`,
     // columns in declaration order with affinity/NOT NULL/default, PK and indices) as JSON. That export
     // is what lets a plain JVM test — no device, no Robolectric — read Android's REAL schema and compare
@@ -73,7 +73,7 @@ abstract class WhoopDatabase : RoomDatabase() {
         const val DB_NAME = "noop_whoop.db"
         /** Room schema version — MUST equal the `@Database(version = …)` above. Surfaced in the backup
          *  manifest (#1410) so an export states its schema. Bump both together on a migration. */
-        const val SCHEMA_VERSION = 35
+        const val SCHEMA_VERSION = 36
 
         @Volatile
         private var instance: WhoopDatabase? = null
@@ -928,6 +928,26 @@ abstract class WhoopDatabase : RoomDatabase() {
         }
 
         /**
+         * v35 -> v36: ADDITIVE, adds `dailyMetric.sleepHrOnly` (nullable INTEGER) so the Recovery Vitals
+         * card can say why HRV and resting HR are blank on a night staged from heart rate alone, rather
+         * than showing a bare "No data" that is indistinguishable from a failed sync (#1801). Nullable
+         * with no default and no backfill: existing rows stay null and read as "not known", which is
+         * honest — the flag is only knowable from a re-score, and a re-score writes it.
+         *
+         * Exposed as a constant so the migration test can pin its SHAPE without Room-testing, the same
+         * way [DAILY_SKIN_TEMP_ABSOLUTE_MIGRATION_SQL] is.
+         */
+        internal val DAILY_SLEEP_HR_ONLY_MIGRATION_SQL: List<String> = listOf(
+            "ALTER TABLE `dailyMetric` ADD COLUMN `sleepHrOnly` INTEGER",
+        )
+
+        internal val MIGRATION_35_36 = object : Migration(35, 36) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                for (stmt in DAILY_SLEEP_HR_ONLY_MIGRATION_SQL) db.execSQL(stmt)
+            }
+        }
+
+        /**
          * Every migration the builder registers, as a VALUE rather than an argument list.
          *
          * It was previously spelled inline in `addMigrations(...)`, which meant nothing could check it. A
@@ -952,7 +972,7 @@ abstract class WhoopDatabase : RoomDatabase() {
             MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22,
             MIGRATION_22_23, MIGRATION_23_24, MIGRATION_24_25, MIGRATION_25_26,
             MIGRATION_26_27, MIGRATION_27_28, MIGRATION_28_29, MIGRATION_29_30,
-            MIGRATION_30_31, MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34, MIGRATION_34_35,
+            MIGRATION_30_31, MIGRATION_31_32, MIGRATION_32_33, MIGRATION_33_34, MIGRATION_34_35, MIGRATION_35_36,
         )
 
 

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -2382,6 +2382,10 @@ class WhoopRepository(
                 remMin = if (sleepFromFiller) filler.remMin else winner.remMin,
                 lightMin = if (sleepFromFiller) filler.lightMin else winner.lightMin,
                 disturbances = if (sleepFromFiller) filler.disturbances else winner.disturbances,
+                // Part of the SLEEP GROUP (#1801): it describes how the stage figures above were derived,
+                // so it moves with them. `copy()` would leave the WINNER's flag in place while the stages
+                // came from the filler — captioning one row's hypnogram with another row's staging.
+                sleepHrOnly = if (sleepFromFiller) filler.sleepHrOnly else winner.sleepHrOnly,
                 spo2Red = if (rawSpo2FromFiller) filler.spo2Red else winner.spo2Red,
                 spo2Ir = if (rawSpo2FromFiller) filler.spo2Ir else winner.spo2Ir,
                 // Independent columns: each stands alone, so a plain per-column fill is safe.

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3085,6 +3085,28 @@ private fun RingNeedsTrackedNight() {
 // three vitals now read directly below the three-ring hero + Synthesis card. [HeroMetricRows] is the
 // README "Metric row" card; the SOLID/CALIBRATING pill + Synthesis insight moved into [SynthesisHeroCard].
 
+/**
+ * Whether the Recovery Vitals card should explain its blanks with the HR-only note (#1801).
+ *
+ * Reads the flag from the SAME row the shown vitals came from. [carriedFromVitals] already decides that
+ * for the date caption, so reusing it keeps the note and the numbers describing ONE night;
+ * `day?.sleepHrOnly ?: vitalsDay?.sleepHrOnly` would instead fall through whenever today's flag is merely
+ * unknown — every row scored before v36 — and caption today's blanks with a different night's staging.
+ *
+ * Gated on something actually being blank so a night that kept its vitals stays quiet, and on `== true`
+ * so the tri-state reads correctly: null means "not known", which earns no claim either way.
+ */
+internal fun showsHrOnlyNote(
+    day: DailyMetric?,
+    vitalsDay: DailyMetric?,
+    carriedFromVitals: Boolean,
+    hrv: Double?,
+    rhr: Int?,
+): Boolean {
+    val source = if (carriedFromVitals) vitalsDay else day
+    return source?.sleepHrOnly == true && (hrv == null || rhr == null)
+}
+
 /** The three hero vitals as README metric rows, HRV (teal) · Resting HR (rose) · Respiratory (blue).
  *  Reads PER-FIELD today-first with a recovery-INDEPENDENT vitals carry ([vitalsDay]) as the fallback
  *  (#543 follow-up), so a night whose recovery was nulled post-update still shows its OWN preserved HRV /
@@ -3103,6 +3125,12 @@ private fun HeroMetricRows(day: DailyMetric?, carriedDay: DailyMetric? = null, v
     // vital is carried do we stamp the carry's date (relabelled "Latest sleep · <date>" when weeks-old).
     val carriedFromVitals = day?.avgHrv == null && day?.restingHr == null && day?.respRateBpm == null &&
         (hrv != null || rhr != null || resp != null) && vitalsDay != null
+    // #1801: why the two blanks below are blank. Read from the SAME row the shown vitals came from —
+    // `carriedFromVitals` already decides that for the date caption, so reusing it keeps the note and the
+    // values describing one night. `day?.sleepHrOnly ?: vitalsDay?.sleepHrOnly` would instead fall through
+    // on a pre-v36 row whose flag is merely unknown, and explain a different night's numbers.
+    // Gated on something actually being blank, so a night that recovered its vitals stays quiet.
+    val hrOnlyNight = showsHrOnlyNote(day, vitalsDay, carriedFromVitals, hrv, rhr)
     // iOS `recoveryVitalsSection`: a frosted card with a "RECOVERY VITALS" header + a "last night · <date>"
     // on the right, then three `vitalRow`s (26dp mini LIQUID VESSEL + label + value). NoopCard supplies the
     // same neutral surfaceRaised + hairline as iOS's frosted card. Inner spacing 12, matching iOS.
@@ -3138,6 +3166,13 @@ private fun HeroMetricRows(day: DailyMetric?, carriedDay: DailyMetric? = null, v
                 tint = Palette.accent,
                 fraction = resp?.let { (it / 24.0).coerceIn(0.0, 1.0) },
             )
+            if (hrOnlyNight) {
+                Text(
+                    uiString(R.string.l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b),
+                    style = NoopType.caption,
+                    color = Palette.textTertiary,
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2683,4 +2683,5 @@
     <string name="l10n_settings_screen_skin_temperature_fc103030">Hauttemperatur</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Für diese Nächte liegt keine gemessene Temperatur vor — angezeigt wird die Abweichung von deinem Basiswert. Eine Synchronisierung bewertet die letzten Nächte neu und ergänzt sie.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Es werden nur Nächte mit gemessener Temperatur angezeigt; für die übrigen wurde nur eine Abweichung vom Basiswert erfasst.</string>
+    <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">Diese Nacht wurde allein anhand der Herzfrequenz ausgewertet, ohne aufgezeichnete Bewegung, daher konnten Herzfrequenzvariabilität und Ruheherzfrequenz nicht gemessen werden. Ein nicht vollständig gekoppelter Strap ist die übliche Ursache.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2670,4 +2670,5 @@
     <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura cutánea</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">No hay temperatura medida para estas noches: se muestra la diferencia respecto a tu referencia. Una sincronización vuelve a analizar las noches recientes y la completa.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Solo se muestran las noches con temperatura medida; en las demás solo se registró la diferencia respecto a la referencia.</string>
+    <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">Esta noche se analizó solo a partir de la frecuencia cardíaca, sin movimiento registrado, por lo que no se pudieron medir la variabilidad de la frecuencia cardíaca ni la frecuencia cardíaca en reposo. La causa habitual es una correa que no está totalmente emparejada.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2669,4 +2669,5 @@
     <string name="l10n_settings_screen_skin_temperature_fc103030">Température cutanée</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Aucune température mesurée pour ces nuits — l\'écart par rapport à votre référence est affiché. Une synchronisation réévalue les nuits récentes et le complète.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Seules les nuits avec une température mesurée sont affichées ; les autres n\'ont enregistré qu\'un écart par rapport à la référence.</string>
+    <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">Cette nuit a été analysée à partir de la seule fréquence cardiaque, sans mouvement enregistré, donc la variabilité de la fréquence cardiaque et la fréquence cardiaque au repos n\'ont pas pu être mesurées. La cause habituelle est un bracelet qui n\'est pas entièrement appairé.</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2674,4 +2674,5 @@
     <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura skóry</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Brak zmierzonej temperatury dla tych nocy — pokazano różnicę względem Twojej wartości bazowej. Synchronizacja ponownie przelicza ostatnie noce i ją uzupełnia.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Pokazywane są tylko noce ze zmierzoną temperaturą; w pozostałych zapisano jedynie różnicę względem wartości bazowej.</string>
+    <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">Ta noc została opracowana wyłącznie na podstawie tętna, bez zarejestrowanego ruchu, więc nie udało się zmierzyć zmienności rytmu serca ani tętna spoczynkowego. Zwykłą przyczyną jest opaska, która nie jest w pełni sparowana.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2662,4 +2662,5 @@
     <string name="l10n_settings_screen_skin_temperature_fc103030">Temperatura da pele</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">Sem temperatura medida para estas noites — a mostrar a diferença em relação à sua referência. Uma sincronização reavalia as noites recentes e preenche-a.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Só são mostradas as noites com temperatura medida; as restantes registaram apenas a diferença em relação à referência.</string>
+    <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">Esta noite foi analisada apenas a partir da frequência cardíaca, sem movimento registado, pelo que não foi possível medir a variabilidade da frequência cardíaca nem a frequência cardíaca em repouso. A causa habitual é uma pulseira que não está totalmente emparelhada.</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -2554,4 +2554,5 @@
         <item quantity="many">%1$s тренировок</item>
         <item quantity="other">%1$s тренировки</item>
     </plurals>
+    <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">Эта ночь определена только по пульсу, без записанного движения, поэтому вариабельность сердечного ритма и пульс в покое измерить не удалось. Обычная причина — ремешок, сопряжённый не полностью.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2583,4 +2583,5 @@
     <string name="l10n_settings_screen_skin_temperature_fc103030">皮肤温度</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">这些夜晚没有实测温度，显示的是与基线的差值。同步后会重新计算近期夜晚并补上。</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">仅显示有实测温度的夜晚；其余夜晚只记录了与基线的差值。</string>
+    <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">这一晚仅根据心率推算，没有记录到动作，因此无法测量心率变异性和静息心率。通常的原因是手环尚未完全配对。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2696,4 +2696,5 @@
     <string name="l10n_settings_screen_skin_temperature_fc103030">Skin temperature</string>
     <string name="l10n_health_screen_no_measured_temperature_for_these_nights_showing_the_differe_69d4efae">No measured temperature for these nights — showing the difference from your baseline. A sync re-scores recent nights and fills it in.</string>
     <string name="l10n_health_screen_only_nights_with_a_measured_temperature_are_shown_the_others_b6f7c45b">Only nights with a measured temperature are shown; the others recorded a baseline difference only.</string>
+    <string name="l10n_today_screen_this_night_was_staged_from_heart_rate_4d0f1f9b">This night was staged from heart rate alone, with no motion recorded, so HRV and resting heart rate could not be measured. A strap that is not fully paired is the usual cause.</string>
 </resources>

--- a/android/app/src/test/java/com/noop/data/DailySkinTempAbsoluteCarryTest.kt
+++ b/android/app/src/test/java/com/noop/data/DailySkinTempAbsoluteCarryTest.kt
@@ -60,4 +60,28 @@ class DailySkinTempAbsoluteCarryTest {
         // And the deviation every downstream gate reads is untouched by carrying the absolute.
         assertEquals(0.2, merged.single().skinTempDevC!!, 1e-12)
     }
+
+    // MARK: - The HR-only staging flag rides the same seams (#1801)
+
+    @Test
+    fun `the staging flag moves with the sleep block, not independently`() {
+        // The winner has no sleep at all, so the sleep block comes from the filler — and the flag
+        // describing those stage figures has to come with them. `copy()` alone would leave the winner's
+        // null in place and caption the filler's hypnogram as if its staging were unknown.
+        val winner = DailyMetric(deviceId = "a", day = "2026-09-03", restingHr = 55)
+        val filler = DailyMetric(deviceId = "b", day = "2026-09-03", totalSleepMin = 400.0,
+            deepMin = 39.0, remMin = 54.0, lightMin = 57.0, sleepHrOnly = true)
+        assertEquals(true, WhoopRepository.coalesceDay(winner, filler).sleepHrOnly)
+    }
+
+    @Test
+    fun `a winner that owns the sleep block keeps its own staging flag`() {
+        // The reverse: the winner's stages win, so its staging answer must too — taking the filler's
+        // would describe one row's hypnogram with another row's provenance.
+        val winner = DailyMetric(deviceId = "a", day = "2026-09-03", totalSleepMin = 420.0,
+            deepMin = 90.0, sleepHrOnly = false)
+        val filler = DailyMetric(deviceId = "b", day = "2026-09-03", totalSleepMin = 300.0,
+            sleepHrOnly = true)
+        assertEquals(false, WhoopRepository.coalesceDay(winner, filler).sleepHrOnly)
+    }
 }

--- a/android/app/src/test/java/com/noop/data/DailySleepHrOnlyMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/DailySleepHrOnlyMigrationTest.kt
@@ -1,0 +1,47 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * v35 -> v36 (#1801): whether every sleep session that day was staged from heart rate alone.
+ *
+ * Twin of the Swift `v42-daily-sleep-hr-only` GRDB migration.
+ *
+ * This environment has no Robolectric / Room-testing (see [AppleStepHourMigrationTest]), so the SQL is
+ * exposed as an internal constant and pinned to shape here rather than executed.
+ */
+class DailySleepHrOnlyMigrationTest {
+
+    @Test
+    fun migrationIsOneNullableAdditiveColumn() {
+        val sql = WhoopDatabase.DAILY_SLEEP_HR_ONLY_MIGRATION_SQL
+        assertEquals(listOf("ALTER TABLE `dailyMetric` ADD COLUMN `sleepHrOnly` INTEGER"), sql)
+        val upper = sql.single().uppercase()
+        assertTrue(upper.startsWith("ALTER TABLE"))
+        // Nullable and defaultless on purpose. The flag is only knowable from a re-score, and defaulting
+        // it to 0 would state "this night had motion" about every night scored before v36 — the exact
+        // false reassurance the column exists to remove.
+        assertTrue(!upper.contains("NOT NULL") && !upper.contains("DEFAULT"))
+        for (banned in listOf("DROP ", "DELETE ", "UPDATE ", "INSERT ", "RENAME ")) {
+            assertTrue("migration must not contain $banned", !upper.contains(banned))
+        }
+    }
+
+    @Test
+    fun migrationSpansTheRightVersions() {
+        assertEquals(35, WhoopDatabase.MIGRATION_35_36.startVersion)
+        assertEquals(36, WhoopDatabase.MIGRATION_35_36.endVersion)
+    }
+
+    @Test
+    fun theFlagIsTriStateAndOldRowsStayUnknown() {
+        val old = DailyMetric(deviceId = "my-whoop", day = "2026-09-03", respRateBpm = 13.3)
+        assertNull("a pre-v36 row knows nothing about its staging", old.sleepHrOnly)
+        // The three states are distinct: unknown, staged with motion, staged without.
+        assertEquals(false, old.copy(sleepHrOnly = false).sleepHrOnly)
+        assertEquals(true, old.copy(sleepHrOnly = true).sleepHrOnly)
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/HrOnlyNoteTest.kt
+++ b/android/app/src/test/java/com/noop/ui/HrOnlyNoteTest.kt
@@ -1,0 +1,49 @@
+package com.noop.ui
+
+import com.noop.data.DailyMetric
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The Recovery Vitals card's HR-only note (#1801) — when it appears, and whose night it describes.
+ *
+ * A field log showed HRV and resting HR blank for a week beside a populated respiratory rate, which reads
+ * as a failed sync. It was not: with no motion the HR-only spine stages the night and nulls both vitals on
+ * purpose. The note says so. These pin the two ways it could lie instead: appearing on a night that has
+ * its vitals, and explaining a DIFFERENT night's staging than the numbers shown.
+ */
+class HrOnlyNoteTest {
+
+    private fun day(hrOnly: Boolean?) =
+        DailyMetric(deviceId = "my-whoop", day = "2026-09-03", sleepHrOnly = hrOnly)
+
+    @Test
+    fun `shows when today was staged from heart rate alone and a vital is blank`() {
+        assertTrue(showsHrOnlyNote(day(true), null, carriedFromVitals = false, hrv = null, rhr = null))
+    }
+
+    @Test
+    fun `stays quiet when the night kept its vitals`() {
+        // Both present: nothing to explain, so the note would be noise.
+        assertFalse(showsHrOnlyNote(day(true), null, carriedFromVitals = false, hrv = 42.0, rhr = 55))
+    }
+
+    @Test
+    fun `an unknown flag earns no claim`() {
+        // Tri-state: null is "not known" (every row scored before v36), not "had motion".
+        assertFalse(showsHrOnlyNote(day(null), null, carriedFromVitals = false, hrv = null, rhr = null))
+        assertFalse(showsHrOnlyNote(day(false), null, carriedFromVitals = false, hrv = null, rhr = null))
+    }
+
+    @Test
+    fun `it describes the night the shown vitals came from, not today`() {
+        // Carried: the numbers on screen are the CARRY's, so the note must read the carry's flag.
+        assertTrue(showsHrOnlyNote(day(null), day(true), carriedFromVitals = true, hrv = null, rhr = null))
+        // And the reverse — today's own blank night must not be explained by a carry that had motion.
+        assertFalse(showsHrOnlyNote(day(false), day(true), carriedFromVitals = false, hrv = null, rhr = null))
+        // The bug this shape avoids: `day?.sleepHrOnly ?: vitalsDay?.sleepHrOnly` would fall through on a
+        // pre-v36 today and stamp the carry's staging onto today's numbers.
+        assertFalse(showsHrOnlyNote(day(null), day(true), carriedFromVitals = false, hrv = null, rhr = null))
+    }
+}

--- a/android/app/src/test/resources/schema_oracle.json
+++ b/android/app/src/test/resources/schema_oracle.json
@@ -42,7 +42,8 @@
     "v38-apple-step-hour",
     "v39-ppg-burst-index",
     "v40-daily-skin-temp-absolute",
-    "v41-drop-raw-imu-sample"
+    "v41-drop-raw-imu-sample",
+    "v42-daily-sleep-hr-only"
   ],
   "divergenceReasons": {
     "android-orphan-synced-column": "REAL COLUMN DRIFT: `synced` exists on Android only. GRDB's v10 note is explicit that stepSample gets no `synced` column ('unused; see StreamStore'), and v12's ppgHrSample never had one either; the Room entities copied the flag from the older per-second entities. Nothing reads it on Android — the per-row upload flag belongs to an upload path that does not exist there — so it is dead width, not divergent data. Removing it needs a Room table rebuild.",

--- a/android/app/src/test/resources/schema_oracle.json
+++ b/android/app/src/test/resources/schema_oracle.json
@@ -1,6 +1,6 @@
 {
   "_readme": "SHARED Room<->GRDB SCHEMA ORACLE (#775). Two byte-identical copies: Packages/WhoopStore/Tests/WhoopStoreTests/Resources/schema_oracle.json and android/app/src/test/resources/schema_oracle.json. SchemaOracleTests.swift compares GRDB's PRAGMA table_info/index_list against it; SchemaOracleTest.kt compares Room's exported schema JSON against it. `columns` is the iOS/GRDB shape in GRDB column order (macOS is the reference implementation); every way Android differs is spelled out in an `android` / `iosAbsent` / `androidColumnOrder` override naming a key in `divergenceReasons`. Adding a column, reordering one, or changing a type/nullability on one platform only fails both suites until it is either fixed or written down here.",
-  "roomVersion": 35,
+  "roomVersion": 36,
   "grdbMigrations": [
     "v1",
     "v2",
@@ -372,6 +372,16 @@
           "affinity": "REAL",
           "notNull": false,
           "default": null
+        },
+        {
+          "name": "sleepHrOnly",
+          "affinity": "NUMERIC",
+          "notNull": false,
+          "default": null,
+          "android": {
+            "affinity": "INTEGER"
+          },
+          "divergence": "grdb-boolean-affinity"
         }
       ],
       "primaryKey": [


### PR DESCRIPTION
From a screenshot: **Heart-rate variability — No data. Resting heart rate — No data. Breaths per minute — 13.3 rpm.** Same card, same night.

Nothing was broken. With no motion banked, the HR-only spine stages the night and builds its sessions with `restingHR = null, avgHRV = null, hrOnly = true` **on purpose** — bounds inferred from heart rate alone are not firm enough to hang a resting HR or a nightly RMSSD on. `AnalyticsEngine` then gates exactly those two on `matched.filter { !it.hrOnly }`, while respiratory survives because for a WHOOP owner it is an RSA estimate off R-R. Every metric on that card was behaving correctly, and the card had no way to say so — which reads as a failed sync.

It now explains itself.

## Where the flag lives

Recorded where the condition is evaluated, using the same expression that empties the two fields:

```kotlin
sleepHrOnly = if (matched.isEmpty()) null else physiologySessions.isEmpty()
```

Re-deriving it in the UI would create a second definition that can disagree with the values it explains.

## Both platforms, deliberately

`sleepHrOnly` is added by Room `MIGRATION_35_36` **and** the GRDB twin `v42-daily-sleep-hr-only`, with the shared oracle updated in both committed copies (verified byte-identical in the commit).

`sleepSession.stagingSparse` is the precedent — a staging-quality flag carried for exactly this "caption a degraded night" purpose, present on both sides with no divergence marker. Android-only columns in the oracle are labelled *"REAL COLUMN DRIFT — literally the case #775 was filed about"*, so shipping this one-sided would have added a row to the list that issue exists to shrink. The affinity difference (`NUMERIC` on GRDB, `INTEGER` on Room for a Boolean) reuses the existing `grdb-boolean-affinity` reason rather than inventing one.

**Update — Apple now populates it too.** Apple already had the identical gate (`AnalyticsEngine.swift:686`), so it nulls the same two vitals on the same nights; it just never recorded why. The writer is the byte-identical twin of the Kotlin line. Only the Apple *card* is still unwired, which is UI and platform-specific by contract.

## Tri-state, not a boolean

Nullable, no default, no backfill. Every row scored before v36 stays null and reads as *not known*. Defaulting to `0` would assert "this night had motion" about every historical night — the exact false reassurance the column exists to remove. `showsHrOnlyNote` tests `== true`, so unknown earns no claim either way.

## The note describes the right night

It reads the flag from the row the shown vitals came from, reusing `carriedFromVitals` — the same decision the date caption already makes. The obvious shorthand is wrong:

```kotlin
day?.sleepHrOnly ?: vitalsDay?.sleepHrOnly   // falls through on a pre-v36 today,
                                             // stamping the carry's staging onto today's numbers
```

That case is pinned by a test. The decision is a pure function so the rule is tested rather than asserted.

## Verification

- **Full Android suite: 630 classes, 5172 tests, 0 failures** — forced with `--rerun-tasks`, and I checked all 630 result XMLs were written in the last five minutes rather than trusting a 10-second "BUILD SUCCESSFUL" over stale files.
- `SchemaOracleTest` (4) confirms Room's generated schema matches the updated oracle; `WhoopDatabaseMigrationChainTest` (4) confirms no holes to 36. New `DailySleepHrOnlyMigrationTest` (3) pins the SQL shape, the version span, and the tri-state; new `HrOnlyNoteTest` (4) pins when the note shows and whose night it describes.
- All three version numbers agree: `@Database(version = 36)`, `SCHEMA_VERSION = 36`, `MIGRATION_35_36` registered in `ALL_MIGRATIONS`.
- `lintVitalFullRelease -PstagingRelease` clean — the fatal `ExtraTranslation` gate that compile and the i18n audit both miss. `i18n_audit.py --ci` and `doc_comment_lint.py` clean.
- Both Swift files pass `swiftc -parse`. The package tests need macOS, so `swift-packages.yml` is what actually verifies the GRDB half.
- New string added to all 8 locale files with a key derived by the repo's own algorithm.

**Not verified on a device**, and the Swift half is not verified by me at all — CI owns that.

## Caught in re-review

The Swift upsert had **23 columns against 22 placeholders** after I added the field — every daily-metric write on Apple would have failed. Counted programmatically and fixed; the column list, placeholders and bound arguments are now all 23.

## Not done here

- `PushDao.DAILY` enumerates columns explicitly and already omits `avgSdnn` and `skinTempC`. Leaving `sleepHrOnly` out is consistent with that rather than a new gap, but it is now a list of three. Worth its own look.
- Apple's card still shows a bare `No data`; the column is there when someone wants to wire it.
- None of this restores anyone's HRV. Groundwork for #1801, and the usual cause is a strap that is not fully paired.

## What re-review found after the first push

Four rounds, and every finding was on the persistence side — none of them things a compiler can see, because all of them are "a field nobody mentioned".

1. **SQL arity.** After adding the field, the Swift upsert had 23 columns against 22 placeholders — every daily-metric write on Apple would have failed. Counted programmatically.
2. **`grdbMigrations`.** The oracle pins the schema in *three* places and I updated two; `v42-daily-sleep-hr-only` was registered in `Database.swift` but absent from the oracle's migration roster. **CI caught this, I did not** — the Kotlin `SchemaOracleTest` cannot see the GRDB roster, so the Android suite stayed green.
3. **Four rebuild seams.** `DailyMetric` is a Swift struct with no `copy()`, so every rebuild respells the field list. The codebase warns about this directly above the helpers: *"the seams a new DailyMetric column is most easily dropped at"*. The scoring rebuild is on the persistence path, so without it the Swift writer would have computed the flag and discarded it before the database — correct-looking, compiling, and inert.
4. **A fifth seam, found by sweeping rather than by induction.** `coalesceDay` builds the struct itself. It moves columns that only mean something together as a **group**, and the flag describes the stage figures, so it belongs to the sleep group — a plain `winner ?? filler` would caption one row's hypnogram with another row's staging. **Kotlin had the same bug inverted**: its `coalesceDay` is a `winner.copy()`, so the flag was not dropped but silently inherited the *winner's* value even when the whole sleep block came from the filler. Not a crash, just quietly wrong, and a divergence from the Swift twin it is documented as.

`.copy()` cuts both ways: it saved Kotlin at the four `with(...)`-style seams and hid the bug at the fifth. That asymmetry is why every defect here landed on the half I cannot execute.

Seam sweep is now exhaustive — every other function that returns a `DailyMetric` *selects* an existing row rather than rebuilding one.

Final local state: **630 classes, 5174 tests, 0 failures**, all freshly rerun; `i18n_audit --ci`, `doc_comment_lint` and `lintVitalFullRelease -PstagingRelease` clean.
