### PR TITLE
ble: stop the suppression log telling a refusing strap to retry, on both platforms

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/ScanAdvertisementSummary.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/ScanAdvertisementSummary.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// A redacted description of what a strap ADVERTISED, for the #1635 pairing-mode question.
+///
+/// The one thing no strap log can currently answer is the question the field report put back to the
+/// thread: *was the strap in pairing mode during any of those refusals?* A strap that accepts pairing
+/// almost certainly advertises differently from one that refuses, but the scan path reads only the
+/// device name and discards the rest, so the evidence is thrown away at the moment it exists.
+///
+/// It is also the ONLY diagnostic on this path that still works unbonded. The event census and the
+/// battery-pack read both ride characteristics that need an encrypted link, so on the strap we are
+/// actually trying to debug they are silent by construction. An advertisement arrives before any of it.
+///
+/// STRUCTURE, NOT PAYLOAD. The local name can carry a person's name ("<Name>'s Whoop" is what WHOOP
+/// sets by default), service data can carry a serial, and manufacturer data is opaque. So this reports
+/// what is PRESENT and how big it is and never a byte of any of it — enough to tell two advertising
+/// modes apart, which is the whole question, and carrying nothing identifying.
+///
+/// Kotlin twin: `ScanAdvertisementSummary`.
+public enum ScanAdvertisementSummary {
+
+    /// - Parameters:
+    ///   - localNameLength: the local name's SIZE, which can differ between advertising modes and,
+    ///     unlike the name itself, identifies nobody.
+    public static func line(flags: Int?,
+                            serviceUuids: [String],
+                            serviceDataLengths: [String: Int],
+                            manufacturerDataLengths: [Int: Int],
+                            txPower: Int?,
+                            localNameLength: Int?,
+                            connectable: Bool) -> String {
+        var parts: [String] = []
+        parts.append("flags=" + (flags.map { String(format: "0x%02x", $0) } ?? "none"))
+        parts.append("connectable=\(connectable)")
+        parts.append("svc=" + (serviceUuids.isEmpty ? "none" : serviceUuids.sorted().joined(separator: ",")))
+        parts.append("svcData=" + (serviceDataLengths.isEmpty ? "none"
+            : serviceDataLengths.sorted { $0.key < $1.key }.map { "\($0.key):\($0.value)B" }.joined(separator: ",")))
+        parts.append("mfg=" + (manufacturerDataLengths.isEmpty ? "none"
+            : manufacturerDataLengths.sorted { $0.key < $1.key }
+                .map { String(format: "0x%04x:%dB", $0.key, $0.value) }.joined(separator: ",")))
+        parts.append("tx=" + (txPower.map(String.init) ?? "none"))
+        parts.append("nameLen=" + (localNameLength.map(String.init) ?? "none"))
+        return "[adv] " + parts.joined(separator: " ")
+    }
+}

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/ScanAdvertisementSummary.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/ScanAdvertisementSummary.swift
@@ -20,8 +20,8 @@ import Foundation
 public enum ScanAdvertisementSummary {
 
     /// - Parameters:
-    ///   - localNameLength: the local name's SIZE, which can differ between advertising modes and,
-    ///     unlike the name itself, identifies nobody.
+    ///   - localNameLength: the local name's SIZE IN UTF-8 BYTES (see `localNameLength(_:)`), which can
+    ///     differ between advertising modes and, unlike the name itself, identifies nobody.
     public static func line(flags: Int?,
                             serviceUuids: [String],
                             serviceDataLengths: [String: Int],
@@ -63,4 +63,20 @@ public enum ScanAdvertisementSummary {
         default: return s
         }
     }
+
+    /// The local name's size in UTF-8 BYTES — what the advertisement actually carries.
+    ///
+    /// NOT `String.count`. Swift counts grapheme clusters and Java's `String.length` counts UTF-16 code
+    /// units, so a strap named "Whoop 🎉" reported 7 on iOS and 8 on Android — the same divergence, and
+    /// for the same reason, as the short-UUID spelling this file already canonicalises. Names carry
+    /// emoji and accents routinely (WHOOP seeds the name from the account holder), so this was not a
+    /// theoretical case.
+    ///
+    /// Bytes rather than either platform's string model because the AD local-name field IS a UTF-8 byte
+    /// run: it is the physically meaningful number, and it is identical on both platforms by
+    /// construction instead of by one imitating the other.
+    public static func localNameLength(_ name: String?) -> Int? {
+        name.map { $0.utf8.count }
+    }
+
 }

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/ScanAdvertisementSummary.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/ScanAdvertisementSummary.swift
@@ -32,14 +32,35 @@ public enum ScanAdvertisementSummary {
         var parts: [String] = []
         parts.append("flags=" + (flags.map { String(format: "0x%02x", $0) } ?? "none"))
         parts.append("connectable=\(connectable)")
-        parts.append("svc=" + (serviceUuids.isEmpty ? "none" : serviceUuids.sorted().joined(separator: ",")))
-        parts.append("svcData=" + (serviceDataLengths.isEmpty ? "none"
-            : serviceDataLengths.sorted { $0.key < $1.key }.map { "\($0.key):\($0.value)B" }.joined(separator: ",")))
+        let svc = serviceUuids.map(canonicalUuid).sorted()
+        parts.append("svc=" + (svc.isEmpty ? "none" : svc.joined(separator: ",")))
+        // Normalise BEFORE sorting: the canonical form reorders keys that the short form would not.
+        let svcData = serviceDataLengths.map { (canonicalUuid($0.key), $0.value) }.sorted { $0.0 < $1.0 }
+        parts.append("svcData=" + (svcData.isEmpty ? "none"
+            : svcData.map { "\($0.0):\($0.1)B" }.joined(separator: ",")))
         parts.append("mfg=" + (manufacturerDataLengths.isEmpty ? "none"
             : manufacturerDataLengths.sorted { $0.key < $1.key }
                 .map { String(format: "0x%04x:%dB", $0.key, $0.value) }.joined(separator: ",")))
         parts.append("tx=" + (txPower.map(String.init) ?? "none"))
         parts.append("nameLen=" + (localNameLength.map(String.init) ?? "none"))
         return "[adv] " + parts.joined(separator: " ")
+    }
+
+    /// Expand an assigned short Bluetooth UUID to its canonical 128-bit form; pass anything else through.
+    ///
+    /// CoreBluetooth renders an assigned 16-bit UUID as "180d" and a 32-bit one as "0000180d", where
+    /// Android's `UUID.toString()` always expands to the full base UUID. Unnormalised, the same strap
+    /// advertising Heart Rate Service logs a different string on each platform, so an iOS capture cannot
+    /// be compared against an Android one — which is exactly what this line exists to allow. Normalising
+    /// inside `line` rather than at the call site means neither platform's scan path can forget to do it.
+    ///
+    /// A no-op on Android, whose input is already 128-bit; it lives in both twins so the two formatters
+    /// stay behaviourally identical rather than agreeing only by accident of their inputs.
+    static func canonicalUuid(_ s: String) -> String {
+        switch s.count {
+        case 4: return "0000\(s)-0000-1000-8000-00805f9b34fb"
+        case 8: return "\(s)-0000-1000-8000-00805f9b34fb"
+        default: return s
+        }
     }
 }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ScanAdvertisementSummaryTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ScanAdvertisementSummaryTests.swift
@@ -91,4 +91,16 @@ final class ScanAdvertisementSummaryTests: XCTestCase {
         let full = "61080001-8d6d-82b8-614a-1c8cb0f8dcc6"
         XCTAssertEqual(ScanAdvertisementSummary.canonicalUuid(full), full)
     }
+
+    /// The other cross-platform trap in this line, and the reason it is measured in bytes.
+    ///
+    /// Swift's `String.count` would say 7 for this name and Java's `String.length` would say 8, so the
+    /// same strap logged a different size on each platform. The Kotlin twin asserts the SAME 10.
+    func testLocalNameLengthIsUtf8BytesNotCharacters() {
+        XCTAssertEqual(ScanAdvertisementSummary.localNameLength("Whoop \u{1F389}"), 10)
+        XCTAssertEqual("Whoop \u{1F389}".count, 7, "guards the premise: characters would disagree")
+        XCTAssertEqual(ScanAdvertisementSummary.localNameLength("Ryan's Whoop"), 12)
+        XCTAssertNil(ScanAdvertisementSummary.localNameLength(nil))
+    }
+
 }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ScanAdvertisementSummaryTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ScanAdvertisementSummaryTests.swift
