### PR TITLE
Mask WHOOP serials that start with a letter

### DIFF
--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -898,8 +898,17 @@ public final class LiveState: ObservableObject {
         out = out.replacingOccurrences(
             of: "([0-9A-Fa-f]{2}):[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:([0-9A-Fa-f]{2})",
             with: "$1:••:••:••:••:$2", options: .regularExpression)
+        // #1193 field capture: the old rule required a DIGIT straight after "WHOOP ", but real serials
+        // start with letters as often as digits - "WHOOP MGB0779473" sat unredacted in a log attached to
+        // an issue while "WHOOP 4C1594026" beside it was masked. The rule now accepts any alnum run of 6+
+        // that CONTAINS a digit.
+        //
+        // The digit requirement is not decoration, it is what keeps this from eating words: "WHOOP PUFFIN
+        // service 1150" is a real diagnostic line, and PUFFIN is six alnum characters. A serial always
+        // carries a digit; a word does not. "WHOOP 4.0" stays untouched for a different reason - the dot
+        // stops the run at one character, short of the six the lookahead demands.
         out = out.replacingOccurrences(
-            of: "WHOOP (\\d[0-9A-Za-z]{5,})", with: "WHOOP <serial>", options: .regularExpression)
+            of: "WHOOP (?=[0-9A-Za-z]{6,})[0-9A-Za-z]*[0-9][0-9A-Za-z]*", with: "WHOOP <serial>", options: .regularExpression)
         // Mask a CoreBluetooth peripheral UUID, but NOT a standard-BLE / WHOOP-vendor service UUID.
         out = out.replacingOccurrences(
             of: "(?![0-9A-Fa-f]{8}-(?:0000-1000-8000-00805f9b34fb|8d6d-82b8-614a-1c8cb0f8dcc6))[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}",

--- a/StrandTests/PiiRedactionTests.swift
+++ b/StrandTests/PiiRedactionTests.swift
@@ -95,4 +95,32 @@ final class PiiRedactionTests: XCTestCase {
         XCTAssertEqual(LiveState.logSafeDeviceName("Polar OH1"), "Polar OH1")
     }
 
+
+    /// Field evidence (a 2026-09-05 staging log): serials beginning with a LETTER walked straight through
+    /// the old rule, which demanded a digit after "WHOOP ". Both spellings must mask.
+    func testMasksASerialWhateverCharacterItStartsWith() {
+        XCTAssertEqual(LiveState.redactPii("Discovered WHOOP MGB0779473 (rssi -48) - connecting"),
+                       "Discovered WHOOP <serial> (rssi -48) - connecting")
+        XCTAssertEqual(LiveState.redactPii("Discovered WHOOP 4C1594026 (rssi -63)"),
+                       "Discovered WHOOP <serial> (rssi -63)")
+        XCTAssertEqual(LiveState.redactPii("WHOOP 5AG0393796"), "WHOOP <serial>")
+    }
+
+    /// The digit requirement earns its keep here. "WHOOP PUFFIN service 1150" is a real diagnostic line
+    /// from the same log, and PUFFIN is six alnum characters - a length-only rule would mask it and
+    /// destroy the meaning of the line.
+    func testDoesNotMaskAWhoopPrefixedWord() {
+        let line = "WHOOP PUFFIN service 1150 detected but unsupported"
+        XCTAssertEqual(LiveState.redactPii(line), line)
+    }
+
+    /// A bare serial with no "WHOOP " in front of it is NOT covered here, and deliberately so: the only
+    /// rule that could catch it keys on shape alone and would mask ordinary prose. Discovery lines -
+    /// where this actually occurred - are handled at the call site by `logSafeDeviceName` instead.
+    func testABareSerialIsLeftToTheCallSiteNotGuessedAtHere() {
+        XCTAssertEqual(LiveState.redactPii("Discovered WBB5BP1174092 (rssi -64)"),
+                       "Discovered WBB5BP1174092 (rssi -64)")
+        XCTAssertEqual(LiveState.logSafeDeviceName("WBB5BP1174092"), "<name>")
+    }
+
 }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -11233,10 +11233,18 @@ class WhoopBleClient(
 //     replace() threw IndexOutOfBoundsException("No group 3"), and the thrown exception aborted that
 //     strap's activation. The WHOOP path never hit it because it only ever logs "WHOOP <serial>", never
 //     a raw MAC, so the bug was invisible until a Polar H10 / other 0x180D strap was used.)
-//   • WHOOP serial: the device name carries it ("WHOOP 4C1594026"); the dotted model names ("WHOOP 4.0")
-//     are too short / dotted to match.
+//   • WHOOP serial: the device name carries it ("WHOOP 4C1594026"). This used to require a DIGIT straight
+//     after "WHOOP ", but real serials start with letters as often as digits - a field log had
+//     "WHOOP MGB0779473" sitting unredacted next to a masked "WHOOP 4C1594026". Any alnum run of 6+ that
+//     CONTAINS a digit now matches.
+//
+//     The digit requirement is what keeps this from eating words: "WHOOP PUFFIN service 1150" is a real
+//     diagnostic line and PUFFIN is six alnum characters. A serial always carries a digit; a word does
+//     not. The dotted model names ("WHOOP 4.0") stay untouched for a different reason - the dot ends the
+//     run at one character, short of the six the lookahead demands.
 private val PII_MAC_RE = Regex("([0-9A-Fa-f]{2}):[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}:([0-9A-Fa-f]{2})")
-private val PII_WHOOP_SERIAL_RE = Regex("WHOOP (\\d[0-9A-Za-z]{5,})")
+private val PII_WHOOP_SERIAL_RE =
+    Regex("WHOOP (?=[0-9A-Za-z]{6,})[0-9A-Za-z]*[0-9][0-9A-Za-z]*")
 
 /**
  * The account holder's NAME, as WHOOP writes it into the advertised local name.

--- a/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
@@ -243,4 +243,38 @@ class PiiRedactionTest {
         assertEquals("Polar OH1", logSafeDeviceName("Polar OH1"))
     }
 
+
+    /**
+     * Field evidence (a 2026-09-05 staging log): serials beginning with a LETTER walked straight through
+     * the old rule, which demanded a digit after "WHOOP ". Both spellings must mask.
+     */
+    @Test fun `masks a serial whatever character it starts with`() {
+        assertEquals("Discovered WHOOP <serial> (rssi -48) - connecting",
+            redactStrapLogPii("Discovered WHOOP MGB0779473 (rssi -48) - connecting"))
+        assertEquals("Discovered WHOOP <serial> (rssi -63)",
+            redactStrapLogPii("Discovered WHOOP 4C1594026 (rssi -63)"))
+        assertEquals("WHOOP <serial>", redactStrapLogPii("WHOOP 5AG0393796"))
+    }
+
+    /**
+     * The digit requirement earns its keep here. "WHOOP PUFFIN service 1150" is a real diagnostic line
+     * from the same log, and PUFFIN is six alnum characters - a length-only rule would mask it and
+     * destroy the meaning of the line.
+     */
+    @Test fun `does not mask a WHOOP-prefixed WORD`() {
+        val line = "WHOOP PUFFIN service 1150 detected but unsupported"
+        assertEquals(line, redactStrapLogPii(line))
+    }
+
+    /**
+     * A bare serial with no "WHOOP " in front of it is NOT covered here, and deliberately so: the only
+     * rule that could catch it keys on shape alone and would mask ordinary prose. Discovery lines - where
+     * this actually occurred - are handled at the call site by [logSafeDeviceName] instead.
+     */
+    @Test fun `a bare serial is left to the call site, not guessed at here`() {
+        assertEquals("Discovered WBB5BP1174092 (rssi -64)",
+            redactStrapLogPii("Discovered WBB5BP1174092 (rssi -64)"))
+        assertEquals("<name>", logSafeDeviceName("WBB5BP1174092"))
+    }
+
 }


