### PR TITLE
ble: give the battery-pack decoder a caller, and a sanity check before it is believed

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/BatteryPackInfo.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/BatteryPackInfo.swift
@@ -28,6 +28,22 @@ public enum BatteryPackInfo {
         /// read via GET_EXTENDED_BATTERY_INFO (98) which reports voltage, NOT a charge %. nil on 5/MG.
         public let voltageMv: Int?
 
+
+        /// Whether this reading is safe to SHOW.
+        ///
+        /// The offsets here are an unvalidated candidate re-derived from two captures, so a wrong one
+        /// would not fail — it would render a confident wrong number, which is the failure this project
+        /// treats as worse than a blank. A fuel gauge is a percentage: anything outside 0...100 means the
+        /// offset moved, and the caller must render nothing rather than the value.
+        ///
+        /// The fork that first shipped this hit exactly that shape from the other direction, reading a
+        /// 24,881 mV "cell voltage" off a 5/MG frame — a 4.0-path field read on a family that does not
+        /// answer it. A gauge that cannot be sanity-checked will eventually be believed.
+        public var displayable: Bool {
+            guard present, let soc = socPct else { return false }
+            return soc >= 0 && soc <= 100
+        }
+
         public init(present: Bool, socPct: Double?, serial: String?, btAddr: String?, voltageMv: Int? = nil) {
             self.present = present; self.socPct = socPct; self.serial = serial
             self.btAddr = btAddr; self.voltageMv = voltageMv

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BatteryPackInfoTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BatteryPackInfoTests.swift
@@ -73,4 +73,27 @@ final class BatteryPackInfoTests: XCTestCase {
         XCTAssertNil(BatteryPackInfo.decodeExtended(frame: bytes(attachedHex)))
         XCTAssertNil(BatteryPackInfo.decode(frame: bytes(attachedHex))?.voltageMv)
     }
+
+    /// The gauge must be sanity-checked before it is shown. These offsets are an unvalidated candidate
+    /// re-derived from two captures; a wrong one does not fail, it renders a confident wrong number — the
+    /// failure this project treats as worse than a blank. A percentage outside 0...100 means the offset
+    /// moved, so the caller renders nothing.
+    func testOutOfRangeChargeIsNotDisplayable() {
+        XCTAssertFalse(BatteryPackInfo.Info(present: true, socPct: 2488.1, serial: "P", btAddr: "aa").displayable)
+        XCTAssertFalse(BatteryPackInfo.Info(present: true, socPct: -1, serial: "P", btAddr: "aa").displayable)
+    }
+
+    /// A plausible gauge on an attached pack is the one case that shows.
+    func testInRangeChargeOnAnAttachedPackIsDisplayable() {
+        XCTAssertTrue(BatteryPackInfo.Info(present: true, socPct: 73.4, serial: "P", btAddr: "aa").displayable)
+        XCTAssertTrue(BatteryPackInfo.Info(present: true, socPct: 0, serial: "P", btAddr: "aa").displayable)
+        XCTAssertTrue(BatteryPackInfo.Info(present: true, socPct: 100, serial: "P", btAddr: "aa").displayable)
+    }
+
+    /// A removed pack must clear the card, never hold the last reading.
+    func testAbsentPackIsNeverDisplayable() {
+        XCTAssertFalse(BatteryPackInfo.Info(present: false, socPct: nil, serial: nil, btAddr: nil).displayable)
+        // Even if a stale charge rides along, absence wins.
+        XCTAssertFalse(BatteryPackInfo.Info(present: false, socPct: 80, serial: nil, btAddr: nil).displayable)
+    }
 }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BatteryPackInfoTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BatteryPackInfoTests.swift
@@ -96,4 +96,20 @@ final class BatteryPackInfoTests: XCTestCase {
         // Even if a stale charge rides along, absence wins.
         XCTAssertFalse(BatteryPackInfo.Info(present: false, socPct: 80, serial: nil, btAddr: nil).displayable)
     }
+
+    /// The router branch that decodes this reply matches on the command NAME
+    /// (`cmdName.hasPrefix("GET_BATTERY_PACK_INFO(")`), which comes from the schema's CommandNumber table.
+    /// A rename or a removal there would not fail to compile — the branch would simply stop matching and
+    /// the whole feature would go quiet, with the decoder back to having no caller. Pin the string.
+    func testCommand151ResolvesToTheNameTheRouterMatchesOn() {
+        XCTAssertEqual(loadSchema().enumName("CommandNumber", 151), "GET_BATTERY_PACK_INFO(151)")
+    }
+
+    /// `displayable` is about a CHARGE percentage, and the 4.0 path carries a voltage instead — so it is
+    /// always false there, correctly. Pinned because the name is generic enough that a future 4.0 voltage
+    /// card might reach for this gate and get a permanent no.
+    func testFourPointOhVoltagePathIsNeverDisplayable() {
+        let v = BatteryPackInfo.Info(present: true, socPct: nil, serial: nil, btAddr: nil, voltageMv: 3_900)
+        XCTAssertFalse(v.displayable)
+    }
 }

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -4481,6 +4481,11 @@ public final class BLEManager: NSObject, ObservableObject {
         // #battery: ~60 s normally, ~30 s while charging (see `batteryPollDue`).
         if BLEManager.batteryPollDue(tick: keepAliveTick, charging: state.charging == true) {
             send(.getBatteryLevel, payload: [])
+            // The 5/MG battery pack rides the SAME cadence as the strap's own gauge — it is the same
+            // question about the same physical thing, and a second timer would only be a second thing to
+            // get wrong. 5/MG only: a 4.0 never answers 151 (its pack is voltage-only via 98), so asking
+            // would be traffic with no reply.
+            if selectedModel.deviceFamily == .whoop5 { send(.getBatteryPackInfo, payload: []) }
         }
     }
 

