### PR TITLE
daycycle: drop the reliableAwakeCoverage parameter nothing reads (#1572 follow-up)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/DayCycle.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/DayCycle.swift
@@ -50,12 +50,15 @@ public enum DayCycleResolver {
 
     /// Kotlin twin: `DayCycleResolver.activeWindow`.
     public static func activeWindow(mode: DayCycleMode, latestSleep: DayCycleWindow?, now: Int,
-                                    offsetSec: Int, reliableAwakeCoverage: Bool) -> DayCycleWindow {
+                                    offsetSec: Int) -> DayCycleWindow {
         guard mode == .sleepOnset, let latestSleep else { return calendarWindow(now: now, offsetSec: offsetSec) }
         let age = now - latestSleep.startInclusive
         let fallback = fallbackMidnight(after: latestSleep.startInclusive, offsetSec: offsetSec)
-        // Sleep-onset mode remains anchored across midnight when awake coverage is unavailable.
-        // Only the absolute safety cap may synthesize a fallback boundary.
+        // Sleep-onset mode stays anchored across midnight unconditionally: only the absolute safety cap
+        // may synthesize a fallback boundary. An earlier design gated this on whether awake coverage was
+        // reliable and carried a `reliableAwakeCoverage` parameter for it; the gate was dropped but the
+        // parameter survived, unread on both platforms and passed `false` by every one of its five call
+        // sites. Removed rather than left looking like a switch someone could flip.
         guard age < absoluteMaxOpenSeconds else {
             let day = AnalyticsEngine.dayString(fallback, offsetSec: offsetSec)
             return DayCycleWindow(id: "synthetic:\(day)", startInclusive: fallback, endExclusive: now,

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayCycleTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayCycleTests.swift
@@ -22,15 +22,22 @@ final class DayCycleTests: XCTestCase {
         XCTAssertEqual(active.startInclusive, sleep.startInclusive)
     }
 
-    /// The 18-hour fallback rule, which the Kotlin twin
-    /// (`DayCycleResolverTest.fallbackUsesTheFirstMidnightAtLeastEighteenHoursAfterOnset`) pinned and this
-    /// side did not. It is a shared numeric contract with a branch that is easy to get subtly wrong: the
-    /// first midnight at least `minSyntheticMidnightAgeSeconds` after onset, rolling to the NEXT one when
-    /// that midnight falls short. A 23:00 onset is the case that exercises the roll — midnight is one hour
-    /// later, well inside 18 h, so the answer is the midnight after that.
-    func testFallbackUsesTheFirstMidnightAtLeastEighteenHoursAfterOnset() {
-        let monday2300 = 23 * 3_600
-        XCTAssertEqual(DayCycleResolver.fallbackMidnight(after: monday2300, offsetSec: 0), 2 * 86_400)
+    /// Both branches of the 18-hour fallback rule, which neither platform pinned.
+    ///
+    /// `fallbackMidnight` returns the first midnight at least `minSyntheticMidnightAgeSeconds` after onset.
+    /// Because the candidate is `floor(minimum / day) * day`, it is at or BELOW `minimum` always — so the
+    /// direct branch is reachable only on exact equality, when onset sits precisely 18 h before a midnight.
+    /// Every existing case here and on Kotlin used an onset that rolls, so a `>=` quietly weakened to `>`
+    /// would have moved that boundary a full day and nothing would have failed.
+    func testFallbackTakesTheMidnightExactlyEighteenHoursAfterOnset() {
+        // 06:00 + 18 h lands exactly on the next midnight: taken directly, not rolled past.
+        XCTAssertEqual(DayCycleResolver.fallbackMidnight(after: 6 * 3_600, offsetSec: 0), 86_400)
+    }
+
+    /// The rolling branch at a different onset from the case above, so the two are not the same test twice.
+    func testFallbackRollsWhenTheNextMidnightIsTooSoon() {
+        // 23:00 + 18 h overshoots the next midnight, so the one after it wins.
+        XCTAssertEqual(DayCycleResolver.fallbackMidnight(after: 23 * 3_600, offsetSec: 0), 2 * 86_400)
     }
 
     func testAbsoluteCapStillUsesSyntheticMidnight() {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayCycleTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayCycleTests.swift
@@ -40,6 +40,21 @@ final class DayCycleTests: XCTestCase {
         XCTAssertEqual(DayCycleResolver.fallbackMidnight(after: 23 * 3_600, offsetSec: 0), 2 * 86_400)
     }
 
+    /// The boundary is LOCAL midnight, not UTC midnight — and until now nothing said so. Every
+    /// day-cycle case on both platforms passed a zero offset, so the whole offset arithmetic, which is
+    /// the part that decides which local day a boundary lands on, was unpinned. This repo has already
+    /// had days re-bucket on travel once, so it is worth a case rather than an argument.
+    ///
+    /// 06:00 local at UTC-5 is 11:00 UTC. Plus 18 h is 05:00 UTC the next day, which IS local midnight
+    /// there, so the direct branch takes it: 104_400 = 29 h UTC = 00:00 local. A resolver that floored
+    /// to UTC midnight would answer 86_400 and be a day out for a third of the planet.
+    func testFallbackLandsOnLocalMidnightNotUTC() {
+        let offsetSec = -5 * 3_600
+        let onsetLocal0600 = 6 * 3_600 - offsetSec
+        XCTAssertEqual(DayCycleResolver.fallbackMidnight(after: onsetLocal0600, offsetSec: offsetSec),
+                       104_400)
+    }
+
     func testAbsoluteCapStillUsesSyntheticMidnight() {
         let sleep = DayCycleWindow(id: "sleep", startInclusive: 0, endExclusive: 0,
                                    displayDay: "1970-01-01", source: .detectedSleep)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayCycleTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayCycleTests.swift
@@ -6,29 +6,38 @@ final class DayCycleTests: XCTestCase {
         XCTAssertEqual(DayCycleMode.persisted(nil), .sleepOnset)
         XCTAssertEqual(DayCycleMode.persisted("midnight"), .midnight)
         let window = DayCycleResolver.activeWindow(mode: .midnight, latestSleep: nil, now: 86_500,
-                                                   offsetSec: 0, reliableAwakeCoverage: false)
+                                                   offsetSec: 0)
         XCTAssertEqual(window.startInclusive, 86_400)
         XCTAssertEqual(window.source, .calendar)
     }
 
-    func testMissingWakeEvidenceKeepsSleepOnsetCycleAcrossMidnight() {
+    func testSleepOnsetCycleStaysOpenAcrossMidnight() {
         let sleep = DayCycleWindow(id: "sleep", startInclusive: 20 * 3_600, endExclusive: 0,
                                    displayDay: "1970-01-01", source: .detectedSleep)
         let fallback = DayCycleResolver.fallbackMidnight(after: sleep.startInclusive, offsetSec: 0)
         XCTAssertEqual(fallback, 2 * 86_400)
         let active = DayCycleResolver.activeWindow(mode: .sleepOnset, latestSleep: sleep,
-                                                   now: fallback, offsetSec: 0,
-                                                   reliableAwakeCoverage: false)
+                                                   now: fallback, offsetSec: 0)
         XCTAssertEqual(active.source, .detectedSleep)
         XCTAssertEqual(active.startInclusive, sleep.startInclusive)
+    }
+
+    /// The 18-hour fallback rule, which the Kotlin twin
+    /// (`DayCycleResolverTest.fallbackUsesTheFirstMidnightAtLeastEighteenHoursAfterOnset`) pinned and this
+    /// side did not. It is a shared numeric contract with a branch that is easy to get subtly wrong: the
+    /// first midnight at least `minSyntheticMidnightAgeSeconds` after onset, rolling to the NEXT one when
+    /// that midnight falls short. A 23:00 onset is the case that exercises the roll — midnight is one hour
+    /// later, well inside 18 h, so the answer is the midnight after that.
+    func testFallbackUsesTheFirstMidnightAtLeastEighteenHoursAfterOnset() {
+        let monday2300 = 23 * 3_600
+        XCTAssertEqual(DayCycleResolver.fallbackMidnight(after: monday2300, offsetSec: 0), 2 * 86_400)
     }
 
     func testAbsoluteCapStillUsesSyntheticMidnight() {
         let sleep = DayCycleWindow(id: "sleep", startInclusive: 0, endExclusive: 0,
                                    displayDay: "1970-01-01", source: .detectedSleep)
         XCTAssertEqual(DayCycleResolver.activeWindow(mode: .sleepOnset, latestSleep: sleep,
-                                                     now: 40 * 3_600, offsetSec: 0,
-                                                     reliableAwakeCoverage: false).source,
+                                                     now: 40 * 3_600, offsetSec: 0).source,
                        .syntheticMidnight)
     }
 

--- a/Strand/Data/DayCycleIntelligenceIntegration.swift
+++ b/Strand/Data/DayCycleIntelligenceIntegration.swift
@@ -163,7 +163,7 @@ import WhoopStore
             let active = DayCycleResolver.activeWindow(mode: mode,
                 latestSleep: DayCycleWindow(id: latest.sleepId, startInclusive: latest.onset,
                     endExclusive: now, displayDay: day, source: .detectedSleep), now: now,
-                offsetSec: offsetSec, reliableAwakeCoverage: false)
+                offsetSec: offsetSec)
             if active.source == .syntheticMidnight {
                 boundaries.append(.init(sleepId: active.id, onset: active.startInclusive))
                 wakeDayById[active.id] = active.displayDay; ownerById[active.id] = owner

--- a/android/app/src/main/java/com/noop/analytics/DayCycle.kt
+++ b/android/app/src/main/java/com/noop/analytics/DayCycle.kt
@@ -54,13 +54,17 @@ object DayCycleResolver {
     /**
      * Resolve the active window. Sleep-onset mode stays open across midnight even when awake coverage is
      * unavailable. The absolute cap still prevents a stale sleep boundary from remaining active forever.
+     *
+     * That "even when" is unconditional, not a gate: an earlier design decided it from whether awake
+     * coverage was reliable and carried a `reliableAwakeCoverage` parameter for it. The gate was dropped
+     * but the parameter survived — unread on both platforms, and passed `false` by every one of its call
+     * sites — so it was removed rather than left looking like a switch someone could flip.
      */
     fun activeWindow(
         mode: DayCycleMode,
         latestSleep: DayCycleWindow?,
         now: Long,
         tzOffsetSeconds: Long,
-        reliableAwakeCoverage: Boolean,
     ): DayCycleWindow {
         if (mode == DayCycleMode.MIDNIGHT || latestSleep == null) {
             return calendarWindow(now, tzOffsetSeconds)

--- a/android/app/src/main/java/com/noop/analytics/PhysiologicalStepCycleEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/PhysiologicalStepCycleEngine.kt
@@ -174,7 +174,6 @@ internal object PhysiologicalStepCycleEngine {
                     ),
                     now = nowSeconds,
                     tzOffsetSeconds = tzOffsetSeconds,
-                    reliableAwakeCoverage = false,
                 )
                 if (active.source == DayCycleWindow.Source.SYNTHETIC_MIDNIGHT) {
                     val synthetic = PhysiologicalSteps.CycleBoundary(active.id, active.startInclusive)

--- a/android/app/src/test/java/com/noop/analytics/DayCycleResolverTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DayCycleResolverTest.kt
@@ -9,9 +9,20 @@ class DayCycleResolverTest {
         assertEquals(DayCycleMode.SLEEP_ONSET, DayCycleMode.fromPersisted("unknown"))
     }
 
-    @Test fun fallbackUsesTheFirstMidnightAtLeastEighteenHoursAfterOnset() {
+    @Test fun fallbackRollsWhenTheNextMidnightIsTooSoon() {
+        // 23:00 + 18 h overshoots the next midnight, so the one after it wins.
         val monday2300 = 23 * 3_600L
         assertEquals(2 * 86_400L, DayCycleResolver.fallbackMidnightAfter(monday2300, 0))
+    }
+
+    /**
+     * The other branch, which neither platform pinned. The candidate midnight is
+     * `floorDiv(minimum, day) * day`, so it is at or BELOW `minimum` always — the direct branch is
+     * reachable only on exact equality, when onset sits precisely 18 h before a midnight. Every other
+     * case here rolls, so a `>=` quietly weakened to `>` would move this boundary a full day unseen.
+     */
+    @Test fun fallbackTakesTheMidnightExactlyEighteenHoursAfterOnset() {
+        assertEquals(86_400L, DayCycleResolver.fallbackMidnightAfter(6 * 3_600L, 0))
     }
 
     @Test fun allNighterStaysOpenUntilTheAbsoluteCap() {

--- a/android/app/src/test/java/com/noop/analytics/DayCycleResolverTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DayCycleResolverTest.kt
@@ -25,6 +25,21 @@ class DayCycleResolverTest {
         assertEquals(86_400L, DayCycleResolver.fallbackMidnightAfter(6 * 3_600L, 0))
     }
 
+    /**
+     * The boundary is LOCAL midnight, not UTC midnight — and until now nothing said so. Every day-cycle
+     * case on both platforms passed a zero offset, so the offset arithmetic, which decides which local
+     * day a boundary lands on, was unpinned. This repo has already had days re-bucket on travel once.
+     *
+     * 06:00 local at UTC-5 is 11:00 UTC. Plus 18 h is 05:00 UTC the next day, which IS local midnight
+     * there, so the direct branch takes it: 104_400 = 29 h UTC = 00:00 local. A resolver that floored to
+     * UTC midnight would answer 86_400 and be a day out for a third of the planet.
+     */
+    @Test fun fallbackLandsOnLocalMidnightNotUtc() {
+        val offset = -5 * 3_600L
+        val onsetLocal0600 = 6 * 3_600L - offset
+        assertEquals(104_400L, DayCycleResolver.fallbackMidnightAfter(onsetLocal0600, offset))
+    }
+
     @Test fun allNighterStaysOpenUntilTheAbsoluteCap() {
         val sleep = DayCycleWindow("night", 0, 0, "1970-01-01", DayCycleWindow.Source.DETECTED_SLEEP)
         assertEquals(

--- a/android/app/src/test/java/com/noop/analytics/DayCycleResolverTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DayCycleResolverTest.kt
@@ -14,23 +14,23 @@ class DayCycleResolverTest {
         assertEquals(2 * 86_400L, DayCycleResolver.fallbackMidnightAfter(monday2300, 0))
     }
 
-    @Test fun reliableAllNighterStaysOpenUntilTheAbsoluteCap() {
+    @Test fun allNighterStaysOpenUntilTheAbsoluteCap() {
         val sleep = DayCycleWindow("night", 0, 0, "1970-01-01", DayCycleWindow.Source.DETECTED_SLEEP)
         assertEquals(
             DayCycleWindow.Source.DETECTED_SLEEP,
-            DayCycleResolver.activeWindow(DayCycleMode.SLEEP_ONSET, sleep, 39 * 3_600L, 0, true).source,
+            DayCycleResolver.activeWindow(DayCycleMode.SLEEP_ONSET, sleep, 39 * 3_600L, 0).source,
         )
         assertEquals(
             DayCycleWindow.Source.SYNTHETIC_MIDNIGHT,
-            DayCycleResolver.activeWindow(DayCycleMode.SLEEP_ONSET, sleep, 40 * 3_600L, 0, true).source,
+            DayCycleResolver.activeWindow(DayCycleMode.SLEEP_ONSET, sleep, 40 * 3_600L, 0).source,
         )
     }
 
-    @Test fun missingCoverageKeepsSleepOnsetCycleOpenAcrossMidnight() {
+    @Test fun sleepOnsetCycleStaysOpenAcrossMidnight() {
         val sleep = DayCycleWindow("night", 23 * 3_600L, 0, "1970-01-02", DayCycleWindow.Source.DETECTED_SLEEP)
         assertEquals(
             DayCycleWindow.Source.DETECTED_SLEEP,
-            DayCycleResolver.activeWindow(DayCycleMode.SLEEP_ONSET, sleep, 2 * 86_400L + 60, 0, false).source,
+            DayCycleResolver.activeWindow(DayCycleMode.SLEEP_ONSET, sleep, 2 * 86_400L + 60, 0).source,
         )
     }
 
@@ -38,7 +38,7 @@ class DayCycleResolverTest {
         val sleep = DayCycleWindow("night", 23 * 3_600L, 0, "1970-01-02", DayCycleWindow.Source.DETECTED_SLEEP)
         assertEquals(
             DayCycleWindow.Source.CALENDAR,
-            DayCycleResolver.activeWindow(DayCycleMode.MIDNIGHT, sleep, 2 * 86_400L + 60, 0, true).source,
+            DayCycleResolver.activeWindow(DayCycleMode.MIDNIGHT, sleep, 2 * 86_400L + 60, 0).source,
         )
     }
 }


### PR DESCRIPTION
Cleanup on top of #1572, found while reviewing it. Nothing here changes a window boundary.

## A parameter nothing reads

`DayCycleResolver.activeWindow` took `reliableAwakeCoverage` on both platforms. Neither body referenced it, and every call site — both production ones and all the tests — passed a constant. It is the residue of an earlier design that gated staying-open-across-midnight on whether awake coverage was reliable; the gate was dropped and the parameter was not.

Left in, it reads like a working switch, so the next caller to pass `true` would get silence.

## Why it survived

Two Kotlin cases asserted a distinction the code never made:

- `reliableAllNighterStaysOpenUntilTheAbsoluteCap` passed `true`
- `missingCoverageKeepsSleepOnsetCycleOpenAcrossMidnight` passed `false`

Both would have passed either way. Renamed to what they actually pin (`allNighterStaysOpenUntilTheAbsoluteCap`, `sleepOnsetCycleStaysOpenAcrossMidnight`), with the Swift twin renamed to match.

## A fallback branch neither platform reached

My first attempt at this was wrong, and re-review caught it. I added a Swift case asserting a 23:00 onset resolves to `2 * 86_400` — but the existing `testSleepOnsetCycleStaysOpenAcrossMidnight` already asserted that exact value through that exact branch from a 20:00 onset. It was a vacuous test. I had matched case *counts* across the platforms and called that parity, which is not the same as matching what they reach.

The branch **neither** platform reached is the other one. `fallbackMidnightAfter` picks `floorDiv(minimum, day) * day`, which is at or *below* `minimum` always — so `atMidnight >= minimum` is true only on exact equality, when onset sits precisely 18 h before a midnight. Every case on both platforms used an onset that rolls past it.

A `>=` quietly weakened to `>` would therefore have moved that boundary a full day with nothing failing. Verified rather than argued: mutating `>=` to `>` fails the new case and **only** the new case — the five existing ones, including the 23:00 roll, stay green.

Both platforms now pin both branches, with the rolling case kept at an onset distinct from the direct one so the pair are not the same test twice.

## A boundary nothing said was local

Every day-cycle case on both platforms passed a **zero timezone offset**, so the offset arithmetic — the part that decides which *local* day a boundary lands on — was pinned by nothing. That is the one input this repo has already been bitten by, when recent nights re-bucketed on travel.

The two implementations do agree today: Swift's `Int(floor(Double(local) / Double(day)))` and Kotlin's `Math.floorDiv(local, day)` return identical answers across every offset from UTC-12 to UTC+13 and every onset hour across two days. Nothing recorded that agreement; now a case does.

06:00 local at UTC-5 is 11:00 UTC; plus 18 h is 05:00 UTC the next day, which *is* local midnight there, so the direct branch takes it and the answer is `104_400` — 29 h UTC, 00:00 local. A resolver that floored to UTC midnight would answer `86_400` and be a full day out for a third of the planet.

Verified the same way: dropping the offset term so the resolver floors to UTC midnight fails the new case and **only** the new case. All six existing cases stay green — the evidence that they were blind to the offset entirely.

## Verification

- Android full suite **5251 tests, 0 failures** (`--rerun-tasks --no-build-cache`, result-XML timestamps checked).
- Both platforms compile; doc-comment lint and i18n audit clean; no schema change.
- Both new expectations were derived by re-implementing `fallbackMidnight`'s arithmetic independently rather than copying a constant across.

A note for the record: the Kotlin test call sites passed the flag **positionally**, so a search for the parameter name did not find them and the first build failed on four call sites a name-grep had missed.
