### PR TITLE
ble: connect and attribute the strap the user actually selected (#1881)

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/SourceIdentity.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/SourceIdentity.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Which registry device a live BLE link's samples belong to (#1881).
+///
+/// Split out of `BLEManager` because it is the whole of the decision and none of the CoreBluetooth: BLE
+/// behaviour cannot be tested in CI, but *this* can, and it is the part that silently files rows under the
+/// wrong device when it is wrong. The Kotlin twin is `com.noop.ble.SourceIdentity`.
+///
+/// The bug it exists to prevent: `BLEManager` held one `deviceId` meaning "the active device" and reused it
+/// as "the device these bytes came from". Those were the same thing only while every registered device was
+/// a WHOOP. Once a ring could be active, a WHOOP connection filed its samples — including `stepSample` and
+/// `gravitySample`, which only a strap can produce — under the ring's id.
+public enum SourceIdentity {
+
+    /// The device id this connection's samples should be stored under, or nil to leave the current id alone.
+    ///
+    /// Conservative by construction. It returns an id ONLY when a registry row is both matched by peripheral
+    /// and a WHOOP, so every uncertain case keeps today's behaviour rather than guessing:
+    ///   • `address` nil, or no row carries it → nil. This is the legacy single-WHOOP row before it has
+    ///     adopted a `peripheralId`; the coordinator adopts one on this same connect, so the next resolves.
+    ///   • the matched row is not a WHOOP → nil. Nothing else should be arriving on the WHOOP delegate, and
+    ///     if it does, re-pointing the strap's id at it would be the very bug this prevents.
+    ///   • the matched row is already the current id → nil, so there is no write on the common path.
+    ///
+    /// Matching is case-insensitive because the two platforms disagree about case: Apple stores an uppercase
+    /// `CBPeripheral.identifier.uuidString`, Android an uppercase MAC — but neither is guaranteed by the OS,
+    /// and a row written by an older build may carry either.
+    public static func resolve(address: String?, rows: [PairedDevice], currentId: String) -> String? {
+        guard let address, !address.isEmpty else { return nil }
+        guard let row = rows.first(where: {
+            guard let pid = $0.peripheralId else { return false }
+            return pid.caseInsensitiveCompare(address) == .orderedSame
+        }) else { return nil }
+        guard isWhoop(row), row.id != currentId else { return nil }
+        return row.id
+    }
+
+    /// A device is a WHOOP when it is the seeded legacy row or its brand says so. Kept here beside the
+    /// resolver rather than reaching into the app target, so this file has no dependency to test around.
+    /// Byte-identical to `SourceCoordinator.isWhoop` on both platforms.
+    public static func isWhoop(_ device: PairedDevice) -> Bool {
+        device.id == "my-whoop" || device.brand.caseInsensitiveCompare("WHOOP") == .orderedSame
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/SourceIdentity.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/SourceIdentity.swift
@@ -26,7 +26,11 @@ public enum SourceIdentity {
     /// `CBPeripheral.identifier.uuidString`, Android an uppercase MAC — but neither is guaranteed by the OS,
     /// and a row written by an older build may carry either.
     public static func resolve(address: String?, rows: [PairedDevice], currentId: String) -> String? {
-        guard let address, !address.isEmpty else { return nil }
+        // BLANK, not merely empty, so the two platforms agree: Kotlin's `isNullOrBlank` refuses a
+        // whitespace-only address, and a bare `isEmpty` here would let one match a stored blank.
+        guard let address, !address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
         guard let row = rows.first(where: {
             guard let pid = $0.peripheralId else { return false }
             return pid.caseInsensitiveCompare(address) == .orderedSame

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/SourceIdentityTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/SourceIdentityTests.swift
@@ -64,6 +64,9 @@ final class SourceIdentityTests: XCTestCase {
         let blank = row("whoop-blank", "WHOOP", "")
         XCTAssertNil(SourceIdentity.resolve(address: "", rows: [blank], currentId: "oura-abc"))
         XCTAssertNil(SourceIdentity.resolve(address: nil, rows: [blank], currentId: "oura-abc"))
+        // Whitespace is blank on both platforms — Kotlin's `isNullOrBlank` set the contract.
+        let spaces = row("whoop-spaces", "WHOOP", "   ")
+        XCTAssertNil(SourceIdentity.resolve(address: "   ", rows: [spaces], currentId: "oura-abc"))
     }
 
     /// The legacy id is a WHOOP by id even though its brand was never guaranteed.

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/SourceIdentityTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/SourceIdentityTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import WhoopStore
+
+/// Which device a live link's samples belong to (#1881) — the twin of the Kotlin `SourceIdentityTest`,
+/// asserting the same inputs and the same answers so the two platforms cannot drift.
+///
+/// The reported failure is the first case here: with an Oura ring active and a WHOOP merely paired, a
+/// WHOOP connection filed 770 `stepSample` and 770 `gravitySample` rows under the ring's id. A ring has no
+/// pedometer and no accelerometer, so 100% of those rows were misattributed — and because `hrSample` is
+/// written by both paths under one id, contamination there cannot be separated after the fact.
+final class SourceIdentityTests: XCTestCase {
+
+    private func row(_ id: String, _ brand: String, _ peripheralId: String?) -> PairedDevice {
+        PairedDevice(id: id, brand: brand, model: "m", peripheralId: peripheralId,
+                     sourceKind: .liveBLE, capabilities: [.hr], status: .paired,
+                     addedAt: 0, lastSeenAt: 0)
+    }
+
+    private lazy var ring = row("oura-abc", "Oura", "AA:BB:CC:DD:EE:01")
+    private lazy var strap = row("whoop-123", "WHOOP", "AA:BB:CC:DD:EE:02")
+
+    /// The reported bug: the ring is active, the STRAP connected, so the strap's id must win.
+    func testStrapConnectingWhileRingActiveIsAttributedToTheStrap() {
+        XCTAssertEqual(SourceIdentity.resolve(address: "AA:BB:CC:DD:EE:02",
+                                              rows: [ring, strap], currentId: "oura-abc"), "whoop-123")
+    }
+
+    /// The legacy single-WHOOP path, and the reason this returns nil rather than guessing: the seeded row
+    /// has not adopted an address yet. The coordinator adopts one on this same connect, so the NEXT connect
+    /// resolves — and until then the id stays exactly what it is today.
+    func testUnadoptedRowLeavesTheIdAlone() {
+        let legacy = row("my-whoop", "WHOOP", nil)
+        XCTAssertNil(SourceIdentity.resolve(address: "AA:BB:CC:DD:EE:02",
+                                            rows: [legacy], currentId: "my-whoop"))
+    }
+
+    /// No row carries this address — an unknown strap must never claim an existing device's id.
+    func testUnknownAddressLeavesTheIdAlone() {
+        XCTAssertNil(SourceIdentity.resolve(address: "FF:FF:FF:FF:FF:FF",
+                                            rows: [ring, strap], currentId: "oura-abc"))
+    }
+
+    /// The inverse of the bug. If a non-WHOOP row somehow matches, re-pointing the WHOOP path's id at it
+    /// would file strap samples under a ring — exactly what #1881 reports, arrived at from the other side.
+    func testNonWhoopMatchNeverClaimsTheStrapsSamples() {
+        XCTAssertNil(SourceIdentity.resolve(address: "AA:BB:CC:DD:EE:01",
+                                            rows: [ring, strap], currentId: "whoop-123"))
+    }
+
+    /// Already correct — the common path — must not write.
+    func testIdAlreadyCorrectResolvesToNothing() {
+        XCTAssertNil(SourceIdentity.resolve(address: "AA:BB:CC:DD:EE:02",
+                                            rows: [ring, strap], currentId: "whoop-123"))
+    }
+
+    /// Neither OS guarantees the case of a UUID string or a MAC, and old rows may carry either.
+    func testAddressMatchingIsCaseInsensitive() {
+        XCTAssertEqual(SourceIdentity.resolve(address: "aa:bb:cc:dd:ee:02",
+                                              rows: [ring, strap], currentId: "oura-abc"), "whoop-123")
+    }
+
+    /// A blank address is a missing address, not a wildcard that matches a blank stored value.
+    func testBlankAddressLeavesTheIdAlone() {
+        let blank = row("whoop-blank", "WHOOP", "")
+        XCTAssertNil(SourceIdentity.resolve(address: "", rows: [blank], currentId: "oura-abc"))
+        XCTAssertNil(SourceIdentity.resolve(address: nil, rows: [blank], currentId: "oura-abc"))
+    }
+
+    /// The legacy id is a WHOOP by id even though its brand was never guaranteed.
+    func testLegacyRowCountsAsWhoop() {
+        let legacy = row("my-whoop", "", "AA:BB:CC:DD:EE:03")
+        XCTAssertEqual(SourceIdentity.resolve(address: "AA:BB:CC:DD:EE:03",
+                                              rows: [legacy], currentId: "oura-abc"), "my-whoop")
+    }
+}

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -542,8 +542,12 @@ final class AppModel: ObservableObject {
             registry: registry,
             live: live,
             storeHandle: { [weak self] in await self?.repo.storeHandle() },
-            startWhoop: { [weak self] in self?.scan() },
-            stopWhoop: { [weak self] in self?.disconnect() },
+            // #1881: the flag rides the SAME two closures, so it inherits the coordinator's semantics
+            // exactly — including the deliberate Apple Watch exception, which calls neither and so must
+            // never stop a live WHOOP. `stopWhoop` alone was edge-triggered: it dropped the link once and
+            // nothing stopped `poweredOn` / state restoration / the standing connect bringing it back.
+            startWhoop: { [weak self] in self?.ble.setWhoopIsActiveDevice(true); self?.scan() },
+            stopWhoop: { [weak self] in self?.ble.setWhoopIsActiveDevice(false); self?.disconnect() },
             // WHOOP targeting hooks , thin wrappers over BLEManager's existing additive setters, so the
             // coordinator never references BLEManager directly (mirrors the start/stop injection). On the
             // single-WHOOP path these are setPreferredPeripheral(nil) and (no setActiveDeviceId call),

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1121,6 +1121,7 @@ public final class BLEManager: NSObject, ObservableObject {
     /// `connectFromSystem`'s targeted path already makes: no new outbound command, nothing written to the
     /// strap, so the BLE safety contract is unaffected. Twin of `OuraLiveSource.issueStandingConnect`.
     private func issueStandingConnect(whilePausedForBondLoop: Bool = false) {
+        guard whoopConnectAllowed("standing-connect") else { return }
         guard !intentionalDisconnect else { return }
         // #1539: the bond-loop pause suppresses this by default, but the paused paths deliberately opt in —
         // a parked, timeout-free connect is what lets that pause end without the user.
@@ -1230,9 +1231,35 @@ public final class BLEManager: NSObject, ObservableObject {
     /// 4.0, or an unidentified strap all read false.
     var isWhoop5MG: Bool { whoop5Variant.isMG }
 
+    /// Whether a WHOOP is the device the user actually selected (#1881). FAIL-OPEN: `true` unless
+    /// something positively says otherwise, so the single-WHOOP path and every unknown state behave
+    /// exactly as before — a wrong `false` here would stop the strap connecting for everyone.
+    ///
+    /// This is the DURABLE form of the coordinator's `stopWhoop()`. That call is edge-triggered — it
+    /// fires once on the WHOOP→other-source transition and nothing re-asserts it — while the WHOOP flow
+    /// has system-driven entry points that consult nobody: `poweredOn` (every Bluetooth toggle and
+    /// `bluetoothd` restart), state restoration, and the standing connect CoreBluetooth honours while
+    /// the app is suspended. So a radio toggle resurrected a strap the user had switched away from,
+    /// drained its history, and — before the identity fix below — filed every row under the ACTIVE
+    /// device's id. Reported with a proven case: 770 `stepSample` rows under an Oura ring, which has no
+    /// pedometer.
+    ///
+    /// Set from the same two closures the coordinator already uses to stop and start WHOOP, so the
+    /// deliberate exception survives untouched: an Apple Watch becoming active must NOT stop a live
+    /// WHOOP, and `switchToAppleWatch` calls neither closure.
+    private var whoopIsActiveDevice = true
+
+    /// The last entry point `whoopConnectAllowed` turned away, so the block is logged once per path
+    /// rather than on every tick of the family-rotation timer.
+    private var lastBlockedConnectReason: String?
+
     /// Stable device id; matches the server's existing device for sync parity. Overridable.
     /// Seeded from the init argument, then refined once in bootstrapStore() to the device registry's
     /// active id (still "my-whoop" today) before any store writes use it — see bootstrapStore().
+    ///
+    /// #1881: this is "the device these bytes came from", NOT "the active device". Those were the same
+    /// thing only while every registered device was a WHOOP; `adoptSourceIdentity(for:)` re-points it
+    /// per connection from the peripheral that actually connected.
     private(set) var deviceId: String
     /// Captured (device↔wall) correlation from GET_CLOCK; nil until the response lands.
     private(set) var clockRef: ClockRef?
@@ -1510,6 +1537,7 @@ public final class BLEManager: NSObject, ObservableObject {
     }
 
     private func connectCore(model: WhoopModel) {
+        guard whoopConnectAllowed("connect") else { return }
         intentionalDisconnect = false
         // Connection test mode: stamp when this connect attempt began so didConnect can report the connect
         // latency. A plain Date() assignment, no behaviour change; only read behind the .connection gate.
@@ -1882,6 +1910,63 @@ public final class BLEManager: NSObject, ObservableObject {
         deviceId = id
         collector?.deviceId = id
         backfiller?.deviceId = id
+        // #1881: the alarm readback attributes through the router's own copy (#1706), which this used to
+        // leave pointing at the previous device. Same field, same conflation, one more consumer.
+        router.deviceId = id
+    }
+
+    /// Record whether a WHOOP is the active device (#1881). Called from the SAME two closures the
+    /// `SourceCoordinator` already uses to stop and start the WHOOP, so it inherits their semantics
+    /// exactly — including the deliberate Apple Watch exception, which calls neither.
+    ///
+    /// Re-asserts itself: if a WHOOP link is already up when a different source becomes active, the
+    /// coordinator's own `stopWhoop()` drops it: this only stops it coming back on its own.
+    public func setWhoopIsActiveDevice(_ active: Bool) {
+        guard whoopIsActiveDevice != active else { return }
+        whoopIsActiveDevice = active
+        log(active
+            ? "WHOOP is the active device again — scanning and reconnecting are allowed"
+            : "WHOOP is no longer the active device — not scanning or connecting until it is again (#1881)")
+    }
+
+    /// The one gate every WHOOP scan/connect entry point passes through (#1881).
+    ///
+    /// Deliberately at the CONNECT sites rather than only at `connectCore`: there are five
+    /// `central.connect` sites, and `connectCore` owns two. The rest are reached from `poweredOn` and
+    /// `willRestoreState` (via `connectRestored`), from `didDiscover`, and from the standing connect —
+    /// which involves no scan at all and is honoured while the app is suspended, so no scan-side guard
+    /// can cover it.
+    ///
+    /// `reason` names the entry point in the strap log, so a "why did my ring's data grow legs" report
+    /// says which path tried. Logged only on the transition into blocking, so a rotation timer cannot
+    /// flood the log.
+    private func whoopConnectAllowed(_ reason: String) -> Bool {
+        if whoopIsActiveDevice { return true }
+        if lastBlockedConnectReason != reason {
+            lastBlockedConnectReason = reason
+            log("Not connecting the WHOOP (\(reason)): a different device is active (#1881)")
+        }
+        return false
+    }
+
+    /// Attribute this connection to the strap that ACTUALLY connected, not to whatever device is active
+    /// (#1881). Resolves the registry row whose `peripheralId` matches the connected peripheral and
+    /// re-points `deviceId` + the in-flight `Collector`/`Backfiller`/router to it.
+    ///
+    /// Conservative by construction — it only ever moves the id to a row that is BOTH a WHOOP and
+    /// matched by peripheral:
+    ///   • no registry / unreadable → leave the id alone (today's behaviour).
+    ///   • no row matches this peripheral → leave it alone. This is the legacy single-WHOOP case before
+    ///     the row has adopted a `peripheralId`; `SourceCoordinator.connectedPeripheralChanged` adopts it
+    ///     on this same connect, so the following one resolves.
+    ///   • the matched row is not a WHOOP → leave it alone; nothing else reaches this delegate.
+    ///   • already correct → no write.
+    private func adoptSourceIdentity(for peripheral: CBPeripheral) {
+        guard let registry = registryStore, let rows = try? registry.all() else { return }
+        guard let resolved = SourceIdentity.resolve(address: peripheral.identifier.uuidString,
+                                                    rows: rows, currentId: deviceId) else { return }
+        log("Attributing this link to \(resolved) — the strap that connected, not the active device (#1881)")
+        setActiveDeviceId(resolved)
     }
 
     /// Add-a-WHOOP wizard: scan the selected family's WHOOP service and surface every nearby strap in
@@ -4482,6 +4567,9 @@ public final class BLEManager: NSObject, ObservableObject {
     /// `scanFallbackDelaySeconds` of no discovery — recovers reconnect when the persisted preference is
     /// stale after an update/restore. Discovery/connect cancels the pending rotation. (PR#195)
     private func startScan(for model: WhoopModel, allowFallback: Bool) {
+        // Not strictly required — every connect site is gated — but without it the 4.0 <-> 5.0/MG rotation
+        // keeps the radio scanning indefinitely for a strap we would refuse to connect to anyway.
+        guard whoopConnectAllowed("scan") else { return }
         cancelScanFallback()
         selectedModel = model
         reassembler = Reassembler(family: model.deviceFamily)
@@ -4526,6 +4614,7 @@ public final class BLEManager: NSObject, ObservableObject {
     /// #730 pending-connect probe. Both restore entry points funnel through here so the two paths can be
     /// told apart in a strap log.
     private func connectRestored(_ p: CBPeripheral, reason: String) {
+        guard whoopConnectAllowed("restored/\(reason)") else { return }
         log("Connecting to restored peripheral (\(reason)) — peripheral state=\(peripheralStateName(p.state))")
         central.connect(p, options: nil)
         pendingConnectProbe?.cancel()
@@ -5252,6 +5341,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
             log("Discovered \(name) (\(peripheral.identifier)) — not the preferred strap; ignoring")
             return
         }
+        guard whoopConnectAllowed("discovered") else { return }
         cancelScanFallback()
         persistSelectedModel(selectedModel)
         log("Discovered \(name) (rssi \(RSSI)) — connecting")
@@ -5276,6 +5366,9 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         standingConnectAt = nil     // #1413: a live link means no standing connect is outstanding
         restoredPeripheral = nil
         preparePeripheral(peripheral)
+        // #1881: BEFORE anything persists. The Collector and Backfiller read `deviceId` at flush and at
+        // finishChunk, so re-pointing here is what keeps this link's rows off another device's id.
+        adoptSourceIdentity(for: peripheral)
         // Clear the per-connection bond BEFORE publishing the connected uuid below. SourceCoordinator's #52
         // re-adoption gate keys off `encryptedBond` at the instant `connectedPeripheralUUID` is observed —
         // an ordinary `didConnect` publish must always read false (only the deliberate post-bond #52

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1993,6 +1993,15 @@ public final class BLEManager: NSObject, ObservableObject {
     ///     on this same connect, so the following one resolves.
     ///   • the matched row is not a WHOOP → leave it alone; nothing else reaches this delegate.
     ///   • already correct → no write.
+    ///
+    /// Known narrow residual: the disconnect handler flushes buffered 0x2A37 HR in a deliberately
+    /// fire-and-forget `Task`, and the Collector reads `deviceId` at PERSIST time — so a flush still in
+    /// flight when the next link re-points the id would attribute the previous link's tail to the new
+    /// strap. It needs a re-point to happen at all, which only occurs when the resolved row differs from
+    /// the current id: never on a settled single-WHOOP install. In the reported case the move is from the
+    /// ring to the strap, and those buffered rows are the STRAP's, so the new attribution is the correct
+    /// one. The genuinely wrong case is two WHOOPs where A's tail lands on B — a pre-existing hazard of
+    /// `setActiveDeviceId`, which the coordinator already calls on a WHOOP→WHOOP switch.
     private func adoptSourceIdentity(for peripheral: CBPeripheral) {
         guard let registry = registryStore, let rows = try? registry.all() else { return }
         guard let resolved = SourceIdentity.resolve(address: peripheral.identifier.uuidString,

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1548,11 +1548,16 @@ public final class BLEManager: NSObject, ObservableObject {
     /// path schedules nothing afterwards, so the hammer loop cannot restart. A genuine bond still fully
     /// resets via the didWriteValueFor path, so a strap freed since the give-up self-heals.
     func connectFromSystem(model: WhoopModel = .persisted) {
+        // #1881: the gate belongs HERE, not in the shared `connectCore`. This file already draws the line
+        // the fix needs — `connect()` is the user's explicit Connect button, and every system-initiated
+        // path "MUST use connectFromSystem()" — and the report's complaint is only ever about NOOP acting
+        // on its own. Gating the shared core instead would have made the Connect button silently dead
+        // while the Devices screen showed a "Reconnecting…" toast.
+        guard whoopConnectAllowed("connect-from-system") else { return }
         connectCore(model: model)
     }
 
     private func connectCore(model: WhoopModel) {
-        guard whoopConnectAllowed("connect") else { return }
         intentionalDisconnect = false
         // Connection test mode: stamp when this connect attempt began so didConnect can report the connect
         // latency. A plain Date() assignment, no behaviour change; only read behind the .connection gate.
@@ -4593,10 +4598,10 @@ public final class BLEManager: NSObject, ObservableObject {
     /// `allowFallback` is true, schedule a one-shot rotation to the other WHOOP family after
     /// `scanFallbackDelaySeconds` of no discovery — recovers reconnect when the persisted preference is
     /// stale after an update/restore. Discovery/connect cancels the pending rotation. (PR#195)
+    /// No gate here, deliberately: the ONLY callers are `connectCore` — reached from the user's Connect or
+    /// from the already-gated `connectFromSystem` — and this method's own family-rotation timer, which
+    /// cannot start a scan that one of those did not. Gating here as well would block the user's Connect.
     private func startScan(for model: WhoopModel, allowFallback: Bool) {
-        // Not strictly required — every connect site is gated — but without it the 4.0 <-> 5.0/MG rotation
-        // keeps the radio scanning indefinitely for a strap we would refuse to connect to anyway.
-        guard whoopConnectAllowed("scan") else { return }
         cancelScanFallback()
         selectedModel = model
         reassembler = Reassembler(family: model.deviceFamily)
@@ -5368,7 +5373,8 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
             log("Discovered \(name) (\(peripheral.identifier)) — not the preferred strap; ignoring")
             return
         }
-        guard whoopConnectAllowed("discovered") else { return }
+        // No gate here for the same reason as `startScan`: reaching a discovery means a scan is running,
+        // and a scan only runs because the user asked or because the gated system entry allowed it.
         cancelScanFallback()
         persistSelectedModel(selectedModel)
         log("Discovered \(name) (rssi \(RSSI)) — connecting")

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1371,9 +1371,24 @@ public final class BLEManager: NSObject, ObservableObject {
         let registry = DeviceRegistryStore(dbQueue: store.registryWriter)
         self.registryStore = registry
         seedLastSyncFromActiveStrap(registry: registry)
-        if let activeId = try? registry.activeDeviceId(),
-           !activeId.isEmpty {
-            self.deviceId = activeId
+        if let activeId = try? registry.activeDeviceId(), !activeId.isEmpty {
+            // #1881: adopt the active id ONLY when the active device is a WHOOP. This is the line the
+            // report quotes, and its comment stated the assumption that falsified it — with a ring active
+            // this set `deviceId` to the RING, and every live sample and historical chunk persisted under
+            // it. `adoptSourceIdentity` corrects the id when a strap connects, but not for the window
+            // between here and that connect, so the wrong value must not be adopted in the first place.
+            //
+            // Fail-open on an unknown row (nil): unchanged behaviour for anything the registry can't
+            // classify. Only a POSITIVELY non-WHOOP active device is refused, and that same fact seeds the
+            // connect gate — which closes the launch race where `poweredOn` can reach the WHOOP flow
+            // before `SourceCoordinator` has wired up and asserted it.
+            let activeRow = (try? registry.all())?.first(where: { $0.id == activeId })
+            if let activeRow, !SourceIdentity.isWhoop(activeRow) {
+                setWhoopIsActiveDevice(false)
+                log("Active device \(activeId) is not a WHOOP — leaving sample attribution on \(deviceId) (#1881)")
+            } else {
+                self.deviceId = activeId
+            }
         }
         // Look up the active device's real brand/model instead of a hardcoded string — this predated
         // multi-device support and mislabeled every non-"WHOOP 4.0" device (a WHOOP 5.0/MG strap, an Oura
@@ -1942,6 +1957,18 @@ public final class BLEManager: NSObject, ObservableObject {
     /// flood the log.
     private func whoopConnectAllowed(_ reason: String) -> Bool {
         if whoopIsActiveDevice { return true }
+        // The flag is a CACHE of a registry fact, and the registry is the authority. Re-validate before
+        // refusing, so the gate can never latch: it is set from the coordinator's stop/start closures and
+        // seeded at bootstrap, and if those ever disagree — the coordinator failing to wire after the seed
+        // said "not a WHOOP", say — a stale `false` would stop the strap connecting for the whole session.
+        // Only on the blocked path, so the common case still costs nothing.
+        if let registry = registryStore, let activeId = try? registry.activeDeviceId() {
+            let row = (try? registry.all())?.first(where: { $0.id == activeId })
+            if row.map(SourceIdentity.isWhoop) ?? true {
+                setWhoopIsActiveDevice(true)
+                return true
+            }
+        }
         if lastBlockedConnectReason != reason {
             lastBlockedConnectReason = reason
             log("Not connecting the WHOOP (\(reason)): a different device is active (#1881)")
@@ -5863,7 +5890,13 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         clockRequested = false
         clockRetries = 0
         // Ensure the store is ready before restored BLE data arrives (idempotent; no-op if already built).
-        Task { @MainActor in await bootstrapStore() }
+        Task { @MainActor in
+            await bootstrapStore()
+            // #1881: `didConnect` never fires on this path (see above), so the identity adoption that lives
+            // there would be skipped for a restored link — the very path a radio toggle and a relaunch take.
+            // After `bootstrapStore`, because it is what creates `registryStore`.
+            if let p = self.peripheral ?? self.restoredPeripheral { self.adoptSourceIdentity(for: p) }
+        }
         if p.state == .connected {
             state.connected = true
             // #613: the inherited notify subscriptions come back reported-active but dead. Force one real

--- a/Strand/BLE/SourceCoordinator.swift
+++ b/Strand/BLE/SourceCoordinator.swift
@@ -588,7 +588,9 @@ final class SourceCoordinator: ObservableObject {
     }
 
     /// A device is WHOOP when its brand is "WHOOP" (the seeded `my-whoop` row's brand).
-    static func isWhoop(_ device: PairedDevice) -> Bool {
-        device.id == "my-whoop" || device.brand.caseInsensitiveCompare("WHOOP") == .orderedSame
-    }
+    ///
+    /// #1881 gave the BLE engine the same question to answer, so the rule now lives in ONE place
+    /// (`SourceIdentity`, beside `PairedDevice`) and this delegates. Two spellings of "is this a WHOOP"
+    /// that could disagree is precisely how a strap's samples end up filed under a ring.
+    static func isWhoop(_ device: PairedDevice) -> Bool { SourceIdentity.isWhoop(device) }
 }

--- a/android/app/src/main/java/com/noop/NoopApplication.kt
+++ b/android/app/src/main/java/com/noop/NoopApplication.kt
@@ -139,8 +139,12 @@ class NoopApplication : Application() {
             // path (status=133 on an OS-bonded strap). Mirrors macOS AppModel.scan() reading the persisted
             // "selectedWhoopModel". Same-strap switches now adopt in place (no reconnect) via the
             // coordinator, so this only fires for a genuinely different WHOOP.
-            startWhoop = { ble.connect(persistedWhoopModel()) },
-            stopWhoop = { ble.disconnect() },
+            // #1881: the flag rides the SAME two closures, so it inherits the coordinator's semantics
+            // exactly. `stopWhoop` alone was edge-triggered: it dropped the link once and nothing stopped
+            // `onBluetoothRadioOn` bringing it straight back — every Bluetooth toggle reached it, and it
+            // clears `intentionalDisconnect` before reconnecting. Swift twin: AppModel.wireSourceCoordinator.
+            startWhoop = { ble.setWhoopIsActiveDevice(true); ble.connect(persistedWhoopModel()) },
+            stopWhoop = { ble.setWhoopIsActiveDevice(false); ble.disconnect() },
             // Multi-WHOOP (MW-2/MW-3): pin the connection to the active WHOOP's persisted address and
             // re-attribute live samples to it on a WHOOP→WHOOP switch. Both inert on the single-WHOOP
             // path — the coordinator only invokes them for a non-legacy WHOOP / a non-null peripheralId.

--- a/android/app/src/main/java/com/noop/NoopApplication.kt
+++ b/android/app/src/main/java/com/noop/NoopApplication.kt
@@ -6,6 +6,7 @@ import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import android.util.Log
 import com.noop.ble.SourceCoordinator
+import com.noop.ble.SourceIdentity
 import com.noop.ble.WhoopBleClient
 import com.noop.ble.WhoopModel
 import com.noop.data.DeviceRegistry
@@ -95,16 +96,39 @@ class NoopApplication : Application() {
         if (newId.isNotEmpty() && newId != activeDeviceId) activeDeviceId = newId
     }
 
+    /**
+     * The id the BLE client should stamp WHOOP samples with at startup (#1881).
+     *
+     * [activeDeviceId] answers "which device did the user select", which is NOT the same question once a
+     * non-WHOOP device can be active: handing it to the client made every WHOOP live sample and historical
+     * chunk persist under, say, an Oura ring. `adoptSourceIdentity` corrects the id when a strap actually
+     * connects, but not for the window between construction and that connect, so the wrong value must not
+     * be adopted in the first place.
+     *
+     * Fail-open: an unreadable registry or an unclassifiable row keeps today's behaviour. Only a
+     * POSITIVELY non-WHOOP active device falls back to the legacy id. Swift twin: `BLEManager.bootstrapStore`.
+     */
+    private fun whoopStartupDeviceId(): String {
+        val id = activeDeviceId
+        val rows = runCatching { runBlocking { deviceRegistry.all() } }.getOrNull() ?: return id
+        val row = rows.firstOrNull { it.id == id } ?: return id
+        return if (SourceIdentity.isWhoop(row)) id else WhoopBleClient.DEFAULT_DEVICE_ID
+    }
+
     /** Process-wide BLE client. Owns the GATT connection and outlives any single Activity/ViewModel. */
     val ble: WhoopBleClient by lazy {
+        val startupId = whoopStartupDeviceId()
         WhoopBleClient(
             applicationContext,
             repository = repository,
-            deviceId = activeDeviceId,
+            deviceId = startupId,
             successfulOffloadSink = {
                 SelfHostedPushScheduler.enqueueAfterSuccessfulOffload(applicationContext)
             },
         ).apply {
+            // #1881: the same fact seeds the connect gate, closing the launch race where the radio can
+            // reach the WHOOP flow before SourceCoordinator has wired up and asserted it.
+            if (startupId != activeDeviceId) setWhoopIsActiveDevice(false)
             // Apply the persisted "Debug logging" preference at the composition root so the low-level
             // client never has to read the UI/prefs layer. Default OFF — see WhoopBleClient.debugLogcat.
             debugLogcat = NoopPrefs.debugLogging(applicationContext)

--- a/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
@@ -647,9 +647,13 @@ class SourceCoordinator(
             return isWhoop(device)
         }
 
-        /** A device is WHOOP when its id is "my-whoop" or its brand is "WHOOP" (the seeded row's brand). */
-        fun isWhoop(device: PairedDeviceRow): Boolean =
-            device.id == WhoopBleClient.DEFAULT_DEVICE_ID ||
-                device.brand.equals("WHOOP", ignoreCase = true)
+        /**
+         * A device is WHOOP when its id is "my-whoop" or its brand is "WHOOP" (the seeded row's brand).
+         *
+         * #1881 gave the BLE client the same question to answer, so the rule now lives in ONE place
+         * ([SourceIdentity]) and this delegates. Two spellings of "is this a WHOOP" that could disagree is
+         * precisely how a strap's samples end up filed under a ring.
+         */
+        fun isWhoop(device: PairedDeviceRow): Boolean = SourceIdentity.isWhoop(device)
     }
 }

--- a/android/app/src/main/java/com/noop/ble/SourceIdentity.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceIdentity.kt
@@ -1,0 +1,48 @@
+package com.noop.ble
+
+import com.noop.data.PairedDeviceRow
+
+/**
+ * Which registry device a live BLE link's samples belong to (#1881).
+ *
+ * Split out of [WhoopBleClient] because it is the whole of the decision and none of the Bluetooth: BLE
+ * behaviour cannot be tested in CI, but *this* can, and it is the part that silently files rows under the
+ * wrong device when it is wrong. Swift twin: `WhoopStore.SourceIdentity`.
+ *
+ * The bug it exists to prevent: the client held one `deviceId` meaning "the active device" and reused it as
+ * "the device these bytes came from". Those were the same thing only while every registered device was a
+ * WHOOP. Once a ring could be active, a WHOOP connection filed its samples — including `stepSample` and
+ * `gravitySample`, which only a strap can produce — under the ring's id.
+ */
+object SourceIdentity {
+
+    /**
+     * The device id this connection's samples should be stored under, or null to leave the current id alone.
+     *
+     * Conservative by construction. It returns an id ONLY when a registry row is both matched by address and
+     * a WHOOP, so every uncertain case keeps today's behaviour rather than guessing:
+     *  - [address] null/blank, or no row carries it -> null. This is the legacy single-WHOOP row before it
+     *    has adopted a `peripheralId`; the coordinator adopts one on this same connect, so the next resolves.
+     *  - the matched row is not a WHOOP -> null. Nothing else should arrive on the WHOOP callback, and if it
+     *    does, re-pointing the strap's id at it would be the very bug this prevents.
+     *  - the matched row is already the current id -> null, so there is no write on the common path.
+     *
+     * Matching is case-insensitive because the two platforms disagree about case (an Apple UUID string vs an
+     * Android MAC), and neither is guaranteed by the OS.
+     */
+    fun resolve(address: String?, rows: List<PairedDeviceRow>, currentId: String): String? {
+        if (address.isNullOrBlank()) return null
+        val row = rows.firstOrNull { it.peripheralId?.equals(address, ignoreCase = true) == true }
+            ?: return null
+        if (!isWhoop(row) || row.id == currentId) return null
+        return row.id
+    }
+
+    /**
+     * A device is a WHOOP when it is the seeded legacy row or its brand says so. Kept here beside the
+     * resolver rather than reaching into [SourceCoordinator], so this file has no dependency to test
+     * around. Byte-identical to `SourceCoordinator.isWhoop` on both platforms.
+     */
+    fun isWhoop(device: PairedDeviceRow): Boolean =
+        device.id == WhoopBleClient.DEFAULT_DEVICE_ID || device.brand.equals("WHOOP", ignoreCase = true)
+}

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3427,7 +3427,11 @@ class WhoopBleClient(
 
     @SuppressLint("MissingPermission")
     private fun connectInternal(model: WhoopModel, userInitiated: Boolean) {
-        if (!whoopConnectAllowed("connect")) return
+        // #1881: only the SYSTEM path is gated. This class already draws that line — `connect()` is the
+        // user's explicit Connect button, `connectFromSystem()` is every automatic path — and the report's
+        // complaint is only ever about NOOP acting on its own. Gating both would have made the Connect
+        // button silently dead while DevicesScreen showed a "Reconnecting…" toast.
+        if (!userInitiated && !whoopConnectAllowed("connect-from-system")) return
         intentionalDisconnect = false
         // #1635: an explicit Connect is the user saying "try the handshake again" — the documented way out
         // of hello suppression, and the reason suppression is never a permanent verdict. Consumed by the
@@ -3514,7 +3518,7 @@ class WhoopBleClient(
                 scanning = false, whoop5Detected = false,
                 statusNote = "Connecting to your ${WhoopModel.WHOOP5_MG.displayName}…",
             ) }
-            connectToDevice(direct)
+            connectToDevice(direct, alreadyAuthorised = userInitiated)
             bondedDirectAttempt = true   // after connectToDevice: reset() must not clear it
             return
         }
@@ -3529,10 +3533,12 @@ class WhoopBleClient(
      * the fallback and the not-found timeout. Port of macOS BLEManager.startScan(for:allowFallback:).
      */
     @SuppressLint("MissingPermission")
+    /**
+     * No gate here, deliberately: the only callers are [connectInternal] — which gates the system path —
+     * and this method's own family-rotation timeout, which cannot start a scan that one of those did not.
+     * Gating here as well would block the user's explicit Connect.
+     */
     private fun startScan(model: WhoopModel, allowFallback: Boolean) {
-        // Without this the 4.0 <-> 5.0/MG rotation keeps the radio scanning indefinitely for a strap
-        // we would refuse to connect to anyway. Every connect site is gated independently.
-        if (!whoopConnectAllowed("scan")) return
         handler.removeCallbacks(scanFallbackRunnable)
         // Defensive: the normal auto-connect scan is NEVER a present-scan. Clearing the flag here means a
         // leaked wizard present-scan (e.g. the wizard was dismissed without stopWhoopScan) can't divert
@@ -5611,7 +5617,7 @@ class WhoopBleClient(
             _state.update { it.copy(statusNote = "Found $name, connecting…") }
             // Port of didDiscover: stop scanning, then connect to this peripheral.
             stopScan()
-            connectToDevice(device)
+            connectToDevice(device, alreadyAuthorised = true)   // #1881: a scan result is already authorised
         }
 
         override fun onScanFailed(errorCode: Int) {
@@ -6209,8 +6215,21 @@ class WhoopBleClient(
     }
 
     @SuppressLint("MissingPermission")
-    private fun connectToDevice(device: BluetoothDevice, autoConnect: Boolean = false) {
-        if (!whoopConnectAllowed("connect-to-device")) return
+    private fun connectToDevice(
+        device: BluetoothDevice,
+        autoConnect: Boolean = false,
+        /**
+         * #1881: true when the decision to connect was ALREADY authorised upstream — the user's explicit
+         * Connect, or a scan result, which can only exist because a gated-or-user scan is running. Every
+         * other caller is automatic (the radio-on re-arm, the reconnect backoff, launch auto-reconnect
+         * #67) and defaults to false, which is what the gate is for.
+         *
+         * Threaded rather than gated once upstream because, unlike Swift, these callers do NOT all funnel
+         * through a single system entry point.
+         */
+        alreadyAuthorised: Boolean = false,
+    ) {
+        if (!alreadyAuthorised && !whoopConnectAllowed("connect-to-device")) return
         // Reset per-connection state (mirrors the Swift flags cleared on connect/disconnect).
         reset()
         // Remember the device so a later dropout can reconnect straight to it (#61).

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -443,6 +443,11 @@ class WhoopBleClient(
      * ("my-whoop") — which matches the Swift default and the rest of the Android app, so behaviour
      * is unchanged today while the registry takes over as the single source of the active id.
      *
+     * `@Volatile` because #1881 added a SECOND cross-thread writer: [adoptSourceIdentity] resolves the
+     * connected strap's row on [ioScope] (the Room registry read is `suspend`) and re-points from there,
+     * while the persist sites read this on the BLE handler thread. Without it that thread could keep
+     * reading the pre-connect value and file the link's rows under the wrong device — the exact bug.
+     *
      * MUTABLE (multi-WHOOP, MW-3): [setActiveDeviceId] re-points it so a WHOOP→WHOOP switch attributes
      * new samples to the newly-active WHOOP immediately, without waiting for a relaunch. The single-WHOOP
      * path NEVER reassigns it (the coordinator only calls [setActiveDeviceId] for a non-legacy WHOOP), so
@@ -450,6 +455,7 @@ class WhoopBleClient(
      * sites + the analyze pass read this field directly; the [Backfiller] captured its own copy at
      * construction, so [setActiveDeviceId] re-points that too (see there).
      */
+    @Volatile
     private var deviceId: String = DEFAULT_DEVICE_ID,
     /** Durable trim-cursor store for the offload safe-trim watermark (see [Backfiller]). */
     private val cursorStore: TrimCursorStore = PrefsTrimCursorStore(context),
@@ -3925,6 +3931,13 @@ class WhoopBleClient(
      * Conservative by construction: only ever moves the id to a row that is BOTH a WHOOP and matched by
      * address. No registry, no match (the legacy single-WHOOP row before it has adopted an address), a
      * non-WHOOP match, or an id already correct all leave it alone.
+     *  - the matched row is already the current id -> no write.
+     *
+     * Known narrow residual: the disconnect path flushes buffered live rows best-effort, and the persist
+     * sites read [deviceId] at PERSIST time — so a flush still in flight when the next link re-points the
+     * id would attribute the previous link's tail to the new strap. It needs a re-point to happen at all,
+     * which only occurs when the resolved row differs from the current id: never on a settled
+     * single-WHOOP install. Swift twin carries the same note.
      */
     private fun adoptSourceIdentity(address: String?) {
         val addr = address ?: return

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3427,6 +3427,7 @@ class WhoopBleClient(
 
     @SuppressLint("MissingPermission")
     private fun connectInternal(model: WhoopModel, userInitiated: Boolean) {
+        if (!whoopConnectAllowed("connect")) return
         intentionalDisconnect = false
         // #1635: an explicit Connect is the user saying "try the handshake again" — the documented way out
         // of hello suppression, and the reason suppression is never a permanent verdict. Consumed by the
@@ -3529,6 +3530,9 @@ class WhoopBleClient(
      */
     @SuppressLint("MissingPermission")
     private fun startScan(model: WhoopModel, allowFallback: Boolean) {
+        // Without this the 4.0 <-> 5.0/MG rotation keeps the radio scanning indefinitely for a strap
+        // we would refuse to connect to anyway. Every connect site is gated independently.
+        if (!whoopConnectAllowed("scan")) return
         handler.removeCallbacks(scanFallbackRunnable)
         // Defensive: the normal auto-connect scan is NEVER a present-scan. Clearing the flag here means a
         // leaked wizard present-scan (e.g. the wizard was dismissed without stopWhoopScan) can't divert
@@ -3839,6 +3843,71 @@ class WhoopBleClient(
         if (id.isEmpty()) return
         deviceId = id
         backfiller.deviceId = id
+    }
+
+    /**
+     * Whether a WHOOP is the device the user actually selected (#1881). FAIL-OPEN: `true` unless
+     * something positively says otherwise, so the single-WHOOP path and every unknown state behave
+     * exactly as before — a wrong `false` here would stop the strap connecting for everyone.
+     *
+     * The DURABLE form of the coordinator's [SourceCoordinator] `stopWhoop`. That call is edge-triggered,
+     * fired once on the WHOOP -> other-source transition, while the WHOOP flow has system-driven entry
+     * points that consult nobody — [onBluetoothRadioOn] above all, which every radio toggle reaches and
+     * which explicitly clears `intentionalDisconnect` before reconnecting. Swift twin: `BLEManager`.
+     */
+    @Volatile
+    private var whoopIsActiveDevice = true
+
+    /** The last entry point [whoopConnectAllowed] turned away, so a rotation timer cannot flood the log. */
+    private var lastBlockedConnectReason: String? = null
+
+    /**
+     * Record whether a WHOOP is the active device (#1881). Called from the SAME closures the
+     * [SourceCoordinator] already uses to stop and start the WHOOP, so it inherits their semantics —
+     * including any deliberate exception that calls neither.
+     */
+    fun setWhoopIsActiveDevice(active: Boolean) {
+        if (whoopIsActiveDevice == active) return
+        whoopIsActiveDevice = active
+        log(
+            if (active) "WHOOP is the active device again — scanning and reconnecting are allowed"
+            else "WHOOP is no longer the active device — not scanning or connecting until it is again (#1881)"
+        )
+    }
+
+    /** The one gate every WHOOP scan/connect entry point passes through (#1881). Swift twin: `BLEManager`. */
+    private fun whoopConnectAllowed(reason: String): Boolean {
+        if (whoopIsActiveDevice) return true
+        if (lastBlockedConnectReason != reason) {
+            lastBlockedConnectReason = reason
+            log("Not connecting the WHOOP ($reason): a different device is active (#1881)")
+        }
+        return false
+    }
+
+    /**
+     * Attribute this connection to the strap that ACTUALLY connected, not to whatever device is active
+     * (#1881). Resolves the registry row whose `peripheralId` matches [address] and re-points [deviceId]
+     * and the in-flight [Backfiller] to it.
+     *
+     * Async because the Room registry read is `suspend` (the Swift twin is synchronous GRDB and does this
+     * inline in `didConnect`). The window is between STATE_CONNECTED and the first persisted sample —
+     * service discovery, notification subscription and the strap's first response all sit inside it — so
+     * a row is not expected to land first; if one ever did it would carry the previous id.
+     *
+     * Conservative by construction: only ever moves the id to a row that is BOTH a WHOOP and matched by
+     * address. No registry, no match (the legacy single-WHOOP row before it has adopted an address), a
+     * non-WHOOP match, or an id already correct all leave it alone.
+     */
+    private fun adoptSourceIdentity(address: String?) {
+        val addr = address ?: return
+        val registry = (context.applicationContext as? com.noop.NoopApplication)?.deviceRegistry ?: return
+        ioScope.launch {
+            val rows = runCatching { registry.all() }.getOrNull() ?: return@launch
+            val resolved = SourceIdentity.resolve(addr, rows, deviceId) ?: return@launch
+            log("Attributing this link to $resolved — the strap that connected, not the active device (#1881)")
+            setActiveDeviceId(resolved)
+        }
     }
 
     /**
@@ -6120,6 +6189,7 @@ class WhoopBleClient(
 
     @SuppressLint("MissingPermission")
     private fun connectToDevice(device: BluetoothDevice, autoConnect: Boolean = false) {
+        if (!whoopConnectAllowed("connect-to-device")) return
         // Reset per-connection state (mirrors the Swift flags cleared on connect/disconnect).
         reset()
         // Remember the device so a later dropout can reconnect straight to it (#61).
@@ -6182,6 +6252,9 @@ class WhoopBleClient(
                     // #1030 (ryanbr): a real link is up — cancel any pending involuntary reconnect so a
                     // stale backoff timer can't fire and reset+close this connection.
                     cancelPendingReconnect()
+                    // #1881: attribute this link to the strap that actually connected, before anything
+                    // persists. Swift twin: `BLEManager.didConnect` -> `adoptSourceIdentity(for:)`.
+                    adoptSourceIdentity(runCatching { g.device?.address }.getOrNull())
                     // A successful connect clears the reconnect backoff — the next involuntary drop starts
                     // the 3,6,12…s schedule afresh (iOS didConnect: failedConnectAttempts=0, #48). Reset
                     // IMMEDIATELY, not behind a survival dwell: a band the OS holds bonded/ACL-connected

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3878,11 +3878,32 @@ class WhoopBleClient(
     /** The one gate every WHOOP scan/connect entry point passes through (#1881). Swift twin: `BLEManager`. */
     private fun whoopConnectAllowed(reason: String): Boolean {
         if (whoopIsActiveDevice) return true
+        // The flag is a CACHE of a registry fact, and the registry is the authority. Re-validate so the
+        // gate can never latch: it is set from the coordinator's stop/start closures and seeded at
+        // startup, and if those ever disagree a stale `false` would stop the strap connecting for the
+        // whole session.
+        //
+        // Asynchronously, unlike the Swift twin's inline read: the Room registry is `suspend` and this
+        // runs on the BLE handler thread, where `runBlocking` would be a worse bug than the one it fixes.
+        // So the re-validation lands for the NEXT attempt rather than this one — which is enough, because
+        // every caller here retries (the family rotation, the reconnect backoff, the radio-on re-arm).
+        revalidateWhoopIsActive()
         if (lastBlockedConnectReason != reason) {
             lastBlockedConnectReason = reason
             log("Not connecting the WHOOP ($reason): a different device is active (#1881)")
         }
         return false
+    }
+
+    /** Re-read whether a WHOOP is active and un-block the gate if it is. See [whoopConnectAllowed]. */
+    private fun revalidateWhoopIsActive() {
+        val registry = (context.applicationContext as? com.noop.NoopApplication)?.deviceRegistry ?: return
+        ioScope.launch {
+            val activeId = runCatching { registry.activeDeviceId() }.getOrNull() ?: return@launch
+            val rows = runCatching { registry.all() }.getOrNull() ?: return@launch
+            val row = rows.firstOrNull { it.id == activeId }
+            if (row == null || SourceIdentity.isWhoop(row)) setWhoopIsActiveDevice(true)
+        }
     }
 
     /**

--- a/android/app/src/test/java/com/noop/ble/SourceIdentityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/SourceIdentityTest.kt
@@ -1,0 +1,90 @@
+package com.noop.ble
+
+import com.noop.data.PairedDeviceRow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Which device a live link's samples belong to (#1881) — the ORACLE for the Swift twin
+ * `SourceIdentityTests`, asserting the same inputs and the same answers on both platforms.
+ *
+ * The reported failure is the first case here: with an Oura ring active and a WHOOP merely paired, a
+ * WHOOP connection filed 770 `stepSample` and 770 `gravitySample` rows under the ring's id. A ring has
+ * no pedometer and no accelerometer, so 100% of those rows were misattributed — and because `hrSample`
+ * is written by both paths under one id, contamination there cannot be separated after the fact.
+ */
+class SourceIdentityTest {
+
+    private fun row(id: String, brand: String, peripheralId: String?) = PairedDeviceRow(
+        id = id, brand = brand, model = "m", nickname = null, peripheralId = peripheralId,
+        sourceKind = "liveBLE", capabilities = "hr", status = "paired", addedAt = 0L, lastSeenAt = 0L,
+    )
+
+    private val ring = row("oura-abc", "Oura", "AA:BB:CC:DD:EE:01")
+    private val strap = row("whoop-123", "WHOOP", "AA:BB:CC:DD:EE:02")
+
+    /** The reported bug: the ring is active, the STRAP connected, so the strap's id must win. */
+    @Test
+    fun `a strap connecting while a ring is active is attributed to the strap`() {
+        assertEquals("whoop-123",
+            SourceIdentity.resolve("AA:BB:CC:DD:EE:02", listOf(ring, strap), currentId = "oura-abc"))
+    }
+
+    /**
+     * The legacy single-WHOOP path, and the reason this returns null rather than guessing: the seeded row
+     * has not adopted an address yet. The coordinator adopts one on this same connect, so the NEXT connect
+     * resolves — and until then the id stays exactly what it is today.
+     */
+    @Test
+    fun `an unadopted row leaves the id alone`() {
+        val legacy = row(WhoopBleClient.DEFAULT_DEVICE_ID, "WHOOP", null)
+        assertNull(SourceIdentity.resolve("AA:BB:CC:DD:EE:02", listOf(legacy),
+            currentId = WhoopBleClient.DEFAULT_DEVICE_ID))
+    }
+
+    /** No row carries this address — an unknown strap must never claim an existing device's id. */
+    @Test
+    fun `an unknown address leaves the id alone`() {
+        assertNull(SourceIdentity.resolve("FF:FF:FF:FF:FF:FF", listOf(ring, strap), currentId = "oura-abc"))
+    }
+
+    /**
+     * The inverse of the bug. If a non-WHOOP row somehow matches, re-pointing the WHOOP path's id at it
+     * would file strap samples under a ring — which is exactly what #1881 reports, arrived at from the
+     * other direction.
+     */
+    @Test
+    fun `a non-WHOOP match never claims the strap's samples`() {
+        assertNull(SourceIdentity.resolve("AA:BB:CC:DD:EE:01", listOf(ring, strap), currentId = "whoop-123"))
+    }
+
+    /** Already correct — the common path — must not write. */
+    @Test
+    fun `an id already correct resolves to nothing`() {
+        assertNull(SourceIdentity.resolve("AA:BB:CC:DD:EE:02", listOf(ring, strap), currentId = "whoop-123"))
+    }
+
+    /** Neither OS guarantees the case of a UUID string or a MAC, and old rows may carry either. */
+    @Test
+    fun `address matching is case-insensitive`() {
+        assertEquals("whoop-123",
+            SourceIdentity.resolve("aa:bb:cc:dd:ee:02", listOf(ring, strap), currentId = "oura-abc"))
+    }
+
+    /** A blank address is a missing address, not a wildcard that matches a blank stored value. */
+    @Test
+    fun `a blank address leaves the id alone`() {
+        val blank = row("whoop-blank", "WHOOP", "")
+        assertNull(SourceIdentity.resolve("", listOf(blank), currentId = "oura-abc"))
+        assertNull(SourceIdentity.resolve(null, listOf(blank), currentId = "oura-abc"))
+    }
+
+    /** The legacy id is a WHOOP by id even though its brand was never guaranteed. */
+    @Test
+    fun `the legacy row counts as a WHOOP`() {
+        val legacy = row(WhoopBleClient.DEFAULT_DEVICE_ID, "", "AA:BB:CC:DD:EE:03")
+        assertEquals(WhoopBleClient.DEFAULT_DEVICE_ID,
+            SourceIdentity.resolve("AA:BB:CC:DD:EE:03", listOf(legacy), currentId = "oura-abc"))
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/SourceIdentityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/SourceIdentityTest.kt
@@ -78,6 +78,9 @@ class SourceIdentityTest {
         val blank = row("whoop-blank", "WHOOP", "")
         assertNull(SourceIdentity.resolve("", listOf(blank), currentId = "oura-abc"))
         assertNull(SourceIdentity.resolve(null, listOf(blank), currentId = "oura-abc"))
+        // Whitespace is blank on both platforms — the Swift twin was aligned to this.
+        val spaces = row("whoop-spaces", "WHOOP", "   ")
+        assertNull(SourceIdentity.resolve("   ", listOf(spaces), currentId = "oura-abc"))
     }
 
     /** The legacy id is a WHOOP by id even though its brand was never guaranteed. */


### PR DESCRIPTION
Addresses #1881, reported by @pipiche38 with file-level analysis and a proven data trace.

Two separable defects, both platforms. Either alone leaves a live bug, so they land together.

## A — a non-active strap was scanned, connected and drained

`SourceCoordinator` *does* call `stopWhoop()` when a different source becomes active. But that is **edge-triggered**: it fires once on the transition and nothing re-asserts it, while the WHOOP flow has system-driven entry points that consult nobody — `poweredOn` (every Bluetooth toggle and `bluetoothd` restart), state restoration, the 4.0 ↔ 5.0/MG scan rotation, and the standing connect CoreBluetooth honours while the app is suspended. A radio toggle resurrected a strap the user had switched away from.

The fix is the **durable form of that same `stopWhoop()`** — a fail-open flag set from the *same two closures* the coordinator already uses to stop and start WHOOP. Riding those closures means it inherits their semantics exactly, including the deliberate Apple Watch exception, which calls neither and must never tear down a live WHOOP. It needs no change to `SourceCoordinator` at all.

**Gated on the SYSTEM paths only** — not at `connectCore` as the report suggested, and not at the scan. `connectCore` is shared by the user's Connect button and the automatic paths, so gating it made that button silently dead while DevicesScreen showed a "Reconnecting…" toast. The line already existed in the code, documented on the functions themselves: `connect()` is "USER-initiated connect (the Connect button, the scan flow, Add-a-WHOOP)" and system paths "MUST use `connectFromSystem()`". The report's complaint is only ever about NOOP acting on its own, so the gate sits on that same line.

Three gates on Apple, all unambiguously automatic: `connectFromSystem`, `connectRestored` (reached from both `poweredOn` and `willRestoreState`) and the standing connect — which involves no scan at all and is honoured while the app is suspended, so no scan-side guard could have covered it. `startScan` and `didDiscover` need none: reaching a discovery means a scan is running, and a scan only runs because the user asked or the gated system entry allowed it.

Android needs one more, threaded rather than gated upstream because its automatic callers do not funnel through a single entry point: `connectToDevice` carries `alreadyAuthorised` — false for the radio-on re-arm, the reconnect backoff, launch auto-reconnect (#67) and the scheduled retry; true for the user's Connect and for a scan result.

## B — samples were attributed to the ACTIVE device, not the SOURCE device

`BLEManager` held one `deviceId` meaning "the active device" and reused it as "the device these bytes came from". Those were the same thing only while every registered device was a WHOOP. The report's evidence is proof, not inference: **770 `stepSample` and 770 `gravitySample` rows under an Oura ring**, which has neither a pedometer nor an accelerometer. And as they carefully say, `hrSample` is written by both paths under one id, so contamination *there* cannot be checked after the fact — the schema records which device was active, never which produced a row.

`didConnect` now resolves the id from the peripheral that actually connected and re-points the in-flight `Collector`/`Backfiller`. It also re-points the router's own copy, which the existing `setActiveDeviceId` left behind — the same conflation, one more consumer (the #1706 alarm readback), not cited in the report.

## The decision is pure, and tested

BLE behaviour can't be tested in CI, but the attribution decision can — and it's the part that silently files rows under the wrong device when it's wrong. It's extracted to `SourceIdentity.resolve(address:rows:currentId:)` with 8 matching cases on each platform, including the reported scenario and its inverse.

It only ever moves the id to a row that is **both** matched by peripheral **and** a WHOOP, so every uncertain case keeps today's behaviour: the legacy single-WHOOP row before it has adopted an address, an unknown address, a non-WHOOP match, and an id already correct all resolve to "leave it alone". `isWhoop` now has one definition instead of two that could disagree.

## Android shares both defects

The report flagged the Android twin as unchecked. It has the same shape and is fixed here:
- **B:** `WhoopBleClient.deviceId` carries the same "all rows are stamped with this… resolved from `DeviceRegistry.activeDeviceId`" contract, and `setActiveDeviceId` fires only for a non-legacy WHOOP.
- **A:** `SourceCoordinator.kt` has the identical churn guard and edge-triggered `stopWhoop()`, and `onBluetoothRadioOn` reconnects with no active-device check — it even clears `intentionalDisconnect` first.

One asymmetry: Android's registry read is `suspend`, so identity adoption there is a coroutine rather than the inline synchronous GRDB read Apple uses. The window is between `STATE_CONNECTED` and the first persisted sample — service discovery, notification subscription and the strap's first response all sit inside it — so a row is not expected to land first. That's documented at the call site rather than left implicit.

## Re-review found three more

**The line the report actually quotes was still wrong.** `bootstrapStore` adopted the active device's id unconditionally, so with a ring active `deviceId` became the ring *before* any strap connected. Per-connection adoption corrected it at `didConnect`, but not for the window between the two — and that window is precisely "the store is ready for restored BLE data". It now adopts the active id only when the active device is a WHOOP. Android constructs its client with the same id and gets the same treatment.

**The adoption was skipped exactly where the reported scenario lands.** CoreBluetooth state restoration hands back an already-connected peripheral, and the code says so itself: *"didConnect never fires for an ALREADY-connected restored peripheral"*. A link restored after a radio toggle or relaunch — the reported trigger — kept the active device's id. Adopted there too, after `bootstrapStore` because that is what creates the registry handle. Apple-only: Android has no equivalent restore seam.

**A latch risk I introduced myself.** Seeding the gate at startup made it settable independently of the coordinator, so if the seed said "not a WHOOP" and the coordinator then failed to wire, a stale `false` would stop the strap connecting for the whole session — the exact regression the fail-open default exists to prevent. The flag is now a *cache* of a registry fact, with the registry as the authority: the gate re-validates before refusing, so it cannot stay wrong. Only on the blocked path. Swift reads inline; Android re-validates asynchronously and lands for the next attempt, because its registry read is `suspend` and this runs on the BLE handler thread where `runBlocking` would be the worse bug.

Also checked and sound: every `stopWhoop()` is either paired with a `startWhoop()` or is the deliberate one in `switchToStrap`, and `switchToStrap` always reaches `onStrap = true` once past its guards — so the flag cannot be left `false` while the coordinator believes WHOOP is running.

**Considered and deliberately left alone:** `readoptWorkingStrap` (the #52 stale-pin handoff) calls the USER `connect(model:)` from a system path, so it bypasses the gate. It only runs mid-recovery of a link that is already up — it cannot start one from idle, which is what the gate is for — and re-pointing it at `connectFromSystem` would change the bond-loop give-up semantics #78 hole-2 deliberately separated.

## Concurrency, and one documented residual

Android's `deviceId` was a plain `private var` read by the persist sites on the BLE handler thread — defensible while the only writer was the coordinator's WHOOP→WHOOP switch. This change adds a **second writer on a different thread**, because the Room registry read is `suspend` and `adoptSourceIdentity` therefore re-points from `ioScope`. Without a barrier the handler thread could keep reading the pre-connect value and file the link's rows under the wrong device — this change's own bug, reintroduced underneath it. Now `@Volatile`, with the reason recorded on the field. Apple needs no equivalent: `BLEManager` is `@MainActor` and both re-point sites run on it.

**Documented, not repaired:** the disconnect handler flushes buffered live rows in a deliberately fire-and-forget `Task`, and the persist sites read `deviceId` at *persist* time — so a flush still in flight when the next link re-points would attribute the previous link's tail to the new strap. It needs a re-point to happen at all, which only occurs when the resolved row differs from the current id: **never on a settled single-WHOOP install**. In the reported case the move is ring → strap and those buffered rows are the strap's, so the new attribution is the correct one. The genuinely wrong case is two WHOOPs where A's tail lands on B — a pre-existing hazard of `setActiveDeviceId`, which the coordinator already calls on a WHOOP→WHOOP switch, and not one this change should grow an async `didConnect` to chase.

## Verification

- Android full suite **5197 tests, 0 failures** (`--rerun-tasks --no-build-cache`), +8 from the new resolver tests; `com.noop.ble` re-run green after the `isWhoop` de-duplication.
- Both platforms compile; i18n audit and doc-comment lint clean; no schema change.
- Checked the add-a-WHOOP wizard is **not** caught by the gate — both platforms' present-scan paths bypass the gated `startScan`, and `reconnectToAddress` is launch auto-reconnect (#67), which is exactly the class that should be gated.

**Not verified on hardware.** The repo rule for anything on the CoreBluetooth / offload / live-HR path is validation on a real strap, and reproducing this specific case needs a WHOOP *and* a second non-WHOOP device registered with the non-WHOOP active. I have not done that. What most needs checking before this ships is the ordinary single-WHOOP path — that a normal strap still scans, connects and offloads exactly as before — because a wrong `false` in that flag would stop the strap connecting for everyone. The flag is fail-open specifically to make that the unlikely direction.
