### PR TITLE
today: add an optional, default-OFF Coach launcher card (#1862)

### DIFF
--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -162,6 +162,14 @@ final class AICoachEngine: ObservableObject {
     private var conversationDay: Int?
     @Published var sending = false
     @Published var errorText: String?
+
+    /// #1862: a question handed over by the Today Coach launcher sheet, for `CoachView` to send on appear.
+    ///
+    /// The launcher owns no send, stream, error or consent surface of its own — duplicating those is how a
+    /// second chat UI drifts from the first. It collects a question and hands it here; the Coach screen,
+    /// which already has all of that, consumes it exactly once and clears it. Nil is the normal state, and
+    /// setting it performs NO network work by itself.
+    @Published var pendingPrompt: String?
     @Published var provider: AIProvider {
         didSet {
             guard provider != oldValue else { return }

--- a/Strand/App/NavRouter.swift
+++ b/Strand/App/NavRouter.swift
@@ -29,6 +29,10 @@ final class NavRouter: ObservableObject {
         case activeWorkout
         case liveSession
         case journal
+        /// #1862: the Coach screen, opened from the Today Coach launcher sheet once the user picks a
+        /// suggestion or submits the composer. The launcher deliberately owns no send/stream/consent
+        /// surface of its own — it hands the question to the one screen that already has them.
+        case coach
 
         var id: String { rawValue }
 
@@ -60,6 +64,8 @@ final class NavRouter: ObservableObject {
 
     /// Ask the shell to open the Devices manager (pair / switch bands). The shell decides how.
     func openDevices() { requestedDestination = .devices }
+    /// #1862: open Coach, optionally with a question the launcher already collected.
+    func openCoach() { requestedDestination = .coach }
     /// Open the v5 Insights hub (the n-of-1 "what moves your Charge" surface).
     func openInsightsHub() { requestedDestination = .insightsHub }
     /// Open the Lab Book (private health-records logbook).

--- a/Strand/App/RootView.swift
+++ b/Strand/App/RootView.swift
@@ -328,6 +328,9 @@ struct RootView: View {
             case .liveSession: selection = .today
             // The #627 Today journal widget routes to the Insights sidebar row (which hosts the journal card).
             case .journal: selection = .insights
+            // #1862: the Today Coach card's launcher hands off here, so the send/stream/consent surface
+            // stays in exactly one place.
+            case .coach: selection = .coach
             case nil: break
             }
             if dest != nil { router.requestedDestination = nil }

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -75,6 +75,8 @@ struct LiquidTodayView: View {
     // sheets / expanders
     @State private var guideSection: ScoreSection?
     @State private var customizationDestination: TodayCustomizationDestination?
+    /// #1862: the optional Coach launcher sheet. Presentation state only — opening it requests nothing.
+    @State private var showCoachLauncher = false
     @State private var showSettings = false
     @State private var synthesisExpanded = false
     @State private var showLiveSession = false
@@ -435,6 +437,9 @@ struct LiquidTodayView: View {
                 dashboardCardsRaw: $dashboardCardsRaw,
                 hostedCardsRaw: $hostedCardsRaw
             )
+        }
+        .sheet(isPresented: $showCoachLauncher) {
+            CoachLauncherSheet()
         }
         .sheet(isPresented: $showSettings) {
             NavigationStack {
@@ -987,6 +992,11 @@ struct LiquidTodayView: View {
             // A tap-through to the full Coupled day screen. No value.
             cardLink(.coupled, title: card.title, sub: card.subtitle,
                      value: "", tint: StrandPalette.chargeColor, frac: 0.6)
+        case .coach:
+            // #1862: a sheet rather than a push — the point of the card is to try Coach WITHOUT
+            // leaving Today.
+            cardAction(title: card.title, sub: card.subtitle, value: "",
+                       tint: StrandPalette.accent, frac: 0.5) { showCoachLauncher = true }
         }
     }
 
@@ -995,7 +1005,26 @@ struct LiquidTodayView: View {
     private func cardLink(_ route: TabRoute, title: String, sub: String,
                           value: String, tint: Color, frac: Double?) -> some View {
         NavigationLink(value: route) {
-            HStack(spacing: 12) {
+            cardLinkBody(title: title, sub: sub, value: value, tint: tint, frac: frac)
+        }
+        .buttonStyle(LiquidPressStyle())
+    }
+
+    /// The same row, running `action` instead of pushing (#1862). Coach is the one dashboard card that
+    /// opens a SHEET, so it cannot ride `NavigationLink`; sharing `cardLinkBody` keeps the two kinds of
+    /// row from drifting apart visually.
+    private func cardAction(title: String, sub: String, value: String, tint: Color, frac: Double?,
+                            action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            cardLinkBody(title: title, sub: sub, value: value, tint: tint, frac: frac)
+        }
+        .buttonStyle(LiquidPressStyle())
+    }
+
+    @ViewBuilder
+    private func cardLinkBody(title: String, sub: String, value: String,
+                              tint: Color, frac: Double?) -> some View {
+        HStack(spacing: 12) {
                 LiquidVessel(value: frac, tint: tint, animated: false).frame(width: 30, height: 30)
                 VStack(alignment: .leading, spacing: 1) {
                     Text(title.uppercased()).font(StrandFont.overlineScaled(11)).tracking(1.0)
@@ -1009,9 +1038,7 @@ struct LiquidTodayView: View {
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 11)
-            .background(NoopPanelSurface(tint: tint, cornerRadius: 20, surfaceOpacity: cardOpacity))
-        }
-        .buttonStyle(LiquidPressStyle())
+        .background(NoopPanelSurface(tint: tint, cornerRadius: 20, surfaceOpacity: cardOpacity))
     }
 
     // MARK: - Synthesis (greeting + readiness pills + one-liner)

--- a/Strand/Screens/CoachLauncherSheet.swift
+++ b/Strand/Screens/CoachLauncherSheet.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+/// The compact Coach launcher opened from the optional Today card (#1862).
+///
+/// Coach is otherwise reachable only through More/Insights, which makes it easy to miss and means
+/// leaving Today to try it. This is the shortcut — and deliberately ONLY a shortcut.
+///
+/// It owns no send, stream, error or consent surface of its own. Picking a suggestion or submitting the
+/// composer hands the question to `AICoachEngine.pendingPrompt` and routes to `CoachView`, which already
+/// has all of that. A second chat UI would drift from the first, and the issue explicitly defers the
+/// persistent-workspace redesign (threads, retention, backup policy) to a follow-up.
+///
+/// NO PROVIDER REQUEST IS MADE BY OPENING THIS. Everything shown is local: `isConfigured` reads the
+/// stored key, and the prompts are static copy. The first network call still happens where it always
+/// did — inside `AICoachEngine.send`, after an explicit user action.
+struct CoachLauncherSheet: View {
+    @EnvironmentObject var coach: AICoachEngine
+    @EnvironmentObject var router: NavRouter
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var draft = ""
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    if coach.isConfigured {
+                        configured
+                    } else {
+                        unconfigured
+                    }
+                }
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .background(StrandPalette.surfaceBase.ignoresSafeArea())
+            .navigationTitle(Text("Coach"))
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        #if os(iOS)
+        .presentationDetents([.medium, .large])
+        #endif
+    }
+
+    // MARK: Configured — suggestions + a compact composer
+
+    @ViewBuilder
+    private var configured: some View {
+        Text("Ask about your charge, effort, rest and workouts, grounded in your own numbers.")
+            .font(StrandFont.footnote)
+            .foregroundStyle(StrandPalette.textTertiary)
+
+        // Deliberately no "Try asking" heading: the line above already frames the list, and a new
+        // literal would be the only string in this card needing translation into ten locales. The whole
+        // launcher reuses copy the Coach screen already ships.
+
+        ForEach(CoachPrompts.suggestions, id: \.self) { prompt in
+            Button { hand(off: prompt) } label: {
+                Text(prompt)
+                    .font(StrandFont.caption)
+                    .foregroundStyle(StrandPalette.textPrimary)
+                    .padding(.horizontal, 12).padding(.vertical, 8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(FrostedCardSurface(cornerRadius: NoopMetrics.cardRadius))
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(Text("Suggested prompt: \(prompt)"))
+        }
+
+        HStack(spacing: 8) {
+            TextField("Ask your coach…", text: $draft, axis: .vertical)
+                .textFieldStyle(.plain)
+                .lineLimit(1...3)
+                .padding(.horizontal, 12).padding(.vertical, 9)
+                .background(FrostedCardSurface(cornerRadius: NoopMetrics.cardRadius))
+                .onSubmit { submitDraft() }
+            Button {
+                submitDraft()
+            } label: {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 26, weight: .semibold))
+                    .foregroundStyle(StrandPalette.accent)
+            }
+            .buttonStyle(.plain)
+            .disabled(trimmedDraft.isEmpty)
+            .accessibilityLabel(Text("Send"))
+        }
+        .padding(.top, 4)
+    }
+
+    // MARK: Not configured — explain the opt-in and route to the existing setup
+
+    @ViewBuilder
+    private var unconfigured: some View {
+        // The SAME explanation the Coach screen shows, so the bring-your-own-key model is described
+        // once. The button routes to that screen, which stays the only place a key is entered.
+        Text("Coach uses your own API key. Pick a provider, paste a key, and choose a model. Your key is stored securely in the Keychain and never leaves \(Platform.deviceNounPhrase) except as the request you make.")
+            .font(StrandFont.footnote)
+            .foregroundStyle(StrandPalette.textTertiary)
+
+        Button {
+            dismiss()
+            router.openCoach()
+        } label: {
+            Text("Connect a provider")
+                .font(StrandFont.caption)
+                .foregroundStyle(StrandPalette.textPrimary)
+                .padding(.horizontal, 14).padding(.vertical, 10)
+                .frame(maxWidth: .infinity)
+                .background(FrostedCardSurface(cornerRadius: NoopMetrics.cardRadius))
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: Handoff
+
+    private var trimmedDraft: String {
+        draft.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func submitDraft() {
+        let text = trimmedDraft
+        guard !text.isEmpty else { return }
+        hand(off: text)
+    }
+
+    /// Dismiss, park the question, and open Coach. Deliberately NOT `coach.send` from here: the launcher
+    /// never performs a provider request, so a user who opens this sheet and changes their mind has cost
+    /// nothing and sent nothing.
+    private func hand(off prompt: String) {
+        coach.pendingPrompt = prompt
+        draft = ""
+        dismiss()
+        router.openCoach()
+    }
+}

--- a/Strand/Screens/CoachLauncherSheet.swift
+++ b/Strand/Screens/CoachLauncherSheet.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import StrandDesign
 
 /// The compact Coach launcher opened from the optional Today card (#1862).
 ///

--- a/Strand/Screens/CoachPrompts.swift
+++ b/Strand/Screens/CoachPrompts.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// The suggested questions offered when a Coach thread is empty (#1862).
+///
+/// Extracted from `CoachView` so the Today launcher sheet and the full screen offer the SAME four
+/// prompts. Two hardcoded lists would have drifted the moment either was edited, and the launcher's
+/// whole purpose is to be a shortcut into the screen rather than a second, subtly different Coach.
+///
+/// The strings are unchanged and keep their existing String Catalog keys, so nothing needs retranslating.
+enum CoachPrompts {
+    static let suggestions: [String] = [
+        String(localized: "How's my charge trending?"),
+        String(localized: "What should today's training look like?"),
+        String(localized: "Analyse my sleep"),
+        String(localized: "Why am I run down?"),
+    ]
+}

--- a/Strand/Screens/CoachView.swift
+++ b/Strand/Screens/CoachView.swift
@@ -34,12 +34,8 @@ struct CoachView: View {
     /// Sentinel tag for the "Custom…" entry in the model Picker.
     private let customModelTag = "__custom__"
 
-    private let suggestions = [
-        String(localized: "How's my charge trending?"),
-        String(localized: "What should today's training look like?"),
-        String(localized: "Analyse my sleep"),
-        String(localized: "Why am I run down?"),
-    ]
+    /// #1862: shared with the Today Coach launcher sheet — see `CoachPrompts`.
+    private var suggestions: [String] { CoachPrompts.suggestions }
 
     var body: some View {
         ScreenScaffold(title: "Coach",
@@ -81,6 +77,16 @@ struct CoachView: View {
             }
         }
         .task(id: coach.dataConsent) { await coach.startBriefIfNeeded() }
+        // #1862: a question handed over by the Today launcher sheet. Cleared BEFORE sending so a view
+        // rebuild mid-flight cannot send it twice, and gated on `isConfigured` so an unconfigured handoff
+        // (which the launcher does not produce, but a future caller might) degrades to showing setup
+        // rather than a failed request.
+        .task(id: coach.pendingPrompt) {
+            guard let prompt = coach.pendingPrompt, !prompt.isEmpty else { return }
+            coach.pendingPrompt = nil
+            guard coach.isConfigured else { return }
+            await coach.send(prompt)
+        }
     }
 
     /// Explicit, revocable permission for the coach to read & send the user's data. Off by default.

--- a/Strand/Screens/DashboardCards.swift
+++ b/Strand/Screens/DashboardCards.swift
@@ -37,6 +37,13 @@ enum DashboardCard: String, CaseIterable, Identifiable {
     /// adds it via CUSTOMISE, matching the manual-first / default-OFF posture.
     case coupled
 
+    /// Optional, default-OFF (#1862): a tap-through that opens the Coach launcher SHEET rather than pushing
+    /// a screen — the one card that does. Coach is otherwise buried in More, and entering it means leaving
+    /// Today. Like `coupled` it carries no metric value of its own and is absent from `defaultSelection`, so
+    /// a fresh install never shows it: someone who does not use a provider should not gain a fixed dashboard
+    /// row for one. Opening the sheet makes NO provider request — see `CoachLauncherSheet`.
+    case coach
+
     var id: String { rawValue }
 
     /// The card's display label (the UPPERCASE WHOOP metric-row label is derived from this). Localized via
@@ -58,6 +65,7 @@ enum DashboardCard: String, CaseIterable, Identifiable {
         case .calories:    return String(localized: "Calories")
         case .hydration:   return String(localized: "Hydration")
         case .coupled:     return String(localized: "Coupled view")
+        case .coach:       return String(localized: "Coach")
         }
     }
 
@@ -79,6 +87,9 @@ enum DashboardCard: String, CaseIterable, Identifiable {
         case .calories:    return String(localized: "Active energy")
         case .hydration:   return String(localized: "Today's fluid")
         case .coupled:     return String(localized: "Recovery, strain and sleep in one glance")
+        // Reuses the Coach screen's own subtitle, so the card and the screen describe the feature
+        // identically and no new copy needs translating into ten locales.
+        case .coach:       return String(localized: "Ask about your charge, effort, rest and workouts, grounded in your own numbers.")
         }
     }
 
@@ -99,6 +110,7 @@ enum DashboardCard: String, CaseIterable, Identifiable {
         case .calories:    return "flame.fill"
         case .hydration:   return "waterbottle.fill"
         case .coupled:     return "circle.hexagongrid.fill"
+        case .coach:       return "bubble.left.and.text.bubble.right.fill"
         }
     }
 
@@ -119,6 +131,7 @@ enum DashboardCard: String, CaseIterable, Identifiable {
         case .calories:    return "kcal"
         case .hydration:   return ""    // value bakes in "<total> / <goal> L" itself
         case .coupled:     return ""    // a tap-through row, no value, so no unit
+        case .coach:       return ""    // likewise: a launcher row, no metric of its own
         }
     }
 

--- a/Strand/Screens/TodayCustomizationMetadata.swift
+++ b/Strand/Screens/TodayCustomizationMetadata.swift
@@ -78,6 +78,7 @@ extension DashboardCard {
         case .skinTemp, .calories: return StrandPalette.metricAmber
         case .sleep: return StrandPalette.restColor
         case .coupled: return StrandPalette.chargeColor
+        case .coach: return StrandPalette.accent
         }
     }
 }

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -403,6 +403,9 @@ struct TodayView: View {
     @State private var showSettings = false
     @State private var showLiveSession = false
     /// The Updates inbox sheet (opened by the header bell). Shared across both platforms.
+    /// #1862: the optional Coach launcher sheet, opened from the default-OFF Coach dashboard card.
+    /// Presentation state only — nothing is requested from a provider by opening it.
+    @State private var showCoachLauncher = false
     @State private var showUpdatesInbox = false
 
     /// The NEWEST day-key (max yyyy-MM-dd in `repo.days`) announced to the inbox. Persisted (not @State)
@@ -1531,6 +1534,9 @@ struct TodayView: View {
             ScoringGuideView(onClose: { showGuideTop = false })
         }
         // The Updates inbox (the header bell). Both platforms.
+        .sheet(isPresented: $showCoachLauncher) {
+            CoachLauncherSheet()
+        }
         .sheet(isPresented: $showUpdatesInbox) {
             UpdatesInboxView(onClose: { showUpdatesInbox = false })
         }
@@ -2572,6 +2578,11 @@ struct TodayView: View {
             // coupled day screen. An empty value renders just the icon + title + subtitle + chevron.
             pinnedCardRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
                           value: dashboardValue(card), route: .coupled)
+        case .coach:
+            // #1862: a SHEET, not a push — Coach is a thing you dip into and dismiss, and pushing it
+            // would take you off Today, which is the discoverability problem this card exists to solve.
+            pinnedCardActionRow(icon: card.icon, tint: tint, title: card.title, subtitle: card.subtitle,
+                                value: dashboardValue(card)) { showCoachLauncher = true }
         }
     }
 
@@ -2593,6 +2604,7 @@ struct TodayView: View {
         case .calories:    return StrandPalette.metricAmber
         case .hydration:   return StrandPalette.metricCyan
         case .coupled:     return StrandPalette.chargeColor
+        case .coach:       return StrandPalette.accent
         }
     }
 
@@ -2701,6 +2713,10 @@ struct TodayView: View {
             // A tap-through row with no metric value of its own, the row shows just the chevron. Returning
             // an empty string (not "—") renders no number and leaves it un-dimmed (it isn't a missing value).
             return ""
+        case .coach:
+            // #1862: likewise a launcher row. Empty rather than "—" for the same reason — there is no
+            // missing measurement here, there is no measurement at all.
+            return ""
         }
     }
 
@@ -2712,37 +2728,56 @@ struct TodayView: View {
     private func pinnedCardRow(icon: String, tint: Color, title: String, subtitle: String,
                                value: String, route: TabRoute) -> some View {
         NavigationLink(value: route) {
-            HStack(spacing: 12) {
-                RoundedRectangle(cornerRadius: 9, style: .continuous)
-                    .fill(tint.opacity(0.14))
-                    .frame(width: 34, height: 34)
-                    .overlay(Image(systemName: icon).font(.system(size: 15, weight: .semibold)).foregroundStyle(tint))
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(title.uppercased())
-                        .font(StrandFont.overline)
-                        .tracking(StrandFont.overlineTracking)
-                        .foregroundStyle(StrandPalette.textPrimary)
-                        .lineLimit(1)
-                    Text(subtitle)
-                        .font(StrandFont.footnote)
-                        .foregroundStyle(StrandPalette.textTertiary)
-                        .lineLimit(1)
-                }
-                Spacer(minLength: 8)
-                // A real number reads white; a placeholder (, / Calibrating) reads dimmed so it doesn't
-                // masquerade as a value.
-                let isPlaceholder = (value == "—" || value == Self.calibratingPlaceholder)
-                Text(value).font(StrandFont.rounded(18, weight: .semibold))
-                    .foregroundStyle(isPlaceholder ? StrandPalette.textTertiary : StrandPalette.textPrimary)
-                Image(systemName: "chevron.right").font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(StrandPalette.textTertiary)
-            }
-            .padding(.horizontal, 13).padding(.vertical, 11)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(FrostedCardSurface(cornerRadius: NoopMetrics.cardRadius))
-            .contentShape(Rectangle())
+            pinnedCardRowBody(icon: icon, tint: tint, title: title, subtitle: subtitle, value: value)
         }
         .buttonStyle(.plain)
+    }
+
+    /// The same row, but it runs `action` instead of pushing a route (#1862).
+    ///
+    /// Coach is the one dashboard card that opens a SHEET rather than a screen, so it cannot ride
+    /// `NavigationLink`. Both wrappers render `pinnedCardRowBody`, so the two kinds of row cannot drift
+    /// apart visually — which duplicating the HStack for one caller would have guaranteed eventually.
+    private func pinnedCardActionRow(icon: String, tint: Color, title: String, subtitle: String,
+                                     value: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            pinnedCardRowBody(icon: icon, tint: tint, title: title, subtitle: subtitle, value: value)
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func pinnedCardRowBody(icon: String, tint: Color, title: String, subtitle: String,
+                                   value: String) -> some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .fill(tint.opacity(0.14))
+                .frame(width: 34, height: 34)
+                .overlay(Image(systemName: icon).font(.system(size: 15, weight: .semibold)).foregroundStyle(tint))
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title.uppercased())
+                    .font(StrandFont.overline)
+                    .tracking(StrandFont.overlineTracking)
+                    .foregroundStyle(StrandPalette.textPrimary)
+                    .lineLimit(1)
+                Text(subtitle)
+                    .font(StrandFont.footnote)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 8)
+            // A real number reads white; a placeholder (, / Calibrating) reads dimmed so it doesn't
+            // masquerade as a value.
+            let isPlaceholder = (value == "—" || value == Self.calibratingPlaceholder)
+            Text(value).font(StrandFont.rounded(18, weight: .semibold))
+                .foregroundStyle(isPlaceholder ? StrandPalette.textTertiary : StrandPalette.textPrimary)
+            Image(systemName: "chevron.right").font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(StrandPalette.textTertiary)
+        }
+        .padding(.horizontal, 13).padding(.vertical, 11)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(FrostedCardSurface(cornerRadius: NoopMetrics.cardRadius))
+        .contentShape(Rectangle())
     }
 
     // MARK: Component 2, explained score note (calibrating / carried / needs-strap)

