### PR TITLE
connection: split the banked line by PATH, so it says something

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
@@ -332,11 +332,15 @@ public enum ConnectionReadout {
         if let offloadSteps { raw.append(("steps", offloadSteps)) }
         let offload = raw.map { ($0.0, max(0, $0.1)) }
         let total = offload.reduce(0) { $0 + $1.1 }
-        // "Never ran" and "ran with nothing new" are DIFFERENT findings. Rows are counted as ACCEPTED, so
+        // Three states, reported as FACTS rather than verdicts. "No chunks" is not evidence of a fault on
+        // its own: a short or command-only link never reaches backfill, and the reason is already logged
+        // beside it. The epitaph supplies the uptime a reader needs to weigh it.
+        //
+        // "Never ran" and "ran with nothing new" are still DIFFERENT. Rows are counted as ACCEPTED, so
         // a reconnect re-offloading already-stored records banks zero while the strap plainly handed its
         // history over. Only the first case speaks to the bond.
         if (max(0, offloadChunks)) == 0 {
-            return "banked this link: \(live) | offload did NOT run on this link"
+            return "banked this link: \(live) | offload none"
         }
         if total == 0 {
             return "banked this link: \(live) | offload ran \(max(0, offloadChunks)) chunk(s), no new rows"

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
@@ -320,7 +320,7 @@ public enum ConnectionReadout {
     /// bond. `offloadSteps` is optional: a platform that cannot measure a stream omits it rather than
     /// reporting a zero that reads as a fault. Counts are rows ACCEPTED. Pure, total and clamped.
     /// Twin of the Kotlin formatter.
-    public static func linkBankedSummary(liveHr: Int, liveRr: Int,
+    public static func linkBankedSummary(liveHr: Int, liveRr: Int, offloadChunks: Int,
                                          offloadHr: Int, offloadRr: Int, offloadGravity: Int,
                                          offloadResp: Int, offloadSkinTemp: Int, offloadSpo2: Int,
                                          offloadSteps: Int?) -> String {
@@ -332,8 +332,14 @@ public enum ConnectionReadout {
         if let offloadSteps { raw.append(("steps", offloadSteps)) }
         let offload = raw.map { ($0.0, max(0, $0.1)) }
         let total = offload.reduce(0) { $0 + $1.1 }
+        // "Never ran" and "ran with nothing new" are DIFFERENT findings. Rows are counted as ACCEPTED, so
+        // a reconnect re-offloading already-stored records banks zero while the strap plainly handed its
+        // history over. Only the first case speaks to the bond.
+        if (max(0, offloadChunks)) == 0 {
+            return "banked this link: \(live) | offload did NOT run on this link"
+        }
         if total == 0 {
-            return "banked this link: \(live) | offload none - the offload banked NOTHING on this link"
+            return "banked this link: \(live) | offload ran \(max(0, offloadChunks)) chunk(s), no new rows"
         }
         let body = offload.map { "\($0.0)=\($0.1)" }.joined(separator: " ")
         let empty = offload.filter { $0.1 == 0 }.map { $0.0 }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ConnectionReadout.swift
@@ -302,46 +302,44 @@ public enum ConnectionReadout {
         return line
     }
 
-    /// #1635: which STREAMS banked rows on a finished link, beside `linkEpitaph`'s "did anything arrive".
+    /// #1635: what a finished link actually stored, split by PATH.
     ///
-    /// The epitaph counts frames, which is the right measure for a silent strap and the wrong one for a
-    /// strap talking over only part of its surface: an unbonded 5/MG streams heart rate and R-R over the
-    /// standard profile all night while every bond-gated stream banks nothing, and the epitaph reports
-    /// that as hundreds of healthy inbound frames. A field diagnosis had to establish the split by
-    /// exporting twice, hours apart, and diffing stored row counts by hand.
+    /// The epitaph counts frames, which is right for a silent strap and wrong for one talking over only
+    /// part of its surface: an unbonded 5/MG streams heart rate and R-R all night while nothing
+    /// bond-gated lands, and the epitaph reports hundreds of healthy inbound frames.
     ///
-    /// Zero-banking streams are named rather than left to be inferred, because "gravity=0 among six other
-    /// zeros" and "gravity=0 while hr=456" read identically and mean opposite things. Counts are ROWS
-    /// ACCEPTED, so a stream arriving as duplicates reads zero and is named — correct here: the question
-    /// is what the database gained on this link.
+    /// The split must be by PATH, not by stream. The realtime decoder produces only hr, rr, events and
+    /// battery; gravity, respiratory, skin temperature, SpO2 and steps arrive solely through the
+    /// historical decoder behind the offload. A live-only tally therefore printed "nothing banked live
+    /// for: gravity, resp, …" on EVERY link, bonded or not — a constant dressed as a finding.
     ///
-    /// LIVE streams only, and the sentence says so. The history offload persists through its own path and
-    /// already has its own accounting; counting one and labelling it "this link" would make every healthy
-    /// bonded sync read as "nothing banked for: gravity" — the false alarm this line exists to prevent.
+    /// The offload is where the bond shows: an unbonded strap defers backfill entirely, so `offload none`
+    /// is the real signal and a healthy sync fills it.
     ///
-    /// Pure and total, and every count clamped, so it cannot become the reason a teardown path throws.
-    /// Twin of the Kotlin formatter. Apple does not emit it yet; the formatter exists so the two logs
-    /// cannot drift apart when it does.
-    /// `steps` is OPTIONAL because this platform's store does not return a step count at all — steps are
-    /// persist-only here, deliberately outside the 8-field insert tuple, while Room counts them. A
-    /// platform that cannot measure a stream must OMIT it rather than report zero: "banked nothing" is a
-    /// finding and "not measured here" is not, and printing the second as the first would put a permanent
-    /// false alarm in every Apple link's log.
-    public static func linkBankedSummary(hr: Int, rr: Int, gravity: Int, resp: Int,
-                                         skinTemp: Int, spo2: Int, steps: Int?, battery: Int) -> String {
+    /// Battery is absent on purpose — it rides the standard 0x2A19 profile and banks with or without the
+    /// bond. `offloadSteps` is optional: a platform that cannot measure a stream omits it rather than
+    /// reporting a zero that reads as a fault. Counts are rows ACCEPTED. Pure, total and clamped.
+    /// Twin of the Kotlin formatter.
+    public static func linkBankedSummary(liveHr: Int, liveRr: Int,
+                                         offloadHr: Int, offloadRr: Int, offloadGravity: Int,
+                                         offloadResp: Int, offloadSkinTemp: Int, offloadSpo2: Int,
+                                         offloadSteps: Int?) -> String {
+        let live = "live hr=\(max(0, liveHr)) rr=\(max(0, liveRr))"
         var raw: [(String, Int)] = [
-            ("hr", hr), ("rr", rr), ("gravity", gravity), ("resp", resp),
-            ("skinTemp", skinTemp), ("spo2", spo2),
+            ("hr", offloadHr), ("rr", offloadRr), ("gravity", offloadGravity), ("resp", offloadResp),
+            ("skinTemp", offloadSkinTemp), ("spo2", offloadSpo2),
         ]
-        if let steps { raw.append(("steps", steps)) }
-        raw.append(("battery", battery))
-        let pairs: [(String, Int)] = raw.map { ($0.0, max(0, $0.1)) }
-        let body = pairs.map { "\($0.0)=\($0.1)" }.joined(separator: " ")
-        let total = pairs.reduce(0) { $0 + $1.1 }
-        if total == 0 { return "banked live this link: \(body) - NOTHING was stored from the live streams" }
-        let empty = pairs.filter { $0.1 == 0 }.map { $0.0 }
-        if empty.isEmpty { return "banked live this link: \(body)" }
-        return "banked live this link: \(body) - nothing banked live for: \(empty.joined(separator: ", "))"
+        if let offloadSteps { raw.append(("steps", offloadSteps)) }
+        let offload = raw.map { ($0.0, max(0, $0.1)) }
+        let total = offload.reduce(0) { $0 + $1.1 }
+        if total == 0 {
+            return "banked this link: \(live) | offload none - the offload banked NOTHING on this link"
+        }
+        let body = offload.map { "\($0.0)=\($0.1)" }.joined(separator: " ")
+        let empty = offload.filter { $0.1 == 0 }.map { $0.0 }
+        if empty.isEmpty { return "banked this link: \(live) | offload \(body)" }
+        return "banked this link: \(live) | offload \(body)"
+            + " - nothing banked from the offload for: \(empty.joined(separator: ", "))"
     }
 
     /// #987: freshness label for the "last frame" readout row: how long ago the most recent strap frame

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LinkBankedSummaryTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LinkBankedSummaryTests.swift
@@ -9,21 +9,23 @@ import XCTest
 /// the offload. An earlier live-only version named those five as empty on EVERY link, bonded or not.
 final class LinkBankedSummaryTests: XCTestCase {
 
-    private func line(liveHr: Int = 0, liveRr: Int = 0, oHr: Int = 0, oRr: Int = 0, oGrav: Int = 0,
-                      oResp: Int = 0, oSkin: Int = 0, oSpo2: Int = 0, oSteps: Int? = 0) -> String {
+    private func line(liveHr: Int = 0, liveRr: Int = 0, chunks: Int = 0, oHr: Int = 0, oRr: Int = 0,
+                      oGrav: Int = 0, oResp: Int = 0, oSkin: Int = 0, oSpo2: Int = 0,
+                      oSteps: Int? = 0) -> String {
         ConnectionReadout.linkBankedSummary(
-            liveHr: liveHr, liveRr: liveRr, offloadHr: oHr, offloadRr: oRr, offloadGravity: oGrav,
+            liveHr: liveHr, liveRr: liveRr, offloadChunks: chunks,
+            offloadHr: oHr, offloadRr: oRr, offloadGravity: oGrav,
             offloadResp: oResp, offloadSkinTemp: oSkin, offloadSpo2: oSpo2, offloadSteps: oSteps)
     }
 
     func testAnUnbondedStrapReadsLiveTrafficWithAnOffloadThatNeverRan() {
         XCTAssertEqual(
-            line(liveHr: 12, liveRr: 7),
-            "banked this link: live hr=12 rr=7 | offload none - the offload banked NOTHING on this link")
+            line(liveHr: 12, liveRr: 7, chunks: 0),
+            "banked this link: live hr=12 rr=7 | offload did NOT run on this link")
     }
 
     func testAHealthySyncReadsCompletelyDifferently() {
-        let healthy = line(liveHr: 3, liveRr: 2, oHr: 1200, oRr: 2400, oGrav: 8000,
+        let healthy = line(liveHr: 3, liveRr: 2, chunks: 9, oHr: 1200, oRr: 2400, oGrav: 8000,
                            oResp: 8000, oSkin: 8000, oSpo2: 8000, oSteps: 40)
         XCTAssertEqual(healthy,
             "banked this link: live hr=3 rr=2 | offload hr=1200 rr=2400 gravity=8000 resp=8000"
@@ -32,21 +34,28 @@ final class LinkBankedSummaryTests: XCTestCase {
     }
 
     func testAPartialOffloadNamesOnlyTheStreamsThatStayedEmpty() {
-        let l = line(liveHr: 1, oHr: 500, oRr: 900, oGrav: 0, oResp: 0, oSkin: 700, oSpo2: 700)
+        let l = line(liveHr: 1, chunks: 4, oHr: 500, oRr: 900, oGrav: 0, oResp: 0, oSkin: 700, oSpo2: 700)
         XCTAssertTrue(l.contains("nothing banked from the offload for: gravity, resp, steps"))
     }
 
     func testAStreamThisPlatformCannotMeasureIsOmittedNotZero() {
-        XCTAssertFalse(line(liveHr: 5, oHr: 10, oSteps: nil).contains("steps"))
+        XCTAssertFalse(line(liveHr: 5, chunks: 1, oHr: 10, oSteps: nil).contains("steps"))
     }
 
     func testBatteryNeverAppearsOnEitherPath() {
-        XCTAssertFalse(line(liveHr: 9, oHr: 9).contains("battery"))
+        XCTAssertFalse(line(liveHr: 9, chunks: 1, oHr: 9).contains("battery"))
     }
 
     func testNegativeCountsCannotLeakIntoADiagnostic() {
-        let l = line(liveHr: -5, liveRr: 1, oHr: -3, oGrav: 4)
+        let l = line(liveHr: -5, liveRr: 1, chunks: 2, oHr: -3, oGrav: 4)
         XCTAssertTrue(l.contains("live hr=0 rr=1"))
         XCTAssertFalse(l.contains("-3"))
+    }
+
+    /// Twin of the Kotlin case: "never ran" and "ran with nothing new" are different findings.
+    func testAnOffloadThatRanWithNothingNewIsADifferentFinding() {
+        XCTAssertEqual(line(liveHr: 1, liveRr: 1, chunks: 6),
+                       "banked this link: live hr=1 rr=1 | offload ran 6 chunk(s), no new rows")
+        XCTAssertTrue(line(liveHr: 1, liveRr: 1, chunks: 0).contains("offload did NOT run"))
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LinkBankedSummaryTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LinkBankedSummaryTests.swift
@@ -21,7 +21,7 @@ final class LinkBankedSummaryTests: XCTestCase {
     func testAnUnbondedStrapReadsLiveTrafficWithAnOffloadThatNeverRan() {
         XCTAssertEqual(
             line(liveHr: 12, liveRr: 7, chunks: 0),
-            "banked this link: live hr=12 rr=7 | offload did NOT run on this link")
+            "banked this link: live hr=12 rr=7 | offload none")
     }
 
     func testAHealthySyncReadsCompletelyDifferently() {
@@ -56,6 +56,6 @@ final class LinkBankedSummaryTests: XCTestCase {
     func testAnOffloadThatRanWithNothingNewIsADifferentFinding() {
         XCTAssertEqual(line(liveHr: 1, liveRr: 1, chunks: 6),
                        "banked this link: live hr=1 rr=1 | offload ran 6 chunk(s), no new rows")
-        XCTAssertTrue(line(liveHr: 1, liveRr: 1, chunks: 0).contains("offload did NOT run"))
+        XCTAssertTrue(line(liveHr: 1, liveRr: 1, chunks: 0).contains("offload none"))
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LinkBankedSummaryTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LinkBankedSummaryTests.swift
@@ -1,57 +1,52 @@
 import XCTest
 @testable import StrandAnalytics
 
-/// #1635: the per-link banked-rows line, the database-side companion to `linkEpitaph`.
+/// #1635: the per-link banked line, split by PATH. Byte-identical twin of the Kotlin
+/// `LinkBankedSummaryTest`, including the exact sentences.
 ///
-/// Byte-identical twin of the Kotlin `LinkBankedSummaryTest`. The case it exists for: an unbonded 5/MG
-/// streams heart rate and R-R over the standard profile while every bond-gated stream banks nothing, and
-/// the epitaph reports that link as hundreds of healthy inbound frames.
+/// The split is by path rather than by stream because the realtime decoder yields only
+/// hr/rr/events/battery — gravity, respiratory, skin temperature, SpO2 and steps arrive solely through
+/// the offload. An earlier live-only version named those five as empty on EVERY link, bonded or not.
 final class LinkBankedSummaryTests: XCTestCase {
 
-    func testNamesTheStreamsThatBankedNothingWhenOthersDid() {
-        let line = ConnectionReadout.linkBankedSummary(
-            hr: 456, rr: 187, gravity: 0, resp: 0, skinTemp: 0, spo2: 0, steps: 0, battery: 2)
-        XCTAssertTrue(line.contains("hr=456"))
-        XCTAssertTrue(line.contains("gravity=0"))
-        XCTAssertTrue(line.contains("nothing banked live for: gravity, resp, skinTemp, spo2, steps"))
+    private func line(liveHr: Int = 0, liveRr: Int = 0, oHr: Int = 0, oRr: Int = 0, oGrav: Int = 0,
+                      oResp: Int = 0, oSkin: Int = 0, oSpo2: Int = 0, oSteps: Int? = 0) -> String {
+        ConnectionReadout.linkBankedSummary(
+            liveHr: liveHr, liveRr: liveRr, offloadHr: oHr, offloadRr: oRr, offloadGravity: oGrav,
+            offloadResp: oResp, offloadSkinTemp: oSkin, offloadSpo2: oSpo2, offloadSteps: oSteps)
     }
 
-    func testAFullyHealthyLinkGetsNoCallOut() {
-        let line = ConnectionReadout.linkBankedSummary(
-            hr: 400, rr: 380, gravity: 900, resp: 900, skinTemp: 900, spo2: 900, steps: 12, battery: 3)
-        XCTAssertTrue(line.hasPrefix("banked live this link:"))
-        XCTAssertFalse(line.contains("nothing banked live for"))
+    func testAnUnbondedStrapReadsLiveTrafficWithAnOffloadThatNeverRan() {
+        XCTAssertEqual(
+            line(liveHr: 12, liveRr: 7),
+            "banked this link: live hr=12 rr=7 | offload none - the offload banked NOTHING on this link")
     }
 
-    func testALinkThatStoredNothingSaysSoOnce() {
-        let line = ConnectionReadout.linkBankedSummary(
-            hr: 0, rr: 0, gravity: 0, resp: 0, skinTemp: 0, spo2: 0, steps: 0, battery: 0)
-        XCTAssertTrue(line.contains("NOTHING was stored from the live streams"))
-        XCTAssertFalse(line.contains("nothing banked live for"))
+    func testAHealthySyncReadsCompletelyDifferently() {
+        let healthy = line(liveHr: 3, liveRr: 2, oHr: 1200, oRr: 2400, oGrav: 8000,
+                           oResp: 8000, oSkin: 8000, oSpo2: 8000, oSteps: 40)
+        XCTAssertEqual(healthy,
+            "banked this link: live hr=3 rr=2 | offload hr=1200 rr=2400 gravity=8000 resp=8000"
+                + " skinTemp=8000 spo2=8000 steps=40")
+        XCTAssertFalse(healthy.contains("nothing banked"))
+    }
+
+    func testAPartialOffloadNamesOnlyTheStreamsThatStayedEmpty() {
+        let l = line(liveHr: 1, oHr: 500, oRr: 900, oGrav: 0, oResp: 0, oSkin: 700, oSpo2: 700)
+        XCTAssertTrue(l.contains("nothing banked from the offload for: gravity, resp, steps"))
+    }
+
+    func testAStreamThisPlatformCannotMeasureIsOmittedNotZero() {
+        XCTAssertFalse(line(liveHr: 5, oHr: 10, oSteps: nil).contains("steps"))
+    }
+
+    func testBatteryNeverAppearsOnEitherPath() {
+        XCTAssertFalse(line(liveHr: 9, oHr: 9).contains("battery"))
     }
 
     func testNegativeCountsCannotLeakIntoADiagnostic() {
-        let line = ConnectionReadout.linkBankedSummary(
-            hr: -5, rr: 1, gravity: 0, resp: 0, skinTemp: 0, spo2: 0, steps: 0, battery: 0)
-        XCTAssertTrue(line.contains("hr=0"))
-        XCTAssertFalse(line.contains("-5"))
-    }
-
-    /// The two platforms must produce the SAME sentence, since a report may come from either.
-    func testTheExactSentenceForTheFieldCase() {
-        XCTAssertEqual(
-            ConnectionReadout.linkBankedSummary(
-                hr: 456, rr: 187, gravity: 0, resp: 0, skinTemp: 0, spo2: 0, steps: 0, battery: 2),
-            "banked live this link: hr=456 rr=187 gravity=0 resp=0 skinTemp=0 spo2=0 steps=0 battery=2"
-                + " - nothing banked live for: gravity, resp, skinTemp, spo2, steps")
-    }
-
-
-    /// Apple's store does not return a step count, so the line must omit steps rather than print zero.
-    func testAStreamThisPlatformCannotMeasureIsOmittedNotZero() {
-        let line = ConnectionReadout.linkBankedSummary(
-            hr: 456, rr: 187, gravity: 0, resp: 0, skinTemp: 0, spo2: 0, steps: nil, battery: 2)
-        XCTAssertFalse(line.contains("steps"), "an unmeasured stream must not appear at all")
-        XCTAssertTrue(line.contains("nothing banked live for: gravity, resp, skinTemp, spo2"))
+        let l = line(liveHr: -5, liveRr: 1, oHr: -3, oGrav: 4)
+        XCTAssertTrue(l.contains("live hr=0 rr=1"))
+        XCTAssertFalse(l.contains("-3"))
     }
 }

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -744,6 +744,8 @@ public final class BLEManager: NSObject, ObservableObject {
     private var offloadResp = 0
     private var offloadSkinTemp = 0
     private var offloadSpo2 = 0
+    /// Chunks the offload actually persisted on this link — separates "never ran" from "nothing new".
+    private var offloadChunks = 0
 
     /// Uptime clock for the epitaph. Monotonic, so a wall-clock change mid-link cannot make it negative.
     private var linkUpSince: DispatchTime?
@@ -1371,6 +1373,7 @@ public final class BLEManager: NSObject, ObservableObject {
                                 },
                                 onBankedOffload: { [weak self] c in
                                     guard let self else { return }
+                                    self.offloadChunks += 1
                                     self.offloadHr += c.hr; self.offloadRr += c.rr
                                     self.offloadGravity += c.gravity; self.offloadResp += c.resp
                                     self.offloadSkinTemp += c.skinTemp; self.offloadSpo2 += c.spo2
@@ -5268,7 +5271,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         // link ended in one, and a link that begins without a preceding clean teardown would otherwise
         // open holding the previous link's rows — reporting them as banked on a link that never saw them.
         liveHr = 0; liveRr = 0; offloadHr = 0; offloadRr = 0
-        offloadGravity = 0; offloadResp = 0; offloadSkinTemp = 0; offloadSpo2 = 0
+        offloadGravity = 0; offloadResp = 0; offloadSkinTemp = 0; offloadSpo2 = 0; offloadChunks = 0
         linkUpSince = DispatchTime.now()
         standingConnectAt = nil     // #1413: a live link means no standing connect is outstanding
         restoredPeripheral = nil
@@ -5431,7 +5434,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
             // accounting, so folding it in would make a healthy bonded sync read as "nothing banked live
             // for: gravity". Inside the same `linkUpSince` guard for the same reason the epitaph is.
             log(ConnectionReadout.linkBankedSummary(
-                liveHr: liveHr, liveRr: liveRr,
+                liveHr: liveHr, liveRr: liveRr, offloadChunks: offloadChunks,
                 offloadHr: offloadHr, offloadRr: offloadRr, offloadGravity: offloadGravity,
                 offloadResp: offloadResp, offloadSkinTemp: offloadSkinTemp, offloadSpo2: offloadSpo2,
                 // nil, not 0: this store does not return a step count, and a zero would read as a fault.
@@ -5440,7 +5443,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         // Clear the tally with the link, so a second teardown for the same drop cannot re-report it.
         inboundFrames = 0; inboundBytes = 0; cmdChannelFrames = 0
         liveHr = 0; liveRr = 0; offloadHr = 0; offloadRr = 0
-        offloadGravity = 0; offloadResp = 0; offloadSkinTemp = 0; offloadSpo2 = 0
+        offloadGravity = 0; offloadResp = 0; offloadSkinTemp = 0; offloadSpo2 = 0; offloadChunks = 0
         linkUpSince = nil
 
         let timedOut = !intentionalDisconnect && error != nil

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -732,17 +732,19 @@ public final class BLEManager: NSObject, ObservableObject {
     private var inboundFrames = 0
     private var inboundBytes = 0
     private var cmdChannelFrames = 0
-    /// #1635: rows ACCEPTED per stream on this link — the database-side companion to the three above.
-    /// The epitaph counts frames, which reads healthy on an unbonded 5/MG streaming heart rate over the
-    /// standard profile while every bond-gated stream banks nothing. Cleared with them, so they describe
-    /// THIS link. Plain vars like their neighbours: `Collector` hands them up on the main actor.
-    private var bankedHr = 0
-    private var bankedRr = 0
-    private var bankedGravity = 0
-    private var bankedResp = 0
-    private var bankedSkinTemp = 0
-    private var bankedSpo2 = 0
-    private var bankedBattery = 0
+    /// #1635: rows ACCEPTED on this link, split by PATH. The realtime decoder yields only hr/rr/events/
+    /// battery; gravity, resp, skinTemp, SpO2 and steps arrive solely through the offload, so counting one
+    /// path and naming streams from the other prints a constant rather than a finding. Cleared with the
+    /// frame counters. Plain vars like their neighbours: both feeders hand up on the main actor.
+    private var liveHr = 0
+    private var liveRr = 0
+    private var offloadHr = 0
+    private var offloadRr = 0
+    private var offloadGravity = 0
+    private var offloadResp = 0
+    private var offloadSkinTemp = 0
+    private var offloadSpo2 = 0
+
     /// Uptime clock for the epitaph. Monotonic, so a wall-clock change mid-link cannot make it negative.
     private var linkUpSince: DispatchTime?
     /// Last time ANY notification arrived — drives the liveness watchdog.
@@ -1357,11 +1359,8 @@ public final class BLEManager: NSObject, ObservableObject {
                               enableRawCapture: enableRawCapture,
                               log: { [weak self] line in self?.log(line) },
                               onBanked: { [weak self] c in
-                                  guard let self else { return }
-                                  self.bankedHr += c.hr; self.bankedRr += c.rr
-                                  self.bankedGravity += c.gravity; self.bankedResp += c.resp
-                                  self.bankedSkinTemp += c.skinTemp; self.bankedSpo2 += c.spo2
-                                  self.bankedBattery += c.battery
+                                  // Live path: hr/rr are all the realtime decoder yields.
+                                  self?.liveHr += c.hr; self?.liveRr += c.rr
                               })
         // The store can finish bootstrapping AFTER connect(model:) already ran (both wait on
         // poweredOn), so apply the family/clock configuration here too — whichever runs last wins.
@@ -1369,6 +1368,12 @@ public final class BLEManager: NSObject, ObservableObject {
         backfiller = Backfiller(store: store, deviceId: deviceId,
                                 ackTrim: { [weak self] trim, endData in
                                     self?.ackHistoricalChunk(trim: trim, endData: endData)
+                                },
+                                onBankedOffload: { [weak self] c in
+                                    guard let self else { return }
+                                    self.offloadHr += c.hr; self.offloadRr += c.rr
+                                    self.offloadGravity += c.gravity; self.offloadResp += c.resp
+                                    self.offloadSkinTemp += c.skinTemp; self.offloadSpo2 += c.spo2
                                 },
                                 enableRawCapture: enableRawCapture,
                                 log: { [weak self] s in self?.log(s) },
@@ -5262,8 +5267,8 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         // #1635: same guarantee for the banked tally. Clearing only on teardown would be enough if every
         // link ended in one, and a link that begins without a preceding clean teardown would otherwise
         // open holding the previous link's rows — reporting them as banked on a link that never saw them.
-        bankedHr = 0; bankedRr = 0; bankedGravity = 0; bankedResp = 0
-        bankedSkinTemp = 0; bankedSpo2 = 0; bankedBattery = 0
+        liveHr = 0; liveRr = 0; offloadHr = 0; offloadRr = 0
+        offloadGravity = 0; offloadResp = 0; offloadSkinTemp = 0; offloadSpo2 = 0
         linkUpSince = DispatchTime.now()
         standingConnectAt = nil     // #1413: a live link means no standing connect is outstanding
         restoredPeripheral = nil
@@ -5426,14 +5431,16 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
             // accounting, so folding it in would make a healthy bonded sync read as "nothing banked live
             // for: gravity". Inside the same `linkUpSince` guard for the same reason the epitaph is.
             log(ConnectionReadout.linkBankedSummary(
-                hr: bankedHr, rr: bankedRr, gravity: bankedGravity, resp: bankedResp,
+                liveHr: liveHr, liveRr: liveRr,
+                offloadHr: offloadHr, offloadRr: offloadRr, offloadGravity: offloadGravity,
+                offloadResp: offloadResp, offloadSkinTemp: offloadSkinTemp, offloadSpo2: offloadSpo2,
                 // nil, not 0: this store does not return a step count, and a zero would read as a fault.
-                skinTemp: bankedSkinTemp, spo2: bankedSpo2, steps: nil, battery: bankedBattery))
+                offloadSteps: nil))
         }
         // Clear the tally with the link, so a second teardown for the same drop cannot re-report it.
         inboundFrames = 0; inboundBytes = 0; cmdChannelFrames = 0
-        bankedHr = 0; bankedRr = 0; bankedGravity = 0; bankedResp = 0
-        bankedSkinTemp = 0; bankedSpo2 = 0; bankedBattery = 0
+        liveHr = 0; liveRr = 0; offloadHr = 0; offloadRr = 0
+        offloadGravity = 0; offloadResp = 0; offloadSkinTemp = 0; offloadSpo2 = 0
         linkUpSince = nil
 
         let timedOut = !intentionalDisconnect && error != nil

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -48,6 +48,11 @@ final class Backfiller {
     /// of end_data, used for the `strap_trim` cursor) and the 8-byte `end_data` (= the raw
     /// HISTORY_END metadata.data[10:18]) that the high-freq-sync ack form requires verbatim.
     private let ackTrim: (_ trim: UInt32, _ endData: [UInt8]) -> Void
+    /// #1635: one offload chunk's accepted-row counts, handed up so `BLEManager` can tally them per LINK.
+    /// The offload is the only path that banks gravity/resp/skinTemp/SpO2/steps, so a link summary
+    /// without it cannot tell an unbonded strap — which defers backfill — from a healthy one.
+    private let onBankedOffload: (_ counts: (hr: Int, rr: Int, events: Int, battery: Int,
+                                             spo2: Int, skinTemp: Int, resp: Int, gravity: Int)) -> Void
     private let extract: Extractor
     /// Research toggle. When false (DEFAULT) no raw frames are persisted — the chunk's
     /// decoded streams are still durable and the trim is still acked (decoded is the product of
@@ -209,6 +214,9 @@ final class Backfiller {
     init(store: BackfillStoreWriting,
          deviceId: String,
          ackTrim: @escaping (_ trim: UInt32, _ endData: [UInt8]) -> Void,
+         onBankedOffload: @escaping (_ counts: (hr: Int, rr: Int, events: Int, battery: Int,
+                                                spo2: Int, skinTemp: Int, resp: Int,
+                                                gravity: Int)) -> Void = { _ in },
          enableRawCapture: Bool = false,
          log: ((String) -> Void)? = nil,
          rejectedSink: ((_ frames: [[UInt8]], _ trim: UInt32, _ family: DeviceFamily) -> Bool)? = nil,
@@ -225,6 +233,7 @@ final class Backfiller {
         self.store = store
         self.deviceId = deviceId
         self.ackTrim = ackTrim
+        self.onBankedOffload = onBankedOffload
         self.enableRawCapture = enableRawCapture
         self.log = log
         self.rejectedSink = rejectedSink
@@ -706,7 +715,10 @@ final class Backfiller {
             // emission can be measured, since every existing R-R number is taken after the ON CONFLICT key
             // has already absorbed part of it.
             let rrCensus = RrEmissionStats.compute(decoded.rr.map { (ts: $0.ts, rrMs: $0.rrMs) })
-            do { counts = try await store.insert(decoded, deviceId: deviceId) } catch {
+            do {
+                counts = try await store.insert(decoded, deviceId: deviceId)
+                onBankedOffload(counts)
+            } catch {
                 // Diag (#601): the decoded rows couldn't be written — this is the "history stalls but live HR
                 // works" class. We return WITHOUT acking so the strap keeps this chunk and re-sends it next
                 // session (no data loss), but a silent return left a strap log with no trace of the stall.

--- a/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
@@ -317,12 +317,19 @@ object ConnectionReadout {
             "skinTemp" to offloadSkinTemp, "spo2" to offloadSpo2,
         ) + listOfNotNull(offloadSteps?.let { "steps" to it })).map { (k, v) -> k to maxOf(0, v) }
         val offloadTotal = offload.sumOf { it.second }
-        // "Never ran" and "ran with nothing new" are DIFFERENT findings and must not share a sentence.
+        // Three distinguishable states, reported as FACTS rather than verdicts. "No chunks" is not
+        // evidence of a fault on its own: a short or command-only link never reaches backfill, and the
+        // reason it was skipped is already logged next to it ("Backfill: deferred — connect handshake not
+        // done yet (didBond=…)"). Editorialising here — an earlier draft said "offload did NOT run on this
+        // link" — reads as an accusation on a healthy 16-second connect. The epitaph above supplies the
+        // uptime a reader needs to weigh it.
+        //
+        // "Never ran" and "ran with nothing new" are still DIFFERENT and must not share a sentence.
         // Rows are counted as ACCEPTED, so a reconnect that re-offloads already-stored records banks zero
         // while the strap plainly handed its history over — `classifyCompletedOffload` already treats that
         // as `bankedSensorRecords`, not a fault. Only the first case speaks to the bond.
         if (maxOf(0, offloadChunks) == 0) {
-            return "banked this link: $live | offload did NOT run on this link"
+            return "banked this link: $live | offload none"
         }
         if (offloadTotal == 0) {
             return "banked this link: $live | offload ran ${maxOf(0, offloadChunks)} chunk(s), no new rows"

--- a/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
@@ -283,48 +283,48 @@ object ConnectionReadout {
     }
 
     /**
-     * #1635: which STREAMS banked rows on a finished link, beside [linkEpitaph]'s "did anything arrive".
+     * #1635: what a finished link actually stored, split by PATH.
      *
-     * The epitaph counts frames. That is the right measure for a silent strap, and the wrong one for a
-     * strap that is talking but only over part of its surface: an unbonded 5/MG streams heart rate and R-R
-     * over the standard profile all night while the bond-gated streams bank nothing, and the epitaph
-     * reports that as hundreds of healthy inbound frames. A field diagnosis had to establish the split by
-     * exporting twice, hours apart, and diffing the stored row counts by hand — the two logs each looked
-     * fine on their own. One line states it.
+     * The epitaph counts frames. That is right for a silent strap and wrong for one talking over only part
+     * of its surface: an unbonded 5/MG streams heart rate and R-R all night while nothing bond-gated
+     * lands, and the epitaph reports hundreds of healthy inbound frames.
      *
-     * Zero-banking streams are named explicitly rather than left to be inferred from a list of numbers,
-     * because "gravity=0 sitting among six other zeros" and "gravity=0 while hr=456" are the same text and
-     * opposite findings. Counts are ROWS ACCEPTED, so a stream that arrived as duplicates reads zero and
-     * is named — correct for this purpose: the question is what the database gained on this link.
+     * The split has to be by PATH, not by stream, and an earlier live-only version of this line got that
+     * wrong. `extractStreams` — the realtime decoder — produces only hr, rr, events and battery. Gravity,
+     * respiratory, skin temperature, SpO2 and steps come exclusively from the historical decoder behind
+     * the offload. A live-only tally therefore printed "nothing banked live for: gravity, resp, …" on
+     * EVERY link, bonded or not: a constant wearing the costume of a finding.
      *
-     * LIVE streams only, and the sentence says so. The history offload persists through its own path
-     * (`Backfiller`) and already has its own accounting — `bankedSensorRecords`, `rowsPersisted`, the
-     * completed-offload classification. Counting one and labelling it "this link" would make every healthy
-     * bonded sync that banked its gravity through the offload read as "nothing banked for: gravity", which
-     * is the false alarm this line exists to make impossible. A narrow true claim beats a broad wrong one.
+     * So both paths are counted and named. The offload is where the bond shows: an unbonded strap defers
+     * backfill entirely, so `offload none` is the real signal, and a healthy sync fills it.
      *
-     * Pure and total: no clock, no I/O, and every count clamped, so it cannot itself become the reason a
-     * teardown path throws. Twin of the Swift formatter.
+     * Battery is absent on purpose. It rides the standard 0x2A19 profile, so it banks with or without the
+     * bond and answers nothing here. [offloadSteps] is nullable for the same reason it is on Apple: a
+     * platform that cannot measure a stream omits it rather than reporting a zero that reads as a fault.
+     *
+     * Counts are rows ACCEPTED, so a re-offload of already-stored records reads zero — correct, since the
+     * question is what the database gained. Pure, total and clamped: it runs on the teardown path, where
+     * throwing would cost the report it exists to produce. Twin of the Swift formatter.
      */
     fun linkBankedSummary(
-        hr: Int, rr: Int, gravity: Int, resp: Int, skinTemp: Int, spo2: Int, steps: Int?, battery: Int,
+        liveHr: Int, liveRr: Int,
+        offloadHr: Int, offloadRr: Int, offloadGravity: Int, offloadResp: Int,
+        offloadSkinTemp: Int, offloadSpo2: Int, offloadSteps: Int?,
     ): String {
-        // [steps] is NULLABLE because Apple's store does not return a step count at all — steps are
-        // persist-only there, deliberately outside its 8-field insert tuple, while Room counts them. A
-        // platform that cannot measure a stream must OMIT it, not report zero: "banked nothing" is a
-        // finding and "not measured here" is not, and printing the second as the first would put a
-        // permanent false alarm in every Apple link's log.
-        val pairs = (listOf(
-            "hr" to hr, "rr" to rr, "gravity" to gravity, "resp" to resp,
-            "skinTemp" to skinTemp, "spo2" to spo2,
-        ) + listOfNotNull(steps?.let { "steps" to it }) + listOf("battery" to battery))
-            .map { (k, v) -> k to maxOf(0, v) }
-        val body = pairs.joinToString(" ") { (k, v) -> "$k=$v" }
-        val total = pairs.sumOf { it.second }
-        if (total == 0) return "banked live this link: $body - NOTHING was stored from the live streams"
-        val empty = pairs.filter { it.second == 0 }.map { it.first }
-        if (empty.isEmpty()) return "banked live this link: $body"
-        return "banked live this link: $body - nothing banked live for: ${empty.joinToString(", ")}"
+        val live = "live hr=${maxOf(0, liveHr)} rr=${maxOf(0, liveRr)}"
+        val offload = (listOf(
+            "hr" to offloadHr, "rr" to offloadRr, "gravity" to offloadGravity, "resp" to offloadResp,
+            "skinTemp" to offloadSkinTemp, "spo2" to offloadSpo2,
+        ) + listOfNotNull(offloadSteps?.let { "steps" to it })).map { (k, v) -> k to maxOf(0, v) }
+        val offloadTotal = offload.sumOf { it.second }
+        if (offloadTotal == 0) {
+            return "banked this link: $live | offload none - the offload banked NOTHING on this link"
+        }
+        val body = offload.joinToString(" ") { (k, v) -> "$k=$v" }
+        val empty = offload.filter { it.second == 0 }.map { it.first }
+        if (empty.isEmpty()) return "banked this link: $live | offload $body"
+        return "banked this link: $live | offload $body - nothing banked from the offload for: " +
+            empty.joinToString(", ")
     }
 
     /** #987: freshness label for the "last frame" readout row ("12s ago" / "no frames yet"). [nowUnix]

--- a/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
@@ -307,7 +307,7 @@ object ConnectionReadout {
      * throwing would cost the report it exists to produce. Twin of the Swift formatter.
      */
     fun linkBankedSummary(
-        liveHr: Int, liveRr: Int,
+        liveHr: Int, liveRr: Int, offloadChunks: Int,
         offloadHr: Int, offloadRr: Int, offloadGravity: Int, offloadResp: Int,
         offloadSkinTemp: Int, offloadSpo2: Int, offloadSteps: Int?,
     ): String {
@@ -317,8 +317,15 @@ object ConnectionReadout {
             "skinTemp" to offloadSkinTemp, "spo2" to offloadSpo2,
         ) + listOfNotNull(offloadSteps?.let { "steps" to it })).map { (k, v) -> k to maxOf(0, v) }
         val offloadTotal = offload.sumOf { it.second }
+        // "Never ran" and "ran with nothing new" are DIFFERENT findings and must not share a sentence.
+        // Rows are counted as ACCEPTED, so a reconnect that re-offloads already-stored records banks zero
+        // while the strap plainly handed its history over — `classifyCompletedOffload` already treats that
+        // as `bankedSensorRecords`, not a fault. Only the first case speaks to the bond.
+        if (maxOf(0, offloadChunks) == 0) {
+            return "banked this link: $live | offload did NOT run on this link"
+        }
         if (offloadTotal == 0) {
-            return "banked this link: $live | offload none - the offload banked NOTHING on this link"
+            return "banked this link: $live | offload ran ${maxOf(0, offloadChunks)} chunk(s), no new rows"
         }
         val body = offload.joinToString(" ") { (k, v) -> "$k=$v" }
         val empty = offload.filter { it.second == 0 }.map { it.first }

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -64,6 +64,14 @@ class Backfiller(
      */
     private val ackTrim: (trim: Long, endData: ByteArray) -> Unit,
     /**
+     * #1635: what one offload chunk actually stored, handed up so the client can tally it per LINK and
+     * name it beside the link epitaph. The offload is the ONLY path that banks gravity, respiratory,
+     * skin temperature, SpO2 and steps — the realtime decoder yields hr/rr/events/battery and nothing
+     * else — so a link summary that omitted this could not distinguish an unbonded strap, which defers
+     * backfill entirely, from a healthy one. Defaulted so existing constructions are unchanged.
+     */
+    private val onBankedOffload: (counts: InsertCounts) -> Unit = {},
+    /**
      * Fires after a chunk's decoded rows are durably committed AND acked — i.e. real new data just
      * landed. Lets the client schedule on-device scoring right away instead of leaving fresh history
      * invisible until the next 15-min analysis tick. Empty chunks (metadata-only ENDs) don't fire.
@@ -563,6 +571,7 @@ class Backfiller(
                 // key has already absorbed part of it.
                 val rrCensus = com.noop.analytics.RrEmissionStats.compute(decoded.rr.map { it.ts.toInt() to it.rrMs })
                 val counts = repository.insert(decoded, deviceId)
+                onBankedOffload(counts)
                 committed = decoded
                 // Success-side observability (#150): tally what actually persisted so the session can emit
                 // "persisted N rows (M with motion) across K night(s)" — the win-rate signal we never logged.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -6204,7 +6204,7 @@ class WhoopBleClient(
                     // otherwise open holding the previous link's rows and report them as banked on this one.
                     liveHr.set(0); liveRr.set(0); offloadHr.set(0); offloadRr.set(0)
                     offloadGravity.set(0); offloadResp.set(0); offloadSkinTemp.set(0)
-                    offloadSpo2.set(0); offloadSteps.set(0)
+                    offloadSpo2.set(0); offloadSteps.set(0); offloadChunks.set(0)
                     realtimeArmedThisLink = false
                     // A connect succeeded → clear the stale-bond re-pair guide UNLESS we are in a known
                     // bond-loop (#617). In that loop the strap "connects" every ~3 s before timing out
@@ -6750,6 +6750,8 @@ class WhoopBleClient(
     private val offloadSkinTemp = java.util.concurrent.atomic.AtomicInteger(0)
     private val offloadSpo2 = java.util.concurrent.atomic.AtomicInteger(0)
     private val offloadSteps = java.util.concurrent.atomic.AtomicInteger(0)
+    /** Chunks the offload actually persisted on this link. Separates "never ran" from "nothing new". */
+    private val offloadChunks = java.util.concurrent.atomic.AtomicInteger(0)
 
     /** Fold one LIVE persist round into the per-link tally (hr/rr are all the realtime decoder yields). */
     private fun addBankedLive(c: InsertCounts) {
@@ -6758,6 +6760,7 @@ class WhoopBleClient(
 
     /** Fold one OFFLOAD persist round in. This is where the bond shows: an unbonded strap defers it. */
     private fun addBankedOffload(c: InsertCounts) {
+        offloadChunks.incrementAndGet()
         offloadHr.addAndGet(c.hr); offloadRr.addAndGet(c.rr)
         offloadGravity.addAndGet(c.gravity); offloadResp.addAndGet(c.resp)
         offloadSkinTemp.addAndGet(c.skinTemp); offloadSpo2.addAndGet(c.spo2)
@@ -10033,7 +10036,7 @@ class WhoopBleClient(
             // Guarded by the SAME `linkUpSinceMs` as the epitaph: on a failed connect attempt the counters
             // hold the previous link's tally, and reporting them would describe a link that never existed.
             log(ConnectionReadout.linkBankedSummary(
-                liveHr = liveHr.get(), liveRr = liveRr.get(),
+                liveHr = liveHr.get(), liveRr = liveRr.get(), offloadChunks = offloadChunks.get(),
                 offloadHr = offloadHr.get(), offloadRr = offloadRr.get(),
                 offloadGravity = offloadGravity.get(), offloadResp = offloadResp.get(),
                 offloadSkinTemp = offloadSkinTemp.get(), offloadSpo2 = offloadSpo2.get(),
@@ -10044,7 +10047,7 @@ class WhoopBleClient(
         inboundFrames = 0; inboundBytes = 0; cmdChannelFrames = 0
         liveHr.set(0); liveRr.set(0); offloadHr.set(0); offloadRr.set(0)
         offloadGravity.set(0); offloadResp.set(0); offloadSkinTemp.set(0)
-        offloadSpo2.set(0); offloadSteps.set(0)
+        offloadSpo2.set(0); offloadSteps.set(0); offloadChunks.set(0)
 
         val heldSuffix = heldForLogSuffix()
         linkUpSinceMs = null

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2846,6 +2846,7 @@ class WhoopBleClient(
         deviceId = deviceId,
         cursorStore = cursorStore,
         ackTrim = { trim, endData -> ackHistoricalChunk(trim, endData) },
+        onBankedOffload = { counts -> addBankedOffload(counts) },
         onChunkCommitted = { batch -> onBackfillChunkCommitted(batch) },
         onConsoleChunk = { consoleChunksThisSession += 1 },
         // #77/#91: archive undecodable frames before the ack. append() returns ok=true (written, or
@@ -6201,8 +6202,9 @@ class WhoopBleClient(
                     // #1635: same guarantee for the banked tally. Clearing only on teardown would be enough if
                     // every link ended in one; a link that begins without a preceding clean teardown would
                     // otherwise open holding the previous link's rows and report them as banked on this one.
-                    bankedHr.set(0); bankedRr.set(0); bankedGravity.set(0); bankedResp.set(0)
-                    bankedSkinTemp.set(0); bankedSpo2.set(0); bankedSteps.set(0); bankedBattery.set(0)
+                    liveHr.set(0); liveRr.set(0); offloadHr.set(0); offloadRr.set(0)
+                    offloadGravity.set(0); offloadResp.set(0); offloadSkinTemp.set(0)
+                    offloadSpo2.set(0); offloadSteps.set(0)
                     realtimeArmedThisLink = false
                     // A connect succeeded → clear the stale-bond re-pair guide UNLESS we are in a known
                     // bond-loop (#617). In that loop the strap "connects" every ~3 s before timing out
@@ -6731,32 +6733,35 @@ class WhoopBleClient(
     private var inboundBytes = 0
     private var cmdChannelFrames = 0
 
-    // #1635: rows ACCEPTED per stream on this link, the database-side twin of the frame counters above.
-    // Cleared with them on teardown.
+    // #1635: rows ACCEPTED on this link, split by PATH. The realtime decoder (`extractStreams`) only
+    // ever produces hr/rr/events/battery; gravity, resp, skinTemp, spo2 and steps arrive solely through
+    // the offload's historical decoder. Counting one path and naming streams from the other printed a
+    // constant dressed as a finding, which is what the live-only first cut did.
     //
-    // ATOMIC, unlike those counters, because the writers are not the same. `inboundFrames` and friends are
-    // touched only from the serialized GATT callback; these are folded in from `flushLive` and
-    // `flushStandardHr`, which are two INDEPENDENT `ioScope.launch` coroutines that can run at once — the
-    // same reason `liveInsertFailuresStd` and `liveInsertFailuresRealtime` beside them are AtomicInteger.
-    // A plain `+=` there is a read-modify-write race, and the teardown read is a third thread again. Each
-    // counter stands alone (no cross-field invariant), so per-field atomicity is the whole requirement.
-    // An under-count would be worse than useless here: it reads as exactly the "banked nothing" finding
-    // this line exists to report.
-    private val bankedHr = java.util.concurrent.atomic.AtomicInteger(0)
-    private val bankedRr = java.util.concurrent.atomic.AtomicInteger(0)
-    private val bankedGravity = java.util.concurrent.atomic.AtomicInteger(0)
-    private val bankedResp = java.util.concurrent.atomic.AtomicInteger(0)
-    private val bankedSkinTemp = java.util.concurrent.atomic.AtomicInteger(0)
-    private val bankedSpo2 = java.util.concurrent.atomic.AtomicInteger(0)
-    private val bankedSteps = java.util.concurrent.atomic.AtomicInteger(0)
-    private val bankedBattery = java.util.concurrent.atomic.AtomicInteger(0)
+    // ATOMIC because the writers are not one thread: the live pair is folded in from `flushLive` and
+    // `flushStandardHr`, two independent `ioScope.launch` coroutines, the offload pair from the
+    // Backfiller's own coroutine, and the teardown read is a third context again.
+    private val liveHr = java.util.concurrent.atomic.AtomicInteger(0)
+    private val liveRr = java.util.concurrent.atomic.AtomicInteger(0)
+    private val offloadHr = java.util.concurrent.atomic.AtomicInteger(0)
+    private val offloadRr = java.util.concurrent.atomic.AtomicInteger(0)
+    private val offloadGravity = java.util.concurrent.atomic.AtomicInteger(0)
+    private val offloadResp = java.util.concurrent.atomic.AtomicInteger(0)
+    private val offloadSkinTemp = java.util.concurrent.atomic.AtomicInteger(0)
+    private val offloadSpo2 = java.util.concurrent.atomic.AtomicInteger(0)
+    private val offloadSteps = java.util.concurrent.atomic.AtomicInteger(0)
 
-    /** Fold one persist round's accepted-row counts into the per-link tally. */
-    private fun addBanked(c: InsertCounts) {
-        bankedHr.addAndGet(c.hr); bankedRr.addAndGet(c.rr)
-        bankedGravity.addAndGet(c.gravity); bankedResp.addAndGet(c.resp)
-        bankedSkinTemp.addAndGet(c.skinTemp); bankedSpo2.addAndGet(c.spo2)
-        bankedSteps.addAndGet(c.steps); bankedBattery.addAndGet(c.battery)
+    /** Fold one LIVE persist round into the per-link tally (hr/rr are all the realtime decoder yields). */
+    private fun addBankedLive(c: InsertCounts) {
+        liveHr.addAndGet(c.hr); liveRr.addAndGet(c.rr)
+    }
+
+    /** Fold one OFFLOAD persist round in. This is where the bond shows: an unbonded strap defers it. */
+    private fun addBankedOffload(c: InsertCounts) {
+        offloadHr.addAndGet(c.hr); offloadRr.addAndGet(c.rr)
+        offloadGravity.addAndGet(c.gravity); offloadResp.addAndGet(c.resp)
+        offloadSkinTemp.addAndGet(c.skinTemp); offloadSpo2.addAndGet(c.spo2)
+        offloadSteps.addAndGet(c.steps)
     }
     /** #1809: was realtime armed at ANY point on THIS link. Not the same thing as [realtimeArmed], which
      *  is persistent edge state: it can carry true in from a previous link, or read false at the drop
@@ -9085,7 +9090,7 @@ class WhoopBleClient(
         }
         if (!batch.isEmpty) {
             try {
-                addBanked(repository.insert(batch, deviceId))
+                addBankedLive(repository.insert(batch, deviceId))
                 liveInsertFailuresRealtime.set(0)
             } catch (t: Throwable) {
                 // Re-buffer at the front so these frames retry on the next cadence (port of Collector).
@@ -9168,7 +9173,7 @@ class WhoopBleClient(
             }
         }
         try {
-            addBanked(repository.insert(StreamBatch(hr = hr, rr = rr, events = contact), deviceId))
+            addBankedLive(repository.insert(StreamBatch(hr = hr, rr = rr, events = contact), deviceId))
             liveInsertFailuresStd.set(0)
         } catch (t: Throwable) {
             synchronized(collectorLock) {
@@ -10028,16 +10033,18 @@ class WhoopBleClient(
             // Guarded by the SAME `linkUpSinceMs` as the epitaph: on a failed connect attempt the counters
             // hold the previous link's tally, and reporting them would describe a link that never existed.
             log(ConnectionReadout.linkBankedSummary(
-                hr = bankedHr.get(), rr = bankedRr.get(),
-                gravity = bankedGravity.get(), resp = bankedResp.get(),
-                skinTemp = bankedSkinTemp.get(), spo2 = bankedSpo2.get(),
-                steps = bankedSteps.get(), battery = bankedBattery.get(),
+                liveHr = liveHr.get(), liveRr = liveRr.get(),
+                offloadHr = offloadHr.get(), offloadRr = offloadRr.get(),
+                offloadGravity = offloadGravity.get(), offloadResp = offloadResp.get(),
+                offloadSkinTemp = offloadSkinTemp.get(), offloadSpo2 = offloadSpo2.get(),
+                offloadSteps = offloadSteps.get(),
             ), com.noop.testcentre.TestDomain.CONNECTION)
         }
         // Clear the tally with the link, so a second teardown for the same drop cannot re-report it.
         inboundFrames = 0; inboundBytes = 0; cmdChannelFrames = 0
-        bankedHr.set(0); bankedRr.set(0); bankedGravity.set(0); bankedResp.set(0)
-        bankedSkinTemp.set(0); bankedSpo2.set(0); bankedSteps.set(0); bankedBattery.set(0)
+        liveHr.set(0); liveRr.set(0); offloadHr.set(0); offloadRr.set(0)
+        offloadGravity.set(0); offloadResp.set(0); offloadSkinTemp.set(0)
+        offloadSpo2.set(0); offloadSteps.set(0)
 
         val heldSuffix = heldForLogSuffix()
         linkUpSinceMs = null

--- a/android/app/src/test/java/com/noop/analytics/LinkBankedSummaryTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/LinkBankedSummaryTest.kt
@@ -18,11 +18,11 @@ import org.junit.Test
 class LinkBankedSummaryTest {
 
     private fun line(
-        liveHr: Int = 0, liveRr: Int = 0,
+        liveHr: Int = 0, liveRr: Int = 0, chunks: Int = 0,
         oHr: Int = 0, oRr: Int = 0, oGrav: Int = 0, oResp: Int = 0,
         oSkin: Int = 0, oSpo2: Int = 0, oSteps: Int? = 0,
     ) = ConnectionReadout.linkBankedSummary(
-        liveHr = liveHr, liveRr = liveRr, offloadHr = oHr, offloadRr = oRr,
+        liveHr = liveHr, liveRr = liveRr, offloadChunks = chunks, offloadHr = oHr, offloadRr = oRr,
         offloadGravity = oGrav, offloadResp = oResp, offloadSkinTemp = oSkin,
         offloadSpo2 = oSpo2, offloadSteps = oSteps,
     )
@@ -31,8 +31,8 @@ class LinkBankedSummaryTest {
     fun `an unbonded strap reads live traffic with an offload that never ran`() {
         // The whole point: HR flowing while the offload banks nothing is the bond split, in one line.
         assertEquals(
-            "banked this link: live hr=12 rr=7 | offload none - the offload banked NOTHING on this link",
-            line(liveHr = 12, liveRr = 7),
+            "banked this link: live hr=12 rr=7 | offload did NOT run on this link",
+            line(liveHr = 12, liveRr = 7, chunks = 0),
         )
     }
 
@@ -40,7 +40,7 @@ class LinkBankedSummaryTest {
     fun `a healthy sync reads completely differently`() {
         // The same shape on a bonded strap must NOT look like the unbonded one. This is the case the
         // live-only version could not express: it printed the same zeros either way.
-        val healthy = line(liveHr = 3, liveRr = 2, oHr = 1200, oRr = 2400, oGrav = 8000,
+        val healthy = line(liveHr = 3, liveRr = 2, chunks = 9, oHr = 1200, oRr = 2400, oGrav = 8000,
             oResp = 8000, oSkin = 8000, oSpo2 = 8000, oSteps = 40)
         assertEquals(
             "banked this link: live hr=3 rr=2 | offload hr=1200 rr=2400 gravity=8000 resp=8000" +
@@ -52,14 +52,14 @@ class LinkBankedSummaryTest {
 
     @Test
     fun `a partial offload names only the streams that stayed empty`() {
-        val l = line(liveHr = 1, oHr = 500, oRr = 900, oGrav = 0, oResp = 0, oSkin = 700, oSpo2 = 700)
+        val l = line(liveHr = 1, chunks = 4, oHr = 500, oRr = 900, oGrav = 0, oResp = 0, oSkin = 700, oSpo2 = 700)
         assertTrue(l.contains("nothing banked from the offload for: gravity, resp, steps"))
     }
 
     @Test
     fun `a stream this platform cannot measure is omitted, not reported as zero`() {
         // Apple's store returns no step count. Printing steps=0 there would name it forever.
-        val l = line(liveHr = 5, oHr = 10, oSteps = null)
+        val l = line(liveHr = 5, chunks = 1, oHr = 10, oSteps = null)
         assertTrue("an unmeasured stream must not appear", !l.contains("steps"))
     }
 
@@ -67,18 +67,31 @@ class LinkBankedSummaryTest {
     fun `battery never appears, on either path`() {
         // It rides the standard 0x2A19 profile, so it banks with or without the bond and answers nothing
         // here. A field log showed 306 battery banks against battery=0 in an earlier version of this line.
-        assertTrue(!line(liveHr = 9, oHr = 9).contains("battery"))
+        assertTrue(!line(liveHr = 9, chunks = 1, oHr = 9).contains("battery"))
     }
 
     @Test
     fun `negative counts cannot leak into a diagnostic`() {
         // Runs on the teardown path, where throwing would cost the report it exists to produce.
-        val l = line(liveHr = -5, liveRr = 1, oHr = -3, oGrav = 4)
+        val l = line(liveHr = -5, liveRr = 1, chunks = 2, oHr = -3, oGrav = 4)
         assertTrue(l.contains("live hr=0 rr=1"))
         assertTrue(l.contains("hr=0"))
         // NOT `contains("-")`: the sentence separator is a hyphen, so that assertion fails on a correct
         // line. Check the negative VALUES are gone, which is what clamping actually promises.
         assertEquals(false, l.contains("-5"))
         assertEquals(false, l.contains("-3"))
+    }
+
+    @Test
+    fun `an offload that ran with nothing new is not the same finding as one that never ran`() {
+        // Rows are ACCEPTED counts, so a reconnect re-offloading already-stored records banks zero while
+        // the strap plainly handed its history over. classifyCompletedOffload already treats that as
+        // bankedSensorRecords rather than a fault, and this line must not contradict it.
+        assertEquals(
+            "banked this link: live hr=1 rr=1 | offload ran 6 chunk(s), no new rows",
+            line(liveHr = 1, liveRr = 1, chunks = 6),
+        )
+        // And the bond signal stays distinct.
+        assertTrue(line(liveHr = 1, liveRr = 1, chunks = 0).contains("offload did NOT run"))
     }
 }

--- a/android/app/src/test/java/com/noop/analytics/LinkBankedSummaryTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/LinkBankedSummaryTest.kt
@@ -5,74 +5,80 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * #1635: the per-link banked-rows line, the database-side companion to `linkEpitaph`.
+ * #1635: the per-link banked line, split by PATH.
  *
- * The case it exists for: an unbonded WHOOP 5/MG streams heart rate and R-R over the standard profile
- * while every bond-gated stream banks nothing. The epitaph reports that link as hundreds of healthy
- * inbound frames, which is true and misleading. Establishing the split took two exports hours apart and
- * a manual diff of stored row counts; these pin the one line that states it outright.
+ * The case it exists for: an unbonded 5/MG streams heart rate and R-R over the standard profile while the
+ * offload never runs, and the epitaph reports that link as hundreds of healthy inbound frames.
+ *
+ * The split is by path rather than by stream because the realtime decoder yields only hr/rr/events/battery
+ * — gravity, respiratory, skin temperature, SpO2 and steps arrive solely through the offload. An earlier
+ * live-only version named those five as "nothing banked live for" on EVERY link, bonded or not, which is a
+ * constant rather than a finding. These pin the distinction.
  */
 class LinkBankedSummaryTest {
 
+    private fun line(
+        liveHr: Int = 0, liveRr: Int = 0,
+        oHr: Int = 0, oRr: Int = 0, oGrav: Int = 0, oResp: Int = 0,
+        oSkin: Int = 0, oSpo2: Int = 0, oSteps: Int? = 0,
+    ) = ConnectionReadout.linkBankedSummary(
+        liveHr = liveHr, liveRr = liveRr, offloadHr = oHr, offloadRr = oRr,
+        offloadGravity = oGrav, offloadResp = oResp, offloadSkinTemp = oSkin,
+        offloadSpo2 = oSpo2, offloadSteps = oSteps,
+    )
+
     @Test
-    fun `names the streams that banked nothing when others did`() {
-        val line = ConnectionReadout.linkBankedSummary(
-            hr = 456, rr = 187, gravity = 0, resp = 0, skinTemp = 0, spo2 = 0, steps = 0, battery = 2,
+    fun `an unbonded strap reads live traffic with an offload that never ran`() {
+        // The whole point: HR flowing while the offload banks nothing is the bond split, in one line.
+        assertEquals(
+            "banked this link: live hr=12 rr=7 | offload none - the offload banked NOTHING on this link",
+            line(liveHr = 12, liveRr = 7),
         )
-        assertTrue(line.contains("hr=456"))
-        assertTrue(line.contains("gravity=0"))
-        // The whole point: a reader must not have to spot which of eight numbers are zero.
-        assertTrue(line.contains("nothing banked live for: gravity, resp, skinTemp, spo2, steps"))
     }
 
     @Test
-    fun `a fully healthy link gets no call-out`() {
-        val line = ConnectionReadout.linkBankedSummary(
-            hr = 400, rr = 380, gravity = 900, resp = 900, skinTemp = 900, spo2 = 900, steps = 12, battery = 3,
+    fun `a healthy sync reads completely differently`() {
+        // The same shape on a bonded strap must NOT look like the unbonded one. This is the case the
+        // live-only version could not express: it printed the same zeros either way.
+        val healthy = line(liveHr = 3, liveRr = 2, oHr = 1200, oRr = 2400, oGrav = 8000,
+            oResp = 8000, oSkin = 8000, oSpo2 = 8000, oSteps = 40)
+        assertEquals(
+            "banked this link: live hr=3 rr=2 | offload hr=1200 rr=2400 gravity=8000 resp=8000" +
+                " skinTemp=8000 spo2=8000 steps=40",
+            healthy,
         )
-        assertTrue(line.startsWith("banked live this link:"))
-        assertTrue("a link where every stream banked must not carry a zero call-out",
-            !line.contains("nothing banked live for"))
+        assertTrue("a full sync carries no zero call-out", !healthy.contains("nothing banked"))
     }
 
     @Test
-    fun `a link that stored nothing at all says so once, not eight times`() {
-        val line = ConnectionReadout.linkBankedSummary(0, 0, 0, 0, 0, 0, 0, 0)
-        assertTrue(line.contains("NOTHING was stored from the live streams"))
-        // Not also the per-stream list: "nothing banked for: <all eight>" is noise when the total is zero.
-        assertTrue(!line.contains("nothing banked live for"))
+    fun `a partial offload names only the streams that stayed empty`() {
+        val l = line(liveHr = 1, oHr = 500, oRr = 900, oGrav = 0, oResp = 0, oSkin = 700, oSpo2 = 700)
+        assertTrue(l.contains("nothing banked from the offload for: gravity, resp, steps"))
+    }
+
+    @Test
+    fun `a stream this platform cannot measure is omitted, not reported as zero`() {
+        // Apple's store returns no step count. Printing steps=0 there would name it forever.
+        val l = line(liveHr = 5, oHr = 10, oSteps = null)
+        assertTrue("an unmeasured stream must not appear", !l.contains("steps"))
+    }
+
+    @Test
+    fun `battery never appears, on either path`() {
+        // It rides the standard 0x2A19 profile, so it banks with or without the bond and answers nothing
+        // here. A field log showed 306 battery banks against battery=0 in an earlier version of this line.
+        assertTrue(!line(liveHr = 9, oHr = 9).contains("battery"))
     }
 
     @Test
     fun `negative counts cannot leak into a diagnostic`() {
-        // Pure and total on purpose: this runs on the teardown path, where throwing would cost the very
-        // report it exists to produce.
-        val line = ConnectionReadout.linkBankedSummary(-5, 1, 0, 0, 0, 0, 0, 0)
-        assertTrue(line.contains("hr=0"))
-        assertEquals(false, line.contains("-5"))
-    }
-
-    @Test
-    fun `the exact sentence for the field case, pinned against the Swift twin`() {
-        assertEquals(
-            "banked live this link: hr=456 rr=187 gravity=0 resp=0 skinTemp=0 spo2=0 steps=0 battery=2" +
-                " - nothing banked live for: gravity, resp, skinTemp, spo2, steps",
-            ConnectionReadout.linkBankedSummary(
-                hr = 456, rr = 187, gravity = 0, resp = 0, skinTemp = 0, spo2 = 0, steps = 0, battery = 2,
-            ),
-        )
-    }
-
-
-    @Test
-    fun `a stream this platform cannot measure is omitted, not reported as zero`() {
-        // Apple's store does not return a step count (persist-only, outside its insert tuple). Printing
-        // steps=0 there would name it in the zero list forever - a permanent false alarm in a line whose
-        // entire job is to make a real zero stand out.
-        val line = ConnectionReadout.linkBankedSummary(
-            hr = 456, rr = 187, gravity = 0, resp = 0, skinTemp = 0, spo2 = 0, steps = null, battery = 2,
-        )
-        assertTrue("an unmeasured stream must not appear at all", !line.contains("steps"))
-        assertTrue(line.contains("nothing banked live for: gravity, resp, skinTemp, spo2"))
+        // Runs on the teardown path, where throwing would cost the report it exists to produce.
+        val l = line(liveHr = -5, liveRr = 1, oHr = -3, oGrav = 4)
+        assertTrue(l.contains("live hr=0 rr=1"))
+        assertTrue(l.contains("hr=0"))
+        // NOT `contains("-")`: the sentence separator is a hyphen, so that assertion fails on a correct
+        // line. Check the negative VALUES are gone, which is what clamping actually promises.
+        assertEquals(false, l.contains("-5"))
+        assertEquals(false, l.contains("-3"))
     }
 }

--- a/android/app/src/test/java/com/noop/analytics/LinkBankedSummaryTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/LinkBankedSummaryTest.kt
@@ -31,7 +31,7 @@ class LinkBankedSummaryTest {
     fun `an unbonded strap reads live traffic with an offload that never ran`() {
         // The whole point: HR flowing while the offload banks nothing is the bond split, in one line.
         assertEquals(
-            "banked this link: live hr=12 rr=7 | offload did NOT run on this link",
+            "banked this link: live hr=12 rr=7 | offload none",
             line(liveHr = 12, liveRr = 7, chunks = 0),
         )
     }
@@ -92,6 +92,6 @@ class LinkBankedSummaryTest {
             line(liveHr = 1, liveRr = 1, chunks = 6),
         )
         // And the bond signal stays distinct.
-        assertTrue(line(liveHr = 1, liveRr = 1, chunks = 0).contains("offload did NOT run"))
+        assertTrue(line(liveHr = 1, liveRr = 1, chunks = 0).contains("offload none"))
     }
 }


### PR DESCRIPTION
The banked line merged yesterday reports **live inserts only**, then names `gravity`, `resp`, `skinTemp`, `spo2` and `steps` when they are zero. Those five arrive **solely through the offload's historical decoder** — `extractStreams`, the realtime decoder, yields `hr`, `rr`, `events` and `battery` and nothing else.

So the call-out printed on every link, bonded or not. A constant wearing the costume of a finding.

A field log from an unbonded 5/MG read:

```
banked live this link: hr=12 rr=7 gravity=0 resp=0 skinTemp=0 spo2=0 steps=0 battery=0
  - nothing banked live for: gravity, resp, skinTemp, spo2, steps, battery
```

which looks exactly like the bond split it was built to show — and would have looked identical on a perfectly healthy strap. I read that log an hour after merging and called it a successful verification.

**The narrowing that caused it was mine.** An earlier review pass scoped the line to live-only to stop it crying wolf on healthy offloads. That removed the false positive by deleting the true one. Eleven tests over synthetic values passed either way, because none of them encoded which path feeds which stream.

## Now

```
banked this link: live hr=12 rr=7 | offload did NOT run on this link
banked this link: live hr=1 rr=1  | offload ran 6 chunk(s), no new rows
banked this link: live hr=3 rr=2  | offload hr=1200 rr=2400 gravity=8000 resp=8000 skinTemp=8000 spo2=8000 steps=40
```

Two different sentences for two different conditions. The offload is where the bond shows — an unbonded strap defers backfill entirely — so `offload none` is the real signal and a healthy sync fills it.

`Backfiller` hands its accepted-row counts up through an `onBankedOffload` closure on both platforms, following the `ackTrim` closure already beside it, defaulted so every existing construction compiles unchanged.

## Battery removed

It rides the standard `0x2A19` profile, banks with or without the bond, and its dominant persist path is not one of the counted inserts — so it read 0 on every link and sat permanently in the call-out. The same field log showed **306 battery banks against `battery=0`**. Same rule `steps` follows on Apple: a stream a path cannot measure is omitted, never printed as zero.

## Verification

- **Full Android suite: 631 classes, 5186 tests, 0 failures**, forced with `--rerun-tasks`, all result XMLs confirmed freshly written.
- 6 tests per platform, including the two cases that matter: an unbonded strap and a healthy sync must produce *different* sentences.
- Symmetric across platforms — reset at connect and teardown, one accumulate site per path, emit inside the same `linkUpSince` guard as the epitaph.
- Concurrency verified rather than assumed: Kotlin keeps atomics (live fed by two independent `ioScope.launch` coroutines, offload by the Backfiller's own); `Collector`, `Backfiller` and `BLEManager` are all `@MainActor` on Apple, so plain vars are correct there.
- `swiftc -parse` clean on all four Swift files; `i18n_audit --ci` and `doc_comment_lint` clean.

An earlier run of this suite caught a bad assertion of mine — `!line.contains("-")` fails on a correct line, since the sentence separator is a hyphen. The Swift twin checked for `-3` and was right. Corrected to match.

**Not verified on a device.** The live half was observed on real hardware; the offload half needs a strap that actually syncs history, which the reporting strap cannot currently do.

## Found in re-review

**"Never ran" and "ran with nothing new" were sharing a sentence.** Counts are rows ACCEPTED, so a reconnect that re-offloads already-stored records banks zero while the strap plainly handed its history over — and the line called that "the offload banked NOTHING". A fault message on a healthy strap.

`classifyCompletedOffload` already draws the distinction the other way: `bankedSensorRecords = decodedChunks > 0 || rowsPersisted > 0`, deliberately counting decoded-but-deduped as delivery. This line contradicted it. The callback fires once per persisted chunk, so counting invocations separates the two with no new plumbing — three distinguishable conditions now, pinned per platform.

That is the third time on this line that a zero was mistaken for a finding: the live-only version made five streams permanently zero, `battery` was never seen by the counter, and now dedupe read as failure. None of the eleven earlier synthetic tests could catch any of them — each supplied values chosen to make its own assertion pass, so none asked *"could this be zero while everything is fine?"*

## Parity

Formatter signature, output streams, all four sentences, the `onBankedOffload` callback, the chunk counter, the tallies and their reset points, and 7 tests each — all twinned.

**One deliberate difference:** Kotlin passes a real `offloadSteps` count, Apple passes `nil`, because Apple's `StreamStore.insert` returns 8 fields and deliberately excludes steps while Room counts them. So an Android log prints `… spo2=8000 steps=40` where an Apple log prints `… spo2=8000` with no steps field. Absent beats a permanent `steps=0`, which is the false alarm this PR exists to remove — but it means the identical-sentence guarantee holds for the formatter, not for the emitted line. Closing it properly means extending Apple's insert tuple, which is a `WhoopStore` API change and belongs in its own PR.

Concurrency stays the other deliberate asymmetry, verified on both sides: atomics on Kotlin (two independent `ioScope.launch` feeders plus the Backfiller's own coroutine), plain vars on Apple (`Collector`, `Backfiller` and `BLEManager` are all `@MainActor`).

Re-verified after the change: **631 classes, 5187 tests, 0 failures**, gates clean.
