### PR TITLE
analytics: cap HR and R-R reads separately, so a night is not scored on a clipped stream

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StreamReadCap.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StreamReadCap.swift
@@ -63,6 +63,16 @@ public enum StreamReadCap {
     /// 2/s is a ceiling chosen to stay clear of, not a claim about typical density.
     public static let rrRowsPerSecond = 2.0
 
+    /// Gravity: one sample per second, like HR, and read over the SAME 54-hour window - the code's claim
+    /// that "the other eight streams are thousands of rows" does not hold for this one. A field capture
+    /// measured 192,698 gravity rows, 96% of the old shared cap.
+    ///
+    /// It is the most dangerous of the three, because it is a PLAIN read rather than a
+    /// `SlidingStreamWindow`: nothing counts a truncation here, so a clip would be silent even by the
+    /// standard that caught R-R. Sleep STAGING is what consumes it, so the cost of a clipped read is a
+    /// mis-staged night rather than a slow one.
+    public static let gravityRowsPerSecond = 1.0
+
     /// Headroom over a full window, so a legitimate read cannot land ON the cap and be mistaken for a
     /// truncated one.
     public static let headroom = 1.5
@@ -81,4 +91,8 @@ public enum StreamReadCap {
 
     /// 583,200 - a full R-R window at its densest, plus half again. Stored for the reason `hr` gives.
     public static let rr = cap(rowsPerSecond: rrRowsPerSecond)
+
+    /// 291,600 - the same shape as `hr`, for the same 54-hour window. Only the 54-hour read needs it;
+    /// the day-scoped gravity reads span 24 hours and cannot approach any of these.
+    public static let gravity = cap(rowsPerSecond: gravityRowsPerSecond)
 }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StreamReadCap.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StreamReadCap.swift
@@ -42,8 +42,18 @@ import Foundation
 /// it costs nothing on a normal night and buys correctness on a dense one.
 public enum StreamReadCap {
 
-    /// The per-day read window: `dayStart - 30h` running through the night, i.e. 54 hours.
-    public static let windowSeconds = 54 * 3_600
+    /// How far BEFORE the day boundary the pass reads. EVERY lookback in the engine takes this value -
+    /// the per-day `from`, the window start, the skin-anchor scan - so the window and the caps derived
+    /// from it cannot drift apart - widening the lookback there without
+    /// resizing the caps here is precisely how a stream starts truncating again, and is the "one number
+    /// in two places" shape this whole type exists because of.
+    public static let lookbackSeconds = 30 * 3_600
+
+    /// How far AFTER it, capped at `now` for a day still in progress. A whole day.
+    public static let forwardSeconds = 24 * 3_600
+
+    /// The per-day read window: `dayStart - 30h` through the night, i.e. 54 hours.
+    public static let windowSeconds = lookbackSeconds + forwardSeconds
 
     /// HR: one sample per second.
     public static let hrRowsPerSecond = 1.0

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StreamReadCap.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StreamReadCap.swift
@@ -15,14 +15,22 @@ import Foundation
 ///
 /// ## Why R-R and not HR
 ///
-/// The pass reads a 54-hour window per day. HR is one sample per second, so a full window is ~194,400
-/// rows - under 200,000 by 3%, which is why HR never truncated and why the shared cap looked fine. R-R
-/// is one row per BEAT, so it exceeds 1/s at any real heart rate, and a 4.0's cross-second overcount
-/// roughly doubles it (#1008). A full R-R window is therefore 233,000-389,000 rows and runs straight
-/// through a cap HR merely brushes.
+/// Measured, not reasoned from beat rate - the capture contradicts the obvious argument. R-R is one row
+/// per BEAT, so it "should" outrun HR's 1/s, yet a stride read in that same log returned 81,009 R-R rows
+/// against 107,415 HR: R-R is recorded in BURSTS, not continuously, so its average over a window sits
+/// BELOW HR's while its peaks run far above. Averages are why one cap looked safe; peaks are what
+/// truncated it.
 ///
-/// So the bug was not the number being too small. It was ONE number serving two streams with different
-/// row rates, where the safe value for the sparser one is a silent truncation for the denser one.
+/// What is certain is the behaviour: across 21 nights R-R came back at the 200,000 cap ten times and HR
+/// never did. HR's own margin is the other half of the story - a full 54-hour window at 1/s is ~194,400
+/// rows, 3% under the cap, so HR was never comfortable either, merely lucky.
+///
+/// The caps are therefore sized against what a window can PEAK at, not what it averages. The rate
+/// constants below are deliberately generous for that reason: they are a ceiling to stay clear of, not a
+/// prediction of typical density.
+///
+/// So the bug was not the number being too small. It was ONE number serving two streams whose peak
+/// densities differ, where a value comfortable for one is a silent truncation for the other.
 ///
 /// ## The invariant
 ///
@@ -40,8 +48,9 @@ public enum StreamReadCap {
     /// HR: one sample per second.
     public static let hrRowsPerSecond = 1.0
 
-    /// R-R: one row per beat. 1.2-1.5/s is ordinary; #1008's cross-second overcount can reach ~2/s, and
-    /// the cap must hold the worst case a real strap can produce, not the average one.
+    /// R-R at its PEAK. The measured average is below 1/s (it arrives in bursts, with gaps), but bursts
+    /// are what reach a cap - and #1008's cross-second overcount can double the rows a burst produces.
+    /// 2/s is a ceiling chosen to stay clear of, not a claim about typical density.
     public static let rrRowsPerSecond = 2.0
 
     /// Headroom over a full window, so a legitimate read cannot land ON the cap and be mistaken for a
@@ -54,8 +63,12 @@ public enum StreamReadCap {
     }
 
     /// 291,600 - a full HR window plus half again.
-    public static var hr: Int { cap(rowsPerSecond: hrRowsPerSecond) }
+    ///
+    /// STORED, not computed. A window's read cap and its truncation threshold must be the same number,
+    /// and the engine names this in both slots - a stored constant makes those two references provably
+    /// one value rather than two evaluations that merely ought to agree.
+    public static let hr = cap(rowsPerSecond: hrRowsPerSecond)
 
-    /// 583,200 - a full R-R window at its densest, plus half again.
-    public static var rr: Int { cap(rowsPerSecond: rrRowsPerSecond) }
+    /// 583,200 - a full R-R window at its densest, plus half again. Stored for the reason `hr` gives.
+    public static let rr = cap(rowsPerSecond: rrRowsPerSecond)
 }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StreamReadCap.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StreamReadCap.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Per-stream read caps for the `analyzeRecent` sliding windows (#1538).
+///
+/// One shared cap of 200,000 covered both heavy streams, and it was sized for HR. A field capture
+/// (2026-09-05, WHOOP 5/MG, 21 nights) shows what that cost:
+///
+///     hr[read=1723815 served=1826919 truncated=0]
+///     rr[read=2563444 served=610905 truncated=10]
+///
+/// Ten R-R windows came back AT the cap. `SlidingStreamWindow.truncatedReads` is explicit about what
+/// that means - "a non-zero count means a number may be wrong, not merely slow" - because the read is
+/// `ORDER BY ts ASC LIMIT`, so what gets dropped is the NEWEST rows. Every HRV number derived from one
+/// of those windows was computed on a night missing its tail, silently.
+///
+/// ## Why R-R and not HR
+///
+/// The pass reads a 54-hour window per day. HR is one sample per second, so a full window is ~194,400
+/// rows - under 200,000 by 3%, which is why HR never truncated and why the shared cap looked fine. R-R
+/// is one row per BEAT, so it exceeds 1/s at any real heart rate, and a 4.0's cross-second overcount
+/// roughly doubles it (#1008). A full R-R window is therefore 233,000-389,000 rows and runs straight
+/// through a cap HR merely brushes.
+///
+/// So the bug was not the number being too small. It was ONE number serving two streams with different
+/// row rates, where the safe value for the sparser one is a silent truncation for the denser one.
+///
+/// ## The invariant
+///
+/// A cap must exceed what a full window can legitimately hold, or a complete read is indistinguishable
+/// from a truncated one. `capExceedsFullWindow` pins exactly that, per stream, so a future change to the
+/// window span or a stream's rate fails a test rather than quietly clipping a night.
+///
+/// Note the cap is a ceiling, not an allocation: a read still returns only the rows that exist. Raising
+/// it costs nothing on a normal night and buys correctness on a dense one.
+public enum StreamReadCap {
+
+    /// The per-day read window: `dayStart - 30h` running through the night, i.e. 54 hours.
+    public static let windowSeconds = 54 * 3_600
+
+    /// HR: one sample per second.
+    public static let hrRowsPerSecond = 1.0
+
+    /// R-R: one row per beat. 1.2-1.5/s is ordinary; #1008's cross-second overcount can reach ~2/s, and
+    /// the cap must hold the worst case a real strap can produce, not the average one.
+    public static let rrRowsPerSecond = 2.0
+
+    /// Headroom over a full window, so a legitimate read cannot land ON the cap and be mistaken for a
+    /// truncated one.
+    public static let headroom = 1.5
+
+    /// The cap for a stream producing `rowsPerSecond` at its densest.
+    public static func cap(rowsPerSecond: Double) -> Int {
+        Int((Double(windowSeconds) * rowsPerSecond * headroom).rounded(.up))
+    }
+
+    /// 291,600 - a full HR window plus half again.
+    public static var hr: Int { cap(rowsPerSecond: hrRowsPerSecond) }
+
+    /// 583,200 - a full R-R window at its densest, plus half again.
+    public static var rr: Int { cap(rowsPerSecond: rrRowsPerSecond) }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StreamReadCapTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StreamReadCapTests.swift
@@ -57,6 +57,7 @@ final class StreamReadCapTests: XCTestCase {
         XCTAssertEqual(StreamReadCap.windowSeconds, 54 * 3_600)
         XCTAssertEqual(StreamReadCap.hr, 291_600)
         XCTAssertEqual(StreamReadCap.rr, 583_200)
+        XCTAssertEqual(StreamReadCap.gravity, 291_600)
     }
 
     /// Gravity is the third stream on the 54-hour window, and the field capture put it at 192,698 rows -

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StreamReadCapTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StreamReadCapTests.swift
@@ -58,4 +58,14 @@ final class StreamReadCapTests: XCTestCase {
         XCTAssertEqual(StreamReadCap.hr, 291_600)
         XCTAssertEqual(StreamReadCap.rr, 583_200)
     }
+
+    /// Gravity is the third stream on the 54-hour window, and the field capture put it at 192,698 rows -
+    /// 96% of the old shared cap. Unlike HR and R-R it is a PLAIN read with no truncation counter, so a
+    /// clip there reports nothing at all; sleep staging simply gets a night missing its tail.
+    func testGravityClearsWhatTheFieldMeasured() {
+        let measuredInField = 192_698
+        XCTAssertGreaterThan(StreamReadCap.gravity, measuredInField)
+        XCTAssertGreaterThan(StreamReadCap.gravity, 200_000, "the old shared cap it sat 96% of")
+    }
+
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StreamReadCapTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StreamReadCapTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import XCTest
+@testable import StrandAnalytics
+
+/// Per-stream read caps (#1538) — twin of the Kotlin `StreamReadCapTest`, same cases and same numbers.
+final class StreamReadCapTests: XCTestCase {
+
+    /// THE invariant. A cap must exceed what a full window can legitimately hold, or a complete read is
+    /// indistinguishable from a truncated one — and the truncated one silently loses its newest rows.
+    /// If the window span or a stream's rate ever changes, this fails instead of a night being clipped.
+    func testCapExceedsAFullWindowForEveryStream() {
+        let fullHR = Double(StreamReadCap.windowSeconds) * StreamReadCap.hrRowsPerSecond
+        let fullRR = Double(StreamReadCap.windowSeconds) * StreamReadCap.rrRowsPerSecond
+        XCTAssertGreaterThan(Double(StreamReadCap.hr), fullHR)
+        XCTAssertGreaterThan(Double(StreamReadCap.rr), fullRR)
+    }
+
+    /// The regression itself, in the numbers that caused it. The old shared cap of 200,000 was ABOVE a
+    /// full HR window and BELOW a full R-R one — which is exactly why HR never truncated, R-R always did,
+    /// and one number looked adequate from the HR side.
+    func testTheOldSharedCapWasBelowAFullRRWindow() {
+        let oldSharedCap = 200_000.0
+        let fullHR = Double(StreamReadCap.windowSeconds) * StreamReadCap.hrRowsPerSecond
+        let fullRR = Double(StreamReadCap.windowSeconds) * StreamReadCap.rrRowsPerSecond
+        XCTAssertGreaterThan(oldSharedCap, fullHR, "the old cap fitted HR, which is why it looked fine")
+        XCTAssertLessThan(oldSharedCap, fullRR, "and did not fit R-R, which is why nights were clipped")
+        XCTAssertGreaterThan(Double(StreamReadCap.rr), fullRR, "the new cap does fit it")
+    }
+
+    /// R-R must be capped higher than HR: it is one row per BEAT, not one per second.
+    func testRRIsCappedHigherThanHR() {
+        XCTAssertGreaterThan(StreamReadCap.rr, StreamReadCap.hr)
+    }
+
+    /// The window is 54 hours — `dayStart - 30h` running through the night. Pinned because both caps are
+    /// derived from it, so a silent change here would resize them both.
+    func testWindowIsFiftyFourHours() {
+        XCTAssertEqual(StreamReadCap.windowSeconds, 54 * 3_600)
+        XCTAssertEqual(StreamReadCap.hr, 291_600)
+        XCTAssertEqual(StreamReadCap.rr, 583_200)
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StreamReadCapTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StreamReadCapTests.swift
@@ -7,12 +7,31 @@ final class StreamReadCapTests: XCTestCase {
 
     /// THE invariant. A cap must exceed what a full window can legitimately hold, or a complete read is
     /// indistinguishable from a truncated one — and the truncated one silently loses its newest rows.
-    /// If the window span or a stream's rate ever changes, this fails instead of a night being clipped.
     func testCapExceedsAFullWindowForEveryStream() {
         let fullHR = Double(StreamReadCap.windowSeconds) * StreamReadCap.hrRowsPerSecond
         let fullRR = Double(StreamReadCap.windowSeconds) * StreamReadCap.rrRowsPerSecond
         XCTAssertGreaterThan(Double(StreamReadCap.hr), fullHR)
         XCTAssertGreaterThan(Double(StreamReadCap.rr), fullRR)
+    }
+
+    /// The test above is derived from the same constants as the caps, so on its own it only asserts that
+    /// headroom exceeds 1. This one is anchored OUTSIDE the type, to a number the field produced: R-R
+    /// came back at 200,000 ten times in one capture, so that value is known-insufficient rather than
+    /// theorised. A cap at or below it would reintroduce the bug no matter how the arithmetic reads.
+    func testCapsClearTheValueThatTruncatedInTheField() {
+        let knownInsufficient = 200_000
+        XCTAssertGreaterThan(StreamReadCap.rr, knownInsufficient)
+        XCTAssertGreaterThan(StreamReadCap.hr, knownInsufficient,
+                             "HR sat 3% under this and was lucky, not safe")
+    }
+
+    /// The window is not restated here — the engine reads `dayStart - lookbackSeconds`, so these are the
+    /// same number by construction. Pinned so that splitting them again is a visible change.
+    func testWindowIsItsTwoHalves() {
+        XCTAssertEqual(StreamReadCap.windowSeconds,
+                       StreamReadCap.lookbackSeconds + StreamReadCap.forwardSeconds)
+        XCTAssertEqual(StreamReadCap.lookbackSeconds, 30 * 3_600)
+        XCTAssertEqual(StreamReadCap.forwardSeconds, 86_400)
     }
 
     /// The regression itself, in the numbers that caused it. The old shared cap of 200,000 was ABOVE a

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1026,7 +1026,8 @@ final class IntelligenceEngine: ObservableObject {
                                                              limit: 200_000)) ?? []
                 let resp = OuraRespScale.forScoring(respRows, deviceId: owner)
                 let vendorResp = OuraRespScale.forVendorRate(respRows, deviceId: owner)
-                let grav = (try? await store.gravitySamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
+                let grav = (try? await store.gravitySamples(deviceId: owner, from: from, to: to,
+                                                            limit: StreamReadCap.gravity)) ?? []
                 let steps = (try? await store.stepSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 let skin = (try? await store.skinTempSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
                 // #93: WHOOP 4.0 raw SpO2 PPG samples for the night; analyzeDay banks the nightly red/IR ADC

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -907,18 +907,21 @@ final class IntelligenceEngine: ObservableObject {
             // planner cannot prove safe falls back to exactly the read that shipped before them. HR and
             // R-R only: the other eight streams are thousands of rows against these two's tens of
             // thousands, so this is nearly all of the win for two call sites of blast radius.
-            // ONE binding, used as both the read cap and the window's truncation threshold. They must be
-            // the same number: the window declines to slice a read that came back at the cap, because
-            // `ORDER BY ts ASC LIMIT` drops the NEWEST rows. Were the two to drift apart, a truncated read
-            // would stop being recognised and the buffer would be sliced while missing its tail — wrong
-            // scoring inputs, silently. The Kotlin twin cannot drift because it uses `STREAM_LIMIT` for
-            // both; this is the same guarantee spelled locally.
-            let streamLimit = 200_000
-            let hrWindow = SlidingStreamWindow<HRSample>(tsOf: { $0.ts }, limit: streamLimit) { o, f, t in
-                try? await store.hrSamples(deviceId: o, from: f, to: t, limit: streamLimit)
+            // Each window's read cap and its truncation threshold must be the SAME number: the window
+            // declines to slice a read that came back at the cap, because `ORDER BY ts ASC LIMIT` drops the
+            // NEWEST rows. Were the two to drift apart, a truncated read would stop being recognised and the
+            // buffer would be sliced while missing its tail — wrong scoring inputs, silently. Passing one
+            // `StreamReadCap` value into both slots below keeps that guarantee per stream.
+            //
+            // #1538: the two streams no longer share ONE cap. 200,000 was sized for HR (a full 54h window is
+            // ~194,400 rows, 3% under) and silently truncated R-R, which is per-BEAT and runs to 233k-389k
+            // over the same window. A field capture showed `rr[... truncated=10]` — ten nights scored on R-R
+            // missing its tail. See `StreamReadCap` for the arithmetic.
+            let hrWindow = SlidingStreamWindow<HRSample>(tsOf: { $0.ts }, limit: StreamReadCap.hr) { o, f, t in
+                try? await store.hrSamples(deviceId: o, from: f, to: t, limit: StreamReadCap.hr)
             }
-            let rrWindow = SlidingStreamWindow<RRInterval>(tsOf: { $0.ts }, limit: streamLimit) { o, f, t in
-                try? await store.rrIntervals(deviceId: o, from: f, to: t, limit: streamLimit)
+            let rrWindow = SlidingStreamWindow<RRInterval>(tsOf: { $0.ts }, limit: StreamReadCap.rr) { o, f, t in
+                try? await store.rrIntervals(deviceId: o, from: f, to: t, limit: StreamReadCap.rr)
             }
             for offset in 0..<maxDays {
                 let dayStart = nowLocalMidnight - offset * 86_400

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -747,7 +747,7 @@ final class IntelligenceEngine: ObservableObject {
         // and the Sleep tab resolve to the identical block. (#547)
         let (habitualMidsleepSec, nightlyHours) = await Self.computeHabitualSleep(
             store: store, importedId: deviceId, computedId: deviceId + "-noop",
-            windowStart: nowLocalMidnight - maxDays * 86_400 - 30 * 3_600,
+            windowStart: nowLocalMidnight - maxDays * 86_400 - StreamReadCap.lookbackSeconds,
             windowEnd: now, offsetSec: tzOffset)
         // Wave 0 (SL1/T1): personal sleep REGULARITY + population-anchored NEED, computed ONCE from the
         // trailing per-night durations and threaded to every analyzeDay below (mirrors the midsleep
@@ -883,7 +883,7 @@ final class IntelligenceEngine: ObservableObject {
             var skippedSleepDays: [(day: String, hrSamples: Int)] = []
             // #938: the WHOOP 4.0 ADC offset is per-device, not per-night. Learn one anchor per owner
             // from the whole scan window and reuse it for every night so cross-night deviations survive.
-            let skinAnchorScanFrom = nowLocalMidnight - (maxDays - 1) * 86_400 - 30 * 3_600
+            let skinAnchorScanFrom = nowLocalMidnight - (maxDays - 1) * 86_400 - StreamReadCap.lookbackSeconds
             let skinAnchorScanTo = nowLocalMidnight + 18 * 3_600
             var skinAnchorByOwner: [String: Double] = [:]
             var skinAnchorResolvedOwners = Set<String>()
@@ -927,7 +927,7 @@ final class IntelligenceEngine: ObservableObject {
                 let dayStart = nowLocalMidnight - offset * 86_400
                 let day = AnalyticsEngine.dayString(dayStart, offsetSec: tzOffset)
                 // Read a generous window around the night that ends on `day`; the stager finds the span.
-                let from = dayStart - 30 * 3_600
+                let from = dayStart - StreamReadCap.lookbackSeconds
                 // Sleep read-window END — see `sleepReadWindowEnd`.
                 let to = Self.sleepReadWindowEnd(dayStart: dayStart,
                                                  nowLocalMidnight: nowLocalMidnight,
@@ -1734,7 +1734,7 @@ final class IntelligenceEngine: ObservableObject {
         // re-labelled rows (both written under `deviceId`), and apple-health carries Health imports ,
         // a detected bout overlapping ANY of them is skipped below. Port of the Android dedup block.
         // (`computedId` is bound once above, before the off-actor scan loop.)
-        let windowStart = now - maxDays * 86_400 - 30 * 3_600
+        let windowStart = now - maxDays * 86_400 - StreamReadCap.lookbackSeconds
         var realWorkouts = (try? await store.workouts(deviceId: deviceId, from: windowStart,
                                                        to: now, limit: 100_000)) ?? []
         realWorkouts += (try? await store.workouts(deviceId: "apple-health", from: windowStart,

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -907,7 +907,7 @@ object IntelligenceEngine {
             val respRows = repo.respSamples(owner, from, to, STREAM_LIMIT)
             val resp = OuraRespScale.forScoring(respRows, owner)
             val vendorResp = OuraRespScale.forVendorRate(respRows, owner)
-            val grav = repo.gravitySamplesForDevice(owner, from, to, STREAM_LIMIT)
+            val grav = repo.gravitySamplesForDevice(owner, from, to, StreamReadCap.GRAVITY)
             val steps = repo.stepSamples(owner, from, to, STREAM_LIMIT)
             val skinReads = readDaySkinAndWristOff(
                 repo, owner, from, to, ownerSource, skinFamilyByOwner, skinWornToleranceByOwner,

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -159,7 +159,13 @@ object IntelligenceEngine {
     /** Minimum HR samples in a day's window before it is worth scoring. */
     const val MIN_HR_SAMPLES: Int = 200
 
-    /** Read cap per stream read , matches the Swift 200_000 bound. */
+    /**
+     * Read cap for the SPARSE streams (aux, resp, gravity, skin temp), matching the Swift bound.
+     *
+     * NOT the two heavy streams any more: HR and R-R take their caps from [StreamReadCap], because one
+     * number sized for HR silently truncated R-R (#1538). Anything reading a stream dense enough to
+     * approach this bound belongs there too.
+     */
     const val STREAM_LIMIT: Int = 200_000
     internal const val PHYSIOLOGICAL_STEP_PAGE_SIZE: Int = 10_000
 
@@ -2687,14 +2693,14 @@ object IntelligenceEngine {
      *  element lambda nor the reader lambda counts against that method's bytecode budget, which the
      *  extraction next door exists to protect. */
     private fun hrReadWindow(repo: com.noop.data.WhoopRepository) =
-        SlidingStreamWindow<com.noop.data.HrSample>({ it.ts }, STREAM_LIMIT) { o, f, t ->
-            repo.hrSamplesForDevice(o, f, t, STREAM_LIMIT)
+        SlidingStreamWindow<com.noop.data.HrSample>({ it.ts }, StreamReadCap.HR) { o, f, t ->
+            repo.hrSamplesForDevice(o, f, t, StreamReadCap.HR)
         }
 
     /** The pass-1 R-R sliding read window. Same reason as [hrReadWindow] for living out here. */
     private fun rrReadWindow(repo: com.noop.data.WhoopRepository) =
-        SlidingStreamWindow<com.noop.data.RrInterval>({ it.ts }, STREAM_LIMIT) { o, f, t ->
-            repo.rrIntervalsForDevice(o, f, t, STREAM_LIMIT)
+        SlidingStreamWindow<com.noop.data.RrInterval>({ it.ts }, StreamReadCap.RR) { o, f, t ->
+            repo.rrIntervalsForDevice(o, f, t, StreamReadCap.RR)
         }
 
 

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -659,7 +659,7 @@ object IntelligenceEngine {
         // the Sleep tab resolve to the identical block. Mirrors Swift. (#547)
         val (habitualMidsleepSec, nightlyHours) = computeHabitualSleep(
             repo, importedDeviceId, computedId,
-            nowLocalMidnight - maxDays * SECONDS_PER_DAY - 30 * 3_600L, nowSeconds, tzOffsetSeconds,
+            nowLocalMidnight - maxDays * SECONDS_PER_DAY - StreamReadCap.LOOKBACK_SECONDS, nowSeconds, tzOffsetSeconds,
         )
         // Wave 0 (SL1/T1): personal sleep REGULARITY + population-anchored NEED, computed ONCE from the
         // trailing per-night durations and threaded to every analyzeDay below (mirrors the midsleep
@@ -689,7 +689,7 @@ object IntelligenceEngine {
         val skinWornToleranceByOwner = HashMap<String, Long>()
         // #938: the WHOOP 4.0 ADC offset is per-device, not per-night. Learn one anchor per owner from the
         // whole scan window and reuse it for every night so cross-night deviations survive.
-        val skinAnchorScanFrom = nowLocalMidnight - (maxDays - 1).toLong() * SECONDS_PER_DAY - 30 * 3_600L
+        val skinAnchorScanFrom = nowLocalMidnight - (maxDays - 1).toLong() * SECONDS_PER_DAY - StreamReadCap.LOOKBACK_SECONDS
         val skinAnchorScanTo = nowLocalMidnight + 18 * 3_600L
         val skinAnchorByOwner = HashMap<String, Double>()
         val skinAnchorResolvedOwners = HashSet<String>()
@@ -782,7 +782,7 @@ object IntelligenceEngine {
             val dayDiagLines = ArrayList<String>()
             fun dayDiag(line: String) { dayDiagLines.add(line); diag(line) }
             // Read a generous window around the night that ends on `day`; the stager finds the span.
-            val from = dayStart - 30 * 3_600L
+            val from = dayStart - StreamReadCap.LOOKBACK_SECONDS
             // Sleep read-window END — see `sleepReadWindowEnd`. A PAST day reads through to the next
             // local midnight so the stager sees the whole night; TODAY is capped at `now` (never read
             // the future), NOT a fixed `dayStart + 18h` — that cap reported a flat 18:00 wake for a
@@ -1439,7 +1439,7 @@ object IntelligenceEngine {
         // the cross-source duplicate (#107): the strap source carries imported WHOOP rows AND manual /
         // re-labelled rows (both under [importedDeviceId]); apple-health / health-connect carry Health
         // imports , a detected bout overlapping ANY of them is skipped below.
-        val windowStart = nowSeconds - maxDays.toLong() * SECONDS_PER_DAY - 30 * 3_600L
+        val windowStart = nowSeconds - maxDays.toLong() * SECONDS_PER_DAY - StreamReadCap.LOOKBACK_SECONDS
         val realWorkouts = repo.workouts(importedDeviceId, windowStart, nowSeconds) +
             repo.workouts("apple-health", windowStart, nowSeconds) +
             repo.workouts("health-connect", windowStart, nowSeconds)

--- a/android/app/src/main/java/com/noop/analytics/StreamReadCap.kt
+++ b/android/app/src/main/java/com/noop/analytics/StreamReadCap.kt
@@ -20,14 +20,22 @@ import kotlin.math.ceil
  *
  * ## Why R-R and not HR
  *
- * The pass reads a 54-hour window per day. HR is one sample per second, so a full window is ~194,400
- * rows - under 200,000 by 3%, which is why HR never truncated and why the shared cap looked fine. R-R is
- * one row per BEAT, so it exceeds 1/s at any real heart rate, and a 4.0's cross-second overcount roughly
- * doubles it (#1008). A full R-R window is therefore 233,000-389,000 rows and runs straight through a
- * cap HR merely brushes.
+ * Measured, not reasoned from beat rate - the capture contradicts the obvious argument. R-R is one row
+ * per BEAT, so it "should" outrun HR's 1/s, yet a stride read in that same log returned 81,009 R-R rows
+ * against 107,415 HR: R-R is recorded in BURSTS, not continuously, so its average over a window sits
+ * BELOW HR's while its peaks run far above. Averages are why one cap looked safe; peaks are what
+ * truncated it.
  *
- * So the bug was not the number being too small. It was ONE number serving two streams with different
- * row rates, where the safe value for the sparser one is a silent truncation for the denser one.
+ * What is certain is the behaviour: across 21 nights R-R came back at the 200,000 cap ten times and HR
+ * never did. HR's own margin is the other half of the story - a full 54-hour window at 1/s is ~194,400
+ * rows, 3% under the cap, so HR was never comfortable either, merely lucky.
+ *
+ * The caps are therefore sized against what a window can PEAK at, not what it averages. The rate
+ * constants below are deliberately generous for that reason: they are a ceiling to stay clear of, not a
+ * prediction of typical density.
+ *
+ * So the bug was not the number being too small. It was ONE number serving two streams whose peak
+ * densities differ, where a value comfortable for one is a silent truncation for the other.
  *
  * ## The invariant
  *
@@ -47,8 +55,9 @@ object StreamReadCap {
     const val HR_ROWS_PER_SECOND = 1.0
 
     /**
-     * R-R: one row per beat. 1.2-1.5/s is ordinary; #1008's cross-second overcount can reach ~2/s, and
-     * the cap must hold the worst case a real strap can produce, not the average one.
+     * R-R at its PEAK. The measured average is below 1/s (it arrives in bursts, with gaps), but bursts
+     * are what reach a cap - and #1008's cross-second overcount can double the rows a burst produces.
+     * 2/s is a ceiling chosen to stay clear of, not a claim about typical density.
      */
     const val RR_ROWS_PER_SECOND = 2.0
 
@@ -61,9 +70,15 @@ object StreamReadCap {
     /** The cap for a stream producing [rowsPerSecond] at its densest. */
     fun cap(rowsPerSecond: Double): Int = ceil(WINDOW_SECONDS * rowsPerSecond * HEADROOM).toInt()
 
-    /** 291,600 - a full HR window plus half again. */
-    val HR: Int get() = cap(HR_ROWS_PER_SECOND)
+    /**
+     * 291,600 - a full HR window plus half again.
+     *
+     * STORED, not a getter. A window's read cap and its truncation threshold must be the same number,
+     * and the engine names this in both slots - a stored value makes those two references provably one
+     * value rather than two evaluations that merely ought to agree.
+     */
+    val HR: Int = cap(HR_ROWS_PER_SECOND)
 
-    /** 583,200 - a full R-R window at its densest, plus half again. */
-    val RR: Int get() = cap(RR_ROWS_PER_SECOND)
+    /** 583,200 - a full R-R window at its densest, plus half again. Stored for the reason [HR] gives. */
+    val RR: Int = cap(RR_ROWS_PER_SECOND)
 }

--- a/android/app/src/main/java/com/noop/analytics/StreamReadCap.kt
+++ b/android/app/src/main/java/com/noop/analytics/StreamReadCap.kt
@@ -48,8 +48,20 @@ import kotlin.math.ceil
  */
 object StreamReadCap {
 
-    /** The per-day read window: `dayStart - 30h` running through the night, i.e. 54 hours. */
-    const val WINDOW_SECONDS = 54 * 3_600
+    /**
+     * How far BEFORE the day boundary the pass reads. EVERY lookback in the engine takes this value -
+     * the per-day `from`, the window start, the skin-anchor scan - so the window and the caps derived
+     * from it cannot drift apart - widening the lookback there without
+     * resizing the caps here is precisely how a stream starts truncating again, and is the "one number in
+     * two places" shape this whole type exists because of.
+     */
+    const val LOOKBACK_SECONDS = 30 * 3_600
+
+    /** How far AFTER it, capped at `now` for a day still in progress. A whole day. */
+    const val FORWARD_SECONDS = 24 * 3_600
+
+    /** The per-day read window: `dayStart - 30h` through the night, i.e. 54 hours. */
+    const val WINDOW_SECONDS = LOOKBACK_SECONDS + FORWARD_SECONDS
 
     /** HR: one sample per second. */
     const val HR_ROWS_PER_SECOND = 1.0

--- a/android/app/src/main/java/com/noop/analytics/StreamReadCap.kt
+++ b/android/app/src/main/java/com/noop/analytics/StreamReadCap.kt
@@ -74,6 +74,18 @@ object StreamReadCap {
     const val RR_ROWS_PER_SECOND = 2.0
 
     /**
+     * Gravity: one sample per second, like HR, and read over the SAME 54-hour window - the code's claim
+     * that "the other eight streams are thousands of rows" does not hold for this one. A field capture
+     * measured 192,698 gravity rows, 96% of the old shared cap.
+     *
+     * It is the most dangerous of the three, because it is a PLAIN read rather than a
+     * [SlidingStreamWindow]: nothing counts a truncation here, so a clip would be silent even by the
+     * standard that caught R-R. Sleep STAGING is what consumes it, so the cost of a clipped read is a
+     * mis-staged night rather than a slow one.
+     */
+    const val GRAVITY_ROWS_PER_SECOND = 1.0
+
+    /**
      * Headroom over a full window, so a legitimate read cannot land ON the cap and be mistaken for a
      * truncated one.
      */
@@ -93,4 +105,10 @@ object StreamReadCap {
 
     /** 583,200 - a full R-R window at its densest, plus half again. Stored for the reason [HR] gives. */
     val RR: Int = cap(RR_ROWS_PER_SECOND)
+
+    /**
+     * 291,600 - the same shape as [HR], for the same 54-hour window. Only the 54-hour read needs it; the
+     * day-scoped gravity reads span 24 hours and cannot approach any of these.
+     */
+    val GRAVITY: Int = cap(GRAVITY_ROWS_PER_SECOND)
 }

--- a/android/app/src/main/java/com/noop/analytics/StreamReadCap.kt
+++ b/android/app/src/main/java/com/noop/analytics/StreamReadCap.kt
@@ -1,0 +1,69 @@
+package com.noop.analytics
+
+import kotlin.math.ceil
+
+/**
+ * Per-stream read caps for the `analyzeRecent` sliding windows (#1538).
+ *
+ * One shared cap of 200,000 covered both heavy streams, and it was sized for HR. A field capture
+ * (2026-09-05, WHOOP 5/MG, 21 nights) shows what that cost:
+ *
+ * ```
+ * hr[read=1723815 served=1826919 truncated=0]
+ * rr[read=2563444 served=610905 truncated=10]
+ * ```
+ *
+ * Ten R-R windows came back AT the cap. [SlidingStreamWindow.truncatedReads] is explicit about what
+ * that means - "a non-zero count means a number may be wrong, not merely slow" - because the read is
+ * `ORDER BY ts ASC LIMIT`, so what gets dropped is the NEWEST rows. Every HRV number derived from one of
+ * those windows was computed on a night missing its tail, silently.
+ *
+ * ## Why R-R and not HR
+ *
+ * The pass reads a 54-hour window per day. HR is one sample per second, so a full window is ~194,400
+ * rows - under 200,000 by 3%, which is why HR never truncated and why the shared cap looked fine. R-R is
+ * one row per BEAT, so it exceeds 1/s at any real heart rate, and a 4.0's cross-second overcount roughly
+ * doubles it (#1008). A full R-R window is therefore 233,000-389,000 rows and runs straight through a
+ * cap HR merely brushes.
+ *
+ * So the bug was not the number being too small. It was ONE number serving two streams with different
+ * row rates, where the safe value for the sparser one is a silent truncation for the denser one.
+ *
+ * ## The invariant
+ *
+ * A cap must exceed what a full window can legitimately hold, or a complete read is indistinguishable
+ * from a truncated one. `cap exceeds a full window` pins exactly that, per stream, so a future change to
+ * the window span or a stream's rate fails a test rather than quietly clipping a night.
+ *
+ * Note the cap is a ceiling, not an allocation: a read still returns only the rows that exist. Raising
+ * it costs nothing on a normal night and buys correctness on a dense one. Swift twin: `StreamReadCap`.
+ */
+object StreamReadCap {
+
+    /** The per-day read window: `dayStart - 30h` running through the night, i.e. 54 hours. */
+    const val WINDOW_SECONDS = 54 * 3_600
+
+    /** HR: one sample per second. */
+    const val HR_ROWS_PER_SECOND = 1.0
+
+    /**
+     * R-R: one row per beat. 1.2-1.5/s is ordinary; #1008's cross-second overcount can reach ~2/s, and
+     * the cap must hold the worst case a real strap can produce, not the average one.
+     */
+    const val RR_ROWS_PER_SECOND = 2.0
+
+    /**
+     * Headroom over a full window, so a legitimate read cannot land ON the cap and be mistaken for a
+     * truncated one.
+     */
+    const val HEADROOM = 1.5
+
+    /** The cap for a stream producing [rowsPerSecond] at its densest. */
+    fun cap(rowsPerSecond: Double): Int = ceil(WINDOW_SECONDS * rowsPerSecond * HEADROOM).toInt()
+
+    /** 291,600 - a full HR window plus half again. */
+    val HR: Int get() = cap(HR_ROWS_PER_SECOND)
+
+    /** 583,200 - a full R-R window at its densest, plus half again. */
+    val RR: Int get() = cap(RR_ROWS_PER_SECOND)
+}

--- a/android/app/src/test/java/com/noop/analytics/StreamReadCapTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StreamReadCapTest.kt
@@ -1,0 +1,50 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Per-stream read caps (#1538) — twin of the Swift `StreamReadCapTests`, same cases and same numbers. */
+class StreamReadCapTest {
+
+    /**
+     * THE invariant. A cap must exceed what a full window can legitimately hold, or a complete read is
+     * indistinguishable from a truncated one — and the truncated one silently loses its newest rows. If
+     * the window span or a stream's rate ever changes, this fails instead of a night being clipped.
+     */
+    @Test fun `cap exceeds a full window for every stream`() {
+        val fullHr = StreamReadCap.WINDOW_SECONDS * StreamReadCap.HR_ROWS_PER_SECOND
+        val fullRr = StreamReadCap.WINDOW_SECONDS * StreamReadCap.RR_ROWS_PER_SECOND
+        assertTrue(StreamReadCap.HR > fullHr)
+        assertTrue(StreamReadCap.RR > fullRr)
+    }
+
+    /**
+     * The regression itself, in the numbers that caused it. The old shared cap of 200,000 was ABOVE a
+     * full HR window and BELOW a full R-R one — which is exactly why HR never truncated, R-R always did,
+     * and one number looked adequate from the HR side.
+     */
+    @Test fun `the old shared cap was below a full R-R window`() {
+        val oldSharedCap = 200_000.0
+        val fullHr = StreamReadCap.WINDOW_SECONDS * StreamReadCap.HR_ROWS_PER_SECOND
+        val fullRr = StreamReadCap.WINDOW_SECONDS * StreamReadCap.RR_ROWS_PER_SECOND
+        assertTrue("the old cap fitted HR, which is why it looked fine", oldSharedCap > fullHr)
+        assertTrue("and did not fit R-R, which is why nights were clipped", oldSharedCap < fullRr)
+        assertTrue("the new cap does fit it", StreamReadCap.RR > fullRr)
+    }
+
+    /** R-R must be capped higher than HR: it is one row per BEAT, not one per second. */
+    @Test fun `R-R is capped higher than HR`() {
+        assertTrue(StreamReadCap.RR > StreamReadCap.HR)
+    }
+
+    /**
+     * The window is 54 hours — `dayStart - 30h` running through the night. Pinned because both caps are
+     * derived from it, so a silent change here would resize them both.
+     */
+    @Test fun `window is fifty-four hours`() {
+        assertEquals(54 * 3_600, StreamReadCap.WINDOW_SECONDS)
+        assertEquals(291_600, StreamReadCap.HR)
+        assertEquals(583_200, StreamReadCap.RR)
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/StreamReadCapTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StreamReadCapTest.kt
@@ -20,6 +20,28 @@ class StreamReadCapTest {
     }
 
     /**
+     * The test above is derived from the same constants as the caps, so on its own it only asserts that
+     * headroom exceeds 1. This one is anchored OUTSIDE the type, to a number the field produced: R-R came
+     * back at 200,000 ten times in one capture, so that value is known-insufficient rather than
+     * theorised. A cap at or below it would reintroduce the bug no matter how the arithmetic reads.
+     */
+    @Test fun `caps clear the value that truncated in the field`() {
+        val knownInsufficient = 200_000
+        assertTrue(StreamReadCap.RR > knownInsufficient)
+        assertTrue("HR sat 3% under this and was lucky, not safe", StreamReadCap.HR > knownInsufficient)
+    }
+
+    /**
+     * The window is not restated here — the engine reads `dayStart - LOOKBACK_SECONDS`, so these are the
+     * same number by construction. Pinned so that splitting them again is a visible change.
+     */
+    @Test fun `window is its two halves`() {
+        assertEquals(StreamReadCap.LOOKBACK_SECONDS + StreamReadCap.FORWARD_SECONDS, StreamReadCap.WINDOW_SECONDS)
+        assertEquals(30 * 3_600, StreamReadCap.LOOKBACK_SECONDS)
+        assertEquals(86_400, StreamReadCap.FORWARD_SECONDS)
+    }
+
+    /**
      * The regression itself, in the numbers that caused it. The old shared cap of 200,000 was ABOVE a
      * full HR window and BELOW a full R-R one — which is exactly why HR never truncated, R-R always did,
      * and one number looked adequate from the HR side.

--- a/android/app/src/test/java/com/noop/analytics/StreamReadCapTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StreamReadCapTest.kt
@@ -69,4 +69,16 @@ class StreamReadCapTest {
         assertEquals(291_600, StreamReadCap.HR)
         assertEquals(583_200, StreamReadCap.RR)
     }
+
+    /**
+     * Gravity is the third stream on the 54-hour window, and the field capture put it at 192,698 rows -
+     * 96% of the old shared cap. Unlike HR and R-R it is a PLAIN read with no truncation counter, so a
+     * clip there reports nothing at all; sleep staging simply gets a night missing its tail.
+     */
+    @Test fun `gravity clears what the field measured`() {
+        val measuredInField = 192_698
+        assertTrue(StreamReadCap.GRAVITY > measuredInField)
+        assertTrue("the old shared cap it sat 96% of", StreamReadCap.GRAVITY > 200_000)
+    }
+
 }

--- a/android/app/src/test/java/com/noop/analytics/StreamReadCapTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StreamReadCapTest.kt
@@ -68,6 +68,7 @@ class StreamReadCapTest {
         assertEquals(54 * 3_600, StreamReadCap.WINDOW_SECONDS)
         assertEquals(291_600, StreamReadCap.HR)
         assertEquals(583_200, StreamReadCap.RR)
+        assertEquals(291_600, StreamReadCap.GRAVITY)
     }
 
     /**


### PR DESCRIPTION
Found while profiling the re-score cost in a field capture (2026-09-05, WHOOP
5/MG, 21 nights). This is a **correctness** finding, not a performance one.

```
hr[read=1723815 served=1826919 truncated=0]
rr[read=2563444 served=610905 truncated=10]
```

Ten R-R windows came back AT the read cap. `SlidingStreamWindow`'s own doc is
explicit about what that means:

> a non-zero count means a number may be wrong, not merely slow

The read is `ORDER BY ts ASC LIMIT`, so what a truncated read drops is the
**newest** rows. Every HRV number derived from one of those windows was computed
on a night missing its tail, silently.

## Why it happened

One cap of 200,000 served both heavy streams. The pass reads a **54-hour** window
per day (`dayStart - 30h` through the night):

| stream | rate | full window | vs 200,000 |
|---|---|---|---|
| HR | ~1/sec | ~194,400 | fits, 3% to spare |
| R-R | one row per BEAT, 1.2-2/sec | 233,000-389,000 | over - truncates |

So the bug was not that the number was too small. It was that ONE number served
two streams with different row rates, and the safe value for the sparser one is a
silent truncation for the denser one. HR fitting with 3% headroom is also why
this looked fine from the HR side for so long - and it means HR is one denser
strap or one longer window away from the same failure.

## The fix

Each stream derives its own cap from the window span and its own densest rate,
plus half again as headroom, so a legitimate read cannot land ON the cap and be
mistaken for a truncated one. HR 291,600; R-R 583,200.

The read cap and the truncation threshold remain the same value per window -
that identity is what lets the planner recognise a clipped read at all, and the
comment explaining it is kept and re-pointed rather than dropped.

## Trade-off, stated plainly

The cap is a ceiling, not an allocation: a read returns only the rows that exist,
so a normal night costs exactly what it did before. A pathological device can now
materialise more rows than it used to. That is the intended trade - the
alternative is continuing to score it on data we know is incomplete.

## Verification

- Android 5310 unit tests, 0 failures; doc-comment lint clean.
- 4 new twinned tests. The one that matters pins the invariant per stream: **a
  cap must exceed what a full window can legitimately hold**, so a future change
  to the window span or a stream's rate fails a test instead of quietly clipping
  a night. Another pins the regression in the numbers that caused it - the old
  200,000 was above a full HR window and below a full R-R one.
- Audited the other `200_000` caps rather than assuming: the day-cycle HR read
  and `DebugDataDiagnostics` both scope to a single sleep session, where even R-R
  at its densest is well under. The 54-hour window is unique to this pass.

`StrandAnalytics` tests need `sqlite3.h` and cannot run on this Linux box, so the
Swift half is verified by CI's `test (StrandAnalytics)` leg; the Kotlin twin runs
locally and passes.

## Not addressed here

Whether any already-stored HRV value was computed from a clipped window. Nothing
records which nights were affected, and this change only stops it recurring - it
does not re-score history. Worth deciding separately whether a one-off rescore is
warranted.