### PR TITLE
sleep: report the HRV an HR-only night actually measures (#1884)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -506,17 +506,18 @@ public enum AnalyticsEngine {
         } else {
             let rrSorted = rr.sortedByTsStable()
             let enrichedProvided: [SleepSession] = providedSleep.map { s in
-                // #1801: an HR-only night keeps its NIL restingHR/avgHRV. This is the ONE call site that
-                // can undo the display-only guarantee — enriching here would hand Charge and the baselines
-                // exactly the two values that decision withholds, silently and by default.
-                if s.hrOnly { return s }
+                // #1884: no HR-only special case any more. This used to short-circuit on `s.hrOnly` to
+                // preserve #1801's display-only guarantee, which withheld both values. Now that an HR-only
+                // session reports what it measured, that clause is not merely redundant — an HR-only night
+                // that measured a resting HR but no HRV (no R-R banked) would take the short-circuit and
+                // skip the fill every other session gets. The rule is uniform: fill what is missing.
                 guard s.restingHR == nil || s.avgHRV == nil else { return s }
                 let rhr = s.restingHR ?? SleepStager.sessionRestingHR(start: s.start, end: s.end, hr: hr)
                 let hrv = s.avgHRV ?? SleepStager.sessionAvgHRV(start: s.start, end: s.end, rr: rrSorted)
                 // `hrOnly` carried explicitly: unlike Kotlin's `copy`, this rebuilds the struct field by
-                // field, so a new flag is dropped by DEFAULT unless named here. The guard above means an
-                // HR-only night never reaches this line today; passing it anyway keeps that a belt rather
-                // than the only thing standing between the flag and silent loss.
+                // field, so a new flag is dropped by DEFAULT unless named here. #1884 removed the guard
+                // that used to keep HR-only nights away from this line, so this is now the only thing
+                // standing between the flag and silent loss rather than a belt.
                 return SleepSession(start: s.start, end: s.end, efficiency: s.efficiency,
                                     stages: s.stages, restingHR: rhr, avgHRV: hrv, hrOnly: s.hrOnly)
             }
@@ -958,12 +959,16 @@ public enum AnalyticsEngine {
             // `skinTempDevC`, so the engine's own row is symmetric: any path that persists this
             // struct directly keeps both thermal values, not just the one.
             skinTempC: nightlySkinTempC,
-            // The SAME condition that emptied `restingHr` and `avgHrv` above: `physiologySessions` is
-            // `matched` minus the HR-only ones, so an all-HR-only night leaves it empty and both vitals
-            // nil. Recorded rather than re-derived downstream, so the explanation and the values it
-            // explains cannot disagree. Byte-identical twin of Kotlin `AnalyticsEngine`'s
-            // `sleepHrOnly = if (matched.isEmpty()) null else physiologySessions.isEmpty()`.
-            sleepHrOnly: matched.isEmpty ? nil : physiologySessions.isEmpty)
+            // "Every session this day was staged from heart rate alone."
+            //
+            // #1884: read from the SESSIONS' own marker, NOT from `physiologySessions.isEmpty`. Those two
+            // were equivalent while the set was `matched` minus the HR-only ones, so an all-HR-only night
+            // emptied it. They are NOT equivalent now that the set FALLS BACK to `matched`: it can never
+            // be empty when `matched` is not, which would have pinned this flag to false forever and
+            // silently retired the #1879 note. Deriving it from `hrOnly` states what the flag has always
+            // meant and is independent of how the physiology set is chosen. Byte-identical twin of Kotlin
+            // `AnalyticsEngine`'s `sleepHrOnly = if (matched.isEmpty()) null else matched.all { it.hrOnly }`.
+            sleepHrOnly: matched.isEmpty ? nil : matched.allSatisfy { $0.hrOnly })
         _ = sleepStart; _ = sleepEnd  // available for callers wiring sleep_start/end columns
 
         // ── Cache rows ────────────────────────────────────────────────────────

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -673,17 +673,24 @@ public enum AnalyticsEngine {
         // negligible shift. The Rest/sleep-quality term is main-night; the recovery physiology is
         // day-best-resting, night-dominated. Keep these two definitions distinct on purpose.
         // Daily resting HR = lowest per-session resting HR across matched sessions.
-        // #1801: the sessions whose PHYSIOLOGY may be folded into the day's aggregates. An HR-only night
-        // is excluded — it may describe its own duration, stages and Rest, but resting HR, HRV and SDNN
-        // are what Charge and the baselines are built from, and a baseline is the one thing a false
-        // positive cannot be unwound from.
+        // #1801/#1884: the sessions whose PHYSIOLOGY is folded into the day's aggregates. Motion-backed
+        // sessions are PREFERRED; an HR-only night is used only when the day has no other kind.
         //
-        // Named once rather than filtered at each use, because the nil restingHR/avgHRV an HR-only
-        // session carries only protects the aggregates that READ those fields. The deep-window HRV pool
-        // and the SDNN index below re-derive from `rr` over the session's own stages and would have
-        // folded one in regardless — which is precisely the "one forgotten call site" a scattered filter
-        // invites.
-        let physiologySessions = matched.filter { !$0.hrOnly }
+        // #1801 excluded HR-only nights outright, reasoning that a baseline is the one thing a false positive
+        // cannot be unwound from. #1884 narrowed that rather than reversing it: only the session BOUNDS are
+        // inferred from heart rate — each RMSSD is measured over its own 5-minute window — so excluding the
+        // night discarded a real 22-25ms HRV and left Charge with NO input instead of a slightly fuzzy one, on
+        // every scoring pass in the field log. Preferring keeps the original protection exactly where it earned its keep (a mixed
+        // day still ignores the HR-only night outright) and gives it up only where the alternative was
+        // nothing at all. The night still travels marked `hrOnly` for any consumer that wants to weigh it
+        // down; what it no longer gets is a silent delete.
+        //
+        // Named once rather than filtered at each use: the deep-window HRV pool and the SDNN index below
+        // re-derive from `rr` over each session's own stages instead of reading restingHR/avgHRV, so the
+        // only way to scope them is through the session set itself — which is precisely the "one forgotten
+        // call site" a scattered filter invites.
+        let physiologyOnly = matched.filter { !$0.hrOnly }
+        let physiologySessions = physiologyOnly.isEmpty ? matched : physiologyOnly
         let restingHRDaily = physiologySessions.compactMap { $0.restingHR }.min()
         // Daily avg HRV = in-bed-weighted mean of per-session avg HRV.
         let avgHRVDaily: Double? = {

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -634,11 +634,14 @@ public enum SleepStager {
     /// as a confirmation gate on an already-detected run it is deliberately permissive, but as a primary
     /// threshold it admits over half of any window by definition. See `hrOnlyAnchorPercentile`.
     ///
-    /// `restingHR` and `avgHRV` are left NIL deliberately, and that is the whole display-only guarantee.
-    /// An HR-only night may describe itself — duration, stages, Rest — but the resting HR and HRV it
-    /// would contribute are exactly what Charge and the baselines fold in, and a baseline is the one
-    /// thing a false positive cannot be unwound from. Withholding the values is structural; a downstream
-    /// filter would be one forgotten call site away from failing open.
+    /// `restingHR` and `avgHRV` are MEASURED here and reported (#1884). They were withheld under #1801,
+    /// which treated them as inferred; they are not. Only the session BOUNDS are inferred from heart rate
+    /// — that is what `hrOnly` marks — while each RMSSD is computed over its own 5-minute window, so fuzzy
+    /// bounds change WHICH windows are included, not whether any one of them is valid. Withholding them
+    /// discarded a measured 22-25 ms and left Charge with no input at all, which is a worse error than a
+    /// slightly fuzzy one.
+    ///
+    /// The flag travels on instead, so a consumer that wants to weigh an HR-only night down still can.
     /// `public` because the app target calls it: `Strand/Data/IntelligenceEngine.swift` is the day scan,
     /// and it lives outside this package. The spine and the anchor below it stay `internal` — the tests
     /// reach them with `@testable`, and nothing outside should be building its own spine.

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -674,9 +674,18 @@ public enum SleepStager {
                                                     hr: hrS, rr: rrS, resp: resp)
             staged += 1
             if stages.isEmpty { continue }
+            // #1884: MEASURED, not nilled. The bounds here are inferred from heart rate, which is why
+            // `hrOnly` marks the session — but each RMSSD is computed over its own 5-minute window tagged
+            // by the stage at its centre, so fuzzy bounds change WHICH windows are included, not whether
+            // any one of them is valid. A field log showed this path computing a stable 22-25ms deepOnly
+            // and discarding it, leaving Charge unscoreable. `hrOnly` still travels with the session, so
+            // it is a quality marker now rather than a delete. Kotlin twin: `SleepStager.hrOnlySessions`.
             out.append(SleepSession(start: p.start, end: p.end,
                                     efficiency: efficiency(start: p.start, end: p.end, stages: stages),
-                                    stages: stages, restingHR: nil, avgHRV: nil, hrOnly: true))
+                                    stages: stages,
+                                    restingHR: sessionRestingHR(start: p.start, end: p.end, hr: hrS),
+                                    avgHRV: sessionAvgHRV(start: p.start, end: p.end, rr: rrS),
+                                    hrOnly: true))
         }
         traceSink?(GateTrace.hrOnlyLine(
             anchorBpm: baseline,

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineHrOnlyDayTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalyticsEngineHrOnlyDayTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import XCTest
+import WhoopProtocol
+import WhoopStore
+@testable import StrandAnalytics
+
+/// A whole day whose only sleep is HR-only, driven through `analyzeDay` (#1884).
+///
+/// The ORACLE twin of the Kotlin `AnalyticsEngineHrOnlyDayTest`. The unit tests around this one check the
+/// pieces — `SleepStagerHrOnlySessionsTests` that a session reports what it measured,
+/// `HrOnlyPhysiologyIsolationTests` that the day's physiology set is chosen the way the design says.
+/// Neither runs the whole function, and the gap between them is where #1884's own regression hid:
+/// `sleepHrOnly` was derived from `physiologySessions.isEmpty`, which means "every session was HR-only"
+/// ONLY while that set was an exclusion. Making it a preference means it can never be empty when
+/// `matched` is not, so the flag would have been pinned to false forever.
+///
+/// Nothing pinned that derivation: every other `sleepHrOnly` test supplies the flag as an INPUT (the
+/// carry, the coalesce, the migration, the note gate). This drives it as an OUTPUT.
+final class AnalyticsEngineHrOnlyDayTests: XCTestCase {
+
+    private let profile = UserProfile(weightKg: 75, heightCm: 178, age: 30, sex: "male")
+    private let day = "2026-07-27"
+
+    /// The same field-shaped generator the session tests use — 16 h awake around 74 +/- 11 bpm, then 8 h
+    /// asleep around 64 +/- 5 — anchored so the night runs 00:00-08:00 on `day`. NO gravity, which is what
+    /// makes the night HR-only: an unbonded strap streams standard HR and R-R and banks no motion.
+    private func streams() -> ([HRSample], [RRInterval]) {
+        let dayStart = AnalyticsEngine.dayStartUtcSeconds(day)
+        let t0 = dayStart - 16 * 3600
+        var hr: [HRSample] = []
+        var rr: [RRInterval] = []
+        for i in 0..<(16 * 3600) {
+            let bpm = 74 + Int(sin(Double(i) / 500.0) * 11)
+            hr.append(HRSample(ts: t0 + i, bpm: bpm))
+            rr.append(RRInterval(ts: t0 + i, rrMs: 60000 / bpm))
+        }
+        for j in 0..<(8 * 3600) {
+            let bpm = 64 + Int(sin(Double(j) / 900.0) * 5)
+            hr.append(HRSample(ts: dayStart + j, bpm: bpm))
+            rr.append(RRInterval(ts: dayStart + j, rrMs: 60000 / bpm))
+        }
+        return (hr, rr)
+    }
+
+    func testAllHrOnlyDayReportsMeasuredVitalsAndStillMarksItselfHrOnly() {
+        let (hr, rr) = streams()
+        // The production wiring: IntelligenceEngine stages the HR-only night and hands it to analyzeDay as
+        // `providedSleep`. Driving it the same way is the point — the enrichment call site that used to
+        // short-circuit on `hrOnly` only exists on this path.
+        let provided = SleepStager.hrOnlySessions(hr: hr, rr: rr, resp: [])
+        XCTAssertFalse(provided.isEmpty, "the HR-only spine must stage a night here")
+
+        let res = AnalyticsEngine.analyzeDay(day: day, hr: hr, rr: rr, profile: profile,
+                                             providedSleep: provided)
+
+        XCTAssertFalse(res.sleepSessions.isEmpty, "the staged night must reach the day's sessions")
+        XCTAssertTrue(res.sleepSessions.allSatisfy { $0.hrOnly },
+                      "every session must be HR-only — this day has no gravity at all")
+
+        // #1884: measured, not discarded. Before the change both of these were nil by construction, which
+        // is what left Charge with `nilScore reason=missingInput`.
+        XCTAssertNotNil(res.daily.restingHr, "resting HR is HR-derived and must survive to the day row")
+        XCTAssertNotNil(res.daily.avgHrv,
+                        "the HRV measured over this night's windows must survive to the day row")
+
+        // The regression guard. `sleepHrOnly` says "every session was staged from heart rate alone", and
+        // that remains TRUE of this day — the change made the vitals available, not the staging better.
+        XCTAssertEqual(res.daily.sleepHrOnly, true, "the day must still be marked HR-only")
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrOnlyPhysiologyIsolationTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrOnlyPhysiologyIsolationTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// How an HR-only night reaches the day's physiology, guarded at the level it actually fails.
+///
+/// The twin of the Kotlin `HrOnlyPhysiologyIsolationTest`, which had no Apple counterpart until #1884 —
+/// so the decision was pinned on one platform and free to drift on the other, which is precisely the
+/// asymmetry the parity contract exists to prevent.
+///
+/// #1801 made this an EXCLUSION: an HR-only night was kept out of every physiological aggregate. #1884
+/// made it a PREFERENCE, because the exclusion was discarding a computed HRV and leaving Charge with no
+/// input at all. The night is still marked `hrOnly` for anything that wants to weigh it down; what it no
+/// longer gets is a silent delete.
+///
+/// A nil `restingHR`/`avgHRV` only ever protected an aggregate that READS those fields. Two of the day's
+/// physiological aggregates do not: the deep-window HRV pool and the SDNN index both re-derive from `rr`
+/// over each session's own stages, so an HR-only night — which has stages — would be folded into both,
+/// and from there into Charge and the HRV baseline. `deepHrvWindow` is a user setting, so that path is
+/// reachable, not theoretical.
+///
+/// Read from the source because `physiologySessions` is a local inside `analyzeDay` and cannot be
+/// observed directly, and because the failure this guards is a FUTURE aggregate reaching for `matched`
+/// out of habit. A behavioural test on one path would not catch that; this does.
+final class HrOnlyPhysiologyIsolationTests: XCTestCase {
+
+    /// Walk up from this test file to the package root, so the lookup survives whatever directory the
+    /// test runner happens to start in.
+    private func engineSource() throws -> String {
+        var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        for _ in 0..<5 {
+            let f = dir.appendingPathComponent("Sources/StrandAnalytics/AnalyticsEngine.swift")
+            if FileManager.default.fileExists(atPath: f.path) {
+                return try String(contentsOf: f, encoding: .utf8)
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        XCTFail("AnalyticsEngine.swift not found — this test must not pass by default")
+        throw CocoaError(.fileNoSuchFile)
+    }
+
+    /// The slice of `analyzeDay` running from just after the physiology set is named through the end of
+    /// the SDNN call, which is the last of the four aggregates built from it.
+    private func analyzeDayBody() throws -> String {
+        let src = try engineSource()
+        let decl = try XCTUnwrap(src.range(of: "let physiologySessions"),
+                                 "analyzeDay must name the physiology-session set")
+        // Start AFTER the declaration: those lines read `matched` legitimately, since defining the
+        // preferred set is the one place the unfiltered one belongs.
+        let from = try XCTUnwrap(src.range(of: "\n", range: decl.upperBound..<src.endIndex)).upperBound
+        let sdnn = try XCTUnwrap(src.range(of: "let avgSDNNDaily", range: from..<src.endIndex),
+                                 "expected the SDNN index to follow the physiology set")
+        let seg = try XCTUnwrap(src.range(of: "segmentSec: 300", range: sdnn.lowerBound..<src.endIndex))
+        let close = try XCTUnwrap(src.range(of: ")", range: seg.upperBound..<src.endIndex))
+        return String(src[from..<close.upperBound])
+    }
+
+    /// #1884 changed this from an exclusion to a PREFERENCE. The Kotlin twin's old assertion could not
+    /// tell the difference — it was a prefix `contains`, so appending the fallback reversed the guarantee
+    /// while the guard stayed green. Both spellings are pinned whole here, so the next change to either
+    /// has to be deliberate rather than accidental.
+    func testPhysiologySetPrefersMotionBackedNightsAndFallsBackRatherThanEmptying() throws {
+        let src = try engineSource()
+        XCTAssertTrue(src.contains("let physiologyOnly = matched.filter { !$0.hrOnly }"),
+                      "the hrOnly filter must survive the fallback")
+        XCTAssertTrue(
+            src.contains("let physiologySessions = physiologyOnly.isEmpty ? matched : physiologyOnly"),
+            "physiologySessions must PREFER motion-backed sessions and fall back rather than emptying")
+    }
+
+    /// The four aggregates built from a night's physiology must read the preferred set. `matched` still
+    /// has legitimate uses in `analyzeDay` — duration, stage totals, Rest, the onset — which is exactly
+    /// why this checks the physiology region rather than banning the name outright.
+    func testNoPhysiologicalAggregateReadsTheUnfilteredSessions() throws {
+        let body = try analyzeDayBody()
+        var offenders: [String] = []
+        var i = body.startIndex
+        while let hit = body.range(of: "matched.", range: i..<body.endIndex) {
+            if hit.upperBound < body.endIndex, body[hit.upperBound].isLetter {
+                offenders.append(String(body[hit.lowerBound...hit.upperBound]))
+            }
+            i = hit.upperBound
+        }
+        XCTAssertTrue(offenders.isEmpty,
+                      "physiological aggregates must use physiologySessions, found: \(offenders)")
+        for needle in ["restingHRDaily", "let deep", "let pairs", "avgSDNNDaily"] {
+            XCTAssertTrue(body.contains(needle), "\(needle) must sit inside the guarded region")
+        }
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrOnlyPhysiologyIsolationTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrOnlyPhysiologyIsolationTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 @testable import StrandAnalytics
 

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerHrOnlySessionsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerHrOnlySessionsTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import WhoopProtocol
+@testable import StrandAnalytics
+
+/// Whole HR-only sessions (#1801) and the physiology they report (#1884).
+///
+/// The ORACLE twin of the Kotlin `SleepStagerHrOnlySessionsTest`: the same synthetic night and the same
+/// expectations, so a divergence in the null contract fails on one platform and not the other. The Apple
+/// side had no twin of this file until #1884, which is exactly how the two `restingHR`/`avgHRV` spellings
+/// could have drifted apart unnoticed — Swift structs have no `copy()`, so each rebuild respells the
+/// field list and a field is lost by omission rather than by an edit anyone reviews.
+///
+/// The night is synthetic: a slow HR drift well under the window median, so the spine puts it in the
+/// sleep band. That exercises assembly and the reporting contract; it is NOT a claim that the staging is
+/// accurate on a real night, which no test here can establish.
+final class SleepStagerHrOnlySessionsTests: XCTestCase {
+
+    /// A field-shaped window: `aH` hours awake around 74 +/- 11 bpm, then `nH` hours asleep around
+    /// 64 +/- 5 — the shape the #1801 report shows, and the same generator the Kotlin twin uses.
+    private func window(aH: Int = 16, nH: Int = 8) -> ([HRSample], [RRInterval]) {
+        let t0 = 1_788_300_000
+        var hr: [HRSample] = []
+        var rr: [RRInterval] = []
+        for i in 0..<(aH * 3600) {
+            let bpm = 74 + Int(sin(Double(i) / 500.0) * 11)
+            hr.append(HRSample(ts: t0 + i, bpm: bpm))
+            rr.append(RRInterval(ts: t0 + i, rrMs: 60000 / bpm))
+        }
+        for j in 0..<(nH * 3600) {
+            let bpm = 64 + Int(sin(Double(j) / 900.0) * 5)
+            let t = t0 + aH * 3600 + j
+            hr.append(HRSample(ts: t, bpm: bpm))
+            rr.append(RRInterval(ts: t, rrMs: 60000 / bpm))
+        }
+        return (hr, rr)
+    }
+
+    func testLowHRNightBecomesAtLeastOneStagedSession() {
+        let (hr, rr) = window()
+        let out = SleepStager.hrOnlySessions(hr: hr, rr: rr, resp: [])
+        XCTAssertFalse(out.isEmpty, "expected at least one night, got \(out.count)")
+        XCTAssertTrue(out.allSatisfy { !$0.stages.isEmpty }, "every session must carry stages")
+        XCTAssertTrue(out.allSatisfy { ($0.end - $0.start) >= SleepStager.minSleepMin * 60 },
+                      "every session must span at least minSleepMin")
+        // Conservative by design: it may under-read a night, but must never invent more sleep than the
+        // window holds.
+        XCTAssertLessThanOrEqual(out.reduce(0) { $0 + ($1.end - $1.start) }, 8 * 3600,
+                                 "total must not exceed the 8 h actually asleep")
+    }
+
+    /// #1884 reversed the null contract #1801 established, so the reasoning is worth keeping beside it.
+    ///
+    /// #1801 withheld `restingHR` and `avgHRV` here on the grounds that a baseline is the one thing a
+    /// false positive cannot be unwound from. The field logs showed the withholding was the more damaging
+    /// error: the values are MEASURED, not inferred. The BOUNDS are what heart rate infers — which is why
+    /// the session still marks itself `hrOnly` — but each RMSSD is computed over its own 5-minute window,
+    /// so fuzzy bounds change WHICH windows are included, not whether any one of them is valid. Resting HR
+    /// is HR-derived, and an HR-only night is precisely the night with plenty of HR.
+    ///
+    /// The marker travels with the session, so a consumer that wants to weigh these down still can.
+    func testHrOnlySessionReportsMeasuredRestingHRAndHRVAndStillMarksItself() throws {
+        let (hr, rr) = window()
+        let s = try XCTUnwrap(SleepStager.hrOnlySessions(hr: hr, rr: rr, resp: []).first)
+        XCTAssertTrue(s.hrOnly, "must still be flagged hrOnly")
+        XCTAssertNotNil(s.restingHR, "restingHR is HR-derived and must be reported")
+        XCTAssertNotNil(s.avgHRV, "avgHRV must be reported when R-R is present")
+    }
+
+    /// The honest boundary of the change: reporting is driven by whether the INPUT exists, not by the
+    /// `hrOnly` flag. With no R-R there is nothing to compute an RMSSD from, so HRV is still absent — and
+    /// resting HR, which needs only HR, is still reported. A regression that re-blanked HRV wholesale
+    /// would pass the case above if it also happened to blank on missing R-R; this separates them.
+    func testHrOnlySessionWithoutRRStillReportsRestingHR() throws {
+        let (hr, _) = window()
+        let s = try XCTUnwrap(SleepStager.hrOnlySessions(hr: hr, rr: [], resp: []).first)
+        XCTAssertTrue(s.hrOnly, "must still be flagged hrOnly")
+        XCTAssertNotNil(s.restingHR, "restingHR needs only HR")
+        XCTAssertNil(s.avgHRV, "no R-R means no RMSSD to report")
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerHrOnlySessionsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerHrOnlySessionsTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 import WhoopProtocol
 @testable import StrandAnalytics

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -443,10 +443,12 @@ object AnalyticsEngine {
         } else {
             val rrSorted = rr.sortedBy { it.ts }
             val enrichedProvided = providedSleep.map { s ->
-                // #1801: an HR-only night keeps its NULL restingHR/avgHRV. This is the ONE call site that
-                // can undo the display-only guarantee — enriching here would hand Charge and the baselines
-                // exactly the two values that decision withholds, silently and by default.
-                if (s.hrOnly || (s.restingHR != null && s.avgHRV != null)) s
+                // #1884: no HR-only special case any more. This used to short-circuit on `s.hrOnly` to
+                // preserve #1801's display-only guarantee, which withheld both values. Now that an HR-only
+                // session reports what it measured, that clause is not merely redundant — an HR-only night
+                // that measured a resting HR but no HRV (no R-R banked) would take the short-circuit and
+                // skip the fill every other session gets. The rule is uniform: fill what is missing.
+                if (s.restingHR != null && s.avgHRV != null) s
                 else s.copy(
                     restingHR = s.restingHR ?: SleepStager.sessionRestingHR(s.start, s.end, hr),
                     avgHRV = s.avgHRV ?: SleepStager.sessionAvgHRV(s.start, s.end, rrSorted),
@@ -876,11 +878,15 @@ object AnalyticsEngine {
             disturbances = if (matched.isEmpty()) null else disturbances,
             restingHr = restingHRDaily,
             avgHrv = avgHRVDaily,
-            // The SAME condition that just emptied the two fields above: `physiologySessions` is
-            // `matched` minus the HR-only ones, so an all-HR-only night leaves it empty and both vitals
-            // null. Recording it here rather than re-deriving in the UI keeps the explanation and the
-            // cause as one expression — a second definition could disagree with the values it explains.
-            sleepHrOnly = if (matched.isEmpty()) null else physiologySessions.isEmpty(),
+            // "Every session this day was staged from heart rate alone."
+            //
+            // #1884: read from the SESSIONS' own marker, NOT from `physiologySessions.isEmpty()`. Those
+            // two were equivalent while the set was `matched` minus the HR-only ones, so an all-HR-only
+            // night emptied it. They are NOT equivalent now that the set FALLS BACK to `matched`: it can
+            // never be empty when `matched` is not, which would have pinned this flag to false forever
+            // and silently retired the #1879 note. Deriving it from `hrOnly` states what the flag has
+            // always meant and is independent of how the physiology set is chosen.
+            sleepHrOnly = if (matched.isEmpty()) null else matched.all { it.hrOnly },
             recovery = recovery,
             strain = strain,
             exerciseCount = workouts.size,

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -550,17 +550,23 @@ object AnalyticsEngine {
         // negligible shift. The Rest/sleep-quality term is main-night; the recovery physiology is
         // day-best-resting, night-dominated. Mirrors the Swift note in AnalyticsEngine.swift.
         // Daily resting HR = lowest per-session resting HR across matched sessions.
-        // #1801: the sessions whose PHYSIOLOGY may be folded into the day's aggregates. An HR-only night
-        // is excluded — it may describe its own duration, stages and Rest, but resting HR, HRV and SDNN
-        // are what Charge and the baselines are built from, and a baseline is the one thing a false
-        // positive cannot be unwound from.
+        // #1801/#1884: the sessions whose PHYSIOLOGY is folded into the day's aggregates. Motion-backed
+        // sessions are PREFERRED; an HR-only night is used only when the day has no other kind.
         //
-        // Named once rather than filtered at each use, because the null restingHR/avgHRV an HR-only
-        // session carries only protects the aggregates that READ those fields. The deep-window HRV pool
-        // and the SDNN index below re-derive from `rr` over the session's own stages and would have
-        // folded one in regardless — which is precisely the "one forgotten call site" a scattered filter
-        // invites.
-        val physiologySessions = matched.filter { !it.hrOnly }
+        // #1801 excluded HR-only nights outright, reasoning that a baseline is the one thing a false positive
+        // cannot be unwound from. #1884 narrowed that rather than reversing it: only the session BOUNDS are
+        // inferred from heart rate — each RMSSD is measured over its own 5-minute window — so excluding the
+        // night discarded a real 22-25ms HRV and left Charge with NO input instead of a slightly fuzzy one, on
+        // every scoring pass in the field log. Preferring keeps the original protection exactly where it earned its keep (a mixed
+        // day still ignores the HR-only night outright) and gives it up only where the alternative was
+        // nothing at all. The night still travels marked `hrOnly` for any consumer that wants to weigh it
+        // down; what it no longer gets is a silent delete.
+        //
+        // Named once rather than filtered at each use: the deep-window HRV pool and the SDNN index below
+        // re-derive from `rr` over each session's own stages instead of reading restingHR/avgHRV, so the
+        // only way to scope them is through the session set itself — which is precisely the "one forgotten
+        // call site" a scattered filter invites.
+        val physiologySessions = matched.filter { !it.hrOnly }.ifEmpty { matched }
         val restingHRDaily: Int? = physiologySessions.mapNotNull { it.restingHR }.minOrNull()
         // Daily avg HRV = in-bed-weighted mean of per-session avg HRV.
         val avgHRVDaily: Double? = if (deepHrvWindow) {

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -998,8 +998,8 @@ object IntelligenceEngine {
                         // also lands here, where the owner check previously blocked it. A normal 4.0 day
                         // is untouched — it streams gravity, so it never reaches this gate — and a day
                         // with no motion has too little of anything to clear `minSleepMin`, but "too
-                        // little" is not "none", so the night it could produce is display-only and
-                        // marked [DetectedSleep.hrOnly] like every other.
+                        // little" is not "none", so the night it could produce is marked
+                        // [DetectedSleep.hrOnly] like every other.
                         dayDiag(SleepStagerTrace.hrOnlyGateLine(
                             attempted = true, reason = "no-motion-no-hypnogram",
                             gravRows = grav.size, storedNights = 0,

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -754,8 +754,20 @@ object SleepStager {
                     end = p.end,
                     efficiency = efficiency(start = p.start, end = p.end, stages = stages),
                     stages = stages,
-                    restingHR = null,
-                    avgHRV = null,
+                    // #1884: MEASURED, not nulled. The bounds here are inferred from heart rate, which is
+                    // why `hrOnly` marks the session — but each RMSSD is computed over its own 5-minute
+                    // window tagged by the stage at its centre, so fuzzy bounds change WHICH windows are
+                    // included, not whether any one of them is valid. Field logs showed this path
+                    // computing wholeNight=24.04ms / deepOnly=22.44ms over 55 windows and then throwing it
+                    // away, which left Charge with `nilScore reason=missingInput` on every pass. Resting HR
+                    // is HR-derived and an HR-only night is precisely the night with plenty of HR.
+                    //
+                    // `hrOnly` still travels with the session and is persisted as `dailyMetric.sleepHrOnly`
+                    // (#1879), so it is a quality marker now rather than a delete. Its one reader today,
+                    // `TodayScreen.showsHrOnlyNote`, is gated on a vital ACTUALLY being blank, so the note
+                    // explaining the blanks retires itself on the nights this change fills in.
+                    restingHR = sessionRestingHR(start = p.start, end = p.end, hr = hrS),
+                    avgHRV = sessionAvgHRV(start = p.start, end = p.end, rr = rrS),
                     hrOnly = true,
                 )
             )

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -700,11 +700,14 @@ object SleepStager {
      * as a confirmation gate on an already-detected run it is deliberately permissive, but as a primary
      * threshold it admits over half of any window by definition. See [hrOnlyAnchorPercentile].
      *
-     * [DetectedSleep.restingHR] and [DetectedSleep.avgHRV] are left NULL deliberately, and that is the
-     * whole display-only guarantee. An HR-only night may describe itself — duration, stages, Rest — but
-     * the resting HR and HRV it would contribute are exactly what Charge and the baselines fold in, and
-     * a baseline is the one thing a false positive cannot be unwound from. Withholding the values is
-     * structural; a downstream filter would be one forgotten call site away from failing open.
+     * [DetectedSleep.restingHR] and [DetectedSleep.avgHRV] are MEASURED here and reported (#1884). They
+     * were withheld under #1801, which treated them as inferred; they are not. Only the session BOUNDS
+     * are inferred from heart rate — that is what [DetectedSleep.hrOnly] marks — while each RMSSD is
+     * computed over its own 5-minute window, so fuzzy bounds change WHICH windows are included, not
+     * whether any one of them is valid. Withholding them discarded a measured 22-25 ms and left Charge
+     * with no input at all, which is a worse error than a slightly fuzzy one.
+     *
+     * The flag travels on instead, so a consumer that wants to weigh an HR-only night down still can.
      */
     internal fun hrOnlySessions(
         hr: List<HrSample>,

--- a/android/app/src/test/java/com/noop/analytics/AnalyticsEngineHrOnlyDayTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AnalyticsEngineHrOnlyDayTest.kt
@@ -1,0 +1,80 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import com.noop.data.RrInterval
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * A whole day whose only sleep is HR-only, driven through `analyzeDay` (#1884).
+ *
+ * The unit tests around this one check the pieces: `SleepStagerHrOnlySessionsTest` that a session reports
+ * what it measured, `HrOnlyPhysiologyIsolationTest` that the day's physiology set is chosen the way the
+ * design says. Neither runs the whole function, and the gap between them is where #1884's own regression
+ * hid: `sleepHrOnly` was derived from `physiologySessions.isEmpty()`, which is equivalent to "every
+ * session was HR-only" ONLY while the set was an exclusion. Making it a preference means it can never be
+ * empty when `matched` is not, so the flag would have been pinned to false forever — and the note that
+ * explains a blank Recovery Vitals card would have silently stopped appearing for everyone.
+ *
+ * Nothing pinned that derivation: every other `sleepHrOnly` test supplies the flag as an INPUT (the carry,
+ * the coalesce, the migration, the note gate). This drives it as an OUTPUT.
+ */
+class AnalyticsEngineHrOnlyDayTest {
+
+    private val profile = UserProfile(weightKg = 75.0, heightCm = 178.0, age = 30.0, sex = "male")
+    private val day = "2026-07-27"
+    private val dayStart = LocalDate.parse(day).atStartOfDay(ZoneOffset.UTC).toEpochSecond()
+
+    /**
+     * The same field-shaped generator the session tests use — 16 h awake around 74 +/- 11 bpm, then 8 h
+     * asleep around 64 +/- 5 — anchored so the night runs 00:00-08:00 on `day`. NO gravity, which is what
+     * makes the night HR-only: an unbonded strap streams standard HR and R-R and banks no motion.
+     */
+    private fun streams(): Pair<List<HrSample>, List<RrInterval>> {
+        val t0 = dayStart - 16 * 3600
+        val hr = ArrayList<HrSample>()
+        val rr = ArrayList<RrInterval>()
+        var i = 0
+        while (i < 16 * 3600) {
+            val bpm = 74 + (Math.sin(i / 500.0) * 11).toInt()
+            hr.add(HrSample("t", t0 + i, bpm)); rr.add(RrInterval("t", t0 + i, 60000 / bpm)); i++
+        }
+        var j = 0
+        while (j < 8 * 3600) {
+            val bpm = 64 + (Math.sin(j / 900.0) * 5).toInt()
+            val t = dayStart + j
+            hr.add(HrSample("t", t, bpm)); rr.add(RrInterval("t", t, 60000 / bpm)); j++
+        }
+        return hr to rr
+    }
+
+    @Test
+    fun `an all HR-only day reports its measured vitals and still marks itself HR-only`() {
+        val (hr, rr) = streams()
+        // The production wiring: IntelligenceEngine stages the HR-only night and hands it to analyzeDay
+        // as `providedSleep`. Driving it the same way is the point — the enrichment call site that used to
+        // short-circuit on `hrOnly` only exists on this path.
+        val provided = SleepStager.hrOnlySessions(hr, rr, emptyList())
+        assertTrue("the HR-only spine must stage a night here", provided.isNotEmpty())
+        val res = AnalyticsEngine.analyzeDay(day = day, hr = hr, rr = rr, profile = profile,
+            providedSleep = provided)
+
+        assertTrue("the staged night must reach the day's sessions", res.sleepSessions.isNotEmpty())
+        assertTrue("every session must be HR-only — this day has no gravity at all",
+            res.sleepSessions.all { it.hrOnly })
+
+        // #1884: measured, not discarded. Before the change both of these were null by construction, which
+        // is what left Charge with `nilScore reason=missingInput`.
+        assertNotNull("resting HR is HR-derived and must survive to the day row", res.daily.restingHr)
+        assertNotNull("the HRV measured over this night's windows must survive to the day row",
+            res.daily.avgHrv)
+
+        // The regression guard. `sleepHrOnly` says "every session was staged from heart rate alone", and
+        // that remains TRUE of this day — the change made the vitals available, not the staging better.
+        assertEquals("the day must still be marked HR-only", true, res.daily.sleepHrOnly)
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/HrOnlyPhysiologyIsolationTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrOnlyPhysiologyIsolationTest.kt
@@ -4,7 +4,12 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * The display-only guarantee for an HR-only night (#1801), guarded at the level it actually fails.
+ * How an HR-only night reaches the day's physiology, guarded at the level it actually fails.
+ *
+ * #1801 made this an EXCLUSION: an HR-only night was kept out of every physiological aggregate. #1884
+ * made it a PREFERENCE, because the exclusion was discarding a computed HRV and leaving Charge with no
+ * input at all. The night is still marked `hrOnly` for anything that wants to weigh it down; what it no
+ * longer gets is a silent delete.
  *
  * A null `restingHR`/`avgHRV` only protects an aggregate that READS those fields. Two of the day's
  * physiological aggregates do not: the deep-window HRV pool and the SDNN index both re-derive from `rr`
@@ -40,7 +45,7 @@ class HrOnlyPhysiologyIsolationTest {
     }
 
     @Test
-    fun `the physiology set excludes HR-only nights`() {
+    fun `the physiology set prefers motion-backed nights and falls back rather than emptying`() {
         var root = java.io.File(System.getProperty("user.dir") ?: ".").canonicalFile
         val src = run {
             repeat(4) {
@@ -50,8 +55,18 @@ class HrOnlyPhysiologyIsolationTest {
             }
             error("AnalyticsEngine.kt not found — this test must not pass by default")
         }
-        assertTrue("physiologySessions must filter out hrOnly",
-            src.contains("val physiologySessions = matched.filter { !it.hrOnly }"))
+        // #1884 changed this from an exclusion to a PREFERENCE, and the old assertion could not tell the
+        // difference: it was a `contains` on a prefix, so appending `.ifEmpty { matched }` reversed the
+        // guarantee while the guard stayed green. Pin the whole expression, so the next change to it has
+        // to be deliberate rather than accidental.
+        assertTrue(
+            "physiologySessions must PREFER motion-backed sessions and fall back rather than emptying",
+            src.contains("val physiologySessions = matched.filter { !it.hrOnly }.ifEmpty { matched }"),
+        )
+        // The preference still has to exist: an aggregate that simply read `matched` would fold an
+        // HR-only night in even when a motion-backed one was available on the same day.
+        assertTrue("the hrOnly filter must survive the fallback",
+            src.contains("matched.filter { !it.hrOnly }"))
     }
 
     /**

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlySessionsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlySessionsTest.kt
@@ -3,6 +3,7 @@ package com.noop.analytics
 import com.noop.data.HrSample
 import com.noop.data.RrInterval
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -54,16 +55,39 @@ class SleepStagerHrOnlySessionsTest {
     }
 
     /**
-     * The display-only guarantee at its source. restingHR and avgHRV are the two values Charge and the
-     * baselines fold in, and a baseline is the one thing a false positive cannot be unwound from.
+     * #1884 reversed the null contract this used to pin, so the reasoning is worth keeping beside it.
+     *
+     * #1801 withheld restingHR and avgHRV here on the grounds that a baseline is the one thing a false
+     * positive cannot be unwound from. What the field logs showed is that the withholding was the more
+     * damaging error: the values are MEASURED, not inferred. The bounds are what heart rate infers —
+     * which is why the session still marks itself `hrOnly` — but each RMSSD is computed over its own
+     * 5-minute window, so fuzzy bounds change WHICH windows are included, not whether any one of them
+     * is valid. Resting HR is HR-derived, and an HR-only night is precisely the night with plenty of HR.
+     *
+     * The marker travels with the session, so a consumer that wants to weigh these down still can.
      */
     @Test
-    fun `an HR-only session withholds resting HR and HRV and marks itself`() {
+    fun `an HR-only session reports measured resting HR and HRV and still marks itself`() {
         val (hr, rr) = window()
         val s = SleepStager.hrOnlySessions(hr, rr, emptyList()).first()
-        assertTrue("must be flagged hrOnly", s.hrOnly)
-        assertNull("restingHR must stay null", s.restingHR)
-        assertNull("avgHRV must stay null", s.avgHRV)
+        assertTrue("must still be flagged hrOnly", s.hrOnly)
+        assertNotNull("restingHR is HR-derived and must be reported", s.restingHR)
+        assertNotNull("avgHRV must be reported when R-R is present", s.avgHRV)
+    }
+
+    /**
+     * The honest boundary of the change: reporting is driven by whether the INPUT exists, not by the
+     * `hrOnly` flag. With no R-R there is nothing to compute an RMSSD from, so HRV is still absent —
+     * and resting HR, which needs only HR, is still reported. A regression that re-blanked HRV wholesale
+     * would pass the test above if it also happened to blank on missing R-R; this separates them.
+     */
+    @Test
+    fun `an HR-only session without R-R still reports resting HR`() {
+        val (hr, _) = window()
+        val s = SleepStager.hrOnlySessions(hr, emptyList(), emptyList()).first()
+        assertTrue("must still be flagged hrOnly", s.hrOnly)
+        assertNotNull("restingHR needs only HR", s.restingHR)
+        assertNull("no R-R means no RMSSD to report", s.avgHRV)
     }
 
     /** A stretch below the minimum-duration gate is not a night. */

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlySessionsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerHrOnlySessionsTest.kt
@@ -9,7 +9,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Whole HR-only sessions (#1801), and the display-only guarantee that rides on them.
+ * Whole HR-only sessions (#1801), and the physiology they report (#1884).
  *
  * The night is synthetic: a slow HR drift well under the window median, so the spine puts it in the
  * sleep band. That is enough to exercise assembly and the null contract; it is NOT a claim that the


### PR DESCRIPTION
Addresses #1884.

An HR-only night (#1801) computes a real per-window RMSSD and a real resting HR, then throws both away. `hrOnlySessions` built each `SleepSession` with `restingHR = null, avgHRV = null`, and `analyzeDay` filtered those sessions out of every physiological aggregate.

On a strap that has lost its encrypted bond — streaming standard HR and R-R over `0x2A37` but banking no motion — **every** night is HR-only, so both day vitals were null by construction and Charge had no input at all:

```
[hrv] hrv nightSummary reported=nil wholeNight=24.04ms deepOnly=22.44ms lastSWS=28.5ms nWin=55 nDeep=13
[recovery] charge day=... nilScore reason=missingInput (hrv/rhr/hrvBaseline required)
```

55 windows, 13 of them deep, a stable 22-25 ms — computed, logged, discarded.

### Why the withholding was the wrong call

It treated those numbers as *inferred*. They are *measured*. Only the session **bounds** come from heart rate — which is why the session still marks itself `hrOnly` — while each RMSSD is computed over its own 5-minute window tagged by the stage at its centre. Fuzzy bounds change **which** windows are included, not whether any one of them is valid. Resting HR is HR-derived, and an HR-only night is precisely the night with plenty of heart rate.

### What changes

- `SleepStager.hrOnlySessions` populates `restingHR`/`avgHRV` from the same helpers the motion path uses, instead of hardcoding null.
- `AnalyticsEngine.analyzeDay` **prefers** motion-backed sessions rather than excluding HR-only ones outright.

A **mixed** day is unchanged — the motion sessions win and the HR-only night never enters the aggregate, so #1801's protection is kept exactly where it earned its keep. Only an **all**-HR-only day, which previously produced nothing at all, now falls back to what it has.

`hrOnly` still travels with the session and is persisted as `dailyMetric.sleepHrOnly` (#1879), so it remains available as a quality marker. Its one reader — the note explaining the blank vitals — is gated on a vital *actually* being blank, so that note retires itself on the nights this fills in.

### The guard that would not have caught this

`HrOnlyPhysiologyIsolationTest` exists specifically to pin this decision, and it **passed unchanged** against the reversal: it asserted `contains("val physiologySessions = matched.filter { !it.hrOnly }")`, which is a prefix of the new line, and its region scan starts *after* the declaration where the fallback sits. Both guards are re-pinned to the whole expression rather than deleted.

Both Kotlin guards also gained Apple twins that did not previously exist (`SleepStagerHrOnlySessionsTests`, `HrOnlyPhysiologyIsolationTests`) — the decision had been pinned on one platform and free to drift on the other.

### Verification

- Android full suite: **5189 tests, 0 failures** (`--rerun-tasks --no-build-cache`, result XML timestamps checked). Net +1 test.
- `Tools/i18n_audit.py --ci origin/main` clean; `Tools/doc_comment_lint.py` clean. No new user-facing copy.
- Swift files parse; StrandAnalytics tests are CI-only here (transitive `CSQLite` won't build on Linux). The Swift isolation guard's region-scan algorithm was simulated against the real `AnalyticsEngine.swift` so it isn't first exercised in CI.
- No schema change — nothing to bump.

Not verified on device: whether the user's own blank Recovery Vitals populate on the next scoring pass. The values are re-derived per pass rather than backfilled, so it should take effect without a re-import, but that is the one claim here I can't make from the tree.

### Second re-review pass found a real regression in the first commit

Two sites derived behaviour from the physiology set in ways the change quietly broke.

**`sleepHrOnly` was computed as `physiologySessions.isEmpty()`.** That is equivalent to "every session this day was HR-only" *only while the set is an exclusion*. Now that it falls back to `matched`, it can never be empty when `matched` is not — so the flag would have been **pinned to false forever**, and the note explaining a blank Recovery Vitals card would have silently stopped appearing for everyone, including the users #1879 wrote it for two commits ago. It now reads the sessions' own marker, `matched.all { it.hrOnly }`, which states what the flag has always meant and does not depend on how the physiology set is chosen. Exactly equivalent to the old expression under the old set, so no day changes meaning.

My own grep for consumers missed it because that site never mentions `hrOnly` — it reads the *emptiness of the set*. I swept every remaining use of `physiologySessions` on both platforms afterwards; the other four are the aggregates themselves, consuming it as a collection.

**`analyzeDay`'s provided-sleep enrichment short-circuited on `s.hrOnly`**, with a comment calling itself "the ONE call site that can undo the display-only guarantee". That clause is not merely redundant now: an HR-only night that measured a resting HR but banked no R-R would take the short-circuit and skip the fill every other session gets. Removed, so the rule is uniform — fill what is missing.

**The test that should have existed.** `AnalyticsEngineHrOnlyDayTest` / `AnalyticsEngineHrOnlyDayTests` drive `analyzeDay` end to end over a synthetic all-HR-only day, via `providedSleep` because that is how `IntelligenceEngine` actually reaches this path. I verified it fails on the bug rather than assuming: reverting only the `sleepHrOnly` line fails the assertion, restoring it passes. Nothing pinned that derivation before — every existing `sleepHrOnly` test supplies the flag as an **input** (the carry, the coalesce, the migration, the note gate); this drives it as an **output**.

### Third pass: stale claims of the guarantee that no longer exists

Swept every `display-only` mention on both platforms rather than only the lines the diff touched, and found the phrase surviving in the worst possible place — the doc block on `hrOnlySessions` itself, which still opened "restingHR and avgHRV are left NULL deliberately, and that is the whole display-only guarantee". Also in `IntelligenceEngine`'s HR-only gate (Kotlin only; the Swift twin never carried it) and in the test class header whose own cases now contradict it. All corrected; no behaviour change.

**Deliberately not touched:** the two shipped `AppChangelog` entries for #1801, which tell users an HR-only night "never feeds your resting heart rate or HRV baselines". A changelog records what a release did, and that entry is accurate about that release — the correction belongs in this change's own entry rather than a rewrite of a shipped, eight-locale-localized one. Worth knowing it needs saying there.

**Verified rather than assumed:** `sleepSessionFromProvided` cannot carry `hrOnly` (no such column), so an HR-only night read back through the stored-hypnogram path would lose its marker and flip the day flag. It cannot happen: NOOP-computed sessions are written under `importedDeviceId + "-noop"` while that path reads the raw owner id, so they are never returned by it, and the device-provided hypnograms it does return are never HR-only staged. That same namespace split is why the reported strap re-staged an identically blank night on every pass instead of self-healing.

### Second surface, found on re-review

`IntelligenceEngine` also maps each detected session into the Room `SleepSession` cache row (`restingHr = s.restingHR, avgHrv = s.avgHRV`). Those rows previously stored null for an HR-only night too, so the Sleep tab's **per-night** HRV / resting HR fill in as well, not just the day's Recovery Vitals. Same values, same reasoning — worth naming because it is a user-visible surface this touches that the description above did not mention.

The nightly-RMSSD series the baselines consume comes from `DailyMetric.avgHrv`, i.e. the `analyzeDay` value, not from these cache rows — so the baseline exposure is exactly the one path this change deliberately opens, and no second one.

### Known caveat, not fixed here

`sessionAvgHRV` averages per-window RMSSD, and a window qualifies on `cleaned.nn.count >= 2` — two clean beats. That gate is pre-existing and shared byte-for-byte with the motion path (Kotlin and Swift agree on `>= 2`), so this change does not introduce it. But it does newly expose it on precisely the nights most likely to be sparse: an HR-only night is an unbonded-link night, where R-R can be thin or bursty. A night whose windows are *all* thin can now emit a value that reaches the HRV baseline, where previously it emitted nothing.

Two existing gates bound the damage without removing it: nightly RMSSD outside `Baselines.hrvCfg`'s 5-250 ms is dropped as a decode artefact before the baseline, and `HRVReadiness` refuses to score below `MIN_NIGHTS` valid nights rather than fabricate one. Neither catches a thin-window value that happens to land inside 5-250 ms, which is precisely the case described above — so this is a bound at the extremes, not a fix.

The reported night is not that case — 55 windows, 13 deep, a stable 22-25 ms. And a mixed day never reaches this path at all. I am deliberately not adding a minimum-window count in this PR: choosing that threshold without data on how HR-only window counts actually distribute would repeat the mistake #1801 made, which was picking a conservative-looking rule and finding out much later that it cost 269 scoring passes. The trace already logs `nWin`/`nDeep`, so the distribution is measurable from field logs first.

### Prior art in the same function

`respRateDaily` a few lines below has always been built from `matched`, not the filtered set — so the RSA respiration rate an HR-only night derives *from its own R-R, over its own HR-inferred bounds* was already being folded into the day and shipped. #1801 scoped its exclusion to resting HR, HRV and SDNN specifically, and the isolation guard's region ends at the SDNN call for the same reason, so this is deliberate rather than an oversight.

It is worth stating because it is the same trust question answered the other way, in the same function, since before #1801: R-R measured across HR-inferred bounds was already considered good enough to ship. This change makes the three remaining aggregates consistent with that, in the one case where the alternative was no value at all.
