### PR TITLE
ble: stop telling a strap that refuses pairing to try pairing again (#1635)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -220,7 +220,7 @@ struct BondRefusalGiveUp {
     ///
     /// Pure. Byte-identical to the Kotlin `BondRefusalGiveUp.helloSuppressedHint`.
     static func helloSuppressedHint() -> String {
-        "The secure handshake with your strap never completes, and the attempt itself is what drops the link. NOOP has switched it off for this strap so live heart rate keeps streaming. History sync stays unavailable until it pairs, and so do motion, skin temperature, SpO₂ and respiratory rate, so sleep is staged from heart rate alone. Some straps have paired again after being put in pairing mode (tap until the LEDs flash blue), then tap Connect."
+        "The secure handshake with your strap never completes, and the attempt itself is what drops the link. NOOP has switched it off for this strap so live heart rate keeps streaming. History sync stays unavailable until it pairs, and so do motion, skin temperature, SpO₂ and respiratory rate, so sleep is staged from heart rate alone. Some straps have paired again after being put in pairing mode. Tap until the LEDs flash blue, then tap Connect."
     }
 
     /// The paused hint for a bond that failed WITHOUT the strap ever answering (#1635).

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -209,11 +209,18 @@ struct BondRefusalGiveUp {
     /// #1635: the hint shown when the hello is switched off and the link is KEPT.
     ///
     /// Nothing is paused on this branch, so it must not say auto-reconnect stopped. It names what was lost
-    /// (history sync) and the one action that restores the attempt, without asserting a cause.
+    /// and what to try, without asserting a cause.
+    ///
+    /// #1635 follow-up: it used to end "Tap Connect to try the handshake again", which framed a strap that
+    /// REFUSES pairing as a retryable failure — inviting exactly the hammering the give-up latch exists to
+    /// stop. A field report read all of this and still asked how to fix it, so the ending now leads with
+    /// the only thing anyone has recovered from this state with (pairing mode, reported once on #1635 and
+    /// hedged accordingly) and keeps Connect as the follow-up. It also no longer claims HRV and resting
+    /// heart rate are unavailable: since #1884 an HR-only night reports both.
     ///
     /// Pure. Byte-identical to the Kotlin `BondRefusalGiveUp.helloSuppressedHint`.
     static func helloSuppressedHint() -> String {
-        "The secure handshake with your strap never completes, and the attempt itself is what drops the link. NOOP has switched it off for this strap so live heart rate keeps streaming. History sync stays unavailable until it pairs, and so do motion, skin temperature, SpO₂ and respiratory rate — so sleep is staged from heart rate alone, and HRV and resting heart rate are unavailable. Tap Connect to try the handshake again."
+        "The secure handshake with your strap never completes, and the attempt itself is what drops the link. NOOP has switched it off for this strap so live heart rate keeps streaming. History sync stays unavailable until it pairs, and so do motion, skin temperature, SpO₂ and respiratory rate, so sleep is staged from heart rate alone. Some straps have paired again after being put in pairing mode: hold the strap until its lights flash blue, then tap Connect."
     }
 
     /// The paused hint for a bond that failed WITHOUT the strap ever answering (#1635).

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -220,7 +220,7 @@ struct BondRefusalGiveUp {
     ///
     /// Pure. Byte-identical to the Kotlin `BondRefusalGiveUp.helloSuppressedHint`.
     static func helloSuppressedHint() -> String {
-        "The secure handshake with your strap never completes, and the attempt itself is what drops the link. NOOP has switched it off for this strap so live heart rate keeps streaming. History sync stays unavailable until it pairs, and so do motion, skin temperature, SpO₂ and respiratory rate, so sleep is staged from heart rate alone. Some straps have paired again after being put in pairing mode: hold the strap until its lights flash blue, then tap Connect."
+        "The secure handshake with your strap never completes, and the attempt itself is what drops the link. NOOP has switched it off for this strap so live heart rate keeps streaming. History sync stays unavailable until it pairs, and so do motion, skin temperature, SpO₂ and respiratory rate, so sleep is staged from heart rate alone. Some straps have paired again after being put in pairing mode (tap until the LEDs flash blue), then tap Connect."
     }
 
     /// The paused hint for a bond that failed WITHOUT the strap ever answering (#1635).

--- a/StrandTests/HelloSuppressionTests.swift
+++ b/StrandTests/HelloSuppressionTests.swift
@@ -114,14 +114,22 @@ final class HelloSuppressionTests: XCTestCase {
         let hint = BondRefusalGiveUp.helloSuppressedHint()
         XCTAssertTrue(hint.contains("live heart rate keeps streaming"))
         XCTAssertTrue(hint.contains("History sync stays unavailable"))
-        XCTAssertTrue(hint.contains("Tap Connect"))
+        // #1635 follow-up: the hint no longer LEADS with a retry. Framing a strap that refuses pairing as
+        // a retryable failure invited the hammering the give-up latch exists to stop, and a field report
+        // read the whole hint and still asked how to fix it. Pairing mode comes first now; Connect follows.
+        XCTAssertTrue(hint.contains("pairing mode"))
+        XCTAssertTrue(hint.contains("tap Connect"))
+        // And it must NOT claim these are unavailable: since #1884 an HR-only night reports both.
+        XCTAssertFalse(hint.contains("HRV and resting heart rate are unavailable"))
         // The hint must name what an unbonded strap actually costs, not just history sync: motion,
         // skin temperature, SpO2 and respiratory stop, so sleep falls to the HR-only stager and HRV
         // + resting HR are nulled. A field log showed a week of blank Recovery Vitals under the old
         // wording, which pointed only at a feature the user was not missing.
         XCTAssertTrue(hint.contains("motion"))
-        XCTAssertTrue(hint.contains("HRV"))
-        XCTAssertTrue(hint.contains("resting heart rate"))
+        // #1884 repinned the tail of this: naming HRV and resting HR as LOSSES stopped being true when an
+        // HR-only night began reporting both. What survives from #1878 is the reason they were named at
+        // all - the strap stops sending motion, so sleep falls to the HR-only stager. That still holds.
+        XCTAssertTrue(hint.contains("staged from heart rate alone"))
         XCTAssertFalse(hint.lowercased().contains("paused"))
         XCTAssertFalse(hint.lowercased().contains("stopped retrying"))
     }

--- a/StrandTests/HelloSuppressionTests.swift
+++ b/StrandTests/HelloSuppressionTests.swift
@@ -122,9 +122,10 @@ final class HelloSuppressionTests: XCTestCase {
         // And it must NOT claim these are unavailable: since #1884 an HR-only night reports both.
         XCTAssertFalse(hint.contains("HRV and resting heart rate are unavailable"))
         // The hint must name what an unbonded strap actually costs, not just history sync: motion,
-        // skin temperature, SpO2 and respiratory stop, so sleep falls to the HR-only stager and HRV
-        // + resting HR are nulled. A field log showed a week of blank Recovery Vitals under the old
-        // wording, which pointed only at a feature the user was not missing.
+        // skin temperature, SpO2 and respiratory stop, so sleep falls to the HR-only stager. A field log
+        // showed a week of blank Recovery Vitals under the old wording, which pointed only at a feature
+        // the user was not missing. (It used to end "and HRV + resting HR are nulled" — #1884 made that
+        // false, and leaving it here would have contradicted the assertion four lines down.)
         XCTAssertTrue(hint.contains("motion"))
         // #1884 repinned the tail of this: naming HRV and resting HR as LOSSES stopped being true when an
         // HR-only night began reporting both. What survives from #1878 is the reason they were named at

--- a/android/app/src/main/java/com/noop/ble/BondRefusalGiveUp.kt
+++ b/android/app/src/main/java/com/noop/ble/BondRefusalGiveUp.kt
@@ -94,14 +94,20 @@ class BondRefusalGiveUp(
          * write is not evidence the strap is held by the official app, and the epitaph that asserts that is
          * reserved for an actual auth refusal. Says what was observed and what the user still gets.
          *
+         * #1635 follow-up: it used to end "Tap Connect to try the handshake again", which framed a strap
+         * that REFUSES pairing as a retryable failure. A field report read all of this and still asked how
+         * to fix it, so the ending now leads with pairing mode (reported once on #1635, hedged) and keeps
+         * Connect as the follow-up. It also no longer claims HRV and resting heart rate are unavailable:
+         * since #1884 an HR-only night reports both.
+         *
          * Pure; no em-dash. Byte-identical to the Swift `BondRefusalGiveUp.helloSuppressedHint`.
          */
         fun helloSuppressedHint(): String =
-            "The secure handshake with your strap never completes, and the attempt itself is what drops " +
-                "the link. NOOP has switched it off for this strap so live heart rate keeps streaming. " +
-                "History sync stays unavailable until it pairs, and so do motion, skin temperature, " +
-                "SpO₂ and respiratory rate — so sleep is staged from heart rate alone, and HRV and " +
-                "resting heart rate are unavailable. Tap Connect to try the handshake again."
+            "The secure handshake with your strap never completes, and the attempt itself is what drops t" +
+            "he link. NOOP has switched it off for this strap so live heart rate keeps streaming. History" +
+            " sync stays unavailable until it pairs, and so do motion, skin temperature, SpO₂ and respira" +
+            "tory rate, so sleep is staged from heart rate alone. Some straps have paired again after bei" +
+            "ng put in pairing mode: hold the strap until its lights flash blue, then tap Connect."
 
         /**
          * #1635: the log epitaph for the suppression path.

--- a/android/app/src/main/java/com/noop/ble/BondRefusalGiveUp.kt
+++ b/android/app/src/main/java/com/noop/ble/BondRefusalGiveUp.kt
@@ -107,7 +107,7 @@ class BondRefusalGiveUp(
             "he link. NOOP has switched it off for this strap so live heart rate keeps streaming. History" +
             " sync stays unavailable until it pairs, and so do motion, skin temperature, SpO₂ and respira" +
             "tory rate, so sleep is staged from heart rate alone. Some straps have paired again after bei" +
-            "ng put in pairing mode (tap until the LEDs flash blue), then tap Connect."
+            "ng put in pairing mode. Tap until the LEDs flash blue, then tap Connect."
 
         /**
          * #1635: the log epitaph for the suppression path.

--- a/android/app/src/main/java/com/noop/ble/BondRefusalGiveUp.kt
+++ b/android/app/src/main/java/com/noop/ble/BondRefusalGiveUp.kt
@@ -107,7 +107,7 @@ class BondRefusalGiveUp(
             "he link. NOOP has switched it off for this strap so live heart rate keeps streaming. History" +
             " sync stays unavailable until it pairs, and so do motion, skin temperature, SpO₂ and respira" +
             "tory rate, so sleep is staged from heart rate alone. Some straps have paired again after bei" +
-            "ng put in pairing mode: hold the strap until its lights flash blue, then tap Connect."
+            "ng put in pairing mode (tap until the LEDs flash blue), then tap Connect."
 
         /**
          * #1635: the log epitaph for the suppression path.

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -127,13 +127,21 @@ class HelloSuppressionTest {
         // is holding the strap - the two mistakes this issue has already produced.
         assertFalse(hint.contains("paus", ignoreCase = true))
         assertFalse(hint.contains("WHOOP app", ignoreCase = true))
-        assertTrue(hint.contains("Connect"))
+        // #1635 follow-up: the hint no longer LEADS with a retry. Framing a strap that refuses pairing as
+        // a retryable failure invited the hammering the give-up latch exists to stop, and a field report
+        // read the whole hint and still asked how to fix it. Pairing mode comes first now; Connect follows.
+        assertTrue(hint.contains("pairing mode"))
+        assertTrue(hint.contains("tap Connect"))
+        // And it must NOT claim these are unavailable: since #1884 an HR-only night reports both.
+        assertFalse(hint.contains("HRV and resting heart rate are unavailable"))
         // #1635 field log: a week of blank Recovery Vitals while this hint named only history sync.
         // Unbonded, the strap also stops sending motion / skin temperature / SpO2 / respiratory, which
         // drops sleep onto the HR-only stager and blanks HRV + resting HR by construction.
         assertTrue(hint.contains("motion"))
-        assertTrue(hint.contains("HRV"))
-        assertTrue(hint.contains("resting heart rate"))
+        // #1884 repinned the tail of this: naming HRV and resting HR as LOSSES stopped being true when an
+        // HR-only night began reporting both. What survives from #1878 is the reason they were named at
+        // all — the strap stops sending motion, so sleep falls to the HR-only stager. That still holds.
+        assertTrue(hint.contains("staged from heart rate alone"))
         val epitaph = BondRefusalGiveUp.helloSuppressedEpitaph(5, "abcd1234")
         assertFalse(epitaph.contains("held by", ignoreCase = true))
         assertTrue(epitaph.contains("abcd1234"))

--- a/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/HelloSuppressionTest.kt
@@ -136,7 +136,8 @@ class HelloSuppressionTest {
         assertFalse(hint.contains("HRV and resting heart rate are unavailable"))
         // #1635 field log: a week of blank Recovery Vitals while this hint named only history sync.
         // Unbonded, the strap also stops sending motion / skin temperature / SpO2 / respiratory, which
-        // drops sleep onto the HR-only stager and blanks HRV + resting HR by construction.
+        // drops sleep onto the HR-only stager. (This used to end "and blanks HRV + resting HR by
+        // construction" - #1884 made that false, and leaving it would contradict the assertion below.)
         assertTrue(hint.contains("motion"))
         // #1884 repinned the tail of this: naming HRV and resting HR as LOSSES stopped being true when an
         // HR-only night began reporting both. What survives from #1878 is the reason they were named at


### PR DESCRIPTION
A 5/MG on fw 50.40.1.0 refuses the secure handshake outright, so NOOP latches the give-up and keeps live heart rate streaming. That is the designed end state (#1635), and the Devices card explains it.

The explanation then ended:

> …so sleep is staged from heart rate alone, and HRV and resting heart rate are unavailable. **Tap Connect to try the handshake again.**

## Two things wrong with that

**It frames a permanent refusal as a retryable failure.** For this strap the handshake cannot succeed — the refusal is HCI-confirmed. Ending on "try again" invites precisely the hammering the give-up latch exists to stop, and points the user at an action that will never work.

The evidence it did not land is a field report: the user read the whole hint and still asked *"it's not syncing and keeps disconnecting, how can I fix this?"* Answering that was the copy's one job.

**And one of its claims is now false.** "HRV and resting heart rate are unavailable" was true when #1878 wrote it. #1884 made it untrue — an HR-only night now reports both. It would have shipped wrong in the next release regardless of anything else here.

## What it says now

> …so sleep is staged from heart rate alone. Some straps have paired again after being put in pairing mode (tap until the LEDs flash blue), then tap Connect.

Pairing mode leads because it is the only thing anyone has recovered from this state with, and it is **hedged** — "some straps have paired again after" — because that is a single report on #1635, not a confirmed remedy. Overpromising a fix would be its own version of the same mistake. Connect follows rather than leads.

Byte-identical across both platforms, no em-dash (per the function's own rule), and shorter than what it replaces.

## Tests repinned, not deleted

#1878's test pinned that the hint names HRV and resting heart rate as losses. That invariant is the thing #1884 invalidated, so the assertions move to what survives: the strap stops sending **motion**, so sleep falls to the HR-only stager. Both suites also now assert the hint does *not* claim those two are unavailable, so the false sentence cannot come back.

Apple's suite additionally moves off `"Tap Connect"` to `"pairing mode"` + `"tap Connect"`, matching the new ordering.

## Re-review caught two things

**The gesture was wrong.** I wrote "hold the strap until its lights flash blue". @Zebsi235's report — the entire basis for suggesting pairing mode — says **"tap until the LEDs flash blue"**, and so does `pausedHint` eight lines up in the same file. I invented a gesture for the one instruction whose only value is being correct, and made two hints in one file disagree. Now worded to match its neighbour exactly.

**And the same false claim lives in two more places.** `SettingsView.swift` and `SettingsLogic.kt` also say "HRV and resting heart rate are unavailable". I fixed them, then **reverted** it: that copy is a localized `String(localized:)` whose current text is an xcstrings key with ten translations, so editing it orphans all ten and silently falls back to English.

Notably the i18n audit stayed green through that edit — it matches SwiftUI view constructors, and this literal sits in a plain function, so the gate cannot see it. A green audit was not evidence here. That correction needs the catalogue work done properly and belongs in its own change; it is **still wrong on main** until then.

## Verification

- Android full suite **5268 tests, 0 failures** (`--rerun-tasks --no-build-cache`, XML freshness checked); `HelloSuppressionTest` 29/29.
- Both platforms compile, Swift parses, doc lint and i18n audit clean. The copy is a raw literal on both sides, so there is no translation cost.
- Verified the two strings are byte-identical programmatically rather than by eye.

Copy only — no behaviour change. The give-up latch, the suppression path and the live-HR fallback are untouched.