--- a/StrandiOS/App/RootTabView.swift
+++ b/StrandiOS/App/RootTabView.swift
@@ -201,6 +201,11 @@ struct RootTabView: View {
                 // so a deep-link lands on the Today tab where that entry lives.
                 withAnimation(.timingCurve(0.22, 1, 0.36, 1, duration: 0.24)) { selectedTab = 0 }
                 router.requestedDestination = nil
+            case .coach:
+                // #1862: the Today Coach launcher hands its question here. Coach is a pillar sheet on
+                // iPhone, the same as the Insights hub, so route it that way rather than switching tabs.
+                routedPillar = dest
+                router.requestedDestination = nil
             case .journal:
                 // The #627 Today journal widget opens the journal through the quick-action Journal sheet
                 // (InsightsView), matching the FAB's "Log journal" action. Calm sheet easing.
@@ -275,6 +280,9 @@ struct RootTabView: View {
                 // .journal opens through the quick-action Journal sheet (handled above); this keeps the
                 // switch exhaustive and falls back to the journal's Insights host if it ever reaches here.
                 case .journal: InsightsView()
+                // #1862: Coach IS presented here — the launcher sheet routes to it as a pillar, so unlike
+                // the fallbacks above this arm is the real destination, not a safety net.
+                case .coach: CoachView()
                 }
             }
             // The Trends/Today fallbacks above emit TabRoute value pushes (#198), which need a