@@ -25,7 +25,7 @@ final class ScanAdvertisementSummaryTests: XCTestCase {
     /// The headline guarantee: shape is reported, payload never is.
     func testSummaryCarriesNoPayloadBytesAndNoName() {
         let s = line(svcData: ["fd4b": 9], mfg: [0x01D9: 14], nameLen: 13)
-        XCTAssertTrue(s.contains("fd4b:9B"))
+        XCTAssertTrue(s.contains("0000fd4b-0000-1000-8000-00805f9b34fb:9B"))
         XCTAssertTrue(s.contains("0x01d9:14B"))
         XCTAssertTrue(s.contains("nameLen=13"))
         XCTAssertFalse(s.contains("Whoop"))
@@ -41,7 +41,7 @@ final class ScanAdvertisementSummaryTests: XCTestCase {
         XCTAssertTrue(normal.contains("flags=0x06"))
         XCTAssertTrue(pairing.contains("flags=0x05"))
         XCTAssertTrue(normal.contains("svcData=none"))
-        XCTAssertTrue(pairing.contains("fd4b:4B"))
+        XCTAssertTrue(pairing.contains("0000fd4b-0000-1000-8000-00805f9b34fb:4B"))
     }
 
     /// Absent fields say so rather than vanishing, so two logs stay comparable field by field.
@@ -70,5 +70,25 @@ final class ScanAdvertisementSummaryTests: XCTestCase {
     func testConnectabilityIsReported() {
         XCTAssertTrue(line(connectable: true).contains("connectable=true"))
         XCTAssertTrue(line(connectable: false).contains("connectable=false"))
+    }
+
+    /// The cross-platform guarantee. CoreBluetooth reports an assigned 16-bit UUID as "180d" while
+    /// Android always expands it, so without canonicalisation the SAME strap would log two different
+    /// lines and an iOS capture could not be diffed against an Android one. Both spellings must collapse
+    /// to one string — this is the assertion the Kotlin twin makes verbatim.
+    func testShortAndLongUuidSpellingsProduceTheSameLine() {
+        let short = line(svc: ["180d"], svcData: ["fd4b": 4])
+        let long = line(svc: ["0000180d-0000-1000-8000-00805f9b34fb"],
+                        svcData: ["0000fd4b-0000-1000-8000-00805f9b34fb": 4])
+        XCTAssertEqual(short, long)
+        XCTAssertTrue(short.contains("svc=0000180d-0000-1000-8000-00805f9b34fb"))
+    }
+
+    /// A 32-bit assigned UUID takes the same base, and a 128-bit one is passed through untouched.
+    func testCanonicalisationCoversThirtyTwoBitAndLeavesFullUuidsAlone() {
+        XCTAssertEqual(ScanAdvertisementSummary.canonicalUuid("0000180d"),
+                       "0000180d-0000-1000-8000-00805f9b34fb")
+        let full = "61080001-8d6d-82b8-614a-1c8cb0f8dcc6"
+        XCTAssertEqual(ScanAdvertisementSummary.canonicalUuid(full), full)
     }
 }

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ScanAdvertisementSummaryTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/ScanAdvertisementSummaryTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import XCTest
+@testable import WhoopProtocol
+
+/// The advertisement summary (#1635) — the twin of the Kotlin `ScanAdvertisementSummaryTest`, same
+/// cases and same expected text so the two platforms cannot describe a strap differently.
+///
+/// Its job is to make two advertising modes distinguishable in a strap log without carrying anything
+/// that identifies a person or a device. WHOOP names a strap "<Name>'s Whoop" by default, so the local
+/// name is the one field that must never appear.
+final class ScanAdvertisementSummaryTests: XCTestCase {
+
+    private func line(flags: Int? = 0x06,
+                      svc: [String] = ["61080001-8d6d-82b8-614a-1c8cb0f8dcc6"],
+                      svcData: [String: Int] = [:],
+                      mfg: [Int: Int] = [:],
+                      tx: Int? = nil,
+                      nameLen: Int? = 12,
+                      connectable: Bool = true) -> String {
+        ScanAdvertisementSummary.line(flags: flags, serviceUuids: svc, serviceDataLengths: svcData,
+                                      manufacturerDataLengths: mfg, txPower: tx,
+                                      localNameLength: nameLen, connectable: connectable)
+    }
+
+    /// The headline guarantee: shape is reported, payload never is.
+    func testSummaryCarriesNoPayloadBytesAndNoName() {
+        let s = line(svcData: ["fd4b": 9], mfg: [0x01D9: 14], nameLen: 13)
+        XCTAssertTrue(s.contains("fd4b:9B"))
+        XCTAssertTrue(s.contains("0x01d9:14B"))
+        XCTAssertTrue(s.contains("nameLen=13"))
+        XCTAssertFalse(s.contains("Whoop"))
+        XCTAssertFalse(s.contains("'s"))
+    }
+
+    /// The point of the line: two advertising modes must produce different text, or the #1635 question
+    /// stays unanswerable.
+    func testDifferentAdvertisingModeReadsDifferently() {
+        let normal = line(flags: 0x06, svcData: [:])
+        let pairing = line(flags: 0x05, svcData: ["fd4b": 4])
+        XCTAssertNotEqual(normal, pairing)
+        XCTAssertTrue(normal.contains("flags=0x06"))
+        XCTAssertTrue(pairing.contains("flags=0x05"))
+        XCTAssertTrue(normal.contains("svcData=none"))
+        XCTAssertTrue(pairing.contains("fd4b:4B"))
+    }
+
+    /// Absent fields say so rather than vanishing, so two logs stay comparable field by field.
+    func testAbsentFieldsAreNamedNotOmitted() {
+        let s = line(flags: nil, svc: [], tx: nil, nameLen: nil)
+        XCTAssertTrue(s.contains("flags=none"))
+        XCTAssertTrue(s.contains("svc=none"))
+        XCTAssertTrue(s.contains("tx=none"))
+        XCTAssertTrue(s.contains("nameLen=none"))
+    }
+
+    /// Deterministic ordering, so two captures diff cleanly instead of by dictionary order.
+    func testOutputIsStableRegardlessOfInputOrder() {
+        let a = ScanAdvertisementSummary.line(flags: 6, serviceUuids: ["b", "a"],
+                                              serviceDataLengths: ["y": 1, "x": 2],
+                                              manufacturerDataLengths: [2: 1, 1: 2],
+                                              txPower: nil, localNameLength: 4, connectable: true)
+        let b = ScanAdvertisementSummary.line(flags: 6, serviceUuids: ["a", "b"],
+                                              serviceDataLengths: ["x": 2, "y": 1],
+                                              manufacturerDataLengths: [1: 2, 2: 1],
+                                              txPower: nil, localNameLength: 4, connectable: true)
+        XCTAssertEqual(a, b)
+    }
+
+    /// Connectability separates a pairing-ready strap from a beacon-only one.
+    func testConnectabilityIsReported() {
+        XCTAssertTrue(line(connectable: true).contains("connectable=true"))
+        XCTAssertTrue(line(connectable: false).contains("connectable=false"))
+    }
+}

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1260,6 +1260,11 @@ public final class BLEManager: NSObject, ObservableObject {
     /// rather than on every tick of the family-rotation timer.
     private var lastBlockedConnectReason: String?
 
+    /// #1635: one `ScanAdvertisementSummary` line per SCAN, not per process — the question it answers
+    /// is only visible by comparing a scan before the strap was put in pairing mode against one after,
+    /// so `startScan` reopens it.
+    private var advertisementLogged = false
+
     /// Stable device id; matches the server's existing device for sync parity. Overridable.
     /// Seeded from the init argument, then refined once in bootstrapStore() to the device registry's
     /// active id (still "my-whoop" today) before any store writes use it — see bootstrapStore().
@@ -4623,6 +4628,7 @@ public final class BLEManager: NSObject, ObservableObject {
     /// from the already-gated `connectFromSystem` — and this method's own family-rotation timer, which
     /// cannot start a scan that one of those did not. Gating here as well would block the user's Connect.
     private func startScan(for model: WhoopModel, allowFallback: Bool) {
+        advertisementLogged = false
         cancelScanFallback()
         selectedModel = model
         reassembler = Reassembler(family: model.deviceFamily)
@@ -5349,6 +5355,32 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
                                advertisementData: [String: Any],
                                rssi RSSI: NSNumber) {
         let name = (advertisementData[CBAdvertisementDataLocalNameKey] as? String) ?? peripheral.name ?? "unknown"
+        // #1635: what the strap ADVERTISED, once per scan. The open question there is whether a
+        // refusing strap was in pairing mode, and a strap that accepts pairing should advertise
+        // differently — but nothing recorded the advertisement, so no log could say. Structure only,
+        // never payload: see `ScanAdvertisementSummary`. Test Centre gated. CoreBluetooth exposes no AD
+        // flags byte, so that field reads `none` here and carries on the Kotlin side.
+        if !advertisementLogged, TestCentre.active(.connection) {
+            advertisementLogged = true
+            let svc = (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID])?
+                .map { $0.uuidString.lowercased() } ?? []
+            var svcLens: [String: Int] = [:]
+            if let sd = advertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID: Data] {
+                for (k, v) in sd { svcLens[k.uuidString.lowercased()] = v.count }
+            }
+            var mfgLens: [Int: Int] = [:]
+            if let md = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data, md.count >= 2 {
+                mfgLens[Int(md[0]) | (Int(md[1]) << 8)] = md.count - 2
+            }
+            state.append(log: ScanAdvertisementSummary.line(
+                flags: nil,
+                serviceUuids: svc,
+                serviceDataLengths: svcLens,
+                manufacturerDataLengths: mfgLens,
+                txPower: (advertisementData[CBAdvertisementDataTxPowerLevelKey] as? NSNumber)?.intValue,
+                localNameLength: (advertisementData[CBAdvertisementDataLocalNameKey] as? String)?.count,
+                connectable: (advertisementData[CBAdvertisementDataIsConnectable] as? NSNumber)?.boolValue ?? true))
+        }
         // #716: the seeded "my-whoop" device has model "WHOOP" (no generation). Once a live scan
         // confirms which service family the strap advertises, stamp the correct model so
         // forRegistryModel returns the right DeviceFamily (fixes skin-temp ADC scale + display).

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -6065,7 +6065,11 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                 helloRetryRequested = false
                 let helloSuppressed = HelloSuppressionStore.suppressed(peripheral.identifier.uuidString)
                 if !shouldSendClientHello(suppressedForDevice: helloSuppressed, userInitiated: helloUserAsked) {
-                    log("WHOOP 5/MG: CLIENT_HELLO suppressed for this strap - it was never acknowledged and the write is what drops the link. Staying on live HR (not fully paired); press Connect to try the handshake again (#1635).")
+                    // #1635: says what happened and what has actually worked, not "try again". This strap
+                    // refuses the handshake, so a retry is the one thing that cannot help - and suggesting
+                    // it invites the hammering this suppression exists to stop. Mirrors the user-facing
+                    // hint, which lost the same ending.
+                    log("WHOOP 5/MG: CLIENT_HELLO suppressed for this strap - it was never acknowledged and the write is what drops the link. Staying on live HR (not fully paired). Some straps have paired again after being put in pairing mode (tap until the LEDs flash blue) (#1635).")
                     state.pairingHint = BondRefusalGiveUp.helloSuppressedHint()
                     // The unbonded DIS attempt rides HERE and nowhere else: this is the only 5/MG state
                     // known to be stable - the handshake is off and the link is holding - and it is now

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -5378,7 +5378,8 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
                 serviceDataLengths: svcLens,
                 manufacturerDataLengths: mfgLens,
                 txPower: (advertisementData[CBAdvertisementDataTxPowerLevelKey] as? NSNumber)?.intValue,
-                localNameLength: (advertisementData[CBAdvertisementDataLocalNameKey] as? String)?.count,
+                localNameLength: ScanAdvertisementSummary.localNameLength(
+                    advertisementData[CBAdvertisementDataLocalNameKey] as? String),
                 connectable: (advertisementData[CBAdvertisementDataIsConnectable] as? NSNumber)?.boolValue ?? true))
         }
         // #716: the seeded "my-whoop" device has model "WHOOP" (no generation). Once a live scan

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -5355,6 +5355,9 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
                                advertisementData: [String: Any],
                                rssi RSSI: NSNumber) {
         let name = (advertisementData[CBAdvertisementDataLocalNameKey] as? String) ?? peripheral.name ?? "unknown"
+        // The raw name goes to the DEVICE LIST (the user's own screen, where they need to recognise
+        // their strap); only the log gets the model-only form. See LiveState.logSafeDeviceName.
+        let safeName = LiveState.logSafeDeviceName(name)
         // #1635: what the strap ADVERTISED, once per scan. The open question there is whether a
         // refusing strap was in pairing mode, and a strap that accepts pairing should advertise
         // differently — but nothing recorded the advertisement, so no log could say. Structure only,
@@ -5400,10 +5403,10 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         )
         if !scanDecision.shouldConnect {
             if let family = scanDecision.unsupportedFamily {
-                log("Discovered \(name) (rssi \(RSSI)) — \(family.diagnosticUnsupportedMessage)")
+                log("Discovered \(safeName) (rssi \(RSSI)) — \(family.diagnosticUnsupportedMessage)")
                 return
             }
-            log("Discovered \(name) (rssi \(RSSI)) without \(selectedModel.displayName) service — ignoring")
+            log("Discovered \(safeName) (rssi \(RSSI)) without \(selectedModel.displayName) service — ignoring")
             return
         }
         // Multi-WHOOP present-scan (Add-a-WHOOP wizard): collect the strap, do NOT auto-connect, and
