### PR TITLE
ble: give a WHOOP 4.0 the stable serial identity the 5/MG already has (#1193)

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop4HelloSerial.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Whoop4HelloSerial.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// The WHOOP 4.0 strap serial, read out of the `GET_HELLO_HARVARD` (cmd 35) response (#1193).
+///
+/// A 4.0 does not expose the DIS Serial Number String (`0x2A25`) that gives the 5/MG its stable id, so
+/// until now the only 4.0 identity available was the CoreBluetooth peripheral UUID — which iOS re-mints
+/// whenever the strap is re-paired or re-keyed. That is the whole of #1193: one physical strap forks
+/// into a second registry row and its history is orphaned beside it.
+///
+/// The capture aid added for that hunt found the answer: in a 131-byte 4.0 cmd-35 response the serial is
+/// the 9-character alphanumeric run at offset 14.
+///
+/// ## What this deliberately does NOT read
+///
+/// The same response carries a 54-character alphanumeric run at offset 24 which is the strap's DEVICE
+/// KEY. This decoder reads a fixed 9-byte window and cannot reach it: there is no scanning, no
+/// "longest alnum run", nothing that could drift onto the key as payloads vary. A key must never become
+/// an id, reach a log, or leave the device, and the cheapest way to guarantee that is to never read it.
+///
+/// ## Why the strict shape check
+///
+/// The offset comes from ONE capture. If a future firmware moves the field, a fixed offset lands on
+/// whatever is there instead — so a window that is not entirely `[0-9A-Za-z]` is refused rather than
+/// returned. `WhoopSerialIdentity.adoptedId` then applies its own validation on top. Refusing costs a
+/// strap the stable id it would have gained; returning something wrong migrates its whole history onto
+/// a junk key, which is the failure this exists to prevent.
+public enum Whoop4HelloSerial {
+
+    /// Offset of the serial run inside the cmd-35 response payload.
+    public static let serialOffset = 14
+    /// Length of the serial run. The 54-char device key begins at offset 24, one byte past this window.
+    public static let serialLength = 9
+
+    /// The strap serial, or nil when the payload is too short or the window is not a clean alnum run.
+    public static func decode(payload: [UInt8]) -> String? {
+        guard payload.count >= serialOffset + serialLength else { return nil }
+        var out = ""
+        out.reserveCapacity(serialLength)
+        for i in serialOffset..<(serialOffset + serialLength) {
+            let b = payload[i]
+            let isDigit = b >= 0x30 && b <= 0x39
+            let isUpper = b >= 0x41 && b <= 0x5A
+            let isLower = b >= 0x61 && b <= 0x7A
+            guard isDigit || isUpper || isLower else { return nil }
+            out.append(Character(UnicodeScalar(b)))
+        }
+        return out
+    }
+}
+
+/// Withholds a serial until the SAME value has been seen twice (#1193).
+///
+/// The 5/MG adopts its DIS serial on first read, because `0x2A25` is a spec-defined field that means one
+/// thing. The 4.0 offset is not that: it came off a single capture, so "the 9-char alnum run at offset 14"
+/// is a strong inference rather than a documented field. If that run were per-session rather than
+/// per-strap, adopting immediately would mint a new id on every connect and migrate the history each time
+/// - strictly worse than the duplicate row this exists to prevent.
+///
+/// Two hellos carrying the same run cannot both be a fresh per-session token, which is the only failure
+/// mode that does real damage. The cost is that a 4.0 adopts one connect later than a 5/MG.
+///
+/// Lives here, apart from the BLE classes that use it, because it is the part most likely to be wrong and
+/// the part neither platform can unit-test in place.
+public struct RepeatedSerialGate {
+    private var candidate: String?
+    private var confirmed: String?
+
+    public init() {}
+
+    /// The serial to adopt, or nil while it is still unconfirmed. Returns non-nil only on the transition
+    /// to confirmed, so a caller may act on it directly without re-adopting on every later sighting.
+    public mutating func offer(_ serial: String) -> String? {
+        if confirmed == serial { return nil }        // already acted on
+        guard candidate == serial else {
+            candidate = serial                        // first sighting: remember, withhold
+            return nil
+        }
+        confirmed = serial
+        return serial
+    }
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop4HelloSerialTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop4HelloSerialTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import XCTest
+@testable import WhoopProtocol
+
+/// The 4.0 serial decode (#1193) — twin of the Kotlin `Whoop4HelloSerialTest`, same cases, same values.
+final class Whoop4HelloSerialTests: XCTestCase {
+
+    /// A 131-byte cmd-35 response shaped like the captured one: a 9-char serial at 14, and the 54-char
+    /// DEVICE KEY at 24 that must stay unreachable.
+    private func capturedShape(serial: String = "WBB5AP053",
+                               key: String = String(repeating: "K", count: 54)) -> [UInt8] {
+        var p = [UInt8](repeating: 0, count: 131)
+        for (i, c) in serial.utf8.enumerated() { p[14 + i] = c }
+        for (i, c) in key.utf8.enumerated() { p[24 + i] = c }
+        return p
+    }
+
+    func testReadsTheSerialFromTheCapturedShape() {
+        XCTAssertEqual(Whoop4HelloSerial.decode(payload: capturedShape()), "WBB5AP053")
+    }
+
+    /// The headline safety property: the decoder reads a fixed 9-byte window, so the device key beside
+    /// the serial cannot be returned no matter what it contains.
+    func testNeverReturnsTheDeviceKey() {
+        let out = Whoop4HelloSerial.decode(payload: capturedShape())
+        XCTAssertEqual(out?.count, 9)
+        XCTAssertFalse(out?.contains("K") ?? true)
+    }
+
+    /// A window that is not a clean alnum run is refused rather than guessed at — a moved field must
+    /// cost a strap its stable id, never migrate its history onto junk.
+    func testRefusesANonAlphanumericWindow() {
+        var p = capturedShape()
+        p[18] = 0x00
+        XCTAssertNil(Whoop4HelloSerial.decode(payload: p))
+        p = capturedShape()
+        p[14] = 0x2D  // '-' is legal in an id but is NOT alnum, so this window is not a serial run
+        XCTAssertNil(Whoop4HelloSerial.decode(payload: p))
+    }
+
+    func testRefusesAShortPayload() {
+        XCTAssertNil(Whoop4HelloSerial.decode(payload: [UInt8](repeating: 0x41, count: 22)))
+        XCTAssertNil(Whoop4HelloSerial.decode(payload: []))
+    }
+
+    /// Exactly long enough is enough — the window ends at 23, so a 23-byte payload decodes.
+    func testAcceptsTheMinimumLength() {
+        var p = [UInt8](repeating: 0x41, count: 23)
+        for (i, c) in "ABC123XYZ".utf8.enumerated() { p[14 + i] = c }
+        XCTAssertEqual(Whoop4HelloSerial.decode(payload: p), "ABC123XYZ")
+    }
+}
+
+/// The two-sighting gate (#1193) — twin of the Kotlin `RepeatedSerialGateTest`.
+final class RepeatedSerialGateTests: XCTestCase {
+
+    /// The point of the gate: one sighting is never enough to act on.
+    func testWithholdsUntilTheSameValueRepeats() {
+        var g = RepeatedSerialGate()
+        XCTAssertNil(g.offer("WBB5AP053"))
+        XCTAssertEqual(g.offer("WBB5AP053"), "WBB5AP053")
+    }
+
+    /// The failure this exists to prevent: a per-session value never confirms, so it can never migrate
+    /// a history onto a fresh id per connect.
+    func testAValueThatKeepsChangingNeverConfirms() {
+        var g = RepeatedSerialGate()
+        for s in ["AAA111AAA", "BBB222BBB", "CCC333CCC", "DDD444DDD"] {
+            XCTAssertNil(g.offer(s), "a changing value must never confirm")
+        }
+    }
+
+    /// Confirms once, not on every later sighting — the caller adopts on a non-nil return, and adopting
+    /// repeatedly would redo the migration on every connect.
+    func testConfirmsExactlyOnce() {
+        var g = RepeatedSerialGate()
+        _ = g.offer("WBB5AP053")
+        XCTAssertEqual(g.offer("WBB5AP053"), "WBB5AP053")
+        XCTAssertNil(g.offer("WBB5AP053"))
+        XCTAssertNil(g.offer("WBB5AP053"))
+    }
+
+    /// An interruption resets the run: two sightings must be consecutive, so alternating values cannot
+    /// accumulate their way to a false confirmation.
+    func testAlternatingValuesDoNotConfirm() {
+        var g = RepeatedSerialGate()
+        XCTAssertNil(g.offer("AAA111AAA"))
+        XCTAssertNil(g.offer("BBB222BBB"))
+        XCTAssertNil(g.offer("AAA111AAA"))
+        XCTAssertEqual(g.offer("AAA111AAA"), "AAA111AAA")
+    }
+}

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -1001,6 +1001,24 @@ public final class BLEManager: NSObject, ObservableObject {
     /// number rather than an independently chosen one: this read can cost the link, so the two platforms
     /// should not be probing at different moments when a field capture has to explain a drop.
     static let unbondedDisReadDelay: TimeInterval = 3.0
+    /// #1193: the WHOOP 4.0 strap serial from `GET_HELLO_HARVARD`, once it has been seen TWICE.
+    ///
+    /// The withholding rule itself lives in `RepeatedSerialGate`, beside the decoder, where it is unit
+    /// tested; this pair is just the manager's view of its outcome.
+    ///
+    /// The 5/MG adopts its DIS serial on first read, because `0x2A25` is a spec-defined field that means
+    /// one thing. The 4.0 offset is not that: it was read off a single capture, so "the 9-char alnum run
+    /// at offset 14" is a strong inference rather than a documented field. If that run turned out to be
+    /// per-session rather than per-strap, adopting it immediately would mint a NEW id on every connect and
+    /// migrate the history each time — strictly worse than the duplicate row this exists to prevent.
+    ///
+    /// So a value must repeat before it is trusted. Two hellos carrying the same run cannot both be a
+    /// fresh per-session token, which is the only failure mode that would do real damage. The cost is that
+    /// a 4.0 adopts one connect later than a 5/MG; the benefit is that the destructive failure cannot
+    /// happen at all. Deliberately NOT reset on disconnect — the two sightings are meant to span connects.
+    private var harvardSerialGate = RepeatedSerialGate()
+    private var harvardSerialConfirmed: String?
+
     private var disSerial: String?
     private var disHwRev: String?
     /// #1635 follow-up: the DIS identity extras (firmware, manufacturer, model, software revision) as
@@ -1313,6 +1331,7 @@ public final class BLEManager: NSObject, ObservableObject {
         #endif
         // Strap-as-clock: an incoming EVENT packet kicks a rate-limited catch-up sync.
         router.onSyncTrigger = { [weak self] in self?.requestSync(.strap) }
+        router.onStrapSerial = { [weak self] serial in self?.noteHarvardSerial(serial) }   // #1193
         // #78 hole-4: a paused-for-bond-loop strap gets one bounded salvage attempt per app-foreground.
         installForegroundSalvageProbe()
     }
@@ -1512,6 +1531,7 @@ public final class BLEManager: NSObject, ObservableObject {
         #endif
         // Strap-as-clock: an incoming EVENT packet kicks a rate-limited catch-up sync.
         router.onSyncTrigger = { [weak self] in self?.requestSync(.strap) }
+        router.onStrapSerial = { [weak self] serial in self?.noteHarvardSerial(serial) }   // #1193
         // #78 hole-4: a paused-for-bond-loop strap gets one bounded salvage attempt per app-foreground.
         installForegroundSalvageProbe()
     }
@@ -4838,14 +4858,26 @@ public final class BLEManager: NSObject, ObservableObject {
         adoptWhoopSerialIdentity()
     }
 
+    /// The serial this pairing may adopt: the 5/MG's DIS read, or a 4.0's twice-seen hello serial.
+    private var adoptableSerial: String? { disSerial ?? harvardSerialConfirmed }
+
+    /// #1193: a 4.0 hello serial arrived. Adopt only on the SECOND sighting of the same value — see
+    /// `harvardSerialCandidate` for why a single sighting is not enough to act on destructively.
+    private func noteHarvardSerial(_ serial: String) {
+        guard let confirmed = harvardSerialGate.offer(serial) else { return }
+        harvardSerialConfirmed = confirmed
+        adoptWhoopSerialIdentity()
+    }
+
     /// #1303: the 5/MG DIS read hands us the strap's OWN serial, so re-point this pairing from its
     /// transient CoreBluetooth-UUID id onto a stable `whoop-<serial>` id — through the SAME generic
     /// migration the ring already uses (`adoptSerialIdentity`, #771), so a re-pair or factory reset stops
     /// forking one physical strap into a second row and orphaning its history (#1193).
     ///
-    /// A WHOOP 4.0 is deliberately untouched: it does not expose a DIS serial (the read above is gated
-    /// `!= .whoop4`) and the 4.0 serial's source on the wire is not yet identified, so there is nothing
-    /// honest to adopt onto here.
+    /// A WHOOP 4.0 reaches this by a different road. It exposes no DIS serial (the read above is gated
+    /// `!= .whoop4`), so its serial comes from the `GET_HELLO_HARVARD` response instead — see
+    /// `Whoop4HelloSerial` for the offset and `noteHarvardSerial` for why a 4.0 waits for a second
+    /// sighting before adopting where a 5/MG adopts on the first read (#1193).
     ///
     /// Deferred to the next main-loop turn, mirroring `adoptOuraSerial`: adoption re-points the ACTIVE
     /// device, and the observers that react tear down and rebuild the very connection this callback is
@@ -4856,7 +4888,7 @@ public final class BLEManager: NSObject, ObservableObject {
     /// onto a garbage key, which is worse than not adopting.
     private func adoptWhoopSerialIdentity() {
         guard let rs = registryStore,
-              let serialId = WhoopSerialIdentity.adoptedId(serial: disSerial),
+              let serialId = WhoopSerialIdentity.adoptedId(serial: adoptableSerial),
               let active = try? rs.all().first(where: { $0.status == .active }),
               WhoopSerialIdentity.mayAdopt(currentId: active.id),
               active.id != serialId
@@ -4876,7 +4908,7 @@ public final class BLEManager: NSObject, ObservableObject {
             // `SourceCoordinator.pointWhoop`, which re-points any non-legacy id.
             self.setActiveDeviceId(serialId)
             // Prefix only. `serialId` embeds the full serial, which must never reach a shareable log.
-            self.log("Adopted stable serial identity (serialPrefix=\(WhoopSerialIdentity.logSafe(serial: self.disSerial))) - history re-pointed off the transient pairing id (#1303)")
+            self.log("Adopted stable serial identity (serialPrefix=\(WhoopSerialIdentity.logSafe(serial: self.adoptableSerial))) - history re-pointed off the transient pairing id (#1303)")
             self.onSerialIdentityAdopted?(serialId)
         }
     }

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -4864,6 +4864,13 @@ public final class BLEManager: NSObject, ObservableObject {
     /// #1193: a 4.0 hello serial arrived. Adopt only on the SECOND sighting of the same value — see
     /// `harvardSerialCandidate` for why a single sighting is not enough to act on destructively.
     private func noteHarvardSerial(_ serial: String) {
+        // Do NOT advance the gate before the store exists. The gate confirms EXACTLY ONCE, so a
+        // confirmation raised while `adoptWhoopSerialIdentity` would bail is not deferred, it is lost for
+        // the lifetime of the process — every later sighting returns nil because the value is already
+        // confirmed. The 5/MG path survives the same hazard only because it re-offers its DIS serial on
+        // every connect; a once-only gate has no such second chance, so it must not consume a sighting it
+        // cannot act on. Kotlin twin guards its own missing dependency the same way.
+        guard registryStore != nil else { return }
         guard let confirmed = harvardSerialGate.offer(serial) else { return }
         harvardSerialConfirmed = confirmed
         adoptWhoopSerialIdentity()

--- a/Strand/BLE/FrameRouter.swift
+++ b/Strand/BLE/FrameRouter.swift
@@ -10,6 +10,11 @@ public final class FrameRouter {
     private let state: LiveState
     /// Called when the strap pushes an EVENT packet (WHOOP's strap-as-clock catch-up signal). The
     /// BLEManager wires this to a rate-limited requestSync(.strap). nil in pure/unit contexts.
+    /// #1193: the WHOOP 4.0 strap serial, decoded from the `GET_HELLO_HARVARD` (35) response. A 4.0 has
+    /// no DIS serial, so this is its only stable identity — see `Whoop4HelloSerial`. Fires on every hello;
+    /// the manager decides whether it is confirmed enough to adopt.
+    var onStrapSerial: ((String) -> Void)?
+
     var onSyncTrigger: (() -> Void)?
     /// #1706: which strap this connection is talking to, so an alarm readback can be attributed to a
     /// device. Set per connection by BLEManager immediately AFTER `family`, whose didSet clears this —
@@ -269,7 +274,7 @@ public final class FrameRouter {
                     let r = Self.commandResultByte(in: frame)
                     let rhex = r.map { String(format: "0x%02x", UInt8(truncatingIfNeeded: $0)) } ?? "none"
                     state.append(log: "Alarm: strap answered the arm (SET_ALARM_TIME) with result=\(rhex) — log-only, 4.0 result-code meaning unverified")
-                } else if cmd.hasPrefix("GET_HELLO_HARVARD"), TestCentre.active(.connection) {
+                } else if cmd.hasPrefix("GET_HELLO_HARVARD") {
                     // #1303: capture aid for WHOOP-4.0 stable-serial identity. The strap serial lives in this
                     // GET_HELLO_HARVARD (cmd 35) response. This used to dump the payload RAW, which answered
                     // the question — the serial is the 9-char alnum run at offset 14 — but a captured 4.0
@@ -285,10 +290,18 @@ public final class FrameRouter {
                     // the 5/MG device-name offset and means nothing in a cmd-35 payload — passing it would
                     // mislabel whatever run happened to start there. Log-only; decodes/persists nothing.
                     let helloPay = Self.commandResponsePayload(in: frame) ?? []
-                    state.append(log: HelloIdentityProbe.report(payload: helloPay,
-                                                                block: "HELLO_HARVARD(35)",
-                                                                knownNameOffset: -1)
-                                 + " — locate the strap serial offset (#1303)")
+                    // #1193: the identity read is UNGATED, unlike the probe below it. Adoption has to
+                    // work for every 4.0 user, and Test Centre is off for almost all of them — gating it
+                    // would ship a stable id only to the people already debugging. The decoder reads a
+                    // fixed 9-byte window and can never reach the device key beside it, so nothing here
+                    // widens what an ordinary session touches.
+                    if let serial = Whoop4HelloSerial.decode(payload: helloPay) { onStrapSerial?(serial) }
+                    if TestCentre.active(.connection) {
+                        state.append(log: HelloIdentityProbe.report(payload: helloPay,
+                                                                    block: "HELLO_HARVARD(35)",
+                                                                    knownNameOffset: -1)
+                                     + " — locate the strap serial offset (#1303)")
+                    }
                 }
             }
             // #1303: the 5/MG half of the same hunt. The 4.0 aid above is 4.0-only — correctly, since a

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3242,8 +3242,15 @@ class WhoopBleClient(
      * SAME [onSerial] the 5/MG DIS read uses, so both families share one adoption path (#1193).
      */
     private fun noteHarvardSerial(serial: String) {
+        // Do NOT advance the gate without a listener. The gate confirms EXACTLY ONCE, so a confirmation
+        // delivered to a null [onSerial] is not deferred, it is lost for the lifetime of the process —
+        // every later sighting returns null because the value is already confirmed. And "no listener" is
+        // an ordinary state here, not a defensive hypothetical: [onSerial] is wired by AppViewModel, which
+        // is UI-scoped, while this client also runs under WhoopConnectionService with no UI alive. The
+        // 5/MG path survives the same hazard only because it re-offers its DIS serial on every connect.
+        val cb = onSerial ?: return
         val confirmed = harvardSerialGate.offer(serial) ?: return
-        onSerial?.invoke(confirmed)
+        cb.invoke(confirmed)
     }
 
     private var disSerial: String? = null

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3216,6 +3216,36 @@ class WhoopBleClient(
      * when reading a capture where iOS shows the adoption line and Android does not.
      */
     var onSerial: ((String) -> Unit)? = null
+    /**
+     * #1193: the WHOOP 4.0 strap serial from `GET_HELLO_HARVARD`, once it has been seen TWICE.
+     *
+     * The 5/MG adopts its DIS serial on first read, because `0x2A25` is a spec-defined field that means
+     * one thing. The 4.0 offset is not that: it was read off a single capture, so "the 9-char alnum run at
+     * offset 14" is a strong inference rather than a documented field. If that run turned out to be
+     * per-session rather than per-strap, adopting it immediately would mint a NEW id on every connect and
+     * migrate the history each time — strictly worse than the duplicate row this exists to prevent.
+     *
+     * So a value must repeat before it is trusted. Two hellos carrying the same run cannot both be a fresh
+     * per-session token, which is the only failure mode that would do real damage. The cost is that a 4.0
+     * adopts one connect later than a 5/MG; the benefit is that the destructive failure cannot happen at
+     * all. Deliberately NOT cleared on disconnect — the two sightings are meant to span connects.
+     *
+     * The withholding rule itself lives in [com.noop.protocol.RepeatedSerialGate], beside the decoder,
+     * where it is unit tested; this pair is just the client's view of its outcome.
+     */
+    private val harvardSerialGate = com.noop.protocol.RepeatedSerialGate()
+    private var harvardSerialConfirmed: String? = null
+
+    /**
+     * A 4.0 hello serial arrived. Adopt only on the SECOND sighting of the same value, then hand it to the
+     * SAME [onSerial] the 5/MG DIS read uses, so both families share one adoption path (#1193).
+     */
+    private fun noteHarvardSerial(serial: String) {
+        val confirmed = harvardSerialGate.offer(serial) ?: return
+        harvardSerialConfirmed = confirmed
+        onSerial?.invoke(confirmed)
+    }
+
     private var disSerial: String? = null
     private var disHwRev: String? = null
     /** DIS 0x2A24, the strap's own model number — the authoritative variant signal (#520). */
@@ -7420,9 +7450,14 @@ class WhoopBleClient(
                 // falls outside and is withheld inside the probe rather than by this caller.
                 // knownNameOffset = -1 because 16 is the 5/MG device-name offset and means nothing in a
                 // cmd-35 payload. Log-only; decodes/persists nothing. Twin of the Swift FrameRouter probe.
-                if (connectedFamily == DeviceFamily.WHOOP4 && respCmd?.startsWith("GET_HELLO_HARVARD") == true &&
-                    testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
+                if (connectedFamily == DeviceFamily.WHOOP4 && respCmd?.startsWith("GET_HELLO_HARVARD") == true) {
                     val helloPay = whoop4CommandResponsePayload(frame) ?: ByteArray(0)
+                    // #1193: the identity read is UNGATED, unlike the probe below it. Adoption has to work
+                    // for every 4.0 user, and Test Centre is off for almost all of them — gating it would
+                    // ship a stable id only to the people already debugging. The decoder reads a fixed
+                    // 9-byte window and can never reach the device key beside it.
+                    com.noop.protocol.Whoop4HelloSerial.decode(helloPay)?.let { noteHarvardSerial(it) }
+                    if (testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
                     log(
                         com.noop.protocol.HelloIdentityProbe.report(
                             helloPay,
@@ -7430,6 +7465,7 @@ class WhoopBleClient(
                             knownNameOffset = -1,
                         ) + " — locate the strap serial offset (#1303)",
                     )
+                    }
                 }
                 // #1303: the 5/MG half of the same hunt. The 4.0 aid above is 4.0-only — correctly, since
                 // a 5/MG never answers cmd 35 — so this family had no capture at all, and it needs one

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -3231,10 +3231,11 @@ class WhoopBleClient(
      * all. Deliberately NOT cleared on disconnect — the two sightings are meant to span connects.
      *
      * The withholding rule itself lives in [com.noop.protocol.RepeatedSerialGate], beside the decoder,
-     * where it is unit tested; this pair is just the client's view of its outcome.
+     * where it is unit tested; the gate holds the confirmed value, so nothing here needs to store it. The
+     * Swift twin DOES keep a field, because its adoption reads a property where this side passes the
+     * value into [onSerial] directly - the shapes differ, the behaviour does not.
      */
     private val harvardSerialGate = com.noop.protocol.RepeatedSerialGate()
-    private var harvardSerialConfirmed: String? = null
 
     /**
      * A 4.0 hello serial arrived. Adopt only on the SECOND sighting of the same value, then hand it to the
@@ -3242,7 +3243,6 @@ class WhoopBleClient(
      */
     private fun noteHarvardSerial(serial: String) {
         val confirmed = harvardSerialGate.offer(serial) ?: return
-        harvardSerialConfirmed = confirmed
         onSerial?.invoke(confirmed)
     }
 

--- a/android/app/src/main/java/com/noop/protocol/Whoop4HelloSerial.kt
+++ b/android/app/src/main/java/com/noop/protocol/Whoop4HelloSerial.kt
@@ -1,0 +1,87 @@
+package com.noop.protocol
+
+/**
+ * The WHOOP 4.0 strap serial, read out of the `GET_HELLO_HARVARD` (cmd 35) response (#1193).
+ *
+ * A 4.0 does not expose the DIS Serial Number String (`0x2A25`) that gives the 5/MG its stable id, so
+ * until now the only 4.0 identity available was the transient pairing id the OS mints, which is
+ * re-minted whenever the strap is re-paired or re-keyed. That is the whole of #1193: one physical strap
+ * forks into a second registry row and its history is orphaned beside it.
+ *
+ * The capture aid added for that hunt found the answer: in a 131-byte 4.0 cmd-35 response the serial is
+ * the 9-character alphanumeric run at offset 14.
+ *
+ * ## What this deliberately does NOT read
+ *
+ * The same response carries a 54-character alphanumeric run at offset 24 which is the strap's DEVICE
+ * KEY. This decoder reads a fixed 9-byte window and cannot reach it: there is no scanning, no
+ * "longest alnum run", nothing that could drift onto the key as payloads vary. A key must never become
+ * an id, reach a log, or leave the device, and the cheapest way to guarantee that is to never read it.
+ *
+ * ## Why the strict shape check
+ *
+ * The offset comes from ONE capture. If a future firmware moves the field, a fixed offset lands on
+ * whatever is there instead — so a window that is not entirely `[0-9A-Za-z]` is refused rather than
+ * returned. `WhoopSerialIdentity.adoptedId` then applies its own validation on top. Refusing costs a
+ * strap the stable id it would have gained; returning something wrong migrates its whole history onto a
+ * junk key, which is the failure this exists to prevent.
+ *
+ * Swift twin: `Whoop4HelloSerial`.
+ */
+object Whoop4HelloSerial {
+
+    /** Offset of the serial run inside the cmd-35 response payload. */
+    const val SERIAL_OFFSET = 14
+
+    /** Length of the serial run. The 54-char device key begins at offset 24, one byte past this window. */
+    const val SERIAL_LENGTH = 9
+
+    /** The strap serial, or null when the payload is too short or the window is not a clean alnum run. */
+    fun decode(payload: ByteArray): String? {
+        if (payload.size < SERIAL_OFFSET + SERIAL_LENGTH) return null
+        val sb = StringBuilder(SERIAL_LENGTH)
+        for (i in SERIAL_OFFSET until SERIAL_OFFSET + SERIAL_LENGTH) {
+            val b = payload[i].toInt() and 0xFF
+            val isDigit = b in 0x30..0x39
+            val isUpper = b in 0x41..0x5A
+            val isLower = b in 0x61..0x7A
+            if (!isDigit && !isUpper && !isLower) return null
+            sb.append(b.toChar())
+        }
+        return sb.toString()
+    }
+}
+
+/**
+ * Withholds a serial until the SAME value has been seen twice (#1193).
+ *
+ * The 5/MG adopts its DIS serial on first read, because `0x2A25` is a spec-defined field that means one
+ * thing. The 4.0 offset is not that: it came off a single capture, so "the 9-char alnum run at offset 14"
+ * is a strong inference rather than a documented field. If that run were per-session rather than
+ * per-strap, adopting immediately would mint a new id on every connect and migrate the history each time
+ * - strictly worse than the duplicate row this exists to prevent.
+ *
+ * Two hellos carrying the same run cannot both be a fresh per-session token, which is the only failure
+ * mode that does real damage. The cost is that a 4.0 adopts one connect later than a 5/MG.
+ *
+ * Lives here, apart from the BLE classes that use it, because it is the part most likely to be wrong and
+ * the part neither platform can unit-test in place. Swift twin: `RepeatedSerialGate`.
+ */
+class RepeatedSerialGate {
+    private var candidate: String? = null
+    private var confirmed: String? = null
+
+    /**
+     * The serial to adopt, or null while it is still unconfirmed. Returns non-null only on the transition
+     * to confirmed, so a caller may act on it directly without re-adopting on every later sighting.
+     */
+    fun offer(serial: String): String? {
+        if (confirmed == serial) return null          // already acted on
+        if (candidate != serial) {
+            candidate = serial                         // first sighting: remember, withhold
+            return null
+        }
+        confirmed = serial
+        return serial
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -884,8 +884,10 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         // is deliberately inert on the WHOOP path and never touches WhoopBleClient internals; this class
         // already owns the registry handle and a scope. Twin of Swift `BLEManager.adoptWhoopSerialIdentity`.
         //
-        // A WHOOP 4.0 never reaches here: it exposes no DIS serial, and the 4.0 serial's source on the wire
-        // is not yet identified, so there is nothing honest to adopt onto.
+        // A WHOOP 4.0 reaches here by a different road: it exposes no DIS serial, so its serial is decoded
+        // from the GET_HELLO_HARVARD response (`Whoop4HelloSerial`) and handed to this same callback only
+        // after a SECOND sighting of the same value — see `WhoopBleClient.noteHarvardSerial` for why a 4.0
+        // waits where a 5/MG adopts on the first read (#1193).
         ble.onSerial = { serial ->
             viewModelScope.launch {
                 val serialId = com.noop.data.WhoopSerialIdentity.adoptedId(serial)

--- a/android/app/src/test/java/com/noop/protocol/Whoop4HelloSerialTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop4HelloSerialTest.kt
@@ -1,0 +1,107 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/** The 4.0 serial decode (#1193) — twin of the Swift `Whoop4HelloSerialTests`, same cases, same values. */
+class Whoop4HelloSerialTest {
+
+    /**
+     * A 131-byte cmd-35 response shaped like the captured one: a 9-char serial at 14, and the 54-char
+     * DEVICE KEY at 24 that must stay unreachable.
+     */
+    private fun capturedShape(
+        serial: String = "WBB5AP053",
+        key: String = "K".repeat(54),
+    ): ByteArray {
+        val p = ByteArray(131)
+        serial.forEachIndexed { i, c -> p[14 + i] = c.code.toByte() }
+        key.forEachIndexed { i, c -> p[24 + i] = c.code.toByte() }
+        return p
+    }
+
+    @Test fun `reads the serial from the captured shape`() {
+        assertEquals("WBB5AP053", Whoop4HelloSerial.decode(capturedShape()))
+    }
+
+    /**
+     * The headline safety property: the decoder reads a fixed 9-byte window, so the device key beside
+     * the serial cannot be returned no matter what it contains.
+     */
+    @Test fun `never returns the device key`() {
+        val out = Whoop4HelloSerial.decode(capturedShape())
+        assertEquals(9, out?.length)
+        assertFalse(out!!.contains("K"))
+    }
+
+    /**
+     * A window that is not a clean alnum run is refused rather than guessed at — a moved field must
+     * cost a strap its stable id, never migrate its history onto junk.
+     */
+    @Test fun `refuses a non-alphanumeric window`() {
+        val a = capturedShape().also { it[18] = 0 }
+        assertNull(Whoop4HelloSerial.decode(a))
+        val b = capturedShape().also { it[14] = 0x2D }
+        assertNull(Whoop4HelloSerial.decode(b))
+    }
+
+    @Test fun `refuses a short payload`() {
+        assertNull(Whoop4HelloSerial.decode(ByteArray(22) { 0x41 }))
+        assertNull(Whoop4HelloSerial.decode(ByteArray(0)))
+    }
+
+    /** Exactly long enough is enough — the window ends at 23, so a 23-byte payload decodes. */
+    @Test fun `accepts the minimum length`() {
+        val p = ByteArray(23) { 0x41 }
+        "ABC123XYZ".forEachIndexed { i, c -> p[14 + i] = c.code.toByte() }
+        assertEquals("ABC123XYZ", Whoop4HelloSerial.decode(p))
+    }
+}
+
+/** The two-sighting gate (#1193) — twin of the Swift `RepeatedSerialGateTests`. */
+class RepeatedSerialGateTest {
+
+    /** The point of the gate: one sighting is never enough to act on. */
+    @Test fun `withholds until the same value repeats`() {
+        val g = RepeatedSerialGate()
+        assertNull(g.offer("WBB5AP053"))
+        assertEquals("WBB5AP053", g.offer("WBB5AP053"))
+    }
+
+    /**
+     * The failure this exists to prevent: a per-session value never confirms, so it can never migrate a
+     * history onto a fresh id per connect.
+     */
+    @Test fun `a value that keeps changing never confirms`() {
+        val g = RepeatedSerialGate()
+        listOf("AAA111AAA", "BBB222BBB", "CCC333CCC", "DDD444DDD").forEach {
+            assertNull("a changing value must never confirm", g.offer(it))
+        }
+    }
+
+    /**
+     * Confirms once, not on every later sighting — the caller adopts on a non-null return, and adopting
+     * repeatedly would redo the migration on every connect.
+     */
+    @Test fun `confirms exactly once`() {
+        val g = RepeatedSerialGate()
+        g.offer("WBB5AP053")
+        assertEquals("WBB5AP053", g.offer("WBB5AP053"))
+        assertNull(g.offer("WBB5AP053"))
+        assertNull(g.offer("WBB5AP053"))
+    }
+
+    /**
+     * An interruption resets the run: two sightings must be consecutive, so alternating values cannot
+     * accumulate their way to a false confirmation.
+     */
+    @Test fun `alternating values do not confirm`() {
+        val g = RepeatedSerialGate()
+        assertNull(g.offer("AAA111AAA"))
+        assertNull(g.offer("BBB222BBB"))
+        assertNull(g.offer("AAA111AAA"))
+        assertEquals("AAA111AAA", g.offer("AAA111AAA"))
+    }
+}

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -400,7 +400,7 @@ public func frame(seq: UInt8, payload: [UInt8] = [0x00]) -> [UInt8] {
 | 23 | `HISTORICAL_DATA_RESULT` | `[0x01] + end_data(8)` | ack a `HISTORY_END` chunk / advance trim |
 | 26 | `GET_BATTERY_LEVEL` | `[0x00]` | battery percent; also the **bond** write |
 | 34 | `GET_DATA_RANGE` | `[0x00]` | strap's stored oldest/newest record range; #689 also logs a diagnostic ring-buffer page backlog — see below |
-| 35 | `GET_HELLO_HARVARD` | `[0x00]` | identity/version hello |
+| 35 | `GET_HELLO_HARVARD` | `[0x00]` | identity/version hello; the response carries the 4.0 strap serial — see below |
 | 39 / 40 | `SET_LED_DRIVE` / `GET_LED_DRIVE` | — | optical LED drive (research) |
 | 41 / 42 | `SET_TIA_GAIN` / `GET_TIA_GAIN` | — | optical front-end gain (research) |
 | 43 / 44 | `SET_BIAS_OFFSET` / `GET_BIAS_OFFSET` | — | optical bias (research) |
@@ -954,3 +954,27 @@ is deliberately **not** duplicated here — one table, one place to keep correct
 *Reverse-engineering credit: `johnmiddleton12/my-whoop` (WHOOP 4.0) and `b-nnett/goose`
 (WHOOP 5.0). This is an independent interoperability project for the user's own device and data;
 it is not affiliated with WHOOP and is not a medical device.*
+
+### `GET_HELLO_HARVARD` (35) response — the WHOOP 4.0 serial
+
+A 4.0 exposes no DIS Serial Number String (`0x2A25`), so this response is the only place its stable
+serial appears. In the captures on record the response payload (sliced past `SOF+len+crc8` and
+`[type,seq,cmd,origin_seq,result]`, i.e. from byte 9 of the frame) is **131 bytes** and carries two
+alphanumeric runs:
+
+| payload offset | length | what |
+|---|---|---|
+| 14 | 9 | **strap serial** — the stable per-device id (`Whoop4HelloSerial`) |
+| 24 | 54 | **device key** — a secret; never read it, never log it, never let it become an id |
+
+`Whoop4HelloSerial` reads a FIXED 9-byte window at offset 14 for exactly this reason: a scanning
+"longest alnum run" could drift onto the key as payloads vary, and a fixed window cannot.
+
+**Provenance, because it changes how much this should be trusted:** the offsets come from a single
+capture, not from documentation. They are corroborated only in the sense that two independent places in
+the codebase record the same layout — which is one observation written down twice, not two
+observations. Treat a strap that stops adopting as evidence the field moved, rather than assuming the
+table is wrong about the shape. This is why the 4.0 adoption path waits for the same value on two
+separate hellos before acting on it (`RepeatedSerialGate`), where a 5/MG adopts its spec-defined DIS
+serial on first read.
+


### PR DESCRIPTION
The 4.0 half of #1193. The 5/MG half landed with #1303; the 4.0 was left behind
because nothing on the wire had been identified to adopt onto.

Something had been, since. The capture aid on the `GET_HELLO_HARVARD` (35)
branch found the serial as the 9-character alphanumeric run at offset 14 of a
131-byte response. Both the issue text and the `adoptWhoopSerialIdentity` doc
still said the source was unidentified, so both are corrected here.

## What it does

A 4.0's serial is decoded from the hello response and handed to the SAME
adoption path the ring and the 5/MG already use, so a re-pair folds onto the
existing `whoop-<serial>` row instead of minting a second one.

## Two deliberate restrictions

**A fixed 9-byte window, never a scan.** The same response carries a 54-char
DEVICE KEY at offset 24. A fixed window cannot drift onto it however payloads
vary; a "longest alnum run" could. A key must never become an id or reach a log,
and not reading it is the cheapest way to guarantee that. A window that is not
cleanly alphanumeric is refused rather than returned - refusing costs a strap the
stable id it would have gained, returning something wrong migrates its whole
history onto a junk key.

**The 4.0 waits where the 5/MG does not.** DIS `0x2A25` is a spec-defined field
that means one thing. This offset came off ONE capture, so it is a strong
inference, not a documented fact. If that run were per-session rather than
per-strap, adopting on first sight would mint a new id every connect and migrate
the history each time - strictly worse than the duplicate row this addresses. So
the value must repeat before it is trusted: two hellos carrying the same run
cannot both be a fresh token. A 4.0 therefore adopts one connect later than a
5/MG, which is the price of the destructive failure being impossible rather than
merely unlikely.

`RepeatedSerialGate` holds that rule, beside the decoder rather than inside the
BLE classes, because it is the part most likely to be wrong and the part neither
platform can unit-test in place.

## Gating

The identity read is UNGATED, unlike the structural probe beside it, which stays
Test Centre → Connection. Adoption has to work for every 4.0 owner and Test
Centre is off for almost all of them; gating it would ship a stable id only to
people already debugging. Nothing else about what an ordinary session touches
changes.

## Verification

- Android 5303 unit tests, 0 failures; `WhoopProtocol` package green.
- 9 new twinned tests: the decode against a payload shaped like the captured one,
  that the device key is unreachable, that a non-alnum window is refused, and the
  gate's behaviour including the case that matters - a value that keeps changing
  never confirms.
- Doc-comment lint clean. The raw serial reaches no log: only `logSafe` prefixes.

**Not verified, and it is the part that decides this:** none of it has run
against a strap. The decode is pinned to a synthetic payload built to the
captured shape, not to a live 4.0, and the whole premise is an offset read once.
Before this merges it wants a 4.0 that has been re-paired through the official
app - the exact trigger in the report - to confirm the second connect adopts and
that the row does not fork again. If the run at offset 14 is not what it appears
to be, the gate turns that into "no adoption" rather than a damaged history, but
"it did nothing" is still a failure worth catching on a device rather than in
the field.