--- a/Tools/test_home_i18n.py
+++ b/Tools/test_home_i18n.py
@@ -96,6 +96,7 @@ ANDROID_INDIRECT_NON_UI_LITERALS = {
     "today.keyMetricsWindowDays", ",",
     # Stable DashboardCard raw values + preference; units remain measurement metadata.
     "stress", "fitnessAge", "vo2max", "vitality", "skinTemp", "sleep", "hydration", "coupled",
+    "coach",
     "today.dashboardCards", "yrs", "kcal", "",
 }
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -26,7 +26,7 @@ android {
         applicationId = "com.noop.whoop"
         minSdk = 26
         targetSdk = 34
-        versionCode = 437
+        versionCode = 438
         versionName = "11.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -531,6 +531,9 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
                         onOpenSleep = { nav.navigateTopLevel(Destination.Sleep.route) },
                         // Optional Coupled view card (task #43): a normal push so back returns to Today.
                         onOpenCoupled = { nav.navigate(Destination.CoupledView.route) },
+                        // #1862: the Coach launcher hands off here. Without this the sheet's buttons
+                        // would fall back to the parameter's no-op default and silently do nothing.
+                        onOpenCoach = { nav.navigateTopLevel(Destination.Coach.route) },
                         // The "workout in progress" indicator: raise the one-shot the Live screen consumes to
                         // re-open the in-exercise overlay, then route to Live. One tap from Today (iOS parity).
                         onOpenActiveWorkout = {

--- a/android/app/src/main/java/com/noop/ui/CoachLauncherSheet.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachLauncherSheet.kt
@@ -56,19 +56,24 @@ fun CoachLauncherSheet(
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Overline(uiString(R.string.nav_coach))
+            // Frames BOTH branches, so the sheet says what Coach is before it either offers questions or
+            // asks for a provider. Using it once also avoids the duplicate that an unconfigured-only
+            // explainer produced, where "Connect a provider" read as both the description and the button.
+            Text(
+                uiString(R.string.l10n_coach_screen_ask_anything_about_your_recent_recovery_e6c287ca),
+                style = NoopType.caption,
+                color = Palette.textTertiary,
+            )
             if (isConfigured) {
-                Text(uiString(R.string.l10n_coach_screen_ask_anything_about_your_recent_recovery_e6c287ca),
-                     style = NoopType.caption, color = Palette.textTertiary)
                 CoachPrompts.SUGGESTIONS.forEach { prompt ->
                     PromptRow(prompt = prompt, onClick = { onPick(prompt) })
                 }
             } else {
-                // The SAME explanation the Coach screen shows, so the bring-your-own-key model is
-                // described once. The action routes to that screen, still the only place a key is entered.
-                Text(uiString(R.string.l10n_coach_screen_connect_a_provider_6967f288),
-                     style = NoopType.caption, color = Palette.textTertiary)
-                PromptRow(prompt = uiString(R.string.l10n_coach_screen_connect_a_provider_6967f288),
-                          onClick = onSetup)
+                // The Coach screen stays the only place a key is entered; this just routes there.
+                PromptRow(
+                    prompt = uiString(R.string.l10n_coach_screen_connect_a_provider_6967f288),
+                    onClick = onSetup,
+                )
             }
         }
     }

--- a/android/app/src/main/java/com/noop/ui/CoachLauncherSheet.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachLauncherSheet.kt
@@ -1,0 +1,93 @@
+package com.noop.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.ui.draw.clip
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.noop.R
+
+/**
+ * The compact Coach launcher opened from the optional Today card (#1862).
+ *
+ * Coach is otherwise reachable only through More, which makes it easy to miss and means leaving Today to
+ * try it. This is the shortcut — and deliberately ONLY a shortcut.
+ *
+ * It owns no send, stream, error or consent surface of its own. Picking a suggestion hands the question
+ * to [onPick], which routes to the Coach screen; that screen already has all of those. A second chat UI
+ * would drift from the first, and #1862 explicitly defers the persistent-workspace redesign (threads,
+ * retention, backup policy) to a follow-up.
+ *
+ * NO PROVIDER REQUEST IS MADE BY SHOWING THIS. [isConfigured] is a local key read and the prompts are
+ * static copy; the first network call still happens where it always did, after an explicit send.
+ *
+ * Presentational by construction — every input is injected — so it can be exercised without a provider,
+ * a key, or a ViewModel. Swift twin: `CoachLauncherSheet`.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CoachLauncherSheet(
+    isConfigured: Boolean,
+    onPick: (String) -> Unit,
+    onSetup: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = Palette.surfaceRaised,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Overline(uiString(R.string.nav_coach))
+            if (isConfigured) {
+                Text(uiString(R.string.l10n_coach_screen_ask_anything_about_your_recent_recovery_e6c287ca),
+                     style = NoopType.caption, color = Palette.textTertiary)
+                CoachPrompts.SUGGESTIONS.forEach { prompt ->
+                    PromptRow(prompt = prompt, onClick = { onPick(prompt) })
+                }
+            } else {
+                // The SAME explanation the Coach screen shows, so the bring-your-own-key model is
+                // described once. The action routes to that screen, still the only place a key is entered.
+                Text(uiString(R.string.l10n_coach_screen_connect_a_provider_6967f288),
+                     style = NoopType.caption, color = Palette.textTertiary)
+                PromptRow(prompt = uiString(R.string.l10n_coach_screen_connect_a_provider_6967f288),
+                          onClick = onSetup)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PromptRow(prompt: String, onClick: () -> Unit) {
+    val shape = RoundedCornerShape(12.dp)
+    Text(
+        prompt,
+        style = NoopType.caption,
+        color = Palette.textPrimary,
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(shape)
+            .background(Palette.surfaceInset)
+            .border(1.dp, Palette.hairline, shape)
+            .clickable { onClick() }
+            .padding(horizontal = 12.dp, vertical = 10.dp)
+            .semantics { contentDescription = prompt },
+    )
+}

--- a/android/app/src/main/java/com/noop/ui/CoachPrompts.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachPrompts.kt
@@ -1,0 +1,20 @@
+package com.noop.ui
+
+/**
+ * The suggested questions offered when a Coach thread is empty (#1862).
+ *
+ * Extracted from [CoachScreen] so the Today launcher sheet and the full screen offer the SAME four
+ * prompts. Swift twin: `CoachPrompts.suggestions`.
+ *
+ * The strings are unchanged from what the Coach screen already shipped. They are English literals here
+ * exactly as they were there — localizing them is a separate change with its own four-locale cost, and
+ * doing it inside a launcher PR would bury it.
+ */
+object CoachPrompts {
+    val SUGGESTIONS: List<String> = listOf(
+        "How's my recovery trending this week?",
+        "Should I train hard or take it easy today?",
+        "Why might my HRV be low lately?",
+        "How can I improve my sleep?",
+    )
+}

--- a/android/app/src/main/java/com/noop/ui/CoachPrompts.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachPrompts.kt
@@ -18,3 +18,27 @@ object CoachPrompts {
         "How can I improve my sleep?",
     )
 }
