### PR TITLE
build: restore the Apple targets, and the app-target tests that never compiled

### DIFF
--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -329,7 +329,7 @@ public final class FrameRouter {
                     // an exportable log. Three characters is enough to tell two packs apart, which is all a
                     // diagnostic needs.
                     state.append(log: "[pack] present=\(info.present) soc=\(soc) "
-                                 + "serial=\(WhoopSerialIdentity.logSafe(info.serial)) "
+                                 + "serial=\(WhoopSerialIdentity.logSafe(serial: info.serial)) "
                                  + "displayable=\(info.displayable) (#1303)")
                 } else {
                     state.append(log: "[pack] cmd 151 replied but did not decode — offsets may have moved")

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -3215,7 +3215,11 @@ final class Repository: ObservableObject {
     }
 }
 
-private extension DailyMetric {
+// `internal`, not `private`: `DailySkinTempAbsoluteCarryTests` exercises these two directly, and a
+// `private` extension is invisible even to `@testable import`. They stayed private because the tests
+// that call them have never compiled (StrandTests runs only in the on-demand app-build), so nothing
+// ever demanded the wider access. Still confined to this module.
+extension DailyMetric {
     /// A copy of self where every nil field is backfilled from `fallback`. Used by the field-by-field
     /// daily merge so an imported export keeps its own values while a computed row fills the gaps it
     /// doesn't carry (e.g. on-device Charge / skin-temp deviation / activity totals).

--- a/StrandTests/DailySkinTempAbsoluteCarryTests.swift
+++ b/StrandTests/DailySkinTempAbsoluteCarryTests.swift
@@ -14,14 +14,25 @@ import WhoopStore
 /// automatically, so there is no equivalent seam to drop a column at).
 final class DailySkinTempAbsoluteCarryTests: XCTestCase {
 
+    /// `DailyMetric`'s initializer defaults only from `spo2Pct` onward — its first twelve parameters are
+    /// required. Every case here needs two or three of them, so they go through this rather than each
+    /// spelling out ten `nil`s, and the sleep-carry cases below cannot drift into compact calls that do
+    /// not compile. (They did: these tests shipped uncompilable in #1879, and `StrandTests` runs only in
+    /// the on-demand app-build, so nothing said so.)
     private func row(day: String = "2026-08-25",
+                     totalSleepMin: Double? = nil,
+                     deepMin: Double? = nil,
+                     remMin: Double? = nil,
+                     lightMin: Double? = nil,
+                     restingHr: Int? = nil,
                      skinTempC: Double? = nil,
                      skinTempDevC: Double? = nil,
-                     avgHrv: Double? = nil) -> DailyMetric {
-        DailyMetric(day: day, totalSleepMin: nil, efficiency: nil, deepMin: nil, remMin: nil,
-                    lightMin: nil, disturbances: nil, restingHr: nil, avgHrv: avgHrv,
-                    recovery: nil, strain: nil, exerciseCount: nil,
-                    skinTempDevC: skinTempDevC, skinTempC: skinTempC)
+                     avgHrv: Double? = nil,
+                     sleepHrOnly: Bool? = nil) -> DailyMetric {
+        DailyMetric(day: day, totalSleepMin: totalSleepMin, efficiency: nil, deepMin: deepMin,
+                    remMin: remMin, lightMin: lightMin, disturbances: nil, restingHr: restingHr,
+                    avgHrv: avgHrv, recovery: nil, strain: nil, exerciseCount: nil,
+                    skinTempDevC: skinTempDevC, skinTempC: skinTempC, sleepHrOnly: sleepHrOnly)
     }
 
     /// An imported winner carries no absolute, so the computed filler's must survive the coalesce.
@@ -82,28 +93,28 @@ final class DailySkinTempAbsoluteCarryTests: XCTestCase {
     func testScoringKeepsTheStagingFlag() throws {
         let scored = row(skinTempC: 34.6).with(recovery: 0.71, skinTempDevC: 0.52, skinTempC: 34.6)
         XCTAssertNil(scored.sleepHrOnly, "a row that never carried the flag must not invent one")
-        let hrOnly = DailyMetric(day: "2026-09-03", sleepHrOnly: true)
+        let hrOnly = row(day: "2026-09-03", sleepHrOnly: true)
             .with(recovery: 0.71, skinTempDevC: nil, skinTempC: nil)
         XCTAssertEqual(hrOnly.sleepHrOnly, true, "scoring must not discard how the night was staged")
     }
 
     func testASleepEditKeepsTheStagingFlag() {
-        let edited = DailyMetric(day: "2026-09-03", sleepHrOnly: true)
+        let edited = row(day: "2026-09-03", sleepHrOnly: true)
             .with(totalSleepMin: 400, efficiency: 0.93, deepMin: 80, remMin: 100, lightMin: 220)
         // Correcting the wake window does not change whether the strap banked any motion.
         XCTAssertEqual(edited.sleepHrOnly, true)
     }
 
     func testAnImportedRowTakesTheComputedStagingFlag() {
-        let imported = DailyMetric(day: "2026-09-03")
-        let computed = DailyMetric(day: "2026-09-03", sleepHrOnly: true)
+        let imported = row(day: "2026-09-03")
+        let computed = row(day: "2026-09-03", sleepHrOnly: true)
         XCTAssertEqual(imported.fillingNilFields(from: computed).sleepHrOnly, true,
                        "only a scoring pass knows the staging; an import's nil must not erase it")
     }
 
     func testTheFlagMovesWithTheSleepColumnsItDescribes() {
-        let importRow = DailyMetric(day: "2026-09-03", totalSleepMin: 300)
-        let editedComputed = DailyMetric(day: "2026-09-03", totalSleepMin: 400, sleepHrOnly: true)
+        let importRow = row(day: "2026-09-03", totalSleepMin: 300)
+        let editedComputed = row(day: "2026-09-03", totalSleepMin: 400, sleepHrOnly: true)
         let merged = importRow.takingSleepFields(from: editedComputed)
         XCTAssertEqual(merged.totalSleepMin, 400)
         // The flag describes THOSE stage figures, so it travels with them rather than staying behind.
@@ -112,15 +123,15 @@ final class DailySkinTempAbsoluteCarryTests: XCTestCase {
 
     /// The Swift twin of the Kotlin coalesce cases: the flag belongs to the sleep GROUP.
     func testTheStagingFlagMovesWithTheSleepBlock() {
-        let winner = DailyMetric(day: "2026-09-03", restingHr: 55)
-        let filler = DailyMetric(day: "2026-09-03", totalSleepMin: 400, deepMin: 39,
+        let winner = row(day: "2026-09-03", restingHr: 55)
+        let filler = row(day: "2026-09-03", totalSleepMin: 400, deepMin: 39,
                                  remMin: 54, lightMin: 57, sleepHrOnly: true)
         XCTAssertEqual(Repository.coalesceDay(winner, filler).sleepHrOnly, true)
     }
 
     func testAWinnerThatOwnsTheSleepBlockKeepsItsOwnStagingFlag() {
-        let winner = DailyMetric(day: "2026-09-03", totalSleepMin: 420, deepMin: 90, sleepHrOnly: false)
-        let filler = DailyMetric(day: "2026-09-03", totalSleepMin: 300, sleepHrOnly: true)
+        let winner = row(day: "2026-09-03", totalSleepMin: 420, deepMin: 90, sleepHrOnly: false)
+        let filler = row(day: "2026-09-03", totalSleepMin: 300, sleepHrOnly: true)
         XCTAssertEqual(Repository.coalesceDay(winner, filler).sleepHrOnly, false)
     }
 }

--- a/StrandTests/DayCycleRecoveryTests.swift
+++ b/StrandTests/DayCycleRecoveryTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import StrandAnalytics
 import WhoopStore
 @testable import Strand
 


### PR DESCRIPTION
`main` does not currently compile on iOS or macOS. This restores both, and `app-build` is **green on this branch** (run 33952090013) after four rounds of the gate reporting one layer at a time.

## What was broken

| Fix | Introduced by | Since |
|---|---|---|
| `WhoopSerialIdentity.logSafe(serial:)` called positionally in `FrameRouter` | #1635 copy change | today |
| `DailyMetric(day:sleepHrOnly:)` compact inits — the initializer's first twelve parameters are required | #1879 | earlier |
| `fillingNilFields` / `takingSleepFields` in a `private extension`, invisible even to `@testable` | pre-existing | — |
| `DayCycleRecoveryTests` using `UserProfile` without importing StrandAnalytics | #1572 | on merge |

The `logSafe` one is the live breakage: Kotlin accepts a positional argument so the Android twin compiled and looked correct, while Swift requires the label and both Apple targets stopped building.

## Why none of it was caught

A PR touching only `Strand/` and `android/` runs **no check that compiles Swift**. The package matrix needs `Packages/`; `StrandTests` runs only in the on-demand `app-build`, which is disabled by default. So a green tick on such a PR means Android and the Python tools — nothing about the Apple targets.

That is how four independent breakages accumulated unnoticed, one of them from a community PR. It also means a test file can be merged in a state where it has never compiled and stay that way indefinitely, which is what happened to two of the four above.

## The fixes

Each is the smallest thing that makes the code reachable, not a rewrite:

- The label is added at the call site.
- `DailySkinTempAbsoluteCarryTests` already had a `row(...)` helper filling the twelve required parameters; the sleep-carry cases now use it and it carries the fields they need, so none can drift back into a compact call.
- The `private extension` becomes `internal` — still module-confined. It stayed private only because the tests calling it never ran.
- One missing import.

## Verification

- **`app-build` SUCCESS on both targets** — the only check that compiles this code.
- Android suite unaffected and green; Swift files parse.
- No behaviour change: an argument label, a test helper, an access level, an import.

## Worth doing separately

This will recur. Either make `app-build` required for `Strand/**` changes, or add a cheap compile-only job to the default checks. Without one, the next Swift-only PR merges with the same blind spot.