@@ -5424,14 +5427,14 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
         // WHOOP default) this guard is skipped and the original "connect to the first discovered" path
         // below is byte-for-byte unchanged.
         if let preferred = preferredPeripheralUUID, peripheral.identifier != preferred {
-            log("Discovered \(name) (\(peripheral.identifier)) — not the preferred strap; ignoring")
+            log("Discovered \(safeName) (\(peripheral.identifier)) — not the preferred strap; ignoring")
             return
         }
         // No gate here for the same reason as `startScan`: reaching a discovery means a scan is running,
         // and a scan only runs because the user asked or because the gated system entry allowed it.
         cancelScanFallback()
         persistSelectedModel(selectedModel)
-        log("Discovered \(name) (rssi \(RSSI)) — connecting")
+        log("Discovered \(safeName) (rssi \(RSSI)) — connecting")
         central.stopScan()
         preparePeripheral(peripheral)
         central.connect(peripheral, options: nil)

--- a/Strand/BLE/FTMSSource.swift
+++ b/Strand/BLE/FTMSSource.swift
@@ -200,7 +200,7 @@ extension FTMSSource: @preconcurrency CBCentralManagerDelegate {
         seenPeripherals[id] = peripheral
         let advName = advertisementData[CBAdvertisementDataLocalNameKey] as? String
         let name = advName ?? peripheral.name ?? "Gym Equipment"
-        if firstSight { log("FTMS: found \(name) (\(id)) rssi \(RSSI.intValue)") }
+        if firstSight { log("FTMS: found \(LiveState.logSafeDeviceName(name)) (\(id)) rssi \(RSSI.intValue)") }
         let machine = DiscoveredMachine(id: id, name: name, rssi: RSSI.intValue)
         if let idx = discovered.firstIndex(where: { $0.id == id }) {
             discovered[idx] = machine

--- a/Strand/BLE/HuamiHRSource.swift
+++ b/Strand/BLE/HuamiHRSource.swift
@@ -230,7 +230,7 @@ extension HuamiHRSource: @preconcurrency CBCentralManagerDelegate {
         let id = peripheral.identifier
         let firstSight = seenPeripherals[id] == nil
         seenPeripherals[id] = peripheral
-        if firstSight { log("Huami: found \(name) (\(id)) rssi \(RSSI.intValue)") }
+        if firstSight { log("Huami: found \(LiveState.logSafeDeviceName(name)) (\(id)) rssi \(RSSI.intValue)") }
         let dev = DiscoveredDevice(id: id, name: name.isEmpty ? brand.displayBrand : name, rssi: RSSI.intValue)
         if let idx = discovered.firstIndex(where: { $0.id == id }) {
             discovered[idx] = dev

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -833,15 +833,21 @@ public final class LiveState: ObservableObject {
 
     /// Tokens that identify a MODEL rather than a person, for `logSafeDeviceName`.
     ///
-    /// Three shapes: a known vendor or product word, a version number ("4.0"), and a short model code
-    /// ("H10", "OH1"). The model code is bounded to at most four letters and three digits precisely
-    /// because it is the one loose rule here - it must not become a hole a personal name fits through,
-    /// and a name without digits cannot match it at all.
+    /// Two shapes only, both EXACT: a known vendor, product or model word, and a version number ("4.0").
+    ///
+    /// There is deliberately no letters-plus-digits pattern for model codes. One was tried and it
+    /// defeated the whole design: "[a-z]{1,4}\\d{1,3}" matches "Ryan1" and "Sam99" as readily as "H10",
+    /// so a first name with a digit passed through untouched. A pattern cannot be an allowlist - the
+    /// moment a rule describes a SHAPE rather than a known value it admits everything else of that
+    /// shape. Model codes are therefore listed one by one.
+    ///
+    /// The cost is that an unlisted device logs as "<name>" until its code is added, which is the right
+    /// direction to fail: a missing model is an inconvenience, a leaked name is not.
     ///
     /// Anything not on this list is DROPPED, which is the point: a naming shape nobody anticipated loses
     /// by default. Kotlin twin: `SAFE_DEVICE_NAME_TOKEN_RE`.
     private static let safeDeviceNameToken = try? NSRegularExpression(
-        pattern: "^(whoop|mg|polar|verity|sense|wahoo|tickr|garmin|hrm|forerunner|fenix|vantage|ignite|amazfit|huami|zepp|xiaomi|mi|band|coospo|magene|suunto|scosche|rhythm|kickr|tacx|elite|cateye|decathlon|kalenji|geonaute|\\d+(\\.\\d+)?|[a-z]{1,4}\\d{1,3})$", options: [.caseInsensitive])
+        pattern: "^(whoop|mg|polar|verity|sense|wahoo|tickr|garmin|hrm|forerunner|fenix|vantage|ignite|amazfit|huami|zepp|xiaomi|mi|band|coospo|magene|suunto|scosche|rhythm|kickr|tacx|elite|cateye|decathlon|kalenji|geonaute|h6|h7|h9|h10|h64|h808s|oh1|dual|\\d+(\\.\\d+)?)$", options: [.caseInsensitive])
 
     /// A device name reduced to what is safe to put in a shared log: the MODEL, never the person.
     ///

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -831,6 +831,32 @@ public final class LiveState: ObservableObject {
         return String(out)
     }
 
+    /// Tokens that identify a MODEL rather than a person: "WHOOP", "MG", and versions like "4.0".
+    private static let safeDeviceNameToken = try? NSRegularExpression(
+        pattern: "^(whoop|mg|\\d+(\\.\\d+)?)$", options: [.caseInsensitive])
+
+    /// A device name reduced to what is safe to put in a shared log: the MODEL, never the person.
+    ///
+    /// WHOOP seeds a strap's name from the account holder ("<FirstName>'s Whoop") and people rename
+    /// straps to anything at all. `redactPii` can only GUESS which words in a line are a name; here the
+    /// whole string IS the advertised name, so the safe move is an ALLOWLIST - keep the tokens known to
+    /// name a model and drop everything else. A naming shape nobody anticipated is then dropped by
+    /// default rather than needing a rule to catch it: "Ryan B's WHOOP 4.0" keeps only "WHOOP 4.0", and
+    /// "Dad's spare" keeps nothing.
+    ///
+    /// The "no name advertised" sentinel survives, because "we saw no name" and "we removed a name" are
+    /// different facts to whoever reads the log. Kotlin twin: `logSafeDeviceName`.
+    nonisolated static func logSafeDeviceName(_ name: String?) -> String {
+        let n = (name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if n.isEmpty || n == "unknown" { return "unknown" }
+        let safe = n.split(whereSeparator: { $0.isWhitespace }).filter { tok in
+            guard let re = Self.safeDeviceNameToken else { return false }
+            let t = String(tok)
+            return re.firstMatch(in: t, range: NSRange(location: 0, length: (t as NSString).length)) != nil
+        }
+        return safe.isEmpty ? "<name>" : "<name> " + safe.joined(separator: " ")
+    }
+
     private static let hexRunRegex = try? NSRegularExpression(pattern: "[0-9a-fA-F]{16,}")
 
     nonisolated static func redactPii(_ s: String) -> String {

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -831,9 +831,17 @@ public final class LiveState: ObservableObject {
         return String(out)
     }
 
-    /// Tokens that identify a MODEL rather than a person: "WHOOP", "MG", and versions like "4.0".
+    /// Tokens that identify a MODEL rather than a person, for `logSafeDeviceName`.
+    ///
+    /// Three shapes: a known vendor or product word, a version number ("4.0"), and a short model code
+    /// ("H10", "OH1"). The model code is bounded to at most four letters and three digits precisely
+    /// because it is the one loose rule here - it must not become a hole a personal name fits through,
+    /// and a name without digits cannot match it at all.
+    ///
+    /// Anything not on this list is DROPPED, which is the point: a naming shape nobody anticipated loses
+    /// by default. Kotlin twin: `SAFE_DEVICE_NAME_TOKEN_RE`.
     private static let safeDeviceNameToken = try? NSRegularExpression(
-        pattern: "^(whoop|mg|\\d+(\\.\\d+)?)$", options: [.caseInsensitive])
+        pattern: "^(whoop|mg|polar|verity|sense|wahoo|tickr|garmin|hrm|forerunner|fenix|vantage|ignite|amazfit|huami|zepp|xiaomi|mi|band|coospo|magene|suunto|scosche|rhythm|kickr|tacx|elite|cateye|decathlon|kalenji|geonaute|\\d+(\\.\\d+)?|[a-z]{1,4}\\d{1,3})$", options: [.caseInsensitive])
 
     /// A device name reduced to what is safe to put in a shared log: the MODEL, never the person.
     ///
@@ -849,11 +857,15 @@ public final class LiveState: ObservableObject {
     nonisolated static func logSafeDeviceName(_ name: String?) -> String {
         let n = (name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         if n.isEmpty || n == "unknown" { return "unknown" }
-        let safe = n.split(whereSeparator: { $0.isWhitespace }).filter { tok in
+        let tokens = n.split(whereSeparator: { $0.isWhitespace })
+        let safe = tokens.filter { tok in
             guard let re = Self.safeDeviceNameToken else { return false }
             let t = String(tok)
             return re.firstMatch(in: t, range: NSRange(location: 0, length: (t as NSString).length)) != nil
         }
+        // Say "<name>" only when something was actually removed. An unrenamed "WHOOP 4.0" or "Polar H10"
+        // carries nothing personal, and prefixing it would claim a redaction that never happened.
+        if safe.count == tokens.count { return n }
         return safe.isEmpty ? "<name>" : "<name> " + safe.joined(separator: " ")
     }
 

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -874,6 +874,22 @@ public final class LiveState: ObservableObject {
         out = out.replacingOccurrences(
             of: "whoop-([A-Za-z0-9]{3})[A-Za-z0-9-]{3,}",
             with: "whoop-$1…", options: .regularExpression)
+        // The account holder's NAME, as WHOOP writes it into the advertised local name. WHOOP names a
+        // strap "<FirstName>'s Whoop" by default and the scan path logs that name on every discovery, so
+        // the shareable log (#445) we ask people to attach to public issues carried a real person's name.
+        // No rule above could see it: they key on MAC shape, "WHOOP " + digit, or a "whoop-" id.
+        //
+        // Keeps the possessive and whatever follows, so "Ryan's WHOOP 4.0" keeps the MODEL, which is
+        // diagnostic and identifies nobody. Matches the curly apostrophe because Apple platforms write
+        // U+2019 into default device names — a straight-quote-only rule would miss this platform's logs.
+        //
+        // LIMITATION, deliberate: exactly ONE token before the possessive, so "Ryan B's Whoop" keeps
+        // "Ryan". A multi-token rule cannot tell a name from the surrounding log text and would swallow
+        // "Discovered" with it. A fully custom name with no possessive stays a known gap. Kotlin twin in
+        // `redactStrapLogPii` as `PII_DEVICE_NAME_RE`.
+        out = out.replacingOccurrences(
+            of: "[\\p{L}\\p{N}_.\\-]+(['\u{2019}]s\\s+(?i:whoop))",
+            with: "<name>$1", options: .regularExpression)
         return out
     }
 

--- a/Strand/BLE/StandardHRSource.swift
+++ b/Strand/BLE/StandardHRSource.swift
@@ -305,7 +305,7 @@ extension StandardHRSource: @preconcurrency CBCentralManagerDelegate {
         seenPeripherals[id] = peripheral
         let advName = advertisementData[CBAdvertisementDataLocalNameKey] as? String
         let name = advName ?? peripheral.name ?? "Heart Rate Strap"
-        if firstSight { log("HR-strap: found \(name) (\(id)) rssi \(RSSI.intValue)") }
+        if firstSight { log("HR-strap: found \(LiveState.logSafeDeviceName(name)) (\(id)) rssi \(RSSI.intValue)") }
         let strap = DiscoveredStrap(id: id, name: name, rssi: RSSI.intValue)
         discovered = Self.upsertByProximity(discovered, strap)
         // If we were scanning specifically to reach this strap (a not-yet-cached active strap), connect now

--- a/StrandTests/PiiRedactionTests.swift
+++ b/StrandTests/PiiRedactionTests.swift
@@ -64,4 +64,18 @@ final class PiiRedactionTests: XCTestCase {
         XCTAssertEqual(LiveState.logSafeDeviceName("   "), "unknown")
     }
 
+
+    /// Third-party straps: the MODEL is the diagnostic, so a name carrying no person survives intact.
+    func testLogSafeDeviceNameKeepsAnUnrenamedThirdPartyModel() {
+        XCTAssertEqual(LiveState.logSafeDeviceName("Polar H10"), "Polar H10")
+        XCTAssertEqual(LiveState.logSafeDeviceName("TICKR"), "TICKR")
+        XCTAssertEqual(LiveState.logSafeDeviceName("WHOOP 4.0"), "WHOOP 4.0")
+    }
+
+    /// ...but a renamed one loses the person and keeps the model.
+    func testLogSafeDeviceNameStripsThePersonFromARenamedThirdPartyStrap() {
+        XCTAssertEqual(LiveState.logSafeDeviceName("Ryan's Polar H10"), "<name> Polar H10")
+        XCTAssertEqual(LiveState.logSafeDeviceName("Sarah TICKR"), "<name> TICKR")
+    }
+
 }

--- a/StrandTests/PiiRedactionTests.swift
+++ b/StrandTests/PiiRedactionTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import Strand
+
+/// The account holder's NAME in the shareable strap log (#445).
+///
+/// WHOOP names a strap "<FirstName>'s Whoop" by default, and the scan path logs that advertised name on
+/// every discovery, so the file we ask people to attach to public issues carried a real person's name.
+/// None of the other rules in `LiveState.redactPii` could see it: they key on MAC shape, a "WHOOP " +
+/// digit serial, or a "whoop-" id.
+///
+/// Twin of the Kotlin `PiiRedactionTest` name cases, same inputs and same expected text, so the two
+/// platforms cannot redact a log differently.
+final class PiiRedactionTests: XCTestCase {
+
+    func testPersonalNameInDiscoveryLineIsRedacted() {
+        XCTAssertEqual(
+            LiveState.redactPii("Discovered Ryan's Whoop (rssi -55) - connecting"),
+            "Discovered <name>'s Whoop (rssi -55) - connecting")
+    }
+
+    /// Apple platforms write U+2019 into default device names, so the straight quote is not enough —
+    /// a straight-quote-only rule would miss this platform's own logs.
+    func testCurlyApostropheNameIsRedacted() {
+        XCTAssertEqual(
+            LiveState.redactPii("Discovered Ryan\u{2019}s Whoop (rssi -55)"),
+            "Discovered <name>\u{2019}s Whoop (rssi -55)")
+    }
+
+    /// The MODEL after the possessive is diagnostic and identifies nobody, so it must survive.
+    func testModelSurvivesNameRedaction() {
+        XCTAssertEqual(LiveState.redactPii("Ryan's WHOOP 4.0"), "<name>'s WHOOP 4.0")
+    }
+
+    /// The documented gap, pinned so it stays visible rather than assumed: ONE token before the
+    /// possessive. A multi-token rule cannot tell a name from surrounding log text.
+    func testMultiTokenNameKeepsTheLeadingToken() {
+        XCTAssertEqual(LiveState.redactPii("Ryan B's Whoop"), "Ryan <name>'s Whoop")
+    }
+
+    /// The rule must not touch ids or ordinary text that merely contain "whoop".
+    func testNameRuleLeavesIdsAndPlainTextAlone() {
+        XCTAssertEqual(LiveState.redactPii("my-whoop and my-whoop-noop"), "my-whoop and my-whoop-noop")
+        XCTAssertEqual(LiveState.redactPii("no pii here"), "no pii here")
+    }
+}

--- a/StrandTests/PiiRedactionTests.swift
+++ b/StrandTests/PiiRedactionTests.swift
@@ -42,4 +42,26 @@ final class PiiRedactionTests: XCTestCase {
         XCTAssertEqual(LiveState.redactPii("my-whoop and my-whoop-noop"), "my-whoop and my-whoop-noop")
         XCTAssertEqual(LiveState.redactPii("no pii here"), "no pii here")
     }
+
+    /// The name never reaches a shared log at all. The sink rule is defence-in-depth; this is the real
+    /// guarantee, and it is an ALLOWLIST so an unanticipated naming shape is dropped by default.
+    func testLogSafeDeviceNameKeepsOnlyTheModel() {
+        XCTAssertEqual(LiveState.logSafeDeviceName("Ryan's Whoop"), "<name> Whoop")
+        XCTAssertEqual(LiveState.logSafeDeviceName("Ryan B's WHOOP 4.0"), "<name> WHOOP 4.0")
+        XCTAssertEqual(LiveState.logSafeDeviceName("Ryan\u{2019}s WHOOP 5.0 MG"), "<name> WHOOP 5.0 MG")
+    }
+
+    /// A fully custom name has no model token to keep, so nothing of it survives.
+    func testLogSafeDeviceNameDropsAWhollyCustomName() {
+        XCTAssertEqual(LiveState.logSafeDeviceName("Dad's spare"), "<name>")
+        XCTAssertEqual(LiveState.logSafeDeviceName("Sarah"), "<name>")
+    }
+
+    /// "We saw no name" and "we removed a name" are different facts to a reader, so the sentinel stays.
+    func testLogSafeDeviceNameKeepsTheNoNameSentinel() {
+        XCTAssertEqual(LiveState.logSafeDeviceName("unknown"), "unknown")
+        XCTAssertEqual(LiveState.logSafeDeviceName(nil), "unknown")
+        XCTAssertEqual(LiveState.logSafeDeviceName("   "), "unknown")
+    }
+
 }

--- a/StrandTests/PiiRedactionTests.swift
+++ b/StrandTests/PiiRedactionTests.swift
@@ -78,4 +78,21 @@ final class PiiRedactionTests: XCTestCase {
         XCTAssertEqual(LiveState.logSafeDeviceName("Sarah TICKR"), "<name> TICKR")
     }
 
+
+    /// The hole a model-code PATTERN opened, pinned shut. "[a-z]{1,4}\\d{1,3}" was meant to admit "H10"
+    /// and admitted "Ryan1" and "Sam99" with it, passing a first name through untouched. Model codes are
+    /// listed one by one for this reason; if a pattern is ever reintroduced, these fail.
+    func testANameWithDigitsIsNotMistakenForAModelCode() {
+        XCTAssertEqual(LiveState.logSafeDeviceName("Ryan1"), "<name>")
+        XCTAssertEqual(LiveState.logSafeDeviceName("Anna2"), "<name>")
+        XCTAssertEqual(LiveState.logSafeDeviceName("Bob12"), "<name>")
+        XCTAssertEqual(LiveState.logSafeDeviceName("Sam99 Whoop"), "<name> Whoop")
+    }
+
+    /// The listed codes still survive, so the tightening did not cost the diagnostic.
+    func testListedModelCodesStillSurvive() {
+        XCTAssertEqual(LiveState.logSafeDeviceName("Polar H10"), "Polar H10")
+        XCTAssertEqual(LiveState.logSafeDeviceName("Polar OH1"), "Polar OH1")
+    }
+
 }

--- a/android/app/src/main/java/com/noop/ble/FtmsSource.kt
+++ b/android/app/src/main/java/com/noop/ble/FtmsSource.kt
@@ -169,7 +169,7 @@ class FtmsSource(
             val firstSight = seen.put(address, device) == null
             val name = result.scanRecord?.deviceName ?: runCatching { device.name }.getOrNull()
                 ?: "Gym Equipment"
-            if (firstSight) log("FTMS: found $name ($address) rssi ${result.rssi}")
+            if (firstSight) log("FTMS: found ${logSafeDeviceName(name)} ($address) rssi ${result.rssi}")
             val machine = DiscoveredMachine(address = address, name = name, rssi = result.rssi)
             val list = _discovered.value.toMutableList()
             val i = list.indexOfFirst { it.address == address }

--- a/android/app/src/main/java/com/noop/ble/HuamiHrSource.kt
+++ b/android/app/src/main/java/com/noop/ble/HuamiHrSource.kt
@@ -222,7 +222,7 @@ class HuamiHrSource(
             val brand = ExperimentalBrand.recognise(name)
             if (brand != ExperimentalBrand.AMAZFIT && brand != ExperimentalBrand.MI_BAND) return
             val firstSight = seen.put(address, device) == null
-            if (firstSight) log("Huami: found $name ($address) rssi ${result.rssi}")
+            if (firstSight) log("Huami: found ${logSafeDeviceName(name)} ($address) rssi ${result.rssi}")
             val dev = DiscoveredDevice(
                 address = address,
                 name = name.ifBlank { brand.displayBrand },

--- a/android/app/src/main/java/com/noop/ble/ScanAdvertisementSummary.kt
+++ b/android/app/src/main/java/com/noop/ble/ScanAdvertisementSummary.kt
@@ -30,8 +30,8 @@ object ScanAdvertisementSummary {
      * @param serviceDataLengths bytes per service-data UUID, keyed by that UUID.
      * @param manufacturerDataLengths bytes per manufacturer id.
      * @param txPower advertised TX power, or null.
-     * @param localNameLength length of the local name — its SIZE can differ between advertising modes,
-     *   and unlike the name itself it identifies nobody.
+     * @param localNameLength the local name's size in UTF-8 BYTES (see [localNameLength]) — its SIZE can
+     *   differ between advertising modes, and unlike the name itself it identifies nobody.
      * @param connectable whether the advertisement was connectable.
      */
     fun line(
@@ -73,4 +73,20 @@ object ScanAdvertisementSummary {
         8 -> "$s-0000-1000-8000-00805f9b34fb"
         else -> s
     }
+
+    /**
+     * The local name's size in UTF-8 BYTES — what the advertisement actually carries.
+     *
+     * NOT `String.length`. Java counts UTF-16 code units and Swift's `String.count` counts grapheme
+     * clusters, so a strap named "Whoop \uD83C\uDF89" reported 8 here and 7 on iOS — the same divergence,
+     * and for the same reason, as the short-UUID spelling this file already canonicalises. Names carry
+     * emoji and accents routinely (WHOOP seeds the name from the account holder), so this was not a
+     * theoretical case.
+     *
+     * Bytes rather than either platform's string model because the AD local-name field IS a UTF-8 byte
+     * run: it is the physically meaningful number, and it is identical on both platforms by construction
+     * instead of by one imitating the other.
+     */
+    internal fun localNameLength(name: String?): Int? = name?.toByteArray(Charsets.UTF_8)?.size
+
 }

--- a/android/app/src/main/java/com/noop/ble/ScanAdvertisementSummary.kt
+++ b/android/app/src/main/java/com/noop/ble/ScanAdvertisementSummary.kt
@@ -26,7 +26,7 @@ object ScanAdvertisementSummary {
 
     /**
      * @param flags the AD flags byte, or null when the advertisement carries none.
-     * @param serviceUuids advertised service UUIDs, already lowercased short form where possible.
+     * @param serviceUuids advertised service UUIDs, lowercased; short forms are canonicalised here.
      * @param serviceDataLengths bytes per service-data UUID, keyed by that UUID.
      * @param manufacturerDataLengths bytes per manufacturer id.
      * @param txPower advertised TX power, or null.
@@ -46,13 +46,31 @@ object ScanAdvertisementSummary {
         val parts = mutableListOf<String>()
         parts += "flags=" + (flags?.let { "0x%02x".format(it) } ?: "none")
         parts += "connectable=$connectable"
-        parts += "svc=" + if (serviceUuids.isEmpty()) "none" else serviceUuids.sorted().joinToString(",")
-        parts += "svcData=" + if (serviceDataLengths.isEmpty()) "none" else
-            serviceDataLengths.entries.sortedBy { it.key }.joinToString(",") { "${it.key}:${it.value}B" }
+        val svc = serviceUuids.map { canonicalUuid(it) }.sorted()
+        parts += "svc=" + if (svc.isEmpty()) "none" else svc.joinToString(",")
+        // Normalise BEFORE sorting: the canonical form reorders keys that the short form would not.
+        val svcData = serviceDataLengths.map { canonicalUuid(it.key) to it.value }.sortedBy { it.first }
+        parts += "svcData=" + if (svcData.isEmpty()) "none" else
+            svcData.joinToString(",") { "${it.first}:${it.second}B" }
         parts += "mfg=" + if (manufacturerDataLengths.isEmpty()) "none" else
             manufacturerDataLengths.entries.sortedBy { it.key }.joinToString(",") { "0x%04x:%dB".format(it.key, it.value) }
         parts += "tx=" + (txPower?.toString() ?: "none")
         parts += "nameLen=" + (localNameLength?.toString() ?: "none")
         return "[adv] " + parts.joinToString(" ")
+    }
+
+    /**
+     * Expand an assigned short Bluetooth UUID to its canonical 128-bit form; pass anything else through.
+     *
+     * A no-op on Android, whose `UUID.toString()` is always already 128-bit. It exists because
+     * CoreBluetooth renders an assigned 16-bit UUID as "180d" and a 32-bit one as "0000180d", so an
+     * unnormalised iOS capture of the same strap could not be compared against an Android one — which is
+     * exactly what this line exists to allow. Kept in BOTH twins so the formatters stay behaviourally
+     * identical rather than agreeing only by accident of what their callers happen to pass.
+     */
+    internal fun canonicalUuid(s: String): String = when (s.length) {
+        4 -> "0000$s-0000-1000-8000-00805f9b34fb"
+        8 -> "$s-0000-1000-8000-00805f9b34fb"
+        else -> s
     }
 }

--- a/android/app/src/main/java/com/noop/ble/ScanAdvertisementSummary.kt
+++ b/android/app/src/main/java/com/noop/ble/ScanAdvertisementSummary.kt
@@ -1,0 +1,58 @@
+package com.noop.ble
+
+/**
+ * A redacted description of what a strap ADVERTISED, for the #1635 pairing-mode question.
+ *
+ * The one thing no strap log can currently answer is the question the field report put back to the
+ * thread: *was the strap in pairing mode during any of those refusals?* A strap that accepts pairing
+ * almost certainly advertises differently from one that refuses, but the scan path reads only the
+ * device name and discards the rest, so the evidence is thrown away at the moment it exists.
+ *
+ * It is also the ONLY diagnostic on this path that still works unbonded. The event census and the
+ * battery-pack read both ride characteristics that need an encrypted link, so on the strap we are
+ * actually trying to debug they are silent by construction. An advertisement arrives before any of
+ * that.
+ *
+ * STRUCTURE, NOT PAYLOAD. The local name can carry a person's name ("<Name>'s Whoop" is what WHOOP
+ * sets by default), service data can carry a serial, and manufacturer data is opaque. So this reports
+ * what is PRESENT and how big it is — flags, which service UUIDs, which data blocks and their
+ * lengths — and never a byte of any of them. That is enough to tell two advertising modes apart,
+ * which is the whole question, and carries nothing identifying.
+ *
+ * Pure and platform-free so both platforms format it identically and it can be tested without a radio.
+ * Swift twin: `ScanAdvertisementSummary`.
+ */
+object ScanAdvertisementSummary {
+
+    /**
+     * @param flags the AD flags byte, or null when the advertisement carries none.
+     * @param serviceUuids advertised service UUIDs, already lowercased short form where possible.
+     * @param serviceDataLengths bytes per service-data UUID, keyed by that UUID.
+     * @param manufacturerDataLengths bytes per manufacturer id.
+     * @param txPower advertised TX power, or null.
+     * @param localNameLength length of the local name — its SIZE can differ between advertising modes,
+     *   and unlike the name itself it identifies nobody.
+     * @param connectable whether the advertisement was connectable.
+     */
+    fun line(
+        flags: Int?,
+        serviceUuids: List<String>,
+        serviceDataLengths: Map<String, Int>,
+        manufacturerDataLengths: Map<Int, Int>,
+        txPower: Int?,
+        localNameLength: Int?,
+        connectable: Boolean,
+    ): String {
+        val parts = mutableListOf<String>()
+        parts += "flags=" + (flags?.let { "0x%02x".format(it) } ?: "none")
+        parts += "connectable=$connectable"
+        parts += "svc=" + if (serviceUuids.isEmpty()) "none" else serviceUuids.sorted().joinToString(",")
+        parts += "svcData=" + if (serviceDataLengths.isEmpty()) "none" else
+            serviceDataLengths.entries.sortedBy { it.key }.joinToString(",") { "${it.key}:${it.value}B" }
+        parts += "mfg=" + if (manufacturerDataLengths.isEmpty()) "none" else
+            manufacturerDataLengths.entries.sortedBy { it.key }.joinToString(",") { "0x%04x:%dB".format(it.key, it.value) }
+        parts += "tx=" + (txPower?.toString() ?: "none")
+        parts += "nameLen=" + (localNameLength?.toString() ?: "none")
+        return "[adv] " + parts.joinToString(" ")
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
+++ b/android/app/src/main/java/com/noop/ble/StandardHrSource.kt
@@ -386,7 +386,7 @@ class StandardHrSource(
             val firstSight = seen.put(address, device) == null   // null → not seen before this scan
             val name = result.scanRecord?.deviceName ?: runCatching { device.name }.getOrNull()
                 ?: "Heart Rate Strap"
-            if (firstSight) log("HR-strap: found $name ($address) rssi ${result.rssi}")
+            if (firstSight) log("HR-strap: found ${logSafeDeviceName(name)} ($address) rssi ${result.rssi}")
             val strap = DiscoveredStrap(address = address, name = name, rssi = result.rssi)
             _discovered.value = upsertByProximity(_discovered.value, strap)
             // Replay a connect intent that arrived before the device was discovered.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5595,7 +5595,7 @@ class WhoopBleClient(
                                 k to (rec.manufacturerSpecificData.valueAt(i)?.size ?: 0)
                             },
                         txPower = rec?.txPowerLevel?.takeIf { it != Int.MIN_VALUE },
-                        localNameLength = rec?.deviceName?.length,
+                        localNameLength = ScanAdvertisementSummary.localNameLength(rec?.deviceName),
                         connectable = result.isConnectable,
                     ),
                 )

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -11193,6 +11193,26 @@ private val PII_MAC_RE = Regex("([0-9A-Fa-f]{2}):[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[
 private val PII_WHOOP_SERIAL_RE = Regex("WHOOP (\\d[0-9A-Za-z]{5,})")
 
 /**
+ * The account holder's NAME, as WHOOP writes it into the advertised local name.
+ *
+ * WHOOP names a strap "<FirstName>'s Whoop" by default, and the scan path logs that name on every
+ * discovery, so the shareable strap log (#445) — the file we ask people to attach to public issues —
+ * carried a real person's name on both platforms. No other rule here could see it: they all key on
+ * MAC shape, a "WHOOP " + digit serial, or a "whoop-" id.
+ *
+ * Keeps the possessive and whatever follows it, so "Ryan's WHOOP 4.0" becomes "<name>'s WHOOP 4.0" and
+ * the MODEL survives — that part is diagnostic and identifies nobody. Matches a curly apostrophe too:
+ * Apple platforms write U+2019 into default device names, so a straight-quote-only rule would miss the
+ * iOS half of the logs entirely.
+ *
+ * LIMITATION, deliberate: exactly ONE token before the possessive. "Ryan B's Whoop" keeps "Ryan". A
+ * multi-token rule cannot tell a name apart from the surrounding log text and would eat "Discovered"
+ * along with it, mangling the line. This covers WHOOP's default naming, which is what the logs contain;
+ * a fully custom name with no possessive is not detectable here and stays a known gap.
+ */
+private val PII_DEVICE_NAME_RE = Regex("[\\p{L}\\p{N}_.\\-]+(['\u2019]s\\s+(?i:whoop))")
+
+/**
  * #1303: a device id that has ADOPTED its strap serial (`whoop-<SERIAL>`) is a device identifier in every
  * line that prints an id — the Devices list, each `dayOwner`, the per-source counts. Neither existing rule
  * catches it: [PII_MAC_RE] wants MAC shape, and [PII_WHOOP_SERIAL_RE] wants the literal word "WHOOP "
@@ -11402,6 +11422,9 @@ internal fun redactStrapLogPii(s: String): String = try {
         // for an adopted id. The -noop form runs before the general one so the sibling suffix survives.
         .replace(PII_ADOPTED_ID_NOOP_RE, "whoop-$1…$2")
         .replace(PII_ADOPTED_ID_RE, "whoop-$1…")
+        // Last: the name rule keys on literal text no earlier rule produces or consumes, so it neither
+        // masks a substitution marker nor depends on one.
+        .replace(PII_DEVICE_NAME_RE, "<name>$1")
 } catch (t: Throwable) {
     "[redaction error - line withheld]"
 }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -11416,17 +11416,23 @@ internal fun redactHexDumpPii(hex: String): String {
 /**
  * Tokens that identify a MODEL rather than a person, for [logSafeDeviceName].
  *
- * Three shapes: a known vendor or product word, a version number ("4.0"), and a short model code
- * ("H10", "OH1"). The model code is bounded to at most four letters and three digits precisely because
- * it is the one loose rule here - it must not become a hole a personal name fits through, and a name
- * without digits cannot match it at all.
+ * Two shapes only, both EXACT: a known vendor, product or model word, and a version number ("4.0").
+ *
+ * There is deliberately no letters-plus-digits pattern for model codes. One was tried and it defeated
+ * the whole design: "[a-z]{1,4}\\d{1,3}" matches "Ryan1" and "Sam99" as readily as "H10", so a first
+ * name with a digit passed through untouched. A pattern cannot be an allowlist - the moment a rule
+ * describes a SHAPE rather than a known value, it admits everything else of that shape. Model codes are
+ * therefore listed one by one.
+ *
+ * The cost is that an unlisted device logs as "<name>" until its code is added here, which is the right
+ * direction to fail: a missing model is an inconvenience, a leaked name is not.
  *
  * Anything not on this list is DROPPED, which is the point: a naming shape nobody anticipated loses by
  * default. Extend it when a device logs as "<name>" and its model is worth having. Swift twin:
  * `LiveState.safeDeviceNameToken`.
  */
 private val SAFE_DEVICE_NAME_TOKEN_RE =
-    Regex("(?i)(whoop|mg|polar|verity|sense|wahoo|tickr|garmin|hrm|forerunner|fenix|vantage|ignite|amazfit|huami|zepp|xiaomi|mi|band|coospo|magene|suunto|scosche|rhythm|kickr|tacx|elite|cateye|decathlon|kalenji|geonaute|\\d+(\\.\\d+)?|[a-z]{1,4}\\d{1,3})")
+    Regex("(?i)(whoop|mg|polar|verity|sense|wahoo|tickr|garmin|hrm|forerunner|fenix|vantage|ignite|amazfit|huami|zepp|xiaomi|mi|band|coospo|magene|suunto|scosche|rhythm|kickr|tacx|elite|cateye|decathlon|kalenji|geonaute|h6|h7|h9|h10|h64|h808s|oh1|dual|\\d+(\\.\\d+)?)")
 
 /**
  * A device name reduced to what is safe to put in a shared log: the MODEL, never the person.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5576,6 +5576,9 @@ class WhoopBleClient(
         override fun onScanResult(callbackType: Int, result: ScanResult) {
             val device: BluetoothDevice = result.device
             val name = result.scanRecord?.deviceName ?: device.name ?: "unknown"
+            // The raw name goes to the DEVICE LIST (the user's own screen, where they need to recognise
+            // their strap); only the log gets the model-only form. See logSafeDeviceName.
+            val safeName = logSafeDeviceName(name)
             // #1635: what the strap ADVERTISED, once per scan session. The open question on that issue
             // is whether a refusing strap was in pairing mode, and a strap that accepts pairing should
             // advertise differently — but nothing recorded the advertisement, so no log could say.
@@ -5622,11 +5625,11 @@ class WhoopBleClient(
             val scanDecision = whoopGattScanDecision(selectedModel.service.toString(), advertisedServiceUuids)
             if (!scanDecision.shouldConnect) {
                 scanDecision.unsupportedFamily?.let { family ->
-                    log("Discovered $name (rssi ${result.rssi}) — ${family.diagnosticUnsupportedMessage}")
+                    log("Discovered $safeName (rssi ${result.rssi}) — ${family.diagnosticUnsupportedMessage}")
                     _state.update { it.copy(statusNote = family.diagnosticUnsupportedMessage) }
                     return
                 }
-                log("Discovered $name (rssi ${result.rssi}) without ${selectedModel.displayName} service — ignoring")
+                log("Discovered $safeName (rssi ${result.rssi}) without ${selectedModel.displayName} service — ignoring")
                 return
             }
             // Multi-WHOOP present-scan (Add-a-device wizard, MW-4): accumulate the strap, do NOT
@@ -5648,10 +5651,10 @@ class WhoopBleClient(
             // discovered" path below is byte-for-byte unchanged.
             val preferred = preferredAddress
             if (preferred != null && !device.address.equals(preferred, ignoreCase = true)) {
-                log("Discovered $name (${device.address}) — not the preferred strap; ignoring")
+                log("Discovered $safeName (${device.address}) — not the preferred strap; ignoring")
                 return
             }
-            log("Discovered $name (rssi ${result.rssi}) — connecting")
+            log("Discovered $safeName (rssi ${result.rssi}) — connecting")
             // Found it: cancel the not-found timeout AND the family-rotation fallback, then reflect
             // progress in the UI. (PR#195)
             handler.removeCallbacks(scanTimeoutRunnable)
@@ -11408,6 +11411,29 @@ internal fun redactHexDumpPii(hex: String): String {
         out = out.substring(0, start) + "••".repeat(m.value.length) + out.substring(end)
     }
     return out
+}
+
+/** Tokens that identify a MODEL rather than a person: "WHOOP", "MG", and versions like "4.0". */
+private val SAFE_DEVICE_NAME_TOKEN_RE = Regex("(?i)(whoop|mg|\\d+(\\.\\d+)?)")
+
+/**
+ * A device name reduced to what is safe to put in a shared log: the MODEL, never the person.
+ *
+ * WHOOP seeds a strap's name from the account holder ("<FirstName>'s Whoop") and people rename straps
+ * to anything at all. [redactStrapLogPii] can only GUESS which words in a line are a name; here the
+ * whole string IS the advertised name, so the safe move is an ALLOWLIST - keep the tokens known to name
+ * a model and drop everything else. A naming shape nobody anticipated is then dropped by default rather
+ * than needing a rule to catch it: "Ryan B's WHOOP 4.0" keeps only "WHOOP 4.0", and "Dad's spare" keeps
+ * nothing.
+ *
+ * The "no name advertised" sentinel survives, because "we saw no name" and "we removed a name" are
+ * different facts to whoever reads the log. Swift twin: `LiveState.logSafeDeviceName`.
+ */
+internal fun logSafeDeviceName(name: String?): String {
+    val n = name?.trim().orEmpty()
+    if (n.isEmpty() || n == "unknown") return "unknown"
+    val safe = n.split(Regex("\\s+")).filter { SAFE_DEVICE_NAME_TOKEN_RE.matches(it) }
+    return if (safe.isEmpty()) "<name>" else "<name> " + safe.joinToString(" ")
 }
 
 /** Mask MAC addresses and WHOOP serials in a strap-log line before it's shown/exported.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -9058,9 +9058,14 @@ class WhoopBleClient(
                     // didBond stays false, so leaving it armed would just move the drop from ~4.8s out to
                     // the 7s window — the same loop, slower. There is no handshake left to time out.
                     cancelBondWatchdog()
+                    // #1635: says what happened and what has actually worked, not "try again". This
+                    // strap refuses the handshake, so a retry is the one thing that cannot help — and
+                    // suggesting it invites the hammering this suppression exists to stop. Mirrors the
+                    // user-facing hint, which lost the same ending.
                     log("WHOOP 5/MG: CLIENT_HELLO suppressed for this strap — it was never acknowledged and" +
-                        " the write is what drops the link. Staying on live HR (not fully paired); press" +
-                        " Connect to try the handshake again (#1635).")
+                        " the write is what drops the link. Staying on live HR (not fully paired). Some straps" +
+                        " have paired again after being put in pairing mode (tap until the LEDs flash blue)" +
+                        " (#1635).")
                     // #221: republish the pairing hint, which the Devices card's "Connected · not paired"
                     // pill reads. It is otherwise written only where a refusal FRESHLY crosses the give-up,
                     // and the latch that records the give-up outlives the process while the hint did not —

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -11413,8 +11413,20 @@ internal fun redactHexDumpPii(hex: String): String {
     return out
 }
 
-/** Tokens that identify a MODEL rather than a person: "WHOOP", "MG", and versions like "4.0". */
-private val SAFE_DEVICE_NAME_TOKEN_RE = Regex("(?i)(whoop|mg|\\d+(\\.\\d+)?)")
+/**
+ * Tokens that identify a MODEL rather than a person, for [logSafeDeviceName].
+ *
+ * Three shapes: a known vendor or product word, a version number ("4.0"), and a short model code
+ * ("H10", "OH1"). The model code is bounded to at most four letters and three digits precisely because
+ * it is the one loose rule here - it must not become a hole a personal name fits through, and a name
+ * without digits cannot match it at all.
+ *
+ * Anything not on this list is DROPPED, which is the point: a naming shape nobody anticipated loses by
+ * default. Extend it when a device logs as "<name>" and its model is worth having. Swift twin:
+ * `LiveState.safeDeviceNameToken`.
+ */
+private val SAFE_DEVICE_NAME_TOKEN_RE =
+    Regex("(?i)(whoop|mg|polar|verity|sense|wahoo|tickr|garmin|hrm|forerunner|fenix|vantage|ignite|amazfit|huami|zepp|xiaomi|mi|band|coospo|magene|suunto|scosche|rhythm|kickr|tacx|elite|cateye|decathlon|kalenji|geonaute|\\d+(\\.\\d+)?|[a-z]{1,4}\\d{1,3})")
 
 /**
  * A device name reduced to what is safe to put in a shared log: the MODEL, never the person.
@@ -11432,8 +11444,15 @@ private val SAFE_DEVICE_NAME_TOKEN_RE = Regex("(?i)(whoop|mg|\\d+(\\.\\d+)?)")
 internal fun logSafeDeviceName(name: String?): String {
     val n = name?.trim().orEmpty()
     if (n.isEmpty() || n == "unknown") return "unknown"
-    val safe = n.split(Regex("\\s+")).filter { SAFE_DEVICE_NAME_TOKEN_RE.matches(it) }
-    return if (safe.isEmpty()) "<name>" else "<name> " + safe.joinToString(" ")
+    val tokens = n.split(Regex("\\s+"))
+    val safe = tokens.filter { SAFE_DEVICE_NAME_TOKEN_RE.matches(it) }
+    // Say "<name>" only when something was actually removed. An unrenamed "WHOOP 4.0" or "Polar H10"
+    // carries nothing personal, and prefixing it would claim a redaction that never happened.
+    return when {
+        safe.size == tokens.size -> n
+        safe.isEmpty() -> "<name>"
+        else -> "<name> " + safe.joinToString(" ")
+    }
 }
 
 /** Mask MAC addresses and WHOOP serials in a strap-log line before it's shown/exported.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2507,6 +2507,9 @@ class WhoopBleClient(
     /// The strap family the user chose to pair, remembered so an auto-reconnect after a
     /// dropout re-scans for the same model instead of falling back to WHOOP 4.0.
     private var selectedModel = WhoopModel.WHOOP4
+    /** #1635: one [ScanAdvertisementSummary] line per scan session, not one per discovery burst. */
+    private var advertisementLogged = false
+
     /** #716: true once the seeded "WHOOP" model has been stamped to the correct family. */
     private var modelStamped = false
     /// The last device we connected to, kept so an auto-reconnect after a dropout can connect
@@ -3546,6 +3549,10 @@ class WhoopBleClient(
      * Gating here as well would block the user's explicit Connect.
      */
     private fun startScan(model: WhoopModel, allowFallback: Boolean) {
+        // #1635: one advertisement line per SCAN, not per process. The question this answers is whether
+        // a strap advertises differently in pairing mode, which is only visible by comparing a scan
+        // before it was put into pairing mode against one after — so the latch has to reopen here.
+        advertisementLogged = false
         handler.removeCallbacks(scanFallbackRunnable)
         // Defensive: the normal auto-connect scan is NEVER a present-scan. Clearing the flag here means a
         // leaked wizard present-scan (e.g. the wizard was dismissed without stopWhoopScan) can't divert
@@ -5569,6 +5576,30 @@ class WhoopBleClient(
         override fun onScanResult(callbackType: Int, result: ScanResult) {
             val device: BluetoothDevice = result.device
             val name = result.scanRecord?.deviceName ?: device.name ?: "unknown"
+            // #1635: what the strap ADVERTISED, once per scan session. The open question on that issue
+            // is whether a refusing strap was in pairing mode, and a strap that accepts pairing should
+            // advertise differently — but nothing recorded the advertisement, so no log could say.
+            // Structure only, never payload: see ScanAdvertisementSummary. Test Centre gated.
+            if (!advertisementLogged && testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
+                advertisementLogged = true
+                val rec = result.scanRecord
+                log(
+                    ScanAdvertisementSummary.line(
+                        flags = rec?.advertiseFlags?.takeIf { it >= 0 },
+                        serviceUuids = rec?.serviceUuids?.map { it.uuid.toString() } ?: emptyList(),
+                        serviceDataLengths = rec?.serviceData?.entries
+                            ?.associate { it.key.uuid.toString() to (it.value?.size ?: 0) } ?: emptyMap(),
+                        manufacturerDataLengths = (0 until (rec?.manufacturerSpecificData?.size() ?: 0))
+                            .associate { i ->
+                                val k = rec!!.manufacturerSpecificData.keyAt(i)
+                                k to (rec.manufacturerSpecificData.valueAt(i)?.size ?: 0)
+                            },
+                        txPower = rec?.txPowerLevel?.takeIf { it != Int.MIN_VALUE },
+                        localNameLength = rec?.deviceName?.length,
+                        connectable = result.isConnectable,
+                    ),
+                )
+            }
             // #716: the seeded "my-whoop" device has model "WHOOP" (no generation). Once a live
             // scan confirms which service family the strap advertises, stamp the correct model so
             // forRegistryModel returns the right DeviceFamily (fixes skin-temp ADC scale + display).

--- a/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
@@ -186,4 +186,28 @@ class PiiRedactionTest {
         assertEquals("no pii here", redactStrapLogPii("no pii here"))
     }
 
+
+    /**
+     * The name never reaches a shared log at all. The sink rule below is defence-in-depth; this is the
+     * real guarantee, and it is an ALLOWLIST so an unanticipated naming shape is dropped by default.
+     */
+    @Test fun logSafeDeviceNameKeepsOnlyTheModel() {
+        assertEquals("<name> Whoop", logSafeDeviceName("Ryan's Whoop"))
+        assertEquals("<name> WHOOP 4.0", logSafeDeviceName("Ryan B's WHOOP 4.0"))
+        assertEquals("<name> WHOOP 5.0 MG", logSafeDeviceName("Ryan\u2019s WHOOP 5.0 MG"))
+    }
+
+    /** A fully custom name has no model token to keep, so nothing of it survives. */
+    @Test fun logSafeDeviceNameDropsAWhollyCustomName() {
+        assertEquals("<name>", logSafeDeviceName("Dad's spare"))
+        assertEquals("<name>", logSafeDeviceName("Sarah"))
+    }
+
+    /** "We saw no name" and "we removed a name" are different facts to a reader, so the sentinel stays. */
+    @Test fun logSafeDeviceNameKeepsTheNoNameSentinel() {
+        assertEquals("unknown", logSafeDeviceName("unknown"))
+        assertEquals("unknown", logSafeDeviceName(null))
+        assertEquals("unknown", logSafeDeviceName("   "))
+    }
+
 }

--- a/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
@@ -149,4 +149,41 @@ class PiiRedactionTest {
             assertTrue("must return a value, got null", out.isNotEmpty() || s.isEmpty())
         }
     }
+
+    /**
+     * The account holder's name, which WHOOP writes into the advertised local name and the scan path
+     * logs on every discovery. Nothing here could see it before: the other rules key on MAC shape, a
+     * "WHOOP " + digit serial, or a "whoop-" id. Swift twin in `PiiRedactionTests`.
+     */
+    @Test fun personalNameInDiscoveryLineIsRedacted() {
+        assertEquals(
+            "Discovered <name>'s Whoop (rssi -55) - connecting",
+            redactStrapLogPii("Discovered Ryan's Whoop (rssi -55) - connecting"),
+        )
+    }
+
+    /** Apple platforms write U+2019 into default device names, so the straight quote is not enough. */
+    @Test fun curlyApostropheNameIsRedacted() {
+        assertEquals(
+            "Discovered <name>\u2019s Whoop (rssi -55)",
+            redactStrapLogPii("Discovered Ryan\u2019s Whoop (rssi -55)"),
+        )
+    }
+
+    /** The MODEL after the possessive is diagnostic and identifies nobody, so it must survive. */
+    @Test fun modelSurvivesNameRedaction() {
+        assertEquals("<name>'s WHOOP 4.0", redactStrapLogPii("Ryan's WHOOP 4.0"))
+    }
+
+    /** The documented gap, pinned so it is visible rather than assumed: ONE token before the possessive. */
+    @Test fun multiTokenNameKeepsTheLeadingToken() {
+        assertEquals("Ryan <name>'s Whoop", redactStrapLogPii("Ryan B's Whoop"))
+    }
+
+    /** The rule must not touch ids or ordinary text that merely contain "whoop". */
+    @Test fun nameRuleLeavesIdsAndPlainTextAlone() {
+        assertEquals("my-whoop and my-whoop-noop", redactStrapLogPii("my-whoop and my-whoop-noop"))
+        assertEquals("no pii here", redactStrapLogPii("no pii here"))
+    }
+
 }

--- a/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
@@ -224,4 +224,23 @@ class PiiRedactionTest {
         assertEquals("<name> TICKR", logSafeDeviceName("Sarah TICKR"))
     }
 
+
+    /**
+     * The hole a model-code PATTERN opened, pinned shut. "[a-z]{1,4}\\d{1,3}" was meant to admit "H10"
+     * and admitted "Ryan1" and "Sam99" with it, passing a first name through untouched. Model codes are
+     * listed one by one for this reason; if a pattern is ever reintroduced, these fail.
+     */
+    @Test fun aNameWithDigitsIsNotMistakenForAModelCode() {
+        assertEquals("<name>", logSafeDeviceName("Ryan1"))
+        assertEquals("<name>", logSafeDeviceName("Anna2"))
+        assertEquals("<name>", logSafeDeviceName("Bob12"))
+        assertEquals("<name> Whoop", logSafeDeviceName("Sam99 Whoop"))
+    }
+
+    /** The listed codes still survive, so the tightening did not cost the diagnostic. */
+    @Test fun listedModelCodesStillSurvive() {
+        assertEquals("Polar H10", logSafeDeviceName("Polar H10"))
+        assertEquals("Polar OH1", logSafeDeviceName("Polar OH1"))
+    }
+
 }

--- a/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
@@ -210,4 +210,18 @@ class PiiRedactionTest {
         assertEquals("unknown", logSafeDeviceName("   "))
     }
 
+
+    /** Third-party straps: the MODEL is the diagnostic, so a name carrying no person survives intact. */
+    @Test fun logSafeDeviceNameKeepsAnUnrenamedThirdPartyModel() {
+        assertEquals("Polar H10", logSafeDeviceName("Polar H10"))
+        assertEquals("TICKR", logSafeDeviceName("TICKR"))
+        assertEquals("WHOOP 4.0", logSafeDeviceName("WHOOP 4.0"))
+    }
+
+    /** ...but a renamed one loses the person and keeps the model. */
+    @Test fun logSafeDeviceNameStripsThePersonFromARenamedThirdPartyStrap() {
+        assertEquals("<name> Polar H10", logSafeDeviceName("Ryan's Polar H10"))
+        assertEquals("<name> TICKR", logSafeDeviceName("Sarah TICKR"))
+    }
+
 }

--- a/android/app/src/test/java/com/noop/ble/ScanAdvertisementSummaryTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ScanAdvertisementSummaryTest.kt
@@ -29,7 +29,7 @@ class ScanAdvertisementSummaryTest {
     fun `the summary carries no payload bytes and no name`() {
         val s = line(svcData = mapOf("fd4b" to 9), mfg = mapOf(0x01D9 to 14), nameLen = 13)
         // Lengths and ids, yes. Contents, no.
-        assertTrue(s.contains("fd4b:9B"))
+        assertTrue(s.contains("0000fd4b-0000-1000-8000-00805f9b34fb:9B"))
         assertTrue(s.contains("0x01d9:14B"))
         assertTrue(s.contains("nameLen=13"))
         // Nothing that could be a name or a serial.
@@ -50,7 +50,7 @@ class ScanAdvertisementSummaryTest {
         assertTrue(normal.contains("flags=0x06"))
         assertTrue(pairing.contains("flags=0x05"))
         assertTrue(normal.contains("svcData=none"))
-        assertTrue(pairing.contains("fd4b:4B"))
+        assertTrue(pairing.contains("0000fd4b-0000-1000-8000-00805f9b34fb:4B"))
     }
 
     /** Absent fields say so rather than vanishing, so two logs stay comparable field by field. */
@@ -76,5 +76,33 @@ class ScanAdvertisementSummaryTest {
     fun `connectability is reported`() {
         assertTrue(line(connectable = true).contains("connectable=true"))
         assertTrue(line(connectable = false).contains("connectable=false"))
+    }
+
+    /**
+     * The cross-platform guarantee. CoreBluetooth reports an assigned 16-bit UUID as "180d" while
+     * Android always expands it, so without canonicalisation the SAME strap would log two different
+     * lines and an iOS capture could not be diffed against an Android one. Both spellings must collapse
+     * to one string — the Swift twin asserts this verbatim.
+     */
+    @Test
+    fun `short and long uuid spellings produce the same line`() {
+        val short = line(svc = listOf("180d"), svcData = mapOf("fd4b" to 4))
+        val long = line(
+            svc = listOf("0000180d-0000-1000-8000-00805f9b34fb"),
+            svcData = mapOf("0000fd4b-0000-1000-8000-00805f9b34fb" to 4),
+        )
+        assertEquals(short, long)
+        assertTrue(short.contains("svc=0000180d-0000-1000-8000-00805f9b34fb"))
+    }
+
+    /** A 32-bit assigned UUID takes the same base, and a 128-bit one is passed through untouched. */
+    @Test
+    fun `canonicalisation covers 32-bit and leaves full uuids alone`() {
+        assertEquals(
+            "0000180d-0000-1000-8000-00805f9b34fb",
+            ScanAdvertisementSummary.canonicalUuid("0000180d"),
+        )
+        val full = "61080001-8d6d-82b8-614a-1c8cb0f8dcc6"
+        assertEquals(full, ScanAdvertisementSummary.canonicalUuid(full))
     }
 }

--- a/android/app/src/test/java/com/noop/ble/ScanAdvertisementSummaryTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ScanAdvertisementSummaryTest.kt
@@ -105,4 +105,19 @@ class ScanAdvertisementSummaryTest {
         val full = "61080001-8d6d-82b8-614a-1c8cb0f8dcc6"
         assertEquals(full, ScanAdvertisementSummary.canonicalUuid(full))
     }
+
+    /**
+     * The other cross-platform trap in this line, and the reason it is measured in bytes.
+     *
+     * Java's `String.length` would say 8 for this name and Swift's `String.count` would say 7, so the
+     * same strap logged a different size on each platform. The Swift twin asserts the SAME 10.
+     */
+    @Test
+    fun `local name length is utf-8 bytes, not characters`() {
+        assertEquals(10, ScanAdvertisementSummary.localNameLength("Whoop \uD83C\uDF89"))
+        assertEquals(8, "Whoop \uD83C\uDF89".length)  // guards the premise: length would disagree
+        assertEquals(12, ScanAdvertisementSummary.localNameLength("Ryan's Whoop"))
+        assertEquals(null, ScanAdvertisementSummary.localNameLength(null))
+    }
+
 }

--- a/android/app/src/test/java/com/noop/ble/ScanAdvertisementSummaryTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ScanAdvertisementSummaryTest.kt
@@ -1,0 +1,80 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The advertisement summary (#1635) — the ORACLE for the Swift twin.
+ *
+ * Its job is to make two advertising modes distinguishable in a strap log without carrying anything
+ * that identifies a person or a device. WHOOP names a strap "<Name>'s Whoop" by default, so the local
+ * name is the one field that must never appear.
+ */
+class ScanAdvertisementSummaryTest {
+
+    private fun line(
+        flags: Int? = 0x06,
+        svc: List<String> = listOf("61080001-8d6d-82b8-614a-1c8cb0f8dcc6"),
+        svcData: Map<String, Int> = emptyMap(),
+        mfg: Map<Int, Int> = emptyMap(),
+        tx: Int? = null,
+        nameLen: Int? = 12,
+        connectable: Boolean = true,
+    ) = ScanAdvertisementSummary.line(flags, svc, svcData, mfg, tx, nameLen, connectable)
+
+    /** The headline guarantee: shape is reported, payload never is. */
+    @Test
+    fun `the summary carries no payload bytes and no name`() {
+        val s = line(svcData = mapOf("fd4b" to 9), mfg = mapOf(0x01D9 to 14), nameLen = 13)
+        // Lengths and ids, yes. Contents, no.
+        assertTrue(s.contains("fd4b:9B"))
+        assertTrue(s.contains("0x01d9:14B"))
+        assertTrue(s.contains("nameLen=13"))
+        // Nothing that could be a name or a serial.
+        assertFalse(s.contains("Whoop"))
+        assertFalse(s.contains("'s"))
+    }
+
+    /**
+     * The point of the line: two advertising modes must produce different text. If a strap in pairing
+     * mode advertises an extra service-data block, or flips a flag, the log has to show it — otherwise
+     * the #1635 question stays unanswerable.
+     */
+    @Test
+    fun `a different advertising mode reads differently`() {
+        val normal = line(flags = 0x06, svcData = emptyMap())
+        val pairing = line(flags = 0x05, svcData = mapOf("fd4b" to 4))
+        assertFalse(normal == pairing)
+        assertTrue(normal.contains("flags=0x06"))
+        assertTrue(pairing.contains("flags=0x05"))
+        assertTrue(normal.contains("svcData=none"))
+        assertTrue(pairing.contains("fd4b:4B"))
+    }
+
+    /** Absent fields say so rather than vanishing, so two logs stay comparable field by field. */
+    @Test
+    fun `absent fields are named, not omitted`() {
+        val s = line(flags = null, svc = emptyList(), tx = null, nameLen = null)
+        assertTrue(s.contains("flags=none"))
+        assertTrue(s.contains("svc=none"))
+        assertTrue(s.contains("tx=none"))
+        assertTrue(s.contains("nameLen=none"))
+    }
+
+    /** Deterministic ordering, so two captures diff cleanly instead of by map iteration order. */
+    @Test
+    fun `output is stable regardless of input order`() {
+        val a = ScanAdvertisementSummary.line(6, listOf("b", "a"), mapOf("y" to 1, "x" to 2), mapOf(2 to 1, 1 to 2), null, 4, true)
+        val b = ScanAdvertisementSummary.line(6, listOf("a", "b"), mapOf("x" to 2, "y" to 1), mapOf(1 to 2, 2 to 1), null, 4, true)
+        assertEquals(a, b)
+    }
+
+    /** Connectability separates a pairing-ready strap from a beacon-only one. */
+    @Test
+    fun `connectability is reported`() {
+        assertTrue(line(connectable = true).contains("connectable=true"))
+        assertTrue(line(connectable = false).contains("connectable=false"))
+    }
+}


### PR DESCRIPTION
#1635 removed *"try the handshake again"* from the user-facing hint. The **log line beside it kept it**:

> Staying on live HR (not fully paired); **press Connect to try the handshake again** (#1635).

Same wrong framing. A strap that refuses the handshake cannot be helped by retrying it, and suggesting a retry invites exactly the hammering this suppression latch exists to stop.

Both platforms now end with what has actually worked — pairing mode, hedged the same way the hint is, and worded "tap until the LEDs flash blue" to match both @Zebsi235's report and `pausedHint` in the same file.

## How it was found

A field capture from a 5/MG on firmware **50.41.1.0** — the firmware from the HCI capture that proved the strap refuses SMP. The reporter read the card, tried Connect, and the log recorded the app suggesting it again:

```
20:04:08  WHOOP 5/MG: CLIENT_HELLO suppressed for this strap — it was never acknowledged and
          the write is what drops the link. Staying on live HR (not fully paired); press
          Connect to try the handshake again (#1635).
```

## Why the earlier sweep missed it

The #1635 search looked for the whole sentence. The Android source wraps that string across three concatenated lines and uses an em-dash where Swift uses a hyphen, so an exact-phrase search matched Swift and silently missed Android — on a report that came *from* an Android device.

Searching for user-facing text by its full phrasing finds one platform and quietly misses the other. A short distinctive fragment finds both.

## Verification

- Android full suite **5279 tests, 0 failures** (`--rerun-tasks --no-build-cache`).
- Both platforms compile; doc lint and i18n audit clean.
- Checked for tests pinning the old wording: `UnbondedOffloadProbeTest` asserts `"press Connect"` but on a *different* line (`unbondedProbeSupersedesLine`), so it is unaffected — verified rather than assumed.
- Diagnostics only, Test Centre gated. No behaviour change: the latch, the suppression path and the live-HR fallback are untouched.

## Also added: record what the strap advertised

The same capture shows why `[pack]` never appears — and why `[event]` doesn't either. Both ride characteristics that need an encrypted link, so **on the strap we are actually trying to debug they are silent by construction**. A Connection export from a refusing 5/MG contains zero of each.

Meanwhile #1635's open question is the one @Zebsi235 put back to the thread: *was the strap in pairing mode during any of those refusals?* Their strap refused 8 of 8 outside pairing mode and bonded first try inside it — so the mode is the variable that matters, and no log can say which mode a capture was taken in, because the scan path reads the device name and discards the rest.

So this records the advertisement once per **scan** (not per process, so a capture before pairing mode and one after compare directly), on both platforms, Test Centre gated. It is the only diagnostic here that survives an unbonded strap: an advertisement arrives before any of the encrypted machinery.

**Structure, not payload.** WHOOP names a strap `"<Name>'s Whoop"` by default, service data can carry a serial, manufacturer data is opaque. The line reports what is present and how big it is — flags, connectability, service UUIDs, per-block lengths, TX power, and the name's *length* — and never a byte of any of it. Enough to tell two advertising modes apart, carrying nothing identifying.

Formatting is a pure function with five matching cases per platform, including that two modes produce different text and that no name survives. CoreBluetooth exposes no AD flags byte, so that field reads `none` on Apple and a real value on Android; it is present on both either way, so the logs stay comparable field by field.