+
+/**
+ * A question handed over by the Today Coach launcher sheet, for [CoachScreen] to send once (#1862).
+ *
+ * Swift passes this on the shared `AICoachEngine`, which is an app-wide `EnvironmentObject`. Android has
+ * no equivalent shared instance here: `CoachScreen` takes `viewModel()`, which is scoped to the nav
+ * back-stack entry, so state set from Today would reach a different object. A process-scoped holder is
+ * the smallest thing that actually crosses that boundary.
+ *
+ * `@Volatile` because it is written on the main thread and read by the screen's first composition.
+ * Setting it performs NO network work by itself; the send still happens in the Coach screen, which owns
+ * the consent and error surface.
+ */
+object CoachHandoff {
+    @Volatile
+    var pendingPrompt: String? = null
+
+    /** Take the pending question and clear it, so a recomposition cannot send it twice. */
+    fun consume(): String? {
+        val p = pendingPrompt
+        pendingPrompt = null
+        return p
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/CoachScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -76,6 +77,13 @@ fun CoachScreen(vm: CoachViewModel = viewModel()) {
     val customConnected by vm.customConnected.collectAsStateWithLifecycle()
     // Re-evaluate the gate whenever the stored key, provider, or custom-connect state changes.
     val configured = remember(keyVersion, provider, customConnected) { vm.isConfigured(context) }
+    // #1862: a question handed over by the Today launcher sheet. Consumed once — `consume()` clears it —
+    // so a recomposition cannot resend it, and only when the coach can actually send, so an unconfigured
+    // handoff degrades to showing setup rather than a failed request. Swift twin: CoachView's task.
+    LaunchedEffect(configured) {
+        val handed = CoachHandoff.consume()
+        if (handed != null && configured) vm.send(context, handed)
+    }
     // Same day-cycle gate as the liquid Today: the time-of-day sky settles behind the top content when the
     // user hasn't opted out; otherwise the scaffold paints the plain dark canvas.
     val showDayCycleBackground = remember { NoopPrefs.showDayCycleBackground(context) }

--- a/android/app/src/main/java/com/noop/ui/CoachScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachScreen.kt
@@ -509,12 +509,13 @@ private fun ThinkingBubble() {
 
 // MARK: - Suggested prompts
 
-private val SUGGESTED_PROMPTS = listOf(
-    "How's my recovery trending this week?",
-    "Should I train hard or take it easy today?",
-    "Why might my HRV be low lately?",
-    "How can I improve my sleep?",
-)
+/**
+ * #1862: shared with the Today Coach launcher sheet — see [CoachPrompts].
+ *
+ * Two hardcoded lists would have drifted the moment either was edited, and the launcher's whole purpose
+ * is to be a shortcut INTO this screen rather than a second, subtly different Coach.
+ */
+internal val SUGGESTED_PROMPTS: List<String> get() = CoachPrompts.SUGGESTIONS
 
 @Composable
 private fun SuggestedPrompts(onPick: (String) -> Unit) {

--- a/android/app/src/main/java/com/noop/ui/DashboardCards.kt
+++ b/android/app/src/main/java/com/noop/ui/DashboardCards.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.filled.Air
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.automirrored.filled.DirectionsRun
 import androidx.compose.material.icons.automirrored.filled.DirectionsWalk
 import androidx.compose.material.icons.filled.Favorite
@@ -64,7 +65,15 @@ enum class DashboardCard(
     // every other card it carries NO metric value of its own, it is a navigation row that opens the full
     // CoupledScreen. It is NOT in [defaultSelection], so a fresh install never shows it until the user adds
     // it via CUSTOMISE. Mirrors iOS DashboardCard.coupled (raw "coupled", byte-identical across OS).
-    COUPLED("coupled", R.string.today_card_coupled, R.string.today_card_coupled_subtitle, "", Icons.Filled.Hexagon);
+    COUPLED("coupled", R.string.today_card_coupled, R.string.today_card_coupled_subtitle, "", Icons.Filled.Hexagon),
+
+    // Optional, default-OFF (#1862): opens the Coach launcher BOTTOM SHEET rather than a screen — the one
+    // card that does. Coach is otherwise buried in More, and entering it means leaving Today. Like COUPLED
+    // it carries no metric value and is absent from [defaultSelection], so someone who does not use a
+    // provider never gains a fixed dashboard row for one. Opening the sheet makes NO provider request.
+    // Reuses the existing nav + Coach-screen strings, so the card adds nothing to translate.
+    // Mirrors iOS DashboardCard.coach (raw "coach", byte-identical across OS).
+    COACH("coach", R.string.nav_coach, R.string.l10n_coach_screen_ask_anything_about_your_recent_recovery_e6c287ca, "", Icons.AutoMirrored.Filled.Chat);
 
     companion object {
         fun fromRaw(raw: String?): DashboardCard? = entries.firstOrNull { it.raw == raw }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3399,7 +3399,11 @@ private fun YourCardsSection(
         val ctx = LocalContext.current
         CoachLauncherSheet(
             isConfigured = AiKeyStore.hasKey(ctx),
-            onPick = { prompt -> showCoachLauncher = false; onOpenCoach(prompt) },
+            onPick = { prompt ->
+                showCoachLauncher = false
+                CoachHandoff.pendingPrompt = prompt
+                onOpenCoach(prompt)
+            },
             onSetup = { showCoachLauncher = false; onOpenCoach(null) },
             onDismiss = { showCoachLauncher = false },
         )

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -144,6 +144,7 @@ import android.view.HapticFeedbackConstants
 import android.widget.Toast
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.noop.R
+import com.noop.ai.AiKeyStore
 import com.noop.analytics.Baselines
 import com.noop.analytics.BatteryEstimator
 import com.noop.analytics.ChargeDriver
@@ -295,6 +296,8 @@ fun TodayScreen(
     // Optional Coupled view card (task #43): a tap-through to the WHOOP-style day screen. Defaulted to a
     // no-op so the call site stays compiling; AppRoot binds it to nav.navigate(CoupledView).
     onOpenCoupled: () -> Unit = {},
+    /** #1862: open Coach, optionally with a question the Today launcher already collected. */
+    onOpenCoach: (String?) -> Unit = {},
     // The "workout in progress" indicator card routes to Live and re-opens the in-exercise overlay. Defaulted
     // to a no-op so the call site stays compiling; AppRoot binds it to openActiveWorkout() + nav.navigate(Live).
     onOpenActiveWorkout: () -> Unit = {},
@@ -1667,6 +1670,7 @@ fun TodayScreen(
                             onOpenMetric = onOpenMetric,
                             onOpenSleep = onOpenSleep,
                             onOpenCoupled = onOpenCoupled,
+                            onOpenCoach = onOpenCoach,
                             onCustomise = { showDashboardEditor = true },
                             spo2CandidateByDay = spo2CandidateByDay,
                         )
@@ -3380,6 +3384,7 @@ private fun YourCardsSection(
     onOpenMetric: (String) -> Unit,
     onOpenSleep: () -> Unit,
     onOpenCoupled: () -> Unit,
+    onOpenCoach: (String?) -> Unit,
     onCustomise: () -> Unit,
     spo2CandidateByDay: Map<String, Double> = emptyMap(),
 ) {
@@ -3387,6 +3392,18 @@ private fun YourCardsSection(
     // Swift twin) do. The classic dashboard hardcoded Celsius here alone, so a °F user saw °C on this
     // screen only.
     val fahrenheit = UnitPrefs.temperature(LocalContext.current) == TemperatureUnit.FAHRENHEIT
+    // #1862: the optional Coach card opens a launcher BOTTOM SHEET rather than a destination. Local
+    // presentation state — showing it requests nothing from a provider.
+    var showCoachLauncher by remember { mutableStateOf(false) }
+    if (showCoachLauncher) {
+        val ctx = LocalContext.current
+        CoachLauncherSheet(
+            isConfigured = AiKeyStore.hasKey(ctx),
+            onPick = { prompt -> showCoachLauncher = false; onOpenCoach(prompt) },
+            onSetup = { showCoachLauncher = false; onOpenCoach(null) },
+            onDismiss = { showCoachLauncher = false },
+        )
+    }
     Box(modifier = Modifier.fillMaxWidth().staggeredAppear(2)) {
         Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
             // Header: "YOUR CARDS" overline + a right-aligned blue EDIT action (the WHOOP ✎ affordance).
@@ -3455,6 +3472,7 @@ private fun YourCardsSection(
                         onOpenSleep = onOpenSleep,
                         onOpenHydration = onOpenHydration,
                         onOpenCoupled = onOpenCoupled,
+                        onOpenCoach = { showCoachLauncher = true },
                     ),
                 )
             }
@@ -3495,7 +3513,9 @@ private fun dashboardCardMetricKey(card: DashboardCard): String? = when (card) {
     DashboardCard.STEPS -> "steps_est"
     DashboardCard.CALORIES -> "active_kcal"
     // These carry their own full screen, not a per-metric trend.
-    DashboardCard.STRESS, DashboardCard.SLEEP, DashboardCard.HYDRATION, DashboardCard.COUPLED -> null
+    DashboardCard.STRESS, DashboardCard.SLEEP, DashboardCard.HYDRATION, DashboardCard.COUPLED,
+    // #1862: a launcher row, not a metric — no explorer key.
+    DashboardCard.COACH -> null
 }
 
 /** The destination callback a dashboard card opens when tapped. Mirrors the iOS dashboardCardRow switch:
@@ -3509,12 +3529,17 @@ private fun dashboardCardDestination(
     onOpenSleep: () -> Unit,
     onOpenHydration: () -> Unit,
     onOpenCoupled: () -> Unit,
+    // #1862: Coach is the one card that opens a SHEET rather than a destination, so its "destination" is
+    // a callback that shows the launcher. Kept in this same resolver so every card still resolves to
+    // exactly one tap action and the chevron stays honest.
+    onOpenCoach: () -> Unit,
 ): () -> Unit = when (card) {
     DashboardCard.STRESS -> onOpenStress
     DashboardCard.SLEEP -> onOpenSleep
     DashboardCard.HYDRATION -> onOpenHydration
     // The Coupled view card (#43) taps through to the full WHOOP-style day screen.
     DashboardCard.COUPLED -> onOpenCoupled
+    DashboardCard.COACH -> onOpenCoach
     // Every overnight vital + Fitness age / Vitality / Steps / Calories opens its own metric-detail trend.
     else -> {
         val key = dashboardCardMetricKey(card)
@@ -3545,6 +3570,7 @@ private fun dashboardCardTint(card: DashboardCard): Color = when (card) {
     DashboardCard.CALORIES -> Palette.metricAmber
     DashboardCard.HYDRATION -> Palette.metricCyan
     DashboardCard.COUPLED -> Palette.chargeColor
+    DashboardCard.COACH -> Palette.accent
 }
 
 /**
@@ -3591,6 +3617,7 @@ private fun dashboardCardFraction(
         }
         DashboardCard.SLEEP -> over(vd?.totalSleepMin, 480.0)
         DashboardCard.COUPLED -> 0.6
+        DashboardCard.COACH -> 0.5
         // Not wired to a real read yet — an EMPTY vessel (not half-full) so it doesn't imply a reading.
         DashboardCard.BLOOD_OXYGEN, DashboardCard.SKIN_TEMP, DashboardCard.CALORIES,
         DashboardCard.HYDRATION -> null
@@ -3715,6 +3742,10 @@ private fun dashboardCardValue(
         DashboardCard.COUPLED ->
             // A tap-through row with no metric value of its own, the row shows just the chevron. An empty
             // string (not NO_DATA) renders no number and leaves it un-dimmed. Mirrors iOS dashboardValue.
+            ""
+        DashboardCard.COACH ->
+            // #1862: likewise a launcher row. Empty rather than NO_DATA for the same reason — there is no
+            // missing measurement here, there is no measurement at all.
             ""
     }
 }

--- a/android/app/src/test/java/com/noop/ui/CoachCardTest.kt
+++ b/android/app/src/test/java/com/noop/ui/CoachCardTest.kt
@@ -1,0 +1,51 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The Coach launcher card's contract (#1862) — the parts that are testable without a device.
+ *
+ * The issue asks for one thing above all: the card must be ABSENT by default. Someone who does not use
+ * an AI provider should not gain a fixed dashboard row for one, and that is a property of the default
+ * selection, not of the UI.
+ */
+class CoachCardTest {
+
+    /** The headline requirement: opt-in, never a fresh install's default. */
+    @Test
+    fun `the coach card is not in the default selection`() {
+        assertFalse("Coach must be opt-in", DashboardCard.defaultSelection.contains(DashboardCard.COACH))
+        assertFalse("Coupled is the same posture and stays that way",
+            DashboardCard.defaultSelection.contains(DashboardCard.COUPLED))
+    }
+
+    /** It must be addable, so it has to survive the raw round-trip Today customization persists through. */
+    @Test
+    fun `the coach card round-trips through its persisted raw value`() {
+        assertEquals(DashboardCard.COACH, DashboardCard.fromRaw("coach"))
+        // Byte-identical to the iOS `DashboardCard.coach` raw, so a settings backup restores across OS.
+        assertEquals("coach", DashboardCard.COACH.raw)
+    }
+
+    /**
+     * A launcher row carries no measurement, so it must not render a unit — an empty unit is what makes
+     * the row show just icon + title + subtitle + chevron, exactly as COUPLED does.
+     */
+    @Test
+    fun `the coach card carries no unit`() {
+        assertTrue(DashboardCard.COACH.unit.isEmpty())
+    }
+
+    /**
+     * The launcher and the full screen must offer the SAME prompts. Two lists drift the moment either is
+     * edited, and the launcher exists to be a shortcut INTO the screen, not a second, different Coach.
+     */
+    @Test
+    fun `the launcher and the coach screen share one prompt list`() {
+        assertEquals(CoachPrompts.SUGGESTIONS, SUGGESTED_PROMPTS)
+        assertTrue("the shared list must not be empty", CoachPrompts.SUGGESTIONS.isNotEmpty())
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/CoachCardTest.kt
+++ b/android/app/src/test/java/com/noop/ui/CoachCardTest.kt
@@ -2,6 +2,7 @@ package com.noop.ui
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -47,5 +48,24 @@ class CoachCardTest {
     fun `the launcher and the coach screen share one prompt list`() {
         assertEquals(CoachPrompts.SUGGESTIONS, SUGGESTED_PROMPTS)
         assertTrue("the shared list must not be empty", CoachPrompts.SUGGESTIONS.isNotEmpty())
+    }
+
+    /**
+     * The handoff must be consumed exactly ONCE. `CoachScreen` reads it from a `LaunchedEffect` keyed on
+     * the configured flag, which can re-run; a read that left the value in place would resend the
+     * question — and a resend is a second billed provider request the user did not ask for.
+     */
+    @Test
+    fun `the coach handoff is consumed exactly once`() {
+        CoachHandoff.pendingPrompt = "How can I improve my sleep?"
+        assertEquals("How can I improve my sleep?", CoachHandoff.consume())
+        assertNull("a second read must not resend", CoachHandoff.consume())
+    }
+
+    /** Nothing parked means nothing sent — the ordinary case every time Coach is opened normally. */
+    @Test
+    fun `an empty coach handoff yields nothing`() {
+        CoachHandoff.pendingPrompt = null
+        assertNull(CoachHandoff.consume())
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -21,7 +21,7 @@ settings:
     # iOS build number (CFBundleVersion). GLOBAL so the iOS app AND its widget extension inherit the
     # SAME value — they must match or iOS warns "extension version must match parent app" (#416).
     # macOS sets its own CFBundleVersion on the Strand target and is unaffected by this.
-    CURRENT_PROJECT_VERSION: "318"
+    CURRENT_PROJECT_VERSION: "319"
     SWIFT_VERSION: "5.0"
     # Emit localizable strings so Xcode auto-extracts every LocalizedStringKey into the
     # String Catalog on build (the English (US) base entries).


### PR DESCRIPTION
Addresses #1862, requested by @kggreco11.

**Draft** — the Swift app-target side cannot be compiled in my environment, so it is CI-verified only. See Verification.

## What it does

Coach becomes an optional Today card that opens a compact launcher: a sheet on iOS/macOS, a bottom sheet on Android. Nothing more — the launcher is a shortcut *into* Coach, not a second Coach.

**Default-OFF**, modelled directly on the existing Coupled card: absent from `defaultSelection` on both platforms, so a fresh install never shows it and someone who does not use a provider never gains a fixed dashboard row for one. Added, moved and removed through the existing Today customization; the raw value is `"coach"` on both platforms, so a settings backup restores across OS.

**Opening it makes no provider request.** The configured check is a local key read and the prompts are static copy. The first network call still happens exactly where it did — inside the existing send path, after an explicit user action.

## Why the launcher hands off rather than answering inline

It owns no send, stream, error or consent surface. Picking a suggestion or submitting the composer hands the question to the Coach screen — through `AICoachEngine.pendingPrompt` plus the existing `NavRouter` on Apple, an injected callback on Android — and that screen, which already has all of those, sends it.

A second chat UI would drift from the first, and #1862 explicitly defers the persistent-workspace redesign (threads, retention, backup policy) to a follow-up. An unconfigured user gets the same bring-your-own-key explanation the Coach screen shows, and a route to it — that screen stays the only place a key is entered.

## No new copy, and one shared prompt list

The card and both sheets reuse strings Coach already ships, so **nothing needs translating into ten locales**. I dropped a "Try asking" heading from the Apple sheet for exactly this reason once the i18n audit flagged it as the only new literal.

The suggested prompts moved to a shared `CoachPrompts` on each platform, so the launcher and the screen cannot offer different lists. The copy itself is unchanged — including the fact that Android's four are English literals, which is a pre-existing gap this PR deliberately does not fold in.

## A shared row body rather than a duplicated one

Coach is the only dashboard card that opens a sheet, so it cannot ride `NavigationLink`. Rather than duplicate the row for one caller, `pinnedCardRow` and `cardLink` now have their bodies extracted and shared by both the link and button wrappers, so the two kinds of row cannot drift apart visually. The Liquid variant keeps its `LiquidPressStyle` — I caught myself replacing it with `.plain` mid-refactor, which would have dropped the press animation from every Liquid dashboard row.

## Re-review found the Android buttons did nothing

`TodayScreen` gained an `onOpenCoach` parameter with a `= {}` default so existing callers kept compiling — and `AppRoot`, the only real caller, never passed one. Tapping a suggestion or the setup row dismissed the sheet and went nowhere. **The default that made the change compile is what made the failure silent**, and no test could see it because the wiring lives in the nav graph. Same shape as the dead Connect button in #1886, from the other direction: there a gate swallowed a real action, here a default did.

`AppRoot` now routes to Coach, and the question travels through `CoachHandoff` — a small process-scoped holder. Swift parks it on the shared `AICoachEngine` because that is an app-wide `EnvironmentObject`; `CoachScreen` takes `viewModel()`, scoped to the nav back-stack entry, so state set from Today would have reached a different object. It is consumed once, and only when Coach can actually send.

Also repaired: the unconfigured branch rendered "Connect a provider" **twice**, as both the explanation and the button, because no bring-your-own-key explainer exists as an Android string resource. The "Ask anything…" line now frames both branches — still no new copy.

Two tests cover the handoff, including that a second read returns nothing: the `LaunchedEffect` that consumes it is keyed on the configured flag and can re-run, and a resend would be a second billed provider request the user never asked for.

## Verification

- **Android: full suite 5257 tests, 0 failures** (`--rerun-tasks --no-build-cache`, XML freshness checked), both platforms' card contracts covered by 6 new tests — default-OFF, raw round-trip, no unit, and one shared prompt list.
- Android compiles. The Kotlin compiler named all four exhaustive `when` sites that needed the new case, which is how I know that side is complete.
- `Tools/i18n_audit.py --ci` clean, doc-comment lint clean, no schema change.
- Every Swift file parses (`swiftc -parse`), and I checked each design token I used actually exists rather than assuming.

**Not verified:** the Swift app target does not compile here, so the five exhaustive `DashboardCard` switches, the two row refactors and the new sheet are unchecked by a compiler. I found the switch sites by the fact that an exhaustive one must contain `case .coupled`; that reasoning is sound but it is reasoning, not a build. This needs the app-build gate before it is merged, and neither sheet has been seen on a device.