### PR DESCRIPTION
Found in a field log, not by reading: a 2026-09-05 staging capture has

```
Discovered WHOOP MGB0779473 (rssi -48) — connecting
```

sitting unredacted three lines from a correctly masked `WHOOP 4C1594026`. Same
log, same shape, one letter's difference — the rule was
`WHOOP (\d[0-9A-Za-z]{5,})`, demanding a DIGIT straight after `WHOOP `, and real
serials start with letters as often as digits. These are the logs people attach
to public issues.

## The fix

Any alphanumeric run of six or more that CONTAINS a digit now masks.

**The digit requirement is load-bearing, not decoration.** `WHOOP PUFFIN service
1150` is a real diagnostic line from that same capture, and `PUFFIN` is six
alphanumeric characters — a length-only widening would mask it and destroy the
line's meaning. A serial always carries a digit; a word does not. The dotted
model names (`WHOOP 4.0`) survive for a separate reason worth knowing: the dot
ends the run one character in, short of the six the lookahead demands. So the
two protections are independent, and a test pins each.

## What this deliberately does NOT do

A BARE serial with no `WHOOP ` in front of it — the same log has
`Discovered WBB5BP1174092` — is still not covered by the sink. The only rule
that could catch one keys on shape alone, and at six-plus alphanumerics with a
digit it would mask ordinary prose and identifiers throughout the log.

The place it actually appeared is discovery lines, and those are already handled
at the call site by `logSafeDeviceName`, which reduces a device name by allowlist
before it is ever logged. A test pins both halves of that division — the sink
leaving the bare serial alone, and the call site turning it into `<name>` — so
neither half is later mistaken for an oversight and "fixed" into a rule that
eats prose.

## Verification

- Android 5306 unit tests, 0 failures; doc-comment lint clean.
- 3 new twinned cases per platform, using the REAL strings from the capture:
  the letter-prefixed serial masks, the digit-prefixed one still masks, the
  WHOOP-prefixed WORD is untouched, and the bare serial is left to the call site.
- Every pre-existing expectation still holds, including `WHOOP 4.0` surviving.

The Swift half lives in `StrandTests`, so it runs in the macOS leg rather than
the default matrix.