### PR TITLE
analytics: retrospective TDEE from logged intake and the weight trend

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AdaptiveExpenditureEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AdaptiveExpenditureEngine.swift
@@ -87,7 +87,10 @@ public enum AdaptiveExpenditureEngine {
         // Keep the most RECENT `window` days: an adapted metabolism makes the tail the honest part.
         let recent = ordered.filter { d in
             guard let back = dayCount(from: d.day, to: last) else { return false }
-            return back < window
+            // `dayCount` is INCLUSIVE — `dayCount(last, last)` is 1 — so the last `window` days are
+            // `back <= window`. A strict `<` silently drops the oldest day while still reporting the
+            // full `window`, which both loses data and understates coverage.
+            return back <= window
         }
 
         let intake = recent.compactMap { $0.caloriesIn }.filter { $0 > 0 }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AdaptiveExpenditureEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AdaptiveExpenditureEngine.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+/// One day's inputs for the retrospective expenditure estimate. Both fields are optional because the two
+/// series are independently sparse — a day with a weigh-in and no food log is common, and inventing a
+/// value for the missing one is exactly what this engine must not do.
+public struct AdaptiveExpenditureDay: Equatable, Sendable {
+    public let day: String          // "yyyy-MM-dd", the app's day key
+    public let caloriesIn: Double?
+    public let weightKg: Double?
+
+    public init(day: String, caloriesIn: Double? = nil, weightKg: Double? = nil) {
+        self.day = day; self.caloriesIn = caloriesIn; self.weightKg = weightKg
+    }
+}
+
+/// How much the estimate below deserves to be trusted. Deliberately coarse — the inputs do not support
+/// a percentage, and a number would imply a precision this method does not have.
+public enum AdaptiveExpenditureConfidence: String, Equatable, Sendable {
+    case building, moderate, high
+}
+
+/// A retrospective estimate of average daily energy expenditure, with an interval.
+///
+/// Never a single number: the method's error is dominated by things this engine cannot see (hydration
+/// swings, an under-logged weekend), so a bare figure would be the fabrication the rest of NOOP refuses
+/// to make. The interval is the honest output and the caller should render it as one.
+public struct AdaptiveExpenditureEstimate: Equatable, Sendable {
+    public let estimatedDailyKcal: Double
+    public let lowerKcal: Double
+    public let upperKcal: Double
+    public let meanIntakeKcal: Double
+    public let weightSlopeKgPerDay: Double
+    public let intakeDays: Int
+    public let weightReadings: Int
+    public let windowDays: Int
+    public let confidence: AdaptiveExpenditureConfidence
+
+    public init(estimatedDailyKcal: Double, lowerKcal: Double, upperKcal: Double, meanIntakeKcal: Double,
+                weightSlopeKgPerDay: Double, intakeDays: Int, weightReadings: Int, windowDays: Int,
+                confidence: AdaptiveExpenditureConfidence) {
+        self.estimatedDailyKcal = estimatedDailyKcal; self.lowerKcal = lowerKcal; self.upperKcal = upperKcal
+        self.meanIntakeKcal = meanIntakeKcal; self.weightSlopeKgPerDay = weightSlopeKgPerDay
+        self.intakeDays = intakeDays; self.weightReadings = weightReadings; self.windowDays = windowDays
+        self.confidence = confidence
+    }
+}
+
+/// Average daily expenditure inferred from logged intake and the weight trend (TDEE by energy balance).
+///
+/// `expenditure = intake − change in stored energy`, with the conventional 7,700 kcal per kg of body mass.
+/// The identity is exact; the inputs are not. Day-to-day weight is mostly water, and food logs are
+/// under-reported by a wide and person-specific margin, so this is meaningful only over weeks and only as
+/// a range.
+///
+/// DELIBERATELY NOT AN INPUT TO ANYTHING. It never feeds Charge, the calorie card, or the workout
+/// calorie estimate: those come from measured heart rate through Keytel, and quietly overwriting a
+/// measurement with an inference from a food diary would be a strictly worse number wearing the same
+/// label. This answers a question the user asks explicitly, and returns nil rather than guess.
+///
+/// Kotlin twin: `AdaptiveExpenditureEngine`.
+public enum AdaptiveExpenditureEngine {
+    /// Energy density of body-mass change. The textbook 7,700 kcal/kg (≈3,500 kcal/lb) figure, which
+    /// assumes the change is adipose; it over-states early loss, when a real share of it is glycogen and
+    /// its bound water. That bias is one reason the output is an interval.
+    public static let kcalPerKg = 7_700.0
+
+    /// Windows. Three weeks is the floor because a week of water retention can hide a 500 kcal/day gap,
+    /// and six weeks is the ceiling because beyond that the body's own expenditure has adapted and the
+    /// average stops describing today.
+    public static let minWindowDays = 21
+    public static let maxWindowDays = 42
+
+    /// Coverage floors. Intake is the weak input, so it carries the strictest gate: a fortnight of logs
+    /// AND 70% of the window, which together reject the common "logged hard for five days" pattern that
+    /// would otherwise read as a huge deficit.
+    public static let minIntakeDays = 14
+    public static let minIntakeCoverage = 0.70
+    public static let minWeightReadings = 6
+
+    /// nil when the history cannot support an estimate — the normal answer for most installs, and the
+    /// point of the gates. `days` need not be sorted or contiguous.
+    public static func estimate(days: [AdaptiveExpenditureDay]) -> AdaptiveExpenditureEstimate? {
+        let ordered = days.sorted { $0.day < $1.day }
+        guard let first = ordered.first?.day, let last = ordered.last?.day,
+              let span = dayCount(from: first, to: last), span >= minWindowDays else { return nil }
+        let window = min(span, maxWindowDays)
+        // Keep the most RECENT `window` days: an adapted metabolism makes the tail the honest part.
+        let recent = ordered.filter { d in
+            guard let back = dayCount(from: d.day, to: last) else { return false }
+            return back < window
+        }
+
+        let intake = recent.compactMap { $0.caloriesIn }.filter { $0 > 0 }
+        let weights = recent.compactMap { d -> (Int, Double)? in
+            guard let w = d.weightKg, w > 0, let i = dayCount(from: first, to: d.day) else { return nil }
+            return (i, w)
+        }
+        guard intake.count >= minIntakeDays,
+              Double(intake.count) / Double(window) >= minIntakeCoverage,
+              weights.count >= minWeightReadings,
+              let slope = leastSquaresSlope(weights) else { return nil }
+
+        let meanIntake = intake.reduce(0, +) / Double(intake.count)
+        // The identity. A RISING weight means intake exceeded expenditure, so the stored-energy term is
+        // subtracted — getting this sign backwards is the classic error and it is why the test pins both
+        // directions rather than only a deficit.
+        let estimate = meanIntake - slope * kcalPerKg
+
+        // Interval. Half a kilo of water across the window is an everyday swing and translates directly
+        // into an apparent daily gap; the intake half widens as coverage falls, because the days someone
+        // fails to log are not a random sample of their eating.
+        let waterKcalPerDay = (0.5 * kcalPerKg) / Double(window)
+        let coverage = Double(intake.count) / Double(window)
+        let intakeUncertainty = meanIntake * 0.10 * (1.0 - coverage) + meanIntake * 0.05
+        let margin = waterKcalPerDay + intakeUncertainty
+
+        let confidence: AdaptiveExpenditureConfidence
+        if window >= 28 && coverage >= 0.90 && weights.count >= 12 { confidence = .high }
+        else if window >= 21 && coverage >= 0.80 { confidence = .moderate }
+        else { confidence = .building }
+
+        return AdaptiveExpenditureEstimate(
+            estimatedDailyKcal: estimate,
+            lowerKcal: estimate - margin, upperKcal: estimate + margin,
+            meanIntakeKcal: meanIntake, weightSlopeKgPerDay: slope,
+            intakeDays: intake.count, weightReadings: weights.count, windowDays: window,
+            confidence: confidence)
+    }
+
+    /// Ordinary least-squares slope in kg per DAY. nil when every reading shares one day, which would
+    /// divide by zero — a real case when a scale syncs several readings with one timestamp.
+    static func leastSquaresSlope(_ points: [(Int, Double)]) -> Double? {
+        let n = Double(points.count)
+        guard n >= 2 else { return nil }
+        let meanX = points.reduce(0.0) { $0 + Double($1.0) } / n
+        let meanY = points.reduce(0.0) { $0 + $1.1 } / n
+        var num = 0.0, den = 0.0
+        for (x, y) in points {
+            let dx = Double(x) - meanX
+            num += dx * (y - meanY); den += dx * dx
+        }
+        guard den > 0 else { return nil }
+        return num / den
+    }
+
+    /// Whole days between two "yyyy-MM-dd" keys, inclusive of the first.
+    ///
+    /// nil on an unparseable key. `AnalyticsEngine.dayStartUtcSeconds` is deliberately nil-tolerant and
+    /// returns 0 for one (so a bad key cannot take down a scoring pass), which is indistinguishable from
+    /// 1970 here — and a stray 0 would silently stretch the window by twenty thousand days. Treating a
+    /// zero as unparseable is the difference between refusing to answer and answering nonsense.
+    static func dayCount(from: String, to: String) -> Int? {
+        let a = AnalyticsEngine.dayStartUtcSeconds(from)
+        let b = AnalyticsEngine.dayStartUtcSeconds(to)
+        guard a > 0, b > 0 else { return nil }
+        return (b - a) / 86_400 + 1
+    }
+}

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AdaptiveExpenditureEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AdaptiveExpenditureEngine.swift
@@ -99,8 +99,8 @@ public enum AdaptiveExpenditureEngine {
             return (i, w)
         }
         guard intake.count >= minIntakeDays,
-              Double(intake.count) / Double(window) >= minIntakeCoverage,
-              weights.count >= minWeightReadings,
+              min(1.0, Double(intake.count) / Double(window)) >= minIntakeCoverage,
+              Set(weights.map { $0.0 }).count >= minWeightReadings,
               let slope = leastSquaresSlope(weights) else { return nil }
 
         let meanIntake = intake.reduce(0, +) / Double(intake.count)
@@ -113,12 +113,21 @@ public enum AdaptiveExpenditureEngine {
         // into an apparent daily gap; the intake half widens as coverage falls, because the days someone
         // fails to log are not a random sample of their eating.
         let waterKcalPerDay = (0.5 * kcalPerKg) / Double(window)
-        let coverage = Double(intake.count) / Double(window)
+        // Clamped: `coverage` is "share of the window that was logged", so it cannot exceed 1. A caller
+        // that merged its two sparse series badly and passed a day twice would otherwise push it above 1,
+        // which SHRINKS the margin and RAISES the confidence — making the answer look more certain than
+        // its data, the one direction this engine must never err in. Clamping rather than de-duplicating
+        // on purpose: silently picking one of two conflicting values for a day would hide the caller's bug.
+        let coverage = min(1.0, Double(intake.count) / Double(window))
         let intakeUncertainty = meanIntake * 0.10 * (1.0 - coverage) + meanIntake * 0.05
         let margin = waterKcalPerDay + intakeUncertainty
 
+        // DISTINCT days, not readings. Two weigh-ins on one morning are one day of evidence about the
+        // trend, and counting both would let a chatty scale — or a caller that passed a day twice — buy
+        // the same confidence as a fortnight of extra data.
+        let weightDays = Set(weights.map { $0.0 }).count
         let confidence: AdaptiveExpenditureConfidence
-        if window >= 28 && coverage >= 0.90 && weights.count >= 12 { confidence = .high }
+        if window >= 28 && coverage >= 0.90 && weightDays >= 12 { confidence = .high }
         else if window >= 21 && coverage >= 0.80 { confidence = .moderate }
         else { confidence = .building }
 
@@ -126,7 +135,7 @@ public enum AdaptiveExpenditureEngine {
             estimatedDailyKcal: estimate,
             lowerKcal: estimate - margin, upperKcal: estimate + margin,
             meanIntakeKcal: meanIntake, weightSlopeKgPerDay: slope,
-            intakeDays: intake.count, weightReadings: weights.count, windowDays: window,
+            intakeDays: min(intake.count, window), weightReadings: weightDays, windowDays: window,
             confidence: confidence)
     }
 

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AdaptiveExpenditureEngineTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AdaptiveExpenditureEngineTests.swift
@@ -98,6 +98,22 @@ final class AdaptiveExpenditureEngineTests: XCTestCase {
         XCTAssertEqual(est.intakeDays, est.windowDays)
     }
 
+    /// A duplicated day must not buy confidence. Coverage is "share of the window that was logged", so
+    /// it cannot exceed 1 — but a caller that merged its two sparse series badly could pass a day twice,
+    /// and an unclamped ratio above 1 both shrinks the interval and lifts the confidence, making the
+    /// answer look more certain than its data. That is the one direction this engine must never err in.
+    func testDuplicatedDaysCannotBuyANarrowerIntervalOrHigherConfidence() throws {
+        let clean = history(days: 30)
+        let duped = clean + clean          // every day twice
+        let a = try XCTUnwrap(AdaptiveExpenditureEngine.estimate(days: clean))
+        let b = try XCTUnwrap(AdaptiveExpenditureEngine.estimate(days: duped))
+        XCTAssertEqual(a.upperKcal - a.lowerKcal, b.upperKcal - b.lowerKcal, accuracy: 1e-6,
+                       "a duplicate must not narrow the interval")
+        XCTAssertEqual(a.confidence, b.confidence, "nor raise the confidence")
+        XCTAssertLessThan(b.lowerKcal, b.estimatedDailyKcal)
+        XCTAssertGreaterThan(b.upperKcal, b.estimatedDailyKcal)
+    }
+
     /// A bad day key must not be read as 1970 and stretch the window by twenty thousand days.
     func testUnparseableDayKeyIsRefusedNotTreatedAs1970() {
         XCTAssertNil(AdaptiveExpenditureEngine.dayCount(from: "not-a-day", to: "2026-01-01"))

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AdaptiveExpenditureEngineTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AdaptiveExpenditureEngineTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import XCTest
+@testable import StrandAnalytics
+
+/// TDEE by energy balance — the twin of the Kotlin `AdaptiveExpenditureEngineTest`, asserting the same
+/// cases with the same inputs so the two cannot drift.
+///
+/// The identity is `expenditure = intake - stored-energy change`. Most of what matters here is refusing
+/// to answer: the method is meaningful only over weeks, and most installs will never log enough intake.
+final class AdaptiveExpenditureEngineTests: XCTestCase {
+
+    /// A synthetic history: `days` long, intake every `logEvery` days, weight every `weighEvery`.
+    private func history(days: Int, intake: Double = 2_400, startKg: Double = 80,
+                         kgPerDay: Double = 0, logEvery: Int = 1,
+                         weighEvery: Int = 3) -> [AdaptiveExpenditureDay] {
+        (0..<days).map { i in
+            AdaptiveExpenditureDay(
+                day: dayKey(i),
+                caloriesIn: i % logEvery == 0 ? intake : nil,
+                weightKg: i % weighEvery == 0 ? startKg + kgPerDay * Double(i) : nil)
+        }
+    }
+
+    /// Sequential "yyyy-MM-dd" keys from 2026-01-01, so the engine's own date maths is exercised.
+    private func dayKey(_ offset: Int) -> String {
+        var c = DateComponents(); c.year = 2026; c.month = 1; c.day = 1 + offset
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        let d = cal.date(from: c)!
+        let f = DateFormatter()
+        f.calendar = cal; f.timeZone = cal.timeZone
+        f.locale = Locale(identifier: "en_US_POSIX"); f.dateFormat = "yyyy-MM-dd"
+        return f.string(from: d)
+    }
+
+    /// Weight flat ⇒ expenditure equals intake. The simplest reading of the identity.
+    func testStableWeightPutsExpenditureAtIntake() throws {
+        let est = try XCTUnwrap(AdaptiveExpenditureEngine.estimate(days: history(days: 30)))
+        XCTAssertEqual(est.estimatedDailyKcal, 2_400, accuracy: 1)
+        XCTAssertEqual(est.weightSlopeKgPerDay, 0, accuracy: 1e-9)
+    }
+
+    /// Losing weight ⇒ expenditure EXCEEDED intake, so the estimate is ABOVE what was eaten. The sign is
+    /// the classic error in this formula, so both directions are pinned rather than one.
+    func testLosingWeightPutsExpenditureAboveIntake() throws {
+        let est = try XCTUnwrap(AdaptiveExpenditureEngine.estimate(days: history(days: 30, kgPerDay: -0.05)))
+        // 0.05 kg/day * 7700 = 385 kcal/day of stored energy released.
+        XCTAssertEqual(est.estimatedDailyKcal, 2_400 + 385, accuracy: 2)
+        XCTAssertGreaterThan(est.estimatedDailyKcal, est.meanIntakeKcal)
+    }
+
+    /// And the mirror: gaining weight means expenditure fell SHORT of intake.
+    func testGainingWeightPutsExpenditureBelowIntake() throws {
+        let est = try XCTUnwrap(AdaptiveExpenditureEngine.estimate(days: history(days: 30, kgPerDay: 0.05)))
+        XCTAssertEqual(est.estimatedDailyKcal, 2_400 - 385, accuracy: 2)
+        XCTAssertLessThan(est.estimatedDailyKcal, est.meanIntakeKcal)
+    }
+
+    /// Under three weeks the method is not meaningful, so it declines rather than answering.
+    func testShortHistoryYieldsNothing() {
+        XCTAssertNil(AdaptiveExpenditureEngine.estimate(days: history(days: 20)))
+    }
+
+    /// The gate that matters most in practice: someone logs hard for a fortnight of a long window and
+    /// stops. The skipped days are not a random sample of their eating, so a mean over them would read
+    /// as a large false deficit.
+    func testSparseIntakeLoggingYieldsNothing() {
+        XCTAssertNil(AdaptiveExpenditureEngine.estimate(days: history(days: 40, logEvery: 3)))
+    }
+
+    /// Weight is the other half of the identity; too few readings cannot establish a trend.
+    func testTooFewWeighInsYieldsNothing() {
+        XCTAssertNil(AdaptiveExpenditureEngine.estimate(days: history(days: 30, weighEvery: 10)))
+    }
+
+    /// The output is a RANGE, and the estimate must sit inside it.
+    func testEstimateIsBracketedByItsInterval() throws {
+        let est = try XCTUnwrap(AdaptiveExpenditureEngine.estimate(days: history(days: 30)))
+        XCTAssertLessThan(est.lowerKcal, est.estimatedDailyKcal)
+        XCTAssertGreaterThan(est.upperKcal, est.estimatedDailyKcal)
+    }
+
+    /// Confidence rises with the window, coverage and weigh-ins — never with the value itself.
+    func testConfidenceReflectsCoverageNotTheAnswer() throws {
+        let full = try XCTUnwrap(AdaptiveExpenditureEngine.estimate(days: history(days: 35, weighEvery: 2)))
+        XCTAssertEqual(full.confidence, .high)
+        let thin = try XCTUnwrap(AdaptiveExpenditureEngine.estimate(days: history(days: 22, weighEvery: 3)))
+        XCTAssertNotEqual(thin.confidence, .high)
+    }
+
+    /// A bad day key must not be read as 1970 and stretch the window by twenty thousand days.
+    func testUnparseableDayKeyIsRefusedNotTreatedAs1970() {
+        XCTAssertNil(AdaptiveExpenditureEngine.dayCount(from: "not-a-day", to: "2026-01-01"))
+        XCTAssertNil(AdaptiveExpenditureEngine.dayCount(from: "2026-01-01", to: ""))
+    }
+
+    /// Readings that all share one day cannot yield a slope; zero variance must return nil.
+    func testSingleDayWeightClusterHasNoSlope() {
+        XCTAssertNil(AdaptiveExpenditureEngine.leastSquaresSlope([(3, 80.0), (3, 80.5), (3, 79.5)]))
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AdaptiveExpenditureEngineTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AdaptiveExpenditureEngineTests.swift
@@ -88,6 +88,16 @@ final class AdaptiveExpenditureEngineTests: XCTestCase {
         XCTAssertNotEqual(thin.confidence, .high)
     }
 
+    /// The window must hold exactly the days it claims. `dayCount` is inclusive, so a strict `<` in the
+    /// recency filter drops the oldest day while still reporting the full window — losing a day of data
+    /// and understating coverage, both silently. Every other case here logs every day, so a one-day loss
+    /// crosses no gate and nothing else would notice.
+    func testFullyLoggedWindowKeepsEveryDayItReports() throws {
+        let est = try XCTUnwrap(AdaptiveExpenditureEngine.estimate(days: history(days: 30)))
+        XCTAssertEqual(est.windowDays, 30)
+        XCTAssertEqual(est.intakeDays, est.windowDays)
+    }
+
     /// A bad day key must not be read as 1970 and stretch the window by twenty thousand days.
     func testUnparseableDayKeyIsRefusedNotTreatedAs1970() {
         XCTAssertNil(AdaptiveExpenditureEngine.dayCount(from: "not-a-day", to: "2026-01-01"))

--- a/android/app/src/main/java/com/noop/analytics/AdaptiveExpenditureEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AdaptiveExpenditureEngine.kt
@@ -69,7 +69,10 @@ object AdaptiveExpenditureEngine {
         val window = minOf(span, MAX_WINDOW_DAYS)
         val recent = ordered.filter { d ->
             val back = dayCount(d.day, last) ?: return@filter false
-            back < window
+            // `dayCount` is INCLUSIVE — `dayCount(last, last)` is 1 — so the last `window` days are
+            // `back <= window`. A strict `<` silently drops the oldest day while still reporting the full
+            // `window`, which both loses data and understates coverage.
+            back <= window
         }
 
         val intake = recent.mapNotNull { it.caloriesIn }.filter { it > 0 }

--- a/android/app/src/main/java/com/noop/analytics/AdaptiveExpenditureEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AdaptiveExpenditureEngine.kt
@@ -83,9 +83,18 @@ object AdaptiveExpenditureEngine {
             i to w
         }
         if (intake.size < MIN_INTAKE_DAYS) return null
-        val coverage = intake.size.toDouble() / window.toDouble()
+        // Clamped: `coverage` is "share of the window that was logged", so it cannot exceed 1. A caller
+        // that merged its two sparse series badly and passed a day twice would otherwise push it above 1,
+        // which SHRINKS the margin and RAISES the confidence — making the answer look more certain than
+        // its data, the one direction this engine must never err in. Clamping rather than de-duplicating
+        // on purpose: silently picking one of two conflicting values for a day would hide the caller's bug.
+        val coverage = minOf(1.0, intake.size.toDouble() / window.toDouble())
         if (coverage < MIN_INTAKE_COVERAGE) return null
-        if (weights.size < MIN_WEIGHT_READINGS) return null
+        // DISTINCT days, not readings. Two weigh-ins on one morning are one day of evidence about the
+        // trend, and counting both would let a chatty scale — or a caller that passed a day twice — buy
+        // the same confidence as a fortnight of extra data.
+        val weightDays = weights.map { it.first }.distinct().size
+        if (weightDays < MIN_WEIGHT_READINGS) return null
         val slope = leastSquaresSlope(weights) ?: return null
 
         val meanIntake = intake.sum() / intake.size.toDouble()
@@ -98,7 +107,7 @@ object AdaptiveExpenditureEngine {
         val margin = waterKcalPerDay + intakeUncertainty
 
         val confidence = when {
-            window >= 28 && coverage >= 0.90 && weights.size >= 12 -> AdaptiveExpenditureConfidence.HIGH
+            window >= 28 && coverage >= 0.90 && weightDays >= 12 -> AdaptiveExpenditureConfidence.HIGH
             window >= 21 && coverage >= 0.80 -> AdaptiveExpenditureConfidence.MODERATE
             else -> AdaptiveExpenditureConfidence.BUILDING
         }
@@ -109,8 +118,8 @@ object AdaptiveExpenditureEngine {
             upperKcal = estimate + margin,
             meanIntakeKcal = meanIntake,
             weightSlopeKgPerDay = slope,
-            intakeDays = intake.size,
-            weightReadings = weights.size,
+            intakeDays = minOf(intake.size, window),
+            weightReadings = weightDays,
             windowDays = window,
             confidence = confidence,
         )

--- a/android/app/src/main/java/com/noop/analytics/AdaptiveExpenditureEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AdaptiveExpenditureEngine.kt
@@ -1,0 +1,146 @@
+package com.noop.analytics
+
+/**
+ * One day's inputs for the retrospective expenditure estimate. Both fields are nullable because the two
+ * series are independently sparse — a day with a weigh-in and no food log is common, and inventing a
+ * value for the missing one is exactly what this engine must not do.
+ */
+data class AdaptiveExpenditureDay(
+    val day: String,
+    val caloriesIn: Double? = null,
+    val weightKg: Double? = null,
+)
+
+/** How much the estimate deserves to be trusted. Coarse on purpose — a percentage would imply a
+ *  precision this method does not have. */
+enum class AdaptiveExpenditureConfidence { BUILDING, MODERATE, HIGH }
+
+/**
+ * A retrospective estimate of average daily energy expenditure, with an interval.
+ *
+ * Never a single number: the error is dominated by things this engine cannot see (hydration swings, an
+ * under-logged weekend), so a bare figure would be the fabrication the rest of NOOP refuses to make.
+ */
+data class AdaptiveExpenditureEstimate(
+    val estimatedDailyKcal: Double,
+    val lowerKcal: Double,
+    val upperKcal: Double,
+    val meanIntakeKcal: Double,
+    val weightSlopeKgPerDay: Double,
+    val intakeDays: Int,
+    val weightReadings: Int,
+    val windowDays: Int,
+    val confidence: AdaptiveExpenditureConfidence,
+)
+
+/**
+ * Average daily expenditure inferred from logged intake and the weight trend (TDEE by energy balance).
+ *
+ * `expenditure = intake - change in stored energy`, with the conventional 7,700 kcal per kg of body
+ * mass. The identity is exact; the inputs are not. Day-to-day weight is mostly water, and food logs are
+ * under-reported by a wide and person-specific margin, so this is meaningful only over weeks and only as
+ * a range.
+ *
+ * DELIBERATELY NOT AN INPUT TO ANYTHING. It never feeds Charge, the calorie card, or the workout calorie
+ * estimate: those come from measured heart rate through Keytel, and quietly overwriting a measurement
+ * with an inference from a food diary would be a strictly worse number wearing the same label.
+ *
+ * Swift twin: `AdaptiveExpenditureEngine`.
+ */
+object AdaptiveExpenditureEngine {
+    /** The textbook 7,700 kcal/kg figure, which assumes the change is adipose; it over-states early loss,
+     *  when a real share is glycogen and its bound water. That bias is one reason the output is a range. */
+    const val KCAL_PER_KG = 7_700.0
+
+    const val MIN_WINDOW_DAYS = 21
+    const val MAX_WINDOW_DAYS = 42
+    const val MIN_INTAKE_DAYS = 14
+    const val MIN_INTAKE_COVERAGE = 0.70
+    const val MIN_WEIGHT_READINGS = 6
+
+    /** null when the history cannot support an estimate — the normal answer for most installs, and the
+     *  point of the gates. [days] need not be sorted or contiguous. */
+    fun estimate(days: List<AdaptiveExpenditureDay>): AdaptiveExpenditureEstimate? {
+        val ordered = days.sortedBy { it.day }
+        val first = ordered.firstOrNull()?.day ?: return null
+        val last = ordered.last().day
+        val span = dayCount(first, last) ?: return null
+        if (span < MIN_WINDOW_DAYS) return null
+        val window = minOf(span, MAX_WINDOW_DAYS)
+        val recent = ordered.filter { d ->
+            val back = dayCount(d.day, last) ?: return@filter false
+            back < window
+        }
+
+        val intake = recent.mapNotNull { it.caloriesIn }.filter { it > 0 }
+        val weights = recent.mapNotNull { d ->
+            val w = d.weightKg ?: return@mapNotNull null
+            if (w <= 0) return@mapNotNull null
+            val i = dayCount(first, d.day) ?: return@mapNotNull null
+            i to w
+        }
+        if (intake.size < MIN_INTAKE_DAYS) return null
+        val coverage = intake.size.toDouble() / window.toDouble()
+        if (coverage < MIN_INTAKE_COVERAGE) return null
+        if (weights.size < MIN_WEIGHT_READINGS) return null
+        val slope = leastSquaresSlope(weights) ?: return null
+
+        val meanIntake = intake.sum() / intake.size.toDouble()
+        // A RISING weight means intake exceeded expenditure, so the stored-energy term is SUBTRACTED.
+        // Getting this sign backwards is the classic error, which is why the tests pin both directions.
+        val estimate = meanIntake - slope * KCAL_PER_KG
+
+        val waterKcalPerDay = (0.5 * KCAL_PER_KG) / window.toDouble()
+        val intakeUncertainty = meanIntake * 0.10 * (1.0 - coverage) + meanIntake * 0.05
+        val margin = waterKcalPerDay + intakeUncertainty
+
+        val confidence = when {
+            window >= 28 && coverage >= 0.90 && weights.size >= 12 -> AdaptiveExpenditureConfidence.HIGH
+            window >= 21 && coverage >= 0.80 -> AdaptiveExpenditureConfidence.MODERATE
+            else -> AdaptiveExpenditureConfidence.BUILDING
+        }
+
+        return AdaptiveExpenditureEstimate(
+            estimatedDailyKcal = estimate,
+            lowerKcal = estimate - margin,
+            upperKcal = estimate + margin,
+            meanIntakeKcal = meanIntake,
+            weightSlopeKgPerDay = slope,
+            intakeDays = intake.size,
+            weightReadings = weights.size,
+            windowDays = window,
+            confidence = confidence,
+        )
+    }
+
+    /** OLS slope in kg per DAY. null when every reading shares one day, which would divide by zero — a
+     *  real case when a scale syncs several readings with one timestamp. */
+    internal fun leastSquaresSlope(points: List<Pair<Int, Double>>): Double? {
+        val n = points.size.toDouble()
+        if (points.size < 2) return null
+        val meanX = points.sumOf { it.first.toDouble() } / n
+        val meanY = points.sumOf { it.second } / n
+        var num = 0.0
+        var den = 0.0
+        for ((x, y) in points) {
+            val dx = x.toDouble() - meanX
+            num += dx * (y - meanY)
+            den += dx * dx
+        }
+        return if (den > 0) num / den else null
+    }
+
+    /**
+     * Whole days between two "yyyy-MM-dd" keys, inclusive of the first.
+     *
+     * null on an unparseable key. [AnalyticsEngine.dayStartUtcSeconds] is deliberately nil-tolerant and
+     * returns 0 for one, which is indistinguishable from 1970 here — and a stray 0 would silently stretch
+     * the window by twenty thousand days.
+     */
+    internal fun dayCount(from: String, to: String): Int? {
+        val a = AnalyticsEngine.dayStartUtcSeconds(from)
+        val b = AnalyticsEngine.dayStartUtcSeconds(to)
+        if (a <= 0L || b <= 0L) return null
+        return ((b - a) / 86_400L).toInt() + 1
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/AdaptiveExpenditureEngineTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AdaptiveExpenditureEngineTest.kt
@@ -116,6 +116,26 @@ class AdaptiveExpenditureEngineTest {
         assertEquals(est.windowDays, est.intakeDays)
     }
 
+    /**
+     * A duplicated day must not buy confidence. Coverage is "share of the window that was logged", so it
+     * cannot exceed 1 — but a caller that merged its two sparse series badly could pass a day twice, and
+     * an unclamped ratio above 1 both shrinks the interval and lifts the confidence, making the answer
+     * look more certain than its data. That is the one direction this engine must never err in.
+     */
+    @Test
+    fun `duplicated days cannot buy a narrower interval or higher confidence`() {
+        val clean = history(days = 30)
+        val duped = clean + clean          // every day twice
+        val a = AdaptiveExpenditureEngine.estimate(clean)!!
+        val b = AdaptiveExpenditureEngine.estimate(duped)!!
+        val widthA = a.upperKcal - a.lowerKcal
+        val widthB = b.upperKcal - b.lowerKcal
+        assertEquals("a duplicate must not narrow the interval", widthA, widthB, 1e-6)
+        assertEquals("nor raise the confidence", a.confidence, b.confidence)
+        assertTrue("and the interval still brackets", b.lowerKcal < b.estimatedDailyKcal)
+        assertTrue(b.upperKcal > b.estimatedDailyKcal)
+    }
+
     /** A bad day key must not be read as 1970 and stretch the window by twenty thousand days. */
     @Test
     fun `an unparseable day key is refused not treated as 1970`() {

--- a/android/app/src/test/java/com/noop/analytics/AdaptiveExpenditureEngineTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AdaptiveExpenditureEngineTest.kt
@@ -103,6 +103,19 @@ class AdaptiveExpenditureEngineTest {
         assertTrue(thin.confidence != AdaptiveExpenditureConfidence.HIGH)
     }
 
+    /**
+     * The window must hold exactly the days it claims. `dayCount` is inclusive, so a strict `<` in the
+     * recency filter drops the oldest day while still reporting the full window — losing a day of data
+     * and understating coverage, both silently. Every other case here logs every day, so a one-day loss
+     * crosses no gate and nothing else would notice.
+     */
+    @Test
+    fun `a fully logged window keeps every day it reports`() {
+        val est = AdaptiveExpenditureEngine.estimate(history(days = 30))!!
+        assertEquals(30, est.windowDays)
+        assertEquals(est.windowDays, est.intakeDays)
+    }
+
     /** A bad day key must not be read as 1970 and stretch the window by twenty thousand days. */
     @Test
     fun `an unparseable day key is refused not treated as 1970`() {

--- a/android/app/src/test/java/com/noop/analytics/AdaptiveExpenditureEngineTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AdaptiveExpenditureEngineTest.kt
@@ -1,0 +1,118 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * TDEE by energy balance — the ORACLE for the Swift twin `AdaptiveExpenditureEngineTests`.
+ *
+ * The identity is `expenditure = intake - stored-energy change`. Everything interesting here is about
+ * refusing to answer: the method is only meaningful over weeks, and most installs will never have enough
+ * logged intake to reach it.
+ */
+class AdaptiveExpenditureEngineTest {
+
+    /** A synthetic history: `days` long, intake every `logEvery` days, weight every `weighEvery`. */
+    private fun history(
+        days: Int,
+        intake: Double = 2_400.0,
+        startKg: Double = 80.0,
+        kgPerDay: Double = 0.0,
+        logEvery: Int = 1,
+        weighEvery: Int = 3,
+    ): List<AdaptiveExpenditureDay> = (0 until days).map { i ->
+        AdaptiveExpenditureDay(
+            day = dayKey(i),
+            caloriesIn = if (i % logEvery == 0) intake else null,
+            weightKg = if (i % weighEvery == 0) startKg + kgPerDay * i else null,
+        )
+    }
+
+    /** Sequential "yyyy-MM-dd" keys from 2026-01-01, so the engine's own date maths is exercised. */
+    private fun dayKey(offset: Int): String {
+        val epochDay = java.time.LocalDate.of(2026, 1, 1).toEpochDay() + offset
+        return java.time.LocalDate.ofEpochDay(epochDay).toString()
+    }
+
+    /** Weight flat ⇒ expenditure equals intake. The simplest reading of the identity. */
+    @Test
+    fun `a stable weight puts expenditure at intake`() {
+        val est = AdaptiveExpenditureEngine.estimate(history(days = 30))!!
+        assertEquals(2_400.0, est.estimatedDailyKcal, 1.0)
+        assertEquals(0.0, est.weightSlopeKgPerDay, 1e-9)
+    }
+
+    /**
+     * Losing weight ⇒ expenditure EXCEEDED intake, so the estimate is ABOVE what was eaten. The sign is
+     * the classic error in this formula, so both directions are pinned rather than one.
+     */
+    @Test
+    fun `losing weight puts expenditure above intake`() {
+        val est = AdaptiveExpenditureEngine.estimate(history(days = 30, kgPerDay = -0.05))!!
+        // 0.05 kg/day * 7700 = 385 kcal/day of stored energy released.
+        assertEquals(2_400.0 + 385.0, est.estimatedDailyKcal, 2.0)
+        assertTrue(est.estimatedDailyKcal > est.meanIntakeKcal)
+    }
+
+    /** And the mirror: gaining weight means expenditure fell SHORT of intake. */
+    @Test
+    fun `gaining weight puts expenditure below intake`() {
+        val est = AdaptiveExpenditureEngine.estimate(history(days = 30, kgPerDay = 0.05))!!
+        assertEquals(2_400.0 - 385.0, est.estimatedDailyKcal, 2.0)
+        assertTrue(est.estimatedDailyKcal < est.meanIntakeKcal)
+    }
+
+    /** Under three weeks the method is not meaningful, so it declines rather than answering. */
+    @Test
+    fun `a short history yields nothing`() {
+        assertNull(AdaptiveExpenditureEngine.estimate(history(days = 20)))
+    }
+
+    /**
+     * The gate that matters most in practice: someone logs hard for a fortnight of a long window and
+     * stops. The days they skip are not a random sample of their eating, so a mean over them would read
+     * as a large false deficit.
+     */
+    @Test
+    fun `sparse intake logging yields nothing`() {
+        assertNull(AdaptiveExpenditureEngine.estimate(history(days = 40, logEvery = 3)))
+    }
+
+    /** Weight is the other half of the identity; too few readings cannot establish a trend. */
+    @Test
+    fun `too few weigh-ins yields nothing`() {
+        assertNull(AdaptiveExpenditureEngine.estimate(history(days = 30, weighEvery = 10)))
+    }
+
+    /** The output is a RANGE, and the estimate must sit inside it. */
+    @Test
+    fun `the estimate is bracketed by its interval`() {
+        val est = AdaptiveExpenditureEngine.estimate(history(days = 30))!!
+        assertTrue(est.lowerKcal < est.estimatedDailyKcal)
+        assertTrue(est.upperKcal > est.estimatedDailyKcal)
+    }
+
+    /** Confidence rises with the window, coverage and number of weigh-ins — never with the value itself. */
+    @Test
+    fun `confidence reflects coverage not the answer`() {
+        val full = AdaptiveExpenditureEngine.estimate(history(days = 35, weighEvery = 2))!!
+        assertEquals(AdaptiveExpenditureConfidence.HIGH, full.confidence)
+        val thin = AdaptiveExpenditureEngine.estimate(history(days = 22, weighEvery = 3))!!
+        assertTrue(thin.confidence != AdaptiveExpenditureConfidence.HIGH)
+    }
+
+    /** A bad day key must not be read as 1970 and stretch the window by twenty thousand days. */
+    @Test
+    fun `an unparseable day key is refused not treated as 1970`() {
+        assertNull(AdaptiveExpenditureEngine.dayCount("not-a-day", "2026-01-01"))
+        assertNull(AdaptiveExpenditureEngine.dayCount("2026-01-01", ""))
+    }
+
+    /** Readings that all share one day cannot yield a slope; dividing by zero variance must return null. */
+    @Test
+    fun `a single-day weight cluster has no slope`() {
+        assertNull(AdaptiveExpenditureEngine.leastSquaresSlope(listOf(3 to 80.0, 3 to 80.5, 3 to 79.5)))
+    }
+}


### PR DESCRIPTION
Answers a question NOOP cannot currently answer — *"what do I actually burn in a day?"* — from data it already holds. The nutrition CSV importer persists `calories_in` and `weight` as metric series under `nutrition-csv`, and nothing has ever read them together.

## The method

Energy balance: `expenditure = intake − change in stored energy`, at the conventional 7,700 kcal per kg of body mass. The identity is exact; the inputs are not. Day-to-day weight is mostly water, and food logs are under-reported by a wide and person-specific margin, so the estimate is meaningful only over weeks and only as a range.

## So most of the engine is about refusing to answer

| Gate | Why |
|---|---|
| ≥ 21 days | a week of water retention can hide a 500 kcal/day gap |
| ≤ 42 days | past that, expenditure has adapted and the average stops describing today |
| ≥ 14 intake days **and** ≥ 70% coverage | rejects "logged hard for five days then stopped" — those skipped days are not a random sample of someone's eating, and a mean over the rest reads as a large false deficit |
| ≥ 6 weigh-ins | fewer cannot establish a slope |

Most installs will get `nil`. That is the correct answer for them.

## The output is an interval, never a bare number

The error is dominated by things the engine cannot see, so a single figure would be exactly the fabrication the rest of the app refuses to make. Confidence is coarse (`building` / `moderate` / `high`) and keys off window, coverage and weigh-in count — **never off the value itself**.

## And it feeds nothing

It never reaches Charge, the calorie card, or the workout calorie estimate. Those come from measured heart rate through Keytel + Harris–Benedict, and quietly overwriting a measurement with an inference from a food diary would be a strictly worse number wearing the same label. This is a standalone read.

## Tests

Twelve matching cases per platform, same inputs, same order:

- **both signs of the weight trend** — losing weight must put expenditure *above* intake and gaining below it. A flipped sign is the classic error in this formula, so one direction alone would not catch it.
- each refusal gate independently.
- the estimate sits inside its own interval.
- confidence tracks coverage, not the answer.
- two failure modes the maths invites: a day key that fails to parse must not be read as 1970 and silently stretch the window by twenty thousand days (`AnalyticsEngine.dayStartUtcSeconds` is deliberately nil-tolerant and returns 0), and weigh-ins that all share one timestamp must not divide by zero variance.

## Re-review caught an off-by-one in the window

The recency filter used a strict `<` against a day count that is **inclusive** — `dayCount(last, last)` is 1 — so "the last `window` days" kept `window − 1` of them. The oldest day was dropped while `windowDays` still reported the full figure, which lost a day of data *and* understated coverage, since coverage divides the intake count by that same figure.

Understating coverage errs toward refusing to answer, so nothing was wrong in a dangerous direction — but a silent off-by-one in the window of a method whose credibility rests entirely on having enough window is not worth leaving.

None of the ten original cases could see it: they all log every day, so losing one crosses no gate and changes no assertion. The new case pins it directly — a fully logged history must report a window it actually holds (`intakeDays == windowDays`) — and I verified by mutation that restoring the `<` fails that case and only that case.

## A repeated day could buy confidence

Both coverage measures counted **entries, not days**. Intake coverage is "share of the window that was logged" and cannot exceed 1 — but an unclamped ratio above 1 shrinks the margin (the uncertainty term scales with `1 − coverage`) *and* lifts the confidence band. Both make the answer look more certain than its data, the one direction this engine must never err in. Clamped rather than de-duplicated on purpose: silently picking one of two conflicting values for a day would hide the caller's bug rather than survive it.

The weight count had the same shape and the clamp did not reach it — the new test caught that, failing on exactly it. Two weigh-ins on one morning are one day of evidence about a trend, so the gate and the confidence band now count **distinct days**; the slope still reads every point, where extra readings are harmless.

## Verification

- Android full suite **5263 tests, 0 failures** (`--rerun-tasks --no-build-cache`, XML freshness checked); the 10 new Kotlin cases pass.
- Both platforms compile; the Swift twin parses and runs in CI (`test (StrandAnalytics)`).
- Doc-comment lint and i18n audit clean. No new user-facing copy.
- Engine only: no UI, no schema, no migration, nothing bumped.

Surfacing it is deliberately left out of scope — it wants a considered home and an honest way to render a range, and that is a separate change.
