### PR TITLE
connection: say which streams actually banked on a finished link

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
@@ -302,6 +302,36 @@ public enum ConnectionReadout {
         return line
     }
 
+    /// #1635: which STREAMS banked rows on a finished link, beside `linkEpitaph`'s "did anything arrive".
+    ///
+    /// The epitaph counts frames, which is the right measure for a silent strap and the wrong one for a
+    /// strap talking over only part of its surface: an unbonded 5/MG streams heart rate and R-R over the
+    /// standard profile all night while every bond-gated stream banks nothing, and the epitaph reports
+    /// that as hundreds of healthy inbound frames. A field diagnosis had to establish the split by
+    /// exporting twice, hours apart, and diffing stored row counts by hand.
+    ///
+    /// Zero-banking streams are named rather than left to be inferred, because "gravity=0 among six other
+    /// zeros" and "gravity=0 while hr=456" read identically and mean opposite things. Counts are ROWS
+    /// ACCEPTED, so a stream arriving as duplicates reads zero and is named — correct here: the question
+    /// is what the database gained on this link.
+    ///
+    /// Pure and total, and every count clamped, so it cannot become the reason a teardown path throws.
+    /// Twin of the Kotlin formatter. Apple does not emit it yet; the formatter exists so the two logs
+    /// cannot drift apart when it does.
+    public static func linkBankedSummary(hr: Int, rr: Int, gravity: Int, resp: Int,
+                                         skinTemp: Int, spo2: Int, steps: Int, battery: Int) -> String {
+        let pairs: [(String, Int)] = [
+            ("hr", hr), ("rr", rr), ("gravity", gravity), ("resp", resp),
+            ("skinTemp", skinTemp), ("spo2", spo2), ("steps", steps), ("battery", battery),
+        ].map { ($0.0, max(0, $0.1)) }
+        let body = pairs.map { "\($0.0)=\($0.1)" }.joined(separator: " ")
+        let total = pairs.reduce(0) { $0 + $1.1 }
+        if total == 0 { return "banked this link: \(body) - NOTHING was stored on this link" }
+        let empty = pairs.filter { $0.1 == 0 }.map { $0.0 }
+        if empty.isEmpty { return "banked this link: \(body)" }
+        return "banked this link: \(body) - nothing banked for: \(empty.joined(separator: ", "))"
+    }
+
     /// #987: freshness label for the "last frame" readout row: how long ago the most recent strap frame
     /// was routed ("12s ago"), or "no frames yet" before the first one. `nowUnix` injected for testability.
     public static func lastFrameLabel(lastFrameUnix: Int?, nowUnix: Int) -> String {

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
@@ -322,12 +322,20 @@ public enum ConnectionReadout {
     /// Pure and total, and every count clamped, so it cannot become the reason a teardown path throws.
     /// Twin of the Kotlin formatter. Apple does not emit it yet; the formatter exists so the two logs
     /// cannot drift apart when it does.
+    /// `steps` is OPTIONAL because this platform's store does not return a step count at all — steps are
+    /// persist-only here, deliberately outside the 8-field insert tuple, while Room counts them. A
+    /// platform that cannot measure a stream must OMIT it rather than report zero: "banked nothing" is a
+    /// finding and "not measured here" is not, and printing the second as the first would put a permanent
+    /// false alarm in every Apple link's log.
     public static func linkBankedSummary(hr: Int, rr: Int, gravity: Int, resp: Int,
-                                         skinTemp: Int, spo2: Int, steps: Int, battery: Int) -> String {
-        let pairs: [(String, Int)] = [
+                                         skinTemp: Int, spo2: Int, steps: Int?, battery: Int) -> String {
+        var raw: [(String, Int)] = [
             ("hr", hr), ("rr", rr), ("gravity", gravity), ("resp", resp),
-            ("skinTemp", skinTemp), ("spo2", spo2), ("steps", steps), ("battery", battery),
-        ].map { ($0.0, max(0, $0.1)) }
+            ("skinTemp", skinTemp), ("spo2", spo2),
+        ]
+        if let steps { raw.append(("steps", steps)) }
+        raw.append(("battery", battery))
+        let pairs: [(String, Int)] = raw.map { ($0.0, max(0, $0.1)) }
         let body = pairs.map { "\($0.0)=\($0.1)" }.joined(separator: " ")
         let total = pairs.reduce(0) { $0 + $1.1 }
         if total == 0 { return "banked live this link: \(body) - NOTHING was stored from the live streams" }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
@@ -315,6 +315,10 @@ public enum ConnectionReadout {
     /// ACCEPTED, so a stream arriving as duplicates reads zero and is named — correct here: the question
     /// is what the database gained on this link.
     ///
+    /// LIVE streams only, and the sentence says so. The history offload persists through its own path and
+    /// already has its own accounting; counting one and labelling it "this link" would make every healthy
+    /// bonded sync read as "nothing banked for: gravity" — the false alarm this line exists to prevent.
+    ///
     /// Pure and total, and every count clamped, so it cannot become the reason a teardown path throws.
     /// Twin of the Kotlin formatter. Apple does not emit it yet; the formatter exists so the two logs
     /// cannot drift apart when it does.
@@ -326,10 +330,10 @@ public enum ConnectionReadout {
         ].map { ($0.0, max(0, $0.1)) }
         let body = pairs.map { "\($0.0)=\($0.1)" }.joined(separator: " ")
         let total = pairs.reduce(0) { $0 + $1.1 }
-        if total == 0 { return "banked this link: \(body) - NOTHING was stored on this link" }
+        if total == 0 { return "banked live this link: \(body) - NOTHING was stored from the live streams" }
         let empty = pairs.filter { $0.1 == 0 }.map { $0.0 }
-        if empty.isEmpty { return "banked this link: \(body)" }
-        return "banked this link: \(body) - nothing banked for: \(empty.joined(separator: ", "))"
+        if empty.isEmpty { return "banked live this link: \(body)" }
+        return "banked live this link: \(body) - nothing banked live for: \(empty.joined(separator: ", "))"
     }
 
     /// #987: freshness label for the "last frame" readout row: how long ago the most recent strap frame

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LinkBankedSummaryTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LinkBankedSummaryTests.swift
@@ -45,4 +45,13 @@ final class LinkBankedSummaryTests: XCTestCase {
             "banked live this link: hr=456 rr=187 gravity=0 resp=0 skinTemp=0 spo2=0 steps=0 battery=2"
                 + " - nothing banked live for: gravity, resp, skinTemp, spo2, steps")
     }
+
+
+    /// Apple's store does not return a step count, so the line must omit steps rather than print zero.
+    func testAStreamThisPlatformCannotMeasureIsOmittedNotZero() {
+        let line = ConnectionReadout.linkBankedSummary(
+            hr: 456, rr: 187, gravity: 0, resp: 0, skinTemp: 0, spo2: 0, steps: nil, battery: 2)
+        XCTAssertFalse(line.contains("steps"), "an unmeasured stream must not appear at all")
+        XCTAssertTrue(line.contains("nothing banked live for: gravity, resp, skinTemp, spo2"))
+    }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LinkBankedSummaryTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LinkBankedSummaryTests.swift
@@ -13,21 +13,21 @@ final class LinkBankedSummaryTests: XCTestCase {
             hr: 456, rr: 187, gravity: 0, resp: 0, skinTemp: 0, spo2: 0, steps: 0, battery: 2)
         XCTAssertTrue(line.contains("hr=456"))
         XCTAssertTrue(line.contains("gravity=0"))
-        XCTAssertTrue(line.contains("nothing banked for: gravity, resp, skinTemp, spo2, steps"))
+        XCTAssertTrue(line.contains("nothing banked live for: gravity, resp, skinTemp, spo2, steps"))
     }
 
     func testAFullyHealthyLinkGetsNoCallOut() {
         let line = ConnectionReadout.linkBankedSummary(
             hr: 400, rr: 380, gravity: 900, resp: 900, skinTemp: 900, spo2: 900, steps: 12, battery: 3)
-        XCTAssertTrue(line.hasPrefix("banked this link:"))
-        XCTAssertFalse(line.contains("nothing banked for"))
+        XCTAssertTrue(line.hasPrefix("banked live this link:"))
+        XCTAssertFalse(line.contains("nothing banked live for"))
     }
 
     func testALinkThatStoredNothingSaysSoOnce() {
         let line = ConnectionReadout.linkBankedSummary(
             hr: 0, rr: 0, gravity: 0, resp: 0, skinTemp: 0, spo2: 0, steps: 0, battery: 0)
-        XCTAssertTrue(line.contains("NOTHING was stored on this link"))
-        XCTAssertFalse(line.contains("nothing banked for"))
+        XCTAssertTrue(line.contains("NOTHING was stored from the live streams"))
+        XCTAssertFalse(line.contains("nothing banked live for"))
     }
 
     func testNegativeCountsCannotLeakIntoADiagnostic() {
@@ -42,7 +42,7 @@ final class LinkBankedSummaryTests: XCTestCase {
         XCTAssertEqual(
             ConnectionReadout.linkBankedSummary(
                 hr: 456, rr: 187, gravity: 0, resp: 0, skinTemp: 0, spo2: 0, steps: 0, battery: 2),
-            "banked this link: hr=456 rr=187 gravity=0 resp=0 skinTemp=0 spo2=0 steps=0 battery=2"
-                + " - nothing banked for: gravity, resp, skinTemp, spo2, steps")
+            "banked live this link: hr=456 rr=187 gravity=0 resp=0 skinTemp=0 spo2=0 steps=0 battery=2"
+                + " - nothing banked live for: gravity, resp, skinTemp, spo2, steps")
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LinkBankedSummaryTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LinkBankedSummaryTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// #1635: the per-link banked-rows line, the database-side companion to `linkEpitaph`.
+///
+/// Byte-identical twin of the Kotlin `LinkBankedSummaryTest`. The case it exists for: an unbonded 5/MG
+/// streams heart rate and R-R over the standard profile while every bond-gated stream banks nothing, and
+/// the epitaph reports that link as hundreds of healthy inbound frames.
+final class LinkBankedSummaryTests: XCTestCase {
+
+    func testNamesTheStreamsThatBankedNothingWhenOthersDid() {
+        let line = ConnectionReadout.linkBankedSummary(
+            hr: 456, rr: 187, gravity: 0, resp: 0, skinTemp: 0, spo2: 0, steps: 0, battery: 2)
+        XCTAssertTrue(line.contains("hr=456"))
+        XCTAssertTrue(line.contains("gravity=0"))
+        XCTAssertTrue(line.contains("nothing banked for: gravity, resp, skinTemp, spo2, steps"))
+    }
+
+    func testAFullyHealthyLinkGetsNoCallOut() {
+        let line = ConnectionReadout.linkBankedSummary(
+            hr: 400, rr: 380, gravity: 900, resp: 900, skinTemp: 900, spo2: 900, steps: 12, battery: 3)
+        XCTAssertTrue(line.hasPrefix("banked this link:"))
+        XCTAssertFalse(line.contains("nothing banked for"))
+    }
+
+    func testALinkThatStoredNothingSaysSoOnce() {
+        let line = ConnectionReadout.linkBankedSummary(
+            hr: 0, rr: 0, gravity: 0, resp: 0, skinTemp: 0, spo2: 0, steps: 0, battery: 0)
+        XCTAssertTrue(line.contains("NOTHING was stored on this link"))
+        XCTAssertFalse(line.contains("nothing banked for"))
+    }
+
+    func testNegativeCountsCannotLeakIntoADiagnostic() {
+        let line = ConnectionReadout.linkBankedSummary(
+            hr: -5, rr: 1, gravity: 0, resp: 0, skinTemp: 0, spo2: 0, steps: 0, battery: 0)
+        XCTAssertTrue(line.contains("hr=0"))
+        XCTAssertFalse(line.contains("-5"))
+    }
+
+    /// The two platforms must produce the SAME sentence, since a report may come from either.
+    func testTheExactSentenceForTheFieldCase() {
+        XCTAssertEqual(
+            ConnectionReadout.linkBankedSummary(
+                hr: 456, rr: 187, gravity: 0, resp: 0, skinTemp: 0, spo2: 0, steps: 0, battery: 2),
+            "banked this link: hr=456 rr=187 gravity=0 resp=0 skinTemp=0 spo2=0 steps=0 battery=2"
+                + " - nothing banked for: gravity, resp, skinTemp, spo2, steps")
+    }
+}

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -732,6 +732,17 @@ public final class BLEManager: NSObject, ObservableObject {
     private var inboundFrames = 0
     private var inboundBytes = 0
     private var cmdChannelFrames = 0
+    /// #1635: rows ACCEPTED per stream on this link — the database-side companion to the three above.
+    /// The epitaph counts frames, which reads healthy on an unbonded 5/MG streaming heart rate over the
+    /// standard profile while every bond-gated stream banks nothing. Cleared with them, so they describe
+    /// THIS link. Plain vars like their neighbours: `Collector` hands them up on the main actor.
+    private var bankedHr = 0
+    private var bankedRr = 0
+    private var bankedGravity = 0
+    private var bankedResp = 0
+    private var bankedSkinTemp = 0
+    private var bankedSpo2 = 0
+    private var bankedBattery = 0
     /// Uptime clock for the epitaph. Monotonic, so a wall-clock change mid-link cannot make it negative.
     private var linkUpSince: DispatchTime?
     /// Last time ANY notification arrived — drives the liveness watchdog.
@@ -1344,7 +1355,14 @@ public final class BLEManager: NSObject, ObservableObject {
         let enableRawCapture = UserDefaults.standard.bool(forKey: "enableRawCapture")
         collector = Collector(store: store, deviceId: deviceId,
                               enableRawCapture: enableRawCapture,
-                              log: { [weak self] line in self?.log(line) })
+                              log: { [weak self] line in self?.log(line) },
+                              onBanked: { [weak self] c in
+                                  guard let self else { return }
+                                  self.bankedHr += c.hr; self.bankedRr += c.rr
+                                  self.bankedGravity += c.gravity; self.bankedResp += c.resp
+                                  self.bankedSkinTemp += c.skinTemp; self.bankedSpo2 += c.spo2
+                                  self.bankedBattery += c.battery
+                              })
         // The store can finish bootstrapping AFTER connect(model:) already ran (both wait on
         // poweredOn), so apply the family/clock configuration here too — whichever runs last wins.
         configureCollectorFamily()
@@ -5399,9 +5417,18 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
             log(ConnectionReadout.linkEpitaph(upMillis: upMs, inboundFrames: inboundFrames,
                                               inboundBytes: inboundBytes, cmdChannelFrames: cmdChannelFrames,
                                               realtimeArmed: realtimeArmedAt != nil, ended: endedReason))
+            // #1635: LIVE streams only — the offload persists through `Backfiller` and has its own
+            // accounting, so folding it in would make a healthy bonded sync read as "nothing banked live
+            // for: gravity". Inside the same `linkUpSince` guard for the same reason the epitaph is.
+            log(ConnectionReadout.linkBankedSummary(
+                hr: bankedHr, rr: bankedRr, gravity: bankedGravity, resp: bankedResp,
+                // nil, not 0: this store does not return a step count, and a zero would read as a fault.
+                skinTemp: bankedSkinTemp, spo2: bankedSpo2, steps: nil, battery: bankedBattery))
         }
         // Clear the tally with the link, so a second teardown for the same drop cannot re-report it.
         inboundFrames = 0; inboundBytes = 0; cmdChannelFrames = 0
+        bankedHr = 0; bankedRr = 0; bankedGravity = 0; bankedResp = 0
+        bankedSkinTemp = 0; bankedSpo2 = 0; bankedBattery = 0
         linkUpSince = nil
 
         let timedOut = !intentionalDisconnect && error != nil

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -5259,6 +5259,11 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         // #1809: this link's inbound tally starts empty; the epitaph on disconnect reports exactly what
         // arrived between here and there.
         inboundFrames = 0; inboundBytes = 0; cmdChannelFrames = 0
+        // #1635: same guarantee for the banked tally. Clearing only on teardown would be enough if every
+        // link ended in one, and a link that begins without a preceding clean teardown would otherwise
+        // open holding the previous link's rows — reporting them as banked on a link that never saw them.
+        bankedHr = 0; bankedRr = 0; bankedGravity = 0; bankedResp = 0
+        bankedSkinTemp = 0; bankedSpo2 = 0; bankedBattery = 0
         linkUpSince = DispatchTime.now()
         standingConnectAt = nil     // #1413: a live link means no standing connect is outstanding
         restoredPeripheral = nil

--- a/Strand/Collect/Collector.swift
+++ b/Strand/Collect/Collector.swift
@@ -70,6 +70,11 @@ final class Collector {
     /// #1118: strap-log sink for the per-transport R-R census. Optional and defaulted to nil so the
     /// test fakes that construct a Collector are untouched; `BLEManager` wires its own `log`.
     private let log: ((String) -> Void)?
+    /// #1635: rows ACCEPTED per stream, handed up so `BLEManager` can tally them per LINK and say which
+    /// streams banked when it writes the link epitaph. The counts already exist — `StreamStore.insert`
+    /// returns them and the standard-HR path already binds them for its own trace line — so this carries
+    /// a measurement that was being discarded, rather than taking a new one.
+    private let onBanked: ((BankedCounts) -> Void)?
     /// #1118: last emit of each LIVE census line, unix seconds; 0 = never. Rate-limited — see
     /// `RrEmissionStats.shouldEmitLiveCensus`.
     ///
@@ -107,15 +112,22 @@ final class Collector {
     private var batchStartedAt: TimeInterval
     var bufferedCount: Int { buffer.count }
 
+    /// The per-stream accepted-row counts `StreamStore.insert` returns, named so the closure that carries
+    /// them is readable at both ends.
+    typealias BankedCounts = (hr: Int, rr: Int, events: Int, battery: Int,
+                              spo2: Int, skinTemp: Int, resp: Int, gravity: Int)
+
     init(store: StoreWriting, deviceId: String,
          policy: CollectorPolicy = .default,
          enableRawCapture: Bool = false,
          log: ((String) -> Void)? = nil,
+         onBanked: ((BankedCounts) -> Void)? = nil,
          now: @escaping () -> Int = { Int(Date().timeIntervalSince1970) },
          monotonic: @escaping () -> TimeInterval = { Date().timeIntervalSinceReferenceDate }) {
         self.store = store; self.deviceId = deviceId; self.policy = policy
         self.enableRawCapture = enableRawCapture
         self.log = log
+        self.onBanked = onBanked
         self.now = now; self.monotonic = monotonic
         self.batchStartedAt = monotonic()
         self.concreteStore = store as? WhoopStore
@@ -229,8 +241,9 @@ final class Collector {
             }
         }
         do {
-            try await store.insert(streams, deviceId: deviceId)   // DECODED FIRST (durable)
+            let inserted = try await store.insert(streams, deviceId: deviceId)   // DECODED FIRST (durable)
             realtimeInsertFailures = 0
+            onBanked?(inserted)
         } catch {
             // Re-buffer at the front so these frames (and their parses) are retried on the next cadence.
             buffer.insert(contentsOf: batch, at: 0)
@@ -318,6 +331,7 @@ final class Collector {
         do {
             let inserted = try await store.insert(Streams(hr: hr, rr: rr, events: contact), deviceId: deviceId)
             stdInsertFailures = 0
+            onBanked?(inserted)
             log?(LivePersistTrace.standardHRFlushSucceededLine(
                 reason: reason, offeredHRRows: hr.count, offeredRRRows: rr.count,
                 insertedHRRows: inserted.hr, insertedRRRows: inserted.rr))

--- a/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
@@ -282,6 +282,39 @@ object ConnectionReadout {
         return line
     }
 
+    /**
+     * #1635: which STREAMS banked rows on a finished link, beside [linkEpitaph]'s "did anything arrive".
+     *
+     * The epitaph counts frames. That is the right measure for a silent strap, and the wrong one for a
+     * strap that is talking but only over part of its surface: an unbonded 5/MG streams heart rate and R-R
+     * over the standard profile all night while the bond-gated streams bank nothing, and the epitaph
+     * reports that as hundreds of healthy inbound frames. A field diagnosis had to establish the split by
+     * exporting twice, hours apart, and diffing the stored row counts by hand — the two logs each looked
+     * fine on their own. One line states it.
+     *
+     * Zero-banking streams are named explicitly rather than left to be inferred from a list of numbers,
+     * because "gravity=0 sitting among six other zeros" and "gravity=0 while hr=456" are the same text and
+     * opposite findings. Counts are ROWS ACCEPTED, so a stream that arrived as duplicates reads zero and
+     * is named — correct for this purpose: the question is what the database gained on this link.
+     *
+     * Pure and total: no clock, no I/O, and every count clamped, so it cannot itself become the reason a
+     * teardown path throws. Twin of the Swift formatter.
+     */
+    fun linkBankedSummary(
+        hr: Int, rr: Int, gravity: Int, resp: Int, skinTemp: Int, spo2: Int, steps: Int, battery: Int,
+    ): String {
+        val pairs = listOf(
+            "hr" to hr, "rr" to rr, "gravity" to gravity, "resp" to resp,
+            "skinTemp" to skinTemp, "spo2" to spo2, "steps" to steps, "battery" to battery,
+        ).map { (k, v) -> k to maxOf(0, v) }
+        val body = pairs.joinToString(" ") { (k, v) -> "$k=$v" }
+        val total = pairs.sumOf { it.second }
+        if (total == 0) return "banked this link: $body - NOTHING was stored on this link"
+        val empty = pairs.filter { it.second == 0 }.map { it.first }
+        if (empty.isEmpty()) return "banked this link: $body"
+        return "banked this link: $body - nothing banked for: ${empty.joinToString(", ")}"
+    }
+
     /** #987: freshness label for the "last frame" readout row ("12s ago" / "no frames yet"). [nowUnix]
      *  injected for testability. Twin of the Swift labeller. */
     fun lastFrameLabel(lastFrameUnix: Long?, nowUnix: Long): String {

--- a/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
@@ -297,6 +297,12 @@ object ConnectionReadout {
      * opposite findings. Counts are ROWS ACCEPTED, so a stream that arrived as duplicates reads zero and
      * is named — correct for this purpose: the question is what the database gained on this link.
      *
+     * LIVE streams only, and the sentence says so. The history offload persists through its own path
+     * (`Backfiller`) and already has its own accounting — `bankedSensorRecords`, `rowsPersisted`, the
+     * completed-offload classification. Counting one and labelling it "this link" would make every healthy
+     * bonded sync that banked its gravity through the offload read as "nothing banked for: gravity", which
+     * is the false alarm this line exists to make impossible. A narrow true claim beats a broad wrong one.
+     *
      * Pure and total: no clock, no I/O, and every count clamped, so it cannot itself become the reason a
      * teardown path throws. Twin of the Swift formatter.
      */
@@ -309,10 +315,10 @@ object ConnectionReadout {
         ).map { (k, v) -> k to maxOf(0, v) }
         val body = pairs.joinToString(" ") { (k, v) -> "$k=$v" }
         val total = pairs.sumOf { it.second }
-        if (total == 0) return "banked this link: $body - NOTHING was stored on this link"
+        if (total == 0) return "banked live this link: $body - NOTHING was stored from the live streams"
         val empty = pairs.filter { it.second == 0 }.map { it.first }
-        if (empty.isEmpty()) return "banked this link: $body"
-        return "banked this link: $body - nothing banked for: ${empty.joinToString(", ")}"
+        if (empty.isEmpty()) return "banked live this link: $body"
+        return "banked live this link: $body - nothing banked live for: ${empty.joinToString(", ")}"
     }
 
     /** #987: freshness label for the "last frame" readout row ("12s ago" / "no frames yet"). [nowUnix]

--- a/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
@@ -307,12 +307,18 @@ object ConnectionReadout {
      * teardown path throws. Twin of the Swift formatter.
      */
     fun linkBankedSummary(
-        hr: Int, rr: Int, gravity: Int, resp: Int, skinTemp: Int, spo2: Int, steps: Int, battery: Int,
+        hr: Int, rr: Int, gravity: Int, resp: Int, skinTemp: Int, spo2: Int, steps: Int?, battery: Int,
     ): String {
-        val pairs = listOf(
+        // [steps] is NULLABLE because Apple's store does not return a step count at all — steps are
+        // persist-only there, deliberately outside its 8-field insert tuple, while Room counts them. A
+        // platform that cannot measure a stream must OMIT it, not report zero: "banked nothing" is a
+        // finding and "not measured here" is not, and printing the second as the first would put a
+        // permanent false alarm in every Apple link's log.
+        val pairs = (listOf(
             "hr" to hr, "rr" to rr, "gravity" to gravity, "resp" to resp,
-            "skinTemp" to skinTemp, "spo2" to spo2, "steps" to steps, "battery" to battery,
-        ).map { (k, v) -> k to maxOf(0, v) }
+            "skinTemp" to skinTemp, "spo2" to spo2,
+        ) + listOfNotNull(steps?.let { "steps" to it }) + listOf("battery" to battery))
+            .map { (k, v) -> k to maxOf(0, v) }
         val body = pairs.joinToString(" ") { (k, v) -> "$k=$v" }
         val total = pairs.sumOf { it.second }
         if (total == 0) return "banked live this link: $body - NOTHING was stored from the live streams"

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -26,6 +26,7 @@ import android.os.SystemClock
 import android.util.Log
 import com.noop.NoopApplication
 import com.noop.data.HrRow
+import com.noop.data.InsertCounts
 import com.noop.data.RrRow
 import com.noop.data.EventEntry
 import com.noop.data.StandardHrMapping
@@ -6724,6 +6725,25 @@ class WhoopBleClient(
     private var inboundFrames = 0
     private var inboundBytes = 0
     private var cmdChannelFrames = 0
+
+    // #1635: rows ACCEPTED per stream on this link, the database-side twin of the frame counters above.
+    // Cleared with them on teardown. Written only from the collector coroutines that already own the
+    // insert calls, so they inherit that serialization rather than adding their own.
+    private var bankedHr = 0
+    private var bankedRr = 0
+    private var bankedGravity = 0
+    private var bankedResp = 0
+    private var bankedSkinTemp = 0
+    private var bankedSpo2 = 0
+    private var bankedSteps = 0
+    private var bankedBattery = 0
+
+    /** Fold one persist round's accepted-row counts into the per-link tally. */
+    private fun addBanked(c: InsertCounts) {
+        bankedHr += c.hr; bankedRr += c.rr; bankedGravity += c.gravity; bankedResp += c.resp
+        bankedSkinTemp += c.skinTemp; bankedSpo2 += c.spo2; bankedSteps += c.steps
+        bankedBattery += c.battery
+    }
     /** #1809: was realtime armed at ANY point on THIS link. Not the same thing as [realtimeArmed], which
      *  is persistent edge state: it can carry true in from a previous link, or read false at the drop
      *  after a mid-link disarm. The epitaph needs the per-link fact, which is what the Apple twin's
@@ -9051,7 +9071,7 @@ class WhoopBleClient(
         }
         if (!batch.isEmpty) {
             try {
-                repository.insert(batch, deviceId)
+                addBanked(repository.insert(batch, deviceId))
                 liveInsertFailuresRealtime.set(0)
             } catch (t: Throwable) {
                 // Re-buffer at the front so these frames retry on the next cadence (port of Collector).
@@ -9134,7 +9154,7 @@ class WhoopBleClient(
             }
         }
         try {
-            repository.insert(StreamBatch(hr = hr, rr = rr, events = contact), deviceId)
+            addBanked(repository.insert(StreamBatch(hr = hr, rr = rr, events = contact), deviceId))
             liveInsertFailuresStd.set(0)
         } catch (t: Throwable) {
             synchronized(collectorLock) {
@@ -9986,9 +10006,20 @@ class WhoopBleClient(
                 // before handleDisconnect runs and is not reassigned above, so it is valid here.
                 ended = if (intentionalDisconnect) "intentional" else "status=$status",
             ))
+            // #1635: what the DATABASE gained, beside what the radio carried. An unbonded 5/MG keeps the
+            // epitaph looking healthy — hundreds of inbound frames — while every bond-gated stream banks
+            // nothing, and that split is invisible in a single export. Guarded by the SAME `linkUpSinceMs`
+            // as the epitaph: on a failed connect attempt the counters hold the previous link's tally, and
+            // reporting them here would describe a link that never existed.
+            log(ConnectionReadout.linkBankedSummary(
+                hr = bankedHr, rr = bankedRr, gravity = bankedGravity, resp = bankedResp,
+                skinTemp = bankedSkinTemp, spo2 = bankedSpo2, steps = bankedSteps, battery = bankedBattery,
+            ), com.noop.testcentre.TestDomain.CONNECTION)
         }
         // Clear the tally with the link, so a second teardown for the same drop cannot re-report it.
         inboundFrames = 0; inboundBytes = 0; cmdChannelFrames = 0
+        bankedHr = 0; bankedRr = 0; bankedGravity = 0; bankedResp = 0
+        bankedSkinTemp = 0; bankedSpo2 = 0; bankedSteps = 0; bankedBattery = 0
 
         val heldSuffix = heldForLogSuffix()
         linkUpSinceMs = null

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -6198,6 +6198,11 @@ class WhoopBleClient(
                     // #1809: this link's inbound tally starts empty, so the epitaph on disconnect reports
                     // exactly what arrived on THIS link and never a previous session's traffic.
                     inboundFrames = 0; inboundBytes = 0; cmdChannelFrames = 0
+                    // #1635: same guarantee for the banked tally. Clearing only on teardown would be enough if
+                    // every link ended in one; a link that begins without a preceding clean teardown would
+                    // otherwise open holding the previous link's rows and report them as banked on this one.
+                    bankedHr.set(0); bankedRr.set(0); bankedGravity.set(0); bankedResp.set(0)
+                    bankedSkinTemp.set(0); bankedSpo2.set(0); bankedSteps.set(0); bankedBattery.set(0)
                     realtimeArmedThisLink = false
                     // A connect succeeded → clear the stale-bond re-pair guide UNLESS we are in a known
                     // bond-loop (#617). In that loop the strap "connects" every ~3 s before timing out

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -6727,22 +6727,31 @@ class WhoopBleClient(
     private var cmdChannelFrames = 0
 
     // #1635: rows ACCEPTED per stream on this link, the database-side twin of the frame counters above.
-    // Cleared with them on teardown. Written only from the collector coroutines that already own the
-    // insert calls, so they inherit that serialization rather than adding their own.
-    private var bankedHr = 0
-    private var bankedRr = 0
-    private var bankedGravity = 0
-    private var bankedResp = 0
-    private var bankedSkinTemp = 0
-    private var bankedSpo2 = 0
-    private var bankedSteps = 0
-    private var bankedBattery = 0
+    // Cleared with them on teardown.
+    //
+    // ATOMIC, unlike those counters, because the writers are not the same. `inboundFrames` and friends are
+    // touched only from the serialized GATT callback; these are folded in from `flushLive` and
+    // `flushStandardHr`, which are two INDEPENDENT `ioScope.launch` coroutines that can run at once — the
+    // same reason `liveInsertFailuresStd` and `liveInsertFailuresRealtime` beside them are AtomicInteger.
+    // A plain `+=` there is a read-modify-write race, and the teardown read is a third thread again. Each
+    // counter stands alone (no cross-field invariant), so per-field atomicity is the whole requirement.
+    // An under-count would be worse than useless here: it reads as exactly the "banked nothing" finding
+    // this line exists to report.
+    private val bankedHr = java.util.concurrent.atomic.AtomicInteger(0)
+    private val bankedRr = java.util.concurrent.atomic.AtomicInteger(0)
+    private val bankedGravity = java.util.concurrent.atomic.AtomicInteger(0)
+    private val bankedResp = java.util.concurrent.atomic.AtomicInteger(0)
+    private val bankedSkinTemp = java.util.concurrent.atomic.AtomicInteger(0)
+    private val bankedSpo2 = java.util.concurrent.atomic.AtomicInteger(0)
+    private val bankedSteps = java.util.concurrent.atomic.AtomicInteger(0)
+    private val bankedBattery = java.util.concurrent.atomic.AtomicInteger(0)
 
     /** Fold one persist round's accepted-row counts into the per-link tally. */
     private fun addBanked(c: InsertCounts) {
-        bankedHr += c.hr; bankedRr += c.rr; bankedGravity += c.gravity; bankedResp += c.resp
-        bankedSkinTemp += c.skinTemp; bankedSpo2 += c.spo2; bankedSteps += c.steps
-        bankedBattery += c.battery
+        bankedHr.addAndGet(c.hr); bankedRr.addAndGet(c.rr)
+        bankedGravity.addAndGet(c.gravity); bankedResp.addAndGet(c.resp)
+        bankedSkinTemp.addAndGet(c.skinTemp); bankedSpo2.addAndGet(c.spo2)
+        bankedSteps.addAndGet(c.steps); bankedBattery.addAndGet(c.battery)
     }
     /** #1809: was realtime armed at ANY point on THIS link. Not the same thing as [realtimeArmed], which
      *  is persistent edge state: it can carry true in from a previous link, or read false at the drop
@@ -10006,20 +10015,24 @@ class WhoopBleClient(
                 // before handleDisconnect runs and is not reassigned above, so it is valid here.
                 ended = if (intentionalDisconnect) "intentional" else "status=$status",
             ))
-            // #1635: what the DATABASE gained, beside what the radio carried. An unbonded 5/MG keeps the
-            // epitaph looking healthy — hundreds of inbound frames — while every bond-gated stream banks
-            // nothing, and that split is invisible in a single export. Guarded by the SAME `linkUpSinceMs`
-            // as the epitaph: on a failed connect attempt the counters hold the previous link's tally, and
-            // reporting them here would describe a link that never existed.
+            // #1635: what the DATABASE gained from the LIVE streams, beside what the radio carried. An
+            // unbonded 5/MG keeps the epitaph looking healthy — hundreds of inbound frames — while every
+            // bond-gated stream banks nothing, and that split is invisible in a single export. Live only:
+            // the offload persists through `Backfiller` and has its own accounting, so folding it in here
+            // would be double-counted in one direction and, worse, its ABSENCE reads as a fault.
+            // Guarded by the SAME `linkUpSinceMs` as the epitaph: on a failed connect attempt the counters
+            // hold the previous link's tally, and reporting them would describe a link that never existed.
             log(ConnectionReadout.linkBankedSummary(
-                hr = bankedHr, rr = bankedRr, gravity = bankedGravity, resp = bankedResp,
-                skinTemp = bankedSkinTemp, spo2 = bankedSpo2, steps = bankedSteps, battery = bankedBattery,
+                hr = bankedHr.get(), rr = bankedRr.get(),
+                gravity = bankedGravity.get(), resp = bankedResp.get(),
+                skinTemp = bankedSkinTemp.get(), spo2 = bankedSpo2.get(),
+                steps = bankedSteps.get(), battery = bankedBattery.get(),
             ), com.noop.testcentre.TestDomain.CONNECTION)
         }
         // Clear the tally with the link, so a second teardown for the same drop cannot re-report it.
         inboundFrames = 0; inboundBytes = 0; cmdChannelFrames = 0
-        bankedHr = 0; bankedRr = 0; bankedGravity = 0; bankedResp = 0
-        bankedSkinTemp = 0; bankedSpo2 = 0; bankedSteps = 0; bankedBattery = 0
+        bankedHr.set(0); bankedRr.set(0); bankedGravity.set(0); bankedResp.set(0)
+        bankedSkinTemp.set(0); bankedSpo2.set(0); bankedSteps.set(0); bankedBattery.set(0)
 
         val heldSuffix = heldForLogSuffix()
         linkUpSinceMs = null

--- a/android/app/src/test/java/com/noop/analytics/LinkBankedSummaryTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/LinkBankedSummaryTest.kt
@@ -22,7 +22,7 @@ class LinkBankedSummaryTest {
         assertTrue(line.contains("hr=456"))
         assertTrue(line.contains("gravity=0"))
         // The whole point: a reader must not have to spot which of eight numbers are zero.
-        assertTrue(line.contains("nothing banked for: gravity, resp, skinTemp, spo2, steps"))
+        assertTrue(line.contains("nothing banked live for: gravity, resp, skinTemp, spo2, steps"))
     }
 
     @Test
@@ -30,17 +30,17 @@ class LinkBankedSummaryTest {
         val line = ConnectionReadout.linkBankedSummary(
             hr = 400, rr = 380, gravity = 900, resp = 900, skinTemp = 900, spo2 = 900, steps = 12, battery = 3,
         )
-        assertTrue(line.startsWith("banked this link:"))
+        assertTrue(line.startsWith("banked live this link:"))
         assertTrue("a link where every stream banked must not carry a zero call-out",
-            !line.contains("nothing banked for"))
+            !line.contains("nothing banked live for"))
     }
 
     @Test
     fun `a link that stored nothing at all says so once, not eight times`() {
         val line = ConnectionReadout.linkBankedSummary(0, 0, 0, 0, 0, 0, 0, 0)
-        assertTrue(line.contains("NOTHING was stored on this link"))
+        assertTrue(line.contains("NOTHING was stored from the live streams"))
         // Not also the per-stream list: "nothing banked for: <all eight>" is noise when the total is zero.
-        assertTrue(!line.contains("nothing banked for"))
+        assertTrue(!line.contains("nothing banked live for"))
     }
 
     @Test
@@ -55,8 +55,8 @@ class LinkBankedSummaryTest {
     @Test
     fun `the exact sentence for the field case, pinned against the Swift twin`() {
         assertEquals(
-            "banked this link: hr=456 rr=187 gravity=0 resp=0 skinTemp=0 spo2=0 steps=0 battery=2" +
-                " - nothing banked for: gravity, resp, skinTemp, spo2, steps",
+            "banked live this link: hr=456 rr=187 gravity=0 resp=0 skinTemp=0 spo2=0 steps=0 battery=2" +
+                " - nothing banked live for: gravity, resp, skinTemp, spo2, steps",
             ConnectionReadout.linkBankedSummary(
                 hr = 456, rr = 187, gravity = 0, resp = 0, skinTemp = 0, spo2 = 0, steps = 0, battery = 2,
             ),

--- a/android/app/src/test/java/com/noop/analytics/LinkBankedSummaryTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/LinkBankedSummaryTest.kt
@@ -62,4 +62,17 @@ class LinkBankedSummaryTest {
             ),
         )
     }
+
+
+    @Test
+    fun `a stream this platform cannot measure is omitted, not reported as zero`() {
+        // Apple's store does not return a step count (persist-only, outside its insert tuple). Printing
+        // steps=0 there would name it in the zero list forever - a permanent false alarm in a line whose
+        // entire job is to make a real zero stand out.
+        val line = ConnectionReadout.linkBankedSummary(
+            hr = 456, rr = 187, gravity = 0, resp = 0, skinTemp = 0, spo2 = 0, steps = null, battery = 2,
+        )
+        assertTrue("an unmeasured stream must not appear at all", !line.contains("steps"))
+        assertTrue(line.contains("nothing banked live for: gravity, resp, skinTemp, spo2"))
+    }
 }

--- a/android/app/src/test/java/com/noop/analytics/LinkBankedSummaryTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/LinkBankedSummaryTest.kt
@@ -1,0 +1,65 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1635: the per-link banked-rows line, the database-side companion to `linkEpitaph`.
+ *
+ * The case it exists for: an unbonded WHOOP 5/MG streams heart rate and R-R over the standard profile
+ * while every bond-gated stream banks nothing. The epitaph reports that link as hundreds of healthy
+ * inbound frames, which is true and misleading. Establishing the split took two exports hours apart and
+ * a manual diff of stored row counts; these pin the one line that states it outright.
+ */
+class LinkBankedSummaryTest {
+
+    @Test
+    fun `names the streams that banked nothing when others did`() {
+        val line = ConnectionReadout.linkBankedSummary(
+            hr = 456, rr = 187, gravity = 0, resp = 0, skinTemp = 0, spo2 = 0, steps = 0, battery = 2,
+        )
+        assertTrue(line.contains("hr=456"))
+        assertTrue(line.contains("gravity=0"))
+        // The whole point: a reader must not have to spot which of eight numbers are zero.
+        assertTrue(line.contains("nothing banked for: gravity, resp, skinTemp, spo2, steps"))
+    }
+
+    @Test
+    fun `a fully healthy link gets no call-out`() {
+        val line = ConnectionReadout.linkBankedSummary(
+            hr = 400, rr = 380, gravity = 900, resp = 900, skinTemp = 900, spo2 = 900, steps = 12, battery = 3,
+        )
+        assertTrue(line.startsWith("banked this link:"))
+        assertTrue("a link where every stream banked must not carry a zero call-out",
+            !line.contains("nothing banked for"))
+    }
+
+    @Test
+    fun `a link that stored nothing at all says so once, not eight times`() {
+        val line = ConnectionReadout.linkBankedSummary(0, 0, 0, 0, 0, 0, 0, 0)
+        assertTrue(line.contains("NOTHING was stored on this link"))
+        // Not also the per-stream list: "nothing banked for: <all eight>" is noise when the total is zero.
+        assertTrue(!line.contains("nothing banked for"))
+    }
+
+    @Test
+    fun `negative counts cannot leak into a diagnostic`() {
+        // Pure and total on purpose: this runs on the teardown path, where throwing would cost the very
+        // report it exists to produce.
+        val line = ConnectionReadout.linkBankedSummary(-5, 1, 0, 0, 0, 0, 0, 0)
+        assertTrue(line.contains("hr=0"))
+        assertEquals(false, line.contains("-5"))
+    }
+
+    @Test
+    fun `the exact sentence for the field case, pinned against the Swift twin`() {
+        assertEquals(
+            "banked this link: hr=456 rr=187 gravity=0 resp=0 skinTemp=0 spo2=0 steps=0 battery=2" +
+                " - nothing banked for: gravity, resp, skinTemp, spo2, steps",
+            ConnectionReadout.linkBankedSummary(
+                hr = 456, rr = 187, gravity = 0, resp = 0, skinTemp = 0, spo2 = 0, steps = 0, battery = 2,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
The `Link epitaph` (#1809) answers *"did the strap send anything?"* — the right measure for a silent strap, and the wrong one for a strap talking over only part of its surface.

An unbonded 5/MG streams heart rate and R-R over the standard profile all night while every bond-gated stream banks nothing. The epitaph reports that as hundreds of healthy inbound frames, which is true and reads like a working link:

```
Link epitaph: up 435740ms, inbound 441 frames / 1141 bytes (cmd-channel 0), realtime armed=no, ended=intentional
```

Establishing what was actually wrong took **two exports, hours apart, and a manual diff of stored row counts**:

| stream | delta | path |
|---|---|---|
| hr | +5,607 | unencrypted `0x2A37` |
| rr | +2,582 | unencrypted `0x2A37` |
| gravity / resp / skinTemp / spo2 | **+0 each** | needs the bond |

Neither export said anything was wrong on its own. One line now states it:

```
banked live this link: hr=456 rr=187 gravity=0 resp=0 skinTemp=0 spo2=0 steps=0 battery=2
  - nothing banked live for: gravity, resp, skinTemp, spo2, steps
```

## Design notes

**Zero-banking streams are named, not left to be inferred.** "gravity=0 among six other zeros" and "gravity=0 while hr=456" are the same text and opposite findings; a reader should not have to spot which of eight numbers are zero.

**Counts are rows ACCEPTED**, so a stream arriving entirely as duplicates reads zero and gets named. Correct for this purpose — the question is what the database gained on this link, not what the radio carried, which the epitaph already covers.

**Guarded by the same `linkUpSinceMs` as the epitaph.** I first placed it *outside* that guard, where a failed connect attempt — `handleDisconnect` also runs for those, with the counters still holding the previous link's tally — would have printed "NOTHING was stored on this link" about a link that never existed. That fabricates the exact symptom the line exists to detect, and it is the hazard #1809's own comment warns about two lines above. Caught on review, before compiling.

**Pure, total, clamped.** It runs on the teardown path, where throwing would cost the report it exists to produce. Negative counts are pinned by test.

## Parity

Swift twin added, with the **identical sentence pinned on both sides** so a report from either platform reads the same.

**Correction to an earlier version of this description:** I wrote that leaving Apple's emitter for later "matches how `linkEpitaph`'s twin was introduced". That was wrong — Apple *does* emit the epitaph, at `BLEManager.swift:5399`. So the gap here is real and worth naming precisely: an Apple report currently answers *"did anything arrive?"* but not *"what banked?"*, which is the question this PR exists to answer.

Why it is not simply the same one-line hook: on Kotlin the collector and the per-link counters share a class (`WhoopBleClient`), so accumulating is a local call. On Apple the counters live in `BLEManager` while the live inserts are in `Strand/Collect/Collector.swift` (lines 232 and 319, the twins of `flushLive`/`flushStandardHr`), so the emitter needs a `Collector → BLEManager` callback. `StreamStore.insert` already returns `(hr, rr, events, battery, spo2, skinTemp, resp, gravity)`, and line 319 already binds it as `inserted`, so the counts are there — it is plumbing, not new measurement. App-target Swift, which neither I nor default CI can execute.

## Verification

- **Full Android suite: 631 classes, 5179 tests, 0 failures**, forced with `--rerun-tasks` and confirmed all 631 result XMLs were freshly written.
- 5 Kotlin tests, 5 Swift tests, including the exact-sentence pin shared across platforms.
- `compileFullDebugKotlin` clean, both Swift files pass `swiftc -parse`, `i18n_audit --ci` and `doc_comment_lint` clean.
- Swift package tests need macOS, so `swift-packages.yml` is what verifies the twin.

**Not verified on a device** — the emit path needs a real link teardown to exercise. The formatter is tested; the wiring is not.

## Not done here

The original ask was broader — Bluetooth settings, connection state, debug-log info, any BLE logs. This is the one piece the field case actually justified. Two things I checked and did **not** change:

- **`capture_check: connection MISSING`** looked like a false negative, but it grades on `reconnect n=` and the earlier export simply had no reconnect yet. The later one reads `present (via "reconnect n=")`. Working as designed.
- **A stale OS pairing check** would be redundant: `bond state at connect: BOND_NONE` already *is* the OS bond state, so a phone-side stale pairing would show as `BOND_BONDED`. The existing line answers it.

## Found in re-review

Both defects were in the wiring, not the formatter.

**A data race.** The tally was a plain `var +=`, and my comment claimed the writers "inherit that serialization" from the collector coroutines. They do not — `flushLive` and `flushStandardHr` are two **independent** `ioScope.launch` coroutines that can run at once, and the teardown read is a third thread again. The codebase already knew: `liveInsertFailuresStd` and `liveInsertFailuresRealtime` sit *directly beside* the calls hooked here and are both `AtomicInteger`. Now atomic, with the comment explaining why these differ from the frame counters immediately above them, which really are single-threaded on the GATT callback.

**It would have cried wolf on every healthy sync.** The counters see only the two LIVE insert sites. The history offload persists through `Backfiller.kt:565`, and `SourceCoordinator` has three more. A bonded strap that banked its gravity through an offload would have reported `nothing banked for: gravity, resp, skinTemp, spo2` — the exact false alarm this line exists to prevent, on the working case.

Fixed by narrowing the claim rather than broadening the plumbing: `banked live this link` / `nothing banked live for`, with the doc recording that the offload has its own accounting (`bankedSensorRecords`, `rowsPersisted`, the completed-offload classification). Folding it in would double-count in one direction while its absence read as a fault.

For the unbonded case the distinction is moot — backfill is deferred, so live *is* the complete picture, and the line reads exactly right there.

Re-verified after both fixes: **631 classes, 5179 tests, 0 failures**, freshly rerun; `i18n_audit --ci` and `doc_comment_lint` clean; both sentences re-pinned identically across platforms.