--- a/Strand/BLE/Commands.swift
+++ b/Strand/BLE/Commands.swift
@@ -92,6 +92,11 @@ public enum WhoopCommand: UInt8, CaseIterable {
     /// payloads. If probing (#592): send THIS curated number first and capture the response — do NOT lead
     /// with the decompile's 87, an opcode unknown to this table (the curated-safe-subset rule).
     case getExtendedBatteryInfo = 98
+    /// The 5/MG battery pack's fuel gauge, read THROUGH the strap — the pack talks to the strap over its
+    /// own link, so there is no peripheral to connect to and nothing to scan for. `BatteryPackInfo` has
+    /// decoded this reply since the offsets were captured; until now nothing sent the command, so the
+    /// decoder had no caller. A 4.0 never answers it (its pack is voltage-only via 98).
+    case getBatteryPackInfo = 151
     /// #690: read-only body-location/status probe. Documented in the WHOOP protocol; driven only by the
     /// user-triggered, Test-Centre-gated probeBodyLocationAndStatus(). Decoded to a diagnostic report only.
     case getBodyLocationAndStatus = 84
@@ -226,6 +231,7 @@ public enum WhoopCommand: UInt8, CaseIterable {
         case .enterHighFreqSync:     return "Enter High-Freq Sync"
         case .exitHighFreqSync:      return "Exit High-Freq Sync"
         case .getExtendedBatteryInfo:return "Get Extended Battery Info"
+        case .getBatteryPackInfo:    return "Get Battery Pack Info"
         case .getBodyLocationAndStatus:return "Get Body Location And Status"
         case .startFeatureFlagKeyExchange: return "Start Feature-Flag Key Exchange"
         case .sendNextFeatureFlag:   return "Send Next Feature Flag"

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WhoopProtocol
+import WhoopStore
 import StrandAnalytics
 
 /// Pure decode→state router. Takes a COMPLETE (already reassembled) frame, decodes it with
@@ -322,8 +323,14 @@ public final class FrameRouter {
                TestCentre.active(.connection) {
                 if let info = BatteryPackInfo.decode(frame: frame) {
                     let soc = info.socPct.map { String(format: "%.1f%%", $0) } ?? "—"
+                    // logSafe, NOT the raw serial. `redactPii` cannot catch this one — its rules key on a
+                    // literal "WHOOP " prefix or a `whoop-` id, and a bare `serial=BB5AP…` matches neither —
+                    // so the redaction that protects the strap's serial would have let the pack's through to
+                    // an exportable log. Three characters is enough to tell two packs apart, which is all a
+                    // diagnostic needs.
                     state.append(log: "[pack] present=\(info.present) soc=\(soc) "
-                                 + "serial=\(info.serial ?? "—") displayable=\(info.displayable) (#1303)")
+                                 + "serial=\(WhoopSerialIdentity.logSafe(info.serial)) "
+                                 + "displayable=\(info.displayable) (#1303)")
                 } else {
                     state.append(log: "[pack] cmd 151 replied but did not decode — offsets may have moved")
                 }

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -309,6 +309,25 @@ public final class FrameRouter {
                let pay = Self.commandResponsePayload(in: frame, family: family) {
                 state.append(log: HelloIdentityProbe.report(payload: pay) + " — locate the strap serial (#1303)")
             }
+            // The 5/MG battery pack (cmd 151). `BatteryPackInfo` has decoded this reply since its offsets
+            // were captured, and until now nothing sent the command — so the decoder had no caller and the
+            // offsets have never been seen against a live strap.
+            //
+            // LOG-ONLY, deliberately. Those offsets are an unvalidated candidate re-derived from two
+            // frames, and a wrong one does not fail: it renders a confident wrong number. So this reports
+            // what it read AND whether the reading passes the `displayable` sanity check, which is exactly
+            // the evidence needed before a card can honestly show it. Test Centre → Connection gated, so
+            // nothing here reaches a default (shareable) strap log. Persists nothing.
+            if family == .whoop5, let cmd = parsed.cmdName, cmd.hasPrefix("GET_BATTERY_PACK_INFO("),
+               TestCentre.active(.connection) {
+                if let info = BatteryPackInfo.decode(frame: frame) {
+                    let soc = info.socPct.map { String(format: "%.1f%%", $0) } ?? "—"
+                    state.append(log: "[pack] present=\(info.present) soc=\(soc) "
+                                 + "serial=\(info.serial ?? "—") displayable=\(info.displayable) (#1303)")
+                } else {
+                    state.append(log: "[pack] cmd 151 replied but did not decode — offsets may have moved")
+                }
+            }
             // #900: surface a non-SUCCESS COMMAND_RESPONSE on BOTH families (a result=UNSUPPORTED here is how
             // the MG haptics rejection #48 would show), and — the key part — annotate a reply that DELIVERED
             // ITS VALUE rather than reporting a bare failure. The 4.0 GET_BATTERY_LEVEL replies on record carry

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7422,6 +7422,30 @@ class WhoopBleClient(
                         )
                     }
                 }
+                // The 5/MG battery pack (cmd 151). `BatteryPackInfo` has decoded this reply since its
+                // offsets were captured, and until now nothing sent the command — so the decoder had no
+                // caller and the offsets have never been seen against a live strap.
+                //
+                // LOG-ONLY, deliberately. Those offsets are an unvalidated candidate re-derived from two
+                // frames, and a wrong one does not fail: it renders a confident wrong number. So this
+                // reports what it read AND whether it passes the `displayable` sanity check, which is the
+                // evidence a card needs before it can honestly show anything. Twin of the Swift
+                // FrameRouter branch. Test Centre gated; persists nothing.
+                if (connectedFamily == DeviceFamily.WHOOP5 &&
+                    respCmd?.startsWith("GET_BATTERY_PACK_INFO(") == true &&
+                    testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)
+                ) {
+                    val info = com.noop.protocol.BatteryPackInfo.decode(frame)
+                    if (info != null) {
+                        val soc = info.socPct?.let { String.format("%.1f%%", it) } ?: "—"
+                        log(
+                            "[pack] present=${info.present} soc=$soc serial=${info.serial ?: "—"} " +
+                                "displayable=${info.displayable} (#1303)",
+                        )
+                    } else {
+                        log("[pack] cmd 151 replied but did not decode — offsets may have moved")
+                    }
+                }
                 // Reboot ack (#166): log the COMMAND_RESPONSE result for a user reboot on BOTH families —
                 // the accept/reject signal (the same one that exposed 5/MG haptics rejection). So a 5/MG
                 // owner's strap log confirms whether the (unverified) puffin reboot frame is accepted. The
@@ -7980,6 +8004,12 @@ class WhoopBleClient(
                     // #battery: ~60 s normally, ~30 s while charging (see [batteryPollDue]).
                     if (batteryPollDue(keepAliveTick, s.charging == true)) send(CommandNumber.GET_BATTERY_LEVEL)
                 } else if (connectedFamily == DeviceFamily.WHOOP5) {
+                    // The battery pack rides the SAME cadence as the strap's own gauge — the same question
+                    // about the same physical thing, and a second timer would only be a second thing to get
+                    // wrong. 5/MG only: a 4.0 never answers 151 (its pack is voltage-only via 98).
+                    if (batteryPollDue(keepAliveTick, s.charging == true)) {
+                        send(CommandNumber.GET_BATTERY_PACK_INFO)
+                    }
                     // #1865: re-arm a LAPSED realtime stream. The WHOOP4 branch above re-sends
                     // TOGGLE_REALTIME_HR every tick precisely because "the firmware lets the realtime HR
                     // stream lapse if it isn't re-armed" — a 5/MG got none of that, on the reasoning that it

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7438,8 +7438,13 @@ class WhoopBleClient(
                     val info = com.noop.protocol.BatteryPackInfo.decode(frame)
                     if (info != null) {
                         val soc = info.socPct?.let { String.format("%.1f%%", it) } ?: "—"
+                        // logSafe, NOT the raw serial. The log redaction keys on a literal "WHOOP " prefix
+                        // or a `whoop-` id, and a bare `serial=BB5AP…` matches neither — so the rule that
+                        // protects the strap's serial would have let the pack's through to an exportable
+                        // log. Three characters is enough to tell two packs apart.
+                        val safeSerial = com.noop.data.WhoopSerialIdentity.logSafe(info.serial)
                         log(
-                            "[pack] present=${info.present} soc=$soc serial=${info.serial ?: "—"} " +
+                            "[pack] present=${info.present} soc=$soc serial=$safeSerial " +
                                 "displayable=${info.displayable} (#1303)",
                         )
                     } else {

--- a/android/app/src/main/java/com/noop/protocol/BatteryPackInfo.kt
+++ b/android/app/src/main/java/com/noop/protocol/BatteryPackInfo.kt
@@ -25,7 +25,18 @@ object BatteryPackInfo {
         /** WHOOP 4.0 only: pack VOLTAGE in mV — a 4.0 has no fuel-gauge command, so its pack is read via
          *  GET_EXTENDED_BATTERY_INFO (98) which reports voltage, not a charge %. null on 5/MG. */
         val voltageMv: Int? = null,
-    )
+    ) {
+        /**
+         * Whether this reading is safe to SHOW.
+         *
+         * The offsets here are an unvalidated candidate re-derived from two captures, so a wrong one
+         * would not fail — it would render a confident wrong number, which is the failure this project
+         * treats as worse than a blank. A fuel gauge is a percentage: anything outside 0..100 means the
+         * offset moved, and the caller must render nothing rather than the value.
+         */
+        val displayable: Boolean
+            get() = present && socPct != null && socPct >= 0.0 && socPct <= 100.0
+    }
 
     /** Resp-cmd byte sits at [cmdOff] (10 on WHOOP 5/MG — the only family with a pack). Null when the
      *  frame is not a well-formed 151 SUCCESS response; the caller CRC-gates the frame (framing layer does). */

--- a/android/app/src/main/java/com/noop/protocol/Enums.kt
+++ b/android/app/src/main/java/com/noop/protocol/Enums.kt
@@ -227,6 +227,8 @@ enum class CommandNumber(val rawValue: Int) {
     // dumped in full to the strap log so a normal export settles which number this firmware serves.
     // Mirrors Swift WhoopCommand.getExtendedBatteryInfo.
     GET_EXTENDED_BATTERY_INFO(98),
+    /** The 5/MG battery pack's fuel gauge, read THROUGH the strap. A 4.0 never answers it. */
+    GET_BATTERY_PACK_INFO(151),
     // #690: read-only body-location/status probe. Documented in the WHOOP protocol; driven only by the
     // user-triggered, Test-Centre-gated probeBodyLocationAndStatus(). Decoded to a diagnostic report only.
     GET_BODY_LOCATION_AND_STATUS(84),

--- a/android/app/src/test/java/com/noop/protocol/BatteryPackInfoTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/BatteryPackInfoTest.kt
@@ -2,6 +2,8 @@ package com.noop.protocol
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -70,5 +72,35 @@ class BatteryPackInfoTest {
         assertNull(info.serial)
         assertNull(BatteryPackInfo.decodeExtended(bytes(attachedHex)))   // 151 frame is not a 98 response
         assertNull(BatteryPackInfo.decode(bytes(attachedHex))!!.voltageMv) // 5/MG decode never fills voltage
+    }
+
+    /**
+     * The gauge must be sanity-checked before it is shown. These offsets are an unvalidated candidate
+     * re-derived from two captures; a wrong one does not fail, it renders a confident wrong number — the
+     * failure this project treats as worse than a blank. A percentage outside 0..100 means the offset
+     * moved, so the caller renders nothing.
+     */
+    @Test
+    fun `an out-of-range charge is not displayable`() {
+        val absurd = BatteryPackInfo.Info(present = true, socPct = 2488.1, serial = "P", btAddr = "aa")
+        assertFalse(absurd.displayable)
+        val negative = BatteryPackInfo.Info(present = true, socPct = -1.0, serial = "P", btAddr = "aa")
+        assertFalse(negative.displayable)
+    }
+
+    /** A plausible gauge on an attached pack is the one case that shows. */
+    @Test
+    fun `an in-range charge on an attached pack is displayable`() {
+        assertTrue(BatteryPackInfo.Info(present = true, socPct = 73.4, serial = "P", btAddr = "aa").displayable)
+        assertTrue(BatteryPackInfo.Info(present = true, socPct = 0.0, serial = "P", btAddr = "aa").displayable)
+        assertTrue(BatteryPackInfo.Info(present = true, socPct = 100.0, serial = "P", btAddr = "aa").displayable)
+    }
+
+    /** A removed pack must clear the card, never hold the last reading. */
+    @Test
+    fun `an absent pack is never displayable`() {
+        assertFalse(BatteryPackInfo.Info(present = false, socPct = null, serial = null, btAddr = null).displayable)
+        // Even if a stale charge rides along, absence wins.
+        assertFalse(BatteryPackInfo.Info(present = false, socPct = 80.0, serial = null, btAddr = null).displayable)
     }
 }

--- a/android/app/src/test/java/com/noop/protocol/BatteryPackInfoTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/BatteryPackInfoTest.kt
@@ -103,4 +103,28 @@ class BatteryPackInfoTest {
         // Even if a stale charge rides along, absence wins.
         assertFalse(BatteryPackInfo.Info(present = false, socPct = 80.0, serial = null, btAddr = null).displayable)
     }
+
+    /**
+     * The router branch that decodes this reply matches on the command NAME
+     * (`respCmd.startsWith("GET_BATTERY_PACK_INFO(")`), which comes from this lookup table. A rename or a
+     * removal there would not fail to compile — the branch would simply stop matching and the whole
+     * feature would go quiet, with the decoder back to having no caller. Pin the string.
+     */
+    @Test
+    fun `command 151 resolves to the name the router matches on`() {
+        assertEquals("GET_BATTERY_PACK_INFO", com.noop.protocol.CommandNames.byRaw[151])
+        assertTrue(com.noop.protocol.CommandNames.label(151).startsWith("GET_BATTERY_PACK_INFO("))
+    }
+
+    /**
+     * `displayable` is about a CHARGE percentage, and the 4.0 path carries a voltage instead — so it is
+     * always false there, correctly. Pinned because the name is generic enough that a future 4.0 voltage
+     * card might reach for this gate and get a permanent no.
+     */
+    @Test
+    fun `the 4-0 voltage path is never displayable`() {
+        val v = BatteryPackInfo.Info(present = true, socPct = null, serial = null, btAddr = null,
+                                     voltageMv = 3_900)
+        assertFalse(v.displayable)
+    }
 }


### PR DESCRIPTION
`BatteryPackInfo` has decoded `GET_BATTERY_PACK_INFO` (151) on both platforms since its offsets were captured — the 5/MG pack's charge, serial and Bluetooth address, read **through the strap**, because the pack talks to the strap rather than advertising a peripheral of its own.

**Nothing ever sent the command.** The decoder had no production caller on either platform, its tests ran against two stored frames, and the offsets had never been seen against a live strap.

## What this does

The command now goes out on the **same cadence as the strap's own gauge** — it is the same question about the same physical thing, and a second timer would only be a second thing to get wrong. 5/MG only: a 4.0 never answers 151, its pack being voltage-only via `GET_EXTENDED_BATTERY_INFO` (98).

The reply is decoded and **logged, not stored and not shown**.

## Why log-only

Those offsets are an **unvalidated candidate**, re-derived clean-room from two captured frames — one strap with a pack attached, then physically removed. A wrong offset here does not fail; it renders a confident wrong number, which this project treats as worse than a blank.

So the line reports what was read **and** whether it passes the new `displayable` check — which is precisely the evidence a card needs before it can honestly show anything. Test Centre → Connection gated, so it never reaches a default shareable strap log.

```
[pack] present=true soc=73.4% serial=BB5… displayable=true (#1303)
[pack] cmd 151 replied but did not decode — offsets may have moved
```

## `displayable`

The gate a future card must use. A fuel gauge is a percentage, so anything outside `0...100` means an offset moved and the caller renders nothing. Absence wins over a stale reading, so a removed pack clears rather than holding its last number.

Eight matching cases per platform, including the out-of-range case, both range boundaries, and a stale charge riding along on an absent pack.

## Deliberately not included

No `LiveState` field and no Devices row. A card whose value cannot yet be trusted is exactly what the gate exists to prevent — and this log is what turns two captured frames into confirmation. Once a strap log shows `displayable=true` with a plausible number across an attach and a removal, the card is a small follow-up.

## Re-review: the pack serial was being logged in full

`LiveState.redactPii` protects the strap's serial and I assumed it covered this. It does not — its rules key on a literal `"WHOOP "` prefix followed by a digit, or on a `whoop-` adopted id. A bare `serial=BB5AP01263935` matches neither, so the pack serial would have travelled intact into a log that exists to be exported and pasted into an issue.

Both platforms now write `WhoopSerialIdentity.logSafe` — the same three-characters-then-ellipsis rule the strap's variant line already uses. Three characters still tells two packs apart, which is all a diagnostic needs, and the reasoning is recorded at both call sites so the next identifier added to this line does not repeat the assumption.

## Verification

- Android full suite **5266 tests, 0 failures** (`--rerun-tasks --no-build-cache`, XML freshness checked).
- Both platforms compile; every Swift file parses; doc lint and i18n audit clean. No schema change.
- Checked that the command name actually resolves on both sides before trusting the branch: Swift's `cmdName` comes from the schema JSON (which already carried 151), Kotlin's from `CommandNames.byRaw` (which already carried it too) — so the prefix match fires rather than silently never matching.

**Not verified on hardware.** This is the change that makes hardware verification possible, not one that has had it.
