### PR TITLE
Fix Python capture-tool encoding and SQLite cleanup

### DIFF
--- a/.github/workflows/tools-python.yml
+++ b/.github/workflows/tools-python.yml
@@ -79,3 +79,36 @@ jobs:
             exit 1
           fi
         working-directory: Tools
+
+  windows-capture:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # Keep Windows locale defaults and exercise a strict legacy console, including subprocesses.
+      # UTF-8 mode would hide implicit file encodings; replacement output would hide console bugs.
+      - name: Run Tools/linux-capture tests with legacy Windows encodings
+        working-directory: Tools/linux-capture
+        env:
+          PYTHONUTF8: '0'
+          PYTHONIOENCODING: 'cp1252:strict'
+          PYTHONLEGACYWINDOWSSTDIO: '1'
+        shell: python
+        run: |
+          import sys
+          import unittest
+
+          suite = unittest.defaultTestLoader.discover('.', pattern='test_*.py')
+          count = suite.countTestCases()
+          print(f'collected {count} tests', flush=True)
+          result = unittest.TextTestRunner(verbosity=2).run(suite)
+          if count < 200 or result.testsRun < 200:
+              print('::error::expected at least 200 tests; discovery or execution is incomplete')
+              sys.exit(1)
+          sys.exit(0 if result.wasSuccessful() else 1)

--- a/Tools/linux-capture/analyze_command_responses.py
+++ b/Tools/linux-capture/analyze_command_responses.py
@@ -45,7 +45,8 @@ def main():
     if len(sys.argv) < 2:
         print(__doc__)
         return
-    data = json.load(open(sys.argv[1]))
+    with open(sys.argv[1], encoding="utf-8") as f:
+        data = json.load(f)
     seen = {}
     for r in data:
         h = bytes.fromhex(r["hex"])

--- a/Tools/linux-capture/analyze_command_responses.py
+++ b/Tools/linux-capture/analyze_command_responses.py
@@ -11,6 +11,7 @@ math as the 4.0 `command_response` post-hook so we can confirm the +4 hypothesis
 import json
 import sys
 
+from capture_io import configure_utf8_stdio
 import whoop_frame as wf
 
 # Response command numbers (CommandNumber enum) → human name.
@@ -68,4 +69,5 @@ def main():
 
 
 if __name__ == "__main__":
+    configure_utf8_stdio()
     main()

--- a/Tools/linux-capture/analyze_v25_waveform.py
+++ b/Tools/linux-capture/analyze_v25_waveform.py
@@ -164,7 +164,8 @@ def load_corpus(argv):
         print("No corpus given — running the DEMO on the bundled resting frames (which cannot pin the\n"
               "span; that is the point). Build a real corpus (--template) with a HR ≠ 60.\n")
         return [BUNDLED_RESTING]
-    return json.load(open(paths[0]))
+    with open(paths[0], encoding="utf-8") as f:
+        return json.load(f)
 
 
 def analyze(corpus):

--- a/Tools/linux-capture/analyze_v25_waveform.py
+++ b/Tools/linux-capture/analyze_v25_waveform.py
@@ -52,6 +52,8 @@ import statistics
 import struct
 import sys
 
+from capture_io import configure_utf8_stdio
+
 # --- v25 record geometry (WHOOP 4.0 envelope: 0xAA, len u16, crc8, type@4, version@5, ...) -----------
 TYPE_HISTORICAL = 0x2F        # 47, at byte 4
 VERSION_V25 = 25              # at byte 5
@@ -267,6 +269,7 @@ def selftest():
 
 
 if __name__ == "__main__":
+    configure_utf8_stdio()
     if "--selftest" in sys.argv:
         selftest()
     else:

--- a/Tools/linux-capture/analyze_v26_waveform.py
+++ b/Tools/linux-capture/analyze_v26_waveform.py
@@ -26,6 +26,8 @@ import struct
 import sys
 from collections import Counter
 
+from capture_io import configure_utf8_stdio
+
 WAVE_START, WAVE_END = 27, 75          # 24 LE-i16 samples per record
 SAMPLE_RATE_HZ = 24                     # 24 samples/record, 1 record/second
 
@@ -103,4 +105,5 @@ def main():
 
 
 if __name__ == "__main__":
+    configure_utf8_stdio()
     main()

--- a/Tools/linux-capture/analyze_v26_waveform.py
+++ b/Tools/linux-capture/analyze_v26_waveform.py
@@ -56,7 +56,8 @@ def acf(x, lag):
 
 def main():
     path = sys.argv[1] if len(sys.argv) > 1 else "capture_hist_ack.json"
-    frames = [bytes.fromhex(c["hex"]) for c in json.load(open(path))]
+    with open(path, encoding="utf-8") as f:
+        frames = [bytes.fromhex(c["hex"]) for c in json.load(f)]
     v26 = [r for r in frames if len(r) == 88 and r[8] == 47 and r[9] == 26]
     v18 = [r for r in frames if len(r) == 124 and r[8] == 47 and r[9] == 18]
     if not v26:

--- a/Tools/linux-capture/capture_io.py
+++ b/Tools/linux-capture/capture_io.py
@@ -1,0 +1,11 @@
+"""Shared text-console setup for the executable Linux capture tools."""
+
+import sys
+
+
+def configure_utf8_stdio() -> None:
+    """Keep Unicode diagnostics printable when the host defaults to a legacy code page."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            reconfigure(encoding="utf-8")

--- a/Tools/linux-capture/correlate_ground_truth.py
+++ b/Tools/linux-capture/correlate_ground_truth.py
@@ -29,6 +29,7 @@ import struct
 import sys
 import zipfile
 
+from capture_io import configure_utf8_stdio
 import whoop_frame as wf
 
 # --- Ground-truth CSV loading ----------------------------------------------------------------------
@@ -344,4 +345,5 @@ def main():
 
 
 if __name__ == "__main__":
+    configure_utf8_stdio()
     main()

--- a/Tools/linux-capture/correlate_ground_truth.py
+++ b/Tools/linux-capture/correlate_ground_truth.py
@@ -301,7 +301,7 @@ def main():
                    help="restrict to one record type byte, e.g. 0x2f")
     args = p.parse_args()
 
-    with open(args.capture) as f:
+    with open(args.capture, encoding="utf-8") as f:
         records = json.load(f)
     rows = load_ground_truth(args.export)
     if not rows:

--- a/Tools/linux-capture/decode_features.py
+++ b/Tools/linux-capture/decode_features.py
@@ -242,7 +242,7 @@ def run_whoop_decode(frames_json, binary=None):
     binary = binary or find_whoop_decode()
     fd, path = tempfile.mkstemp(suffix=".json")
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(frames_json, f)
         r = subprocess.run([binary, "--json", "--family", "auto", path],
                            capture_output=True, text=True)

--- a/Tools/linux-capture/hci_extract.py
+++ b/Tools/linux-capture/hci_extract.py
@@ -23,6 +23,7 @@ import json
 import struct
 import sys
 
+from capture_io import configure_utf8_stdio
 import whoop_frame as wf
 
 # --- HCI log container parsing ---------------------------------------------------------------------
@@ -309,4 +310,5 @@ def main():
 
 
 if __name__ == "__main__":
+    configure_utf8_stdio()
     main()

--- a/Tools/linux-capture/hci_extract.py
+++ b/Tools/linux-capture/hci_extract.py
@@ -289,7 +289,7 @@ def main():
     args = p.parse_args()
 
     records, stats = extract(load_hci(args.input), args.family)
-    with open(args.out, "w") as f:
+    with open(args.out, "w", encoding="utf-8") as f:
         json.dump(records, f, indent=1)
 
     if not records:

--- a/Tools/linux-capture/pair_probe.py
+++ b/Tools/linux-capture/pair_probe.py
@@ -2,6 +2,7 @@
 Usage: python3 pair_probe.py <MAC>   (or set WHOOP_MAC). Use on a strap you own; phone BT off."""
 import asyncio, os, sys, time
 from bleak import BleakClient, BleakScanner
+from capture_io import configure_utf8_stdio
 MAC = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("WHOOP_MAC", "")
 if not MAC:
     sys.exit("usage: python3 pair_probe.py <MAC>   (or export WHOOP_MAC=AA:BB:CC:DD:EE:FF)")
@@ -50,4 +51,5 @@ async def main():
     except Exception as e:
         log(f"connect FAILED: {type(e).__name__}: {str(e)[:110]}")
 
+configure_utf8_stdio()
 asyncio.run(main())

--- a/Tools/linux-capture/test_console_encoding.py
+++ b/Tools/linux-capture/test_console_encoding.py
@@ -1,0 +1,62 @@
+"""Executable-path coverage for consoles that default to a legacy Windows encoding.
+
+The subprocesses run on Linux with strict cp1252 stdout/stderr. This reproduces the encoding
+constraint but is not a native Windows test.
+"""
+
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+
+
+def _run_cp1252(script, *args):
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "cp1252:strict"
+    return subprocess.run(
+        [sys.executable, str(HERE / script), *map(str, args)],
+        cwd=HERE,
+        env=env,
+        capture_output=True,
+        timeout=10,
+    )
+
+
+class ConsoleEncodingTests(unittest.TestCase):
+    def test_analyze_v25_real_entrypoint_is_unicode_safe(self):
+        result = _run_cp1252("analyze_v25_waveform.py")
+        self.assertEqual(result.returncode, 0, result.stderr.decode("utf-8", errors="replace"))
+        self.assertIn("running the DEMO", result.stdout.decode("utf-8"))
+
+    def test_whoop_sync_real_entrypoint_is_unicode_safe(self):
+        with tempfile.TemporaryDirectory() as td:
+            db_path = os.path.join(td, "capture.db")
+            con = sqlite3.connect(db_path)
+            con.execute(
+                "CREATE TABLE devices (id INTEGER PRIMARY KEY, address TEXT NOT NULL UNIQUE, "
+                "name TEXT, subject TEXT, model TEXT, created_ms INTEGER)"
+            )
+            con.execute(
+                "CREATE TABLE frames (id INTEGER PRIMARY KEY, device_id INTEGER NOT NULL, "
+                "recv_ms INTEGER NOT NULL, char TEXT, inner_type INTEGER, unix INTEGER, "
+                "hr INTEGER, hex TEXT NOT NULL, UNIQUE(device_id, hex))"
+            )
+            con.execute(
+                "INSERT INTO devices(address, name, model) VALUES('AA:BB:CC:DD:EE:FF', 'strap', 'whoop4')"
+            )
+            con.commit()
+            con.close()
+
+            result = _run_cp1252("whoop_sync.py", "devices", "--db", db_path)
+        self.assertEqual(result.returncode, 0, result.stderr.decode("utf-8", errors="replace"))
+        self.assertIn("→", result.stdout.decode("utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/linux-capture/test_correlate_ground_truth.py
+++ b/Tools/linux-capture/test_correlate_ground_truth.py
@@ -61,7 +61,7 @@ class CsvLoadingTests(unittest.TestCase):
             "2026-07-14 23:51:24,97.29,34.40\n"
         )
         folder = tempfile.mkdtemp()
-        with open(os.path.join(folder, "physiological_cycles.csv"), "w") as f:
+        with open(os.path.join(folder, "physiological_cycles.csv"), "w", encoding="utf-8") as f:
             f.write(cycles)
         rows = cg.load_ground_truth(folder)
         truth = cg.truth_values(rows)
@@ -72,9 +72,9 @@ class CsvLoadingTests(unittest.TestCase):
         cycles = "Startzeit des Zyklus,Herzfrequenzvariabilität (ms)\n2026-06-20 00:24:31,92\n"
         sleep = "Startzeit des Zyklus,Atemfrequenz (Atemzüge/Min.)\n2026-06-20 00:24:31,14.6\n"
         folder = tempfile.mkdtemp()
-        with open(os.path.join(folder, "physiologische_zyklen.csv"), "w") as f:
+        with open(os.path.join(folder, "physiologische_zyklen.csv"), "w", encoding="utf-8") as f:
             f.write(cycles)
-        with open(os.path.join(folder, "Schlaf.csv"), "w") as f:
+        with open(os.path.join(folder, "Schlaf.csv"), "w", encoding="utf-8") as f:
             f.write(sleep)
         rows = cg.load_ground_truth(folder)
         self.assertEqual(len(rows), 1)

--- a/Tools/linux-capture/test_decode_features.py
+++ b/Tools/linux-capture/test_decode_features.py
@@ -9,27 +9,29 @@ import unittest
 import decode_features as df
 
 
-def _conn():
+def _conn(owner=None):
     c = sqlite3.connect(":memory:")
     df.apply_schema(c)
+    if owner is not None:
+        owner.addCleanup(c.close)
     return c
 
 
 class SchemaTests(unittest.TestCase):
     def test_creates_four_feature_tables(self):
-        c = _conn()
+        c = _conn(self)
         names = {r[0] for r in c.execute(
             "SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
         self.assertTrue({"feat_second", "feat_rr", "feat_ppg", "feat_event"} <= names)
 
     def test_schema_is_idempotent(self):
-        c = _conn()
+        c = _conn(self)
         df.apply_schema(c)  # second apply must not raise
         self.assertTrue(True)
 
     def test_feat_ppg_has_burst_index_column(self):
         # PR#553: the raw per-burst counter column ships on a fresh feat_ppg.
-        c = _conn()
+        c = _conn(self)
         cols = {r[1] for r in c.execute("PRAGMA table_info(feat_ppg)")}
         self.assertIn("burst_index", cols)
 
@@ -37,6 +39,7 @@ class SchemaTests(unittest.TestCase):
         # A pre-PR#553 DB has feat_ppg WITHOUT burst_index; apply_schema must ALTER it in once, and a
         # second apply must be a no-op (never raise "duplicate column").
         c = sqlite3.connect(":memory:")
+        self.addCleanup(c.close)
         c.executescript(
             "CREATE TABLE feat_ppg (device_id INTEGER NOT NULL, unix INTEGER NOT NULL, "
             "sample_idx INTEGER NOT NULL, channel INTEGER NOT NULL, value INTEGER NOT NULL, "
@@ -149,7 +152,7 @@ class FeatureToRowsTests(unittest.TestCase):
 
 class ApplyRowsTests(unittest.TestCase):
     def test_inserts_all_tables(self):
-        c = _conn()
+        c = _conn(self)
         mapped = [
             df.feature_to_rows(_rec(47, {"heart_rate": 95, "rr_intervals": [600, 610]})),
             df.feature_to_rows(_rec(47, {"ppg_waveform": [1, 2], "burst_index": 3}, unix=1001, version=26)),
@@ -165,7 +168,7 @@ class ApplyRowsTests(unittest.TestCase):
         self.assertEqual((ch, bi), (0, 3))
 
     def test_idempotent(self):
-        c = _conn()
+        c = _conn(self)
         mapped = [df.feature_to_rows(_rec(47, {"heart_rate": 95, "rr_intervals": [600]}))]
         df.apply_rows(c, 1, mapped)
         df.apply_rows(c, 1, mapped)  # second time changes nothing
@@ -173,7 +176,7 @@ class ApplyRowsTests(unittest.TestCase):
         self.assertEqual(c.execute("SELECT COUNT(*) FROM feat_rr").fetchone()[0], 1)
 
     def test_coalesce_merges_partial_seconds(self):
-        c = _conn()
+        c = _conn(self)
         # scalar-only second, then ppg-only at SAME unix must not clobber hr.
         df.apply_rows(c, 1, [df.feature_to_rows(_rec(47, {"heart_rate": 88}, unix=1000))])
         df.apply_rows(c, 1, [df.feature_to_rows(_rec(47, {"gravity_x": 0.5}, unix=1000, version=18))])
@@ -286,6 +289,11 @@ class _FakeDB:
 
 
 class DecodeNewTests(unittest.TestCase):
+    def _db(self):
+        db = _FakeDB(self._frames())
+        self.addCleanup(db.db.close)
+        return db
+
     def _frames(self):
         return [
             (1, "aa", "6108", 10, 1000, 95, 47),
@@ -302,7 +310,7 @@ class DecodeNewTests(unittest.TestCase):
         ]
 
     def test_decodes_and_advances_cursor(self):
-        fdb = _FakeDB(self._frames())
+        fdb = self._db()
         res = df.decode_new(fdb, 1, decode_fn=self._decoder)
         self.assertEqual(res["frames"], 3)
         self.assertEqual(res["skipped"], 1)              # the inner_type-49 frame
@@ -310,19 +318,19 @@ class DecodeNewTests(unittest.TestCase):
         self.assertEqual(fdb.state(1)["last_decoded_frame_id"], "3")
 
     def test_incremental_second_run_is_noop(self):
-        fdb = _FakeDB(self._frames())
+        fdb = self._db()
         df.decode_new(fdb, 1, decode_fn=self._decoder)
         res2 = df.decode_new(fdb, 1, decode_fn=self._decoder)
         self.assertEqual(res2["frames"], 0)              # cursor past all frames
 
     def test_full_redecodes_from_zero(self):
-        fdb = _FakeDB(self._frames())
+        fdb = self._db()
         df.decode_new(fdb, 1, decode_fn=self._decoder)
         res = df.decode_new(fdb, 1, full=True, decode_fn=self._decoder)
         self.assertEqual(res["frames"], 3)               # full ignores the cursor
 
     def test_decoder_count_mismatch_raises(self):
-        fdb = _FakeDB(self._frames())   # 3 frames
+        fdb = self._db()   # 3 frames
         short = lambda records: [_dec_obj([_fld("heart_rate", 95, "hr")])]  # returns only 1
         with self.assertRaises(RuntimeError):
             df.decode_new(fdb, 1, decode_fn=short)

--- a/Tools/linux-capture/test_validate_spo2_candidate.py
+++ b/Tools/linux-capture/test_validate_spo2_candidate.py
@@ -6,16 +6,63 @@ Stdlib only; synthetic planted captures — no personal health data.
 
 from __future__ import annotations
 
+import builtins
+import io
 import json
 import os
 import sqlite3
 import struct
 import tempfile
 import unittest
+from unittest import mock
 from datetime import datetime, timezone
 
 import validate_spo2_candidate as vs
 from test_whoop_activity import make_v18
+
+
+class EncodingPortabilityTests(unittest.TestCase):
+    """Exercise Windows-like non-UTF-8 defaults without requiring a Windows host."""
+
+    def test_capture_json_is_read_as_utf8_under_cp1252_default(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, "capture.json")
+            expected = [{"hex": "aa", "device": "München"}]
+            with builtins.open(path, "w", encoding="utf-8") as f:
+                json.dump(expected, f, ensure_ascii=False)
+
+            real_open = builtins.open
+
+            def cp1252_default_open(*args, **kwargs):
+                mode = args[1] if len(args) > 1 else kwargs.get("mode", "r")
+                if "b" not in mode and "encoding" not in kwargs:
+                    kwargs["encoding"] = "cp1252"
+                return real_open(*args, **kwargs)
+
+            with mock.patch("builtins.open", side_effect=cp1252_default_open):
+                self.assertEqual(vs.load_frame_records(path), expected)
+
+    def test_postable_summary_prints_to_cp1252_console(self):
+        result = {
+            "device": "strap-a",
+            "classification": "feature_absent",
+            "paired_nights": 0,
+            "r": None,
+            "mae": None,
+            "bias": None,
+            "best_specificity_offset": None,
+            "duty": None,
+            "median_window_coverage": None,
+            "checklist": {"pass": False},
+        }
+        raw = io.BytesIO()
+        console = io.TextIOWrapper(raw, encoding="cp1252")
+        with mock.patch.object(vs.sys, "stdout", console):
+            vs.configure_utf8_stdio()
+            print(vs.format_postable([result]))
+            console.flush()
+        self.assertEqual(console.encoding, "utf-8")
+        self.assertIn("need ≥5 paired nights".encode(), raw.getvalue())
 
 
 def _utc(y, m, d, hh=0, mm=0, ss=0) -> int:
@@ -102,7 +149,7 @@ def _write_export(folder: str, nights: list[tuple[str, float, int, int]]) -> str
         s0 = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
         s1 = datetime.fromtimestamp(t1, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
         lines.append(f"{start},,{spo2:.2f},{s0},{s1}\n")
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.writelines(lines)
     return folder
 
@@ -136,7 +183,7 @@ class PlantedValidationTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as td:
             cap = os.path.join(td, "capture.json")
-            with open(cap, "w") as f:
+            with open(cap, "w", encoding="utf-8") as f:
                 json.dump(frames, f)
             exp = _write_export(td, exports)
             res = vs.validate_device(cap, exp, device="planted-a")
@@ -154,11 +201,11 @@ class PlantedValidationTests(unittest.TestCase):
         frames = _plant_night(t0, t1, 97)
         with tempfile.TemporaryDirectory() as td:
             cap = os.path.join(td, "capture.json")
-            with open(cap, "w") as f:
+            with open(cap, "w", encoding="utf-8") as f:
                 json.dump(frames, f)
             # Export row with empty SpO₂ — must not pair.
             path = os.path.join(td, "physiological_cycles.csv")
-            with open(path, "w") as f:
+            with open(path, "w", encoding="utf-8") as f:
                 f.write(
                     "Cycle start time,Blood oxygen %,Sleep onset,Wake onset\n"
                     "2026-06-10 23:00:00,,"
@@ -182,7 +229,7 @@ class PlantedValidationTests(unittest.TestCase):
             rec["hex"] = bytes(f).hex()
         with tempfile.TemporaryDirectory() as td:
             cap = os.path.join(td, "capture.json")
-            with open(cap, "w") as f:
+            with open(cap, "w", encoding="utf-8") as f:
                 json.dump(frames, f)
             start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
             exp = _write_export(td, [(start, 97.0, t0, t1)])
@@ -204,7 +251,7 @@ class PlantedValidationTests(unittest.TestCase):
             exports.append((start, float(spo2), t0, t1))
         with tempfile.TemporaryDirectory() as td:
             cap = os.path.join(td, "capture.json")
-            with open(cap, "w") as f:
+            with open(cap, "w", encoding="utf-8") as f:
                 json.dump(frames, f)
             exp = _write_export(td, exports)
             res = vs.validate_device(cap, exp, device="spec")
@@ -222,7 +269,7 @@ class PlantedValidationTests(unittest.TestCase):
             exports.append((start, float(spo2), t0, t1))
         with tempfile.TemporaryDirectory() as td:
             cap = os.path.join(td, "capture.json")
-            with open(cap, "w") as f:
+            with open(cap, "w", encoding="utf-8") as f:
                 json.dump(frames, f)
             exp = _write_export(td, exports)
             res = vs.validate_device(cap, exp, device="post")
@@ -248,7 +295,7 @@ class MultiDeviceBatchTests(unittest.TestCase):
                 )
                 exports.append((start, float(spo2), t0, t1))
             cap = os.path.join(td, f"{label}.json")
-            with open(cap, "w") as f:
+            with open(cap, "w", encoding="utf-8") as f:
                 json.dump(frames, f)
             exp_dir = os.path.join(td, label)
             os.makedirs(exp_dir)
@@ -259,7 +306,7 @@ class MultiDeviceBatchTests(unittest.TestCase):
             a = make_device(td, "strap-a", [95, 96, 97, 98, 94, 99])
             b = make_device(td, "strap-b", [93, 94, 95, 96, 97, 98])
             batch = os.path.join(td, "devices.json")
-            with open(batch, "w") as f:
+            with open(batch, "w", encoding="utf-8") as f:
                 json.dump([a, b], f)
             rc = vs.main(["--batch", batch, "--postable"])
             self.assertEqual(rc, 0)
@@ -307,7 +354,7 @@ class LoadFrameRecordsTest(unittest.TestCase):
 
     def test_json_captures_still_load_unchanged(self):
         path = tempfile.mktemp(suffix=".json")
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             json.dump([{"hex": make_v18(sleep_state=2, aux_byte_82=94).hex()}], f)
         self.addCleanup(lambda: os.path.exists(path) and os.unlink(path))
         self.assertFalse(vs.looks_like_sqlite(path))
@@ -471,7 +518,7 @@ class WindowCoverageTests(unittest.TestCase):
         frames = [f for f in self.frames if _unix_of(f) < self.t0 + 3600]
         with tempfile.TemporaryDirectory() as td:
             cap = os.path.join(td, "capture.json")
-            with open(cap, "w") as fh:
+            with open(cap, "w", encoding="utf-8") as fh:
                 json.dump(frames, fh)
             start = datetime.fromtimestamp(self.t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
             exp = _write_export(td, [(start, 96.0, self.t0, self.t1)])
@@ -534,7 +581,7 @@ class VarianceFloorTests(unittest.TestCase):
             start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
             exports.append((start, float(spo2), t0, t1))
         cap = os.path.join(td, "capture.json")
-        with open(cap, "w") as f:
+        with open(cap, "w", encoding="utf-8") as f:
             json.dump(frames, f)
         return cap, _write_export(td, exports)
 
@@ -568,7 +615,7 @@ class VarianceFloorTests(unittest.TestCase):
             exports.append((start, float(spo2), t0, t1))
         with tempfile.TemporaryDirectory() as td:
             cap = os.path.join(td, "capture.json")
-            with open(cap, "w") as f:
+            with open(cap, "w", encoding="utf-8") as f:
                 json.dump(frames, f)
             res = vs.validate_device(cap, _write_export(td, exports), device="flat82")
         self.assertEqual(res["inband_distinct_82"], 2)
@@ -601,7 +648,7 @@ class FeatureAbsentClassificationTests(unittest.TestCase):
             for i in range(n_records)
         ]
         cap = os.path.join(td, f"{label}.json")
-        with open(cap, "w") as f:
+        with open(cap, "w", encoding="utf-8") as f:
             json.dump(frames, f)
         exp_dir = os.path.join(td, label)
         os.makedirs(exp_dir)
@@ -639,7 +686,7 @@ class FeatureAbsentClassificationTests(unittest.TestCase):
                 start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
                 exports.append((start, float(spo2), t0, t1))
             cap = os.path.join(td, f"{label}.json")
-            with open(cap, "w") as f:
+            with open(cap, "w", encoding="utf-8") as f:
                 json.dump(frames, f)
             exp_dir = os.path.join(td, label)
             os.makedirs(exp_dir)
@@ -692,7 +739,7 @@ class FeatureAbsentClassificationTests(unittest.TestCase):
                 start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
                 nights.append((start, 95.0, t0, t1))
             cap = os.path.join(td, "aliased.json")
-            with open(cap, "w") as f:
+            with open(cap, "w", encoding="utf-8") as f:
                 json.dump(frames, f)
             res = vs.validate_device(cap, _write_export(td, nights), device="aliased")
         self.assertEqual(res["duty"]["n_nonzero"], 0)      # the strap works; the capture missed it
@@ -710,7 +757,7 @@ class FeatureAbsentClassificationTests(unittest.TestCase):
                 {"hex": make_v18(unix=u, sleep_state=2, hr=52, aux_byte_82=0).hex()} for u in stamps
             ]
             cap = os.path.join(td, "sparse.json")
-            with open(cap, "w") as f:
+            with open(cap, "w", encoding="utf-8") as f:
                 json.dump(frames, f)
             exp_dir = os.path.join(td, "sparse")
             os.makedirs(exp_dir)
@@ -727,7 +774,7 @@ class FeatureAbsentClassificationTests(unittest.TestCase):
             {"hex": make_v18(unix=u, sleep_state=st, hr=52, aux_byte_82=0).hex()} for u, st in stamps
         ]
         cap = os.path.join(td, f"{label}.json")
-        with open(cap, "w") as f:
+        with open(cap, "w", encoding="utf-8") as f:
             json.dump(frames, f)
         exp_dir = os.path.join(td, label)
         os.makedirs(exp_dir)
@@ -789,7 +836,7 @@ class FeatureAbsentClassificationTests(unittest.TestCase):
                 start = datetime.fromtimestamp(t0, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
                 nights.append((start, float(s), t0, t1))
             cap = os.path.join(td, "vals.json")
-            with open(cap, "w") as f:
+            with open(cap, "w", encoding="utf-8") as f:
                 json.dump(frames, f)
             res = vs.validate_device(cap, _write_export(td, nights), device="vals")
         blob = vs.format_postable([res])
@@ -886,7 +933,7 @@ class AppDbReaderTests(unittest.TestCase):
             app = _write_app_db(td, [(1700000000, 96, 2)])
             self.assertTrue(vs.looks_like_app_db(app))
             cap = os.path.join(td, "cap.json")
-            with open(cap, "w") as f:
+            with open(cap, "w", encoding="utf-8") as f:
                 json.dump([], f)
             self.assertFalse(vs.looks_like_app_db(cap))
 
@@ -975,6 +1022,6 @@ class AppDbReaderTests(unittest.TestCase):
                 frames.append({"hex": make_v18(t0 + k * 60, aux_byte_82=int(round(spo2)),
                                                sleep_state=vs.SLEEP_ASLEEP).hex()})
         cap = os.path.join(td, "cap.json")
-        with open(cap, "w") as f:
+        with open(cap, "w", encoding="utf-8") as f:
             json.dump(frames, f)
         return {"capture": cap, "export": _write_export(td, nights)}

--- a/Tools/linux-capture/test_whoop_spot_hrv.py
+++ b/Tools/linux-capture/test_whoop_spot_hrv.py
@@ -5,8 +5,97 @@ we control — not strap frames. Stdlib only; runs under either `python3 -m unit
 README documents and the only one in requirements.txt) or pytest.
 """
 import math
+import os
+import sqlite3
+import sys
+import tempfile
+from unittest import mock
 
 import whoop_spot_hrv as H
+
+
+def _empty_ppg_db():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    con = sqlite3.connect(path)
+    con.execute(
+        "CREATE TABLE feat_ppg (device_id INTEGER, unix INTEGER, sample_idx INTEGER, "
+        "channel INTEGER, value INTEGER)"
+    )
+    con.close()
+    return path
+
+
+def _assert_connection_closed(con):
+    try:
+        con.execute("SELECT 1")
+    except sqlite3.ProgrammingError:
+        return
+    raise AssertionError("SQLite connection remained open")
+
+
+def _run_main_tracking_connection(path, *extra_args):
+    opened = []
+    real_connect = sqlite3.connect
+
+    def tracking_connect(*args, **kwargs):
+        con = real_connect(*args, **kwargs)
+        opened.append(con)
+        return con
+
+    argv = ["whoop_spot_hrv.py", "--db", path, "--device", "1", *extra_args]
+    with mock.patch.object(H.sqlite3, "connect", side_effect=tracking_connect), \
+            mock.patch.object(sys, "argv", argv):
+        result = H.main()
+    assert len(opened) == 1
+    return result, opened[0]
+
+
+def test_main_closes_database_on_normal_path():
+    path = _empty_ppg_db()
+    try:
+        result, con = _run_main_tracking_connection(path, "--start", "1", "--end", "2")
+        assert result == 0
+        _assert_connection_closed(con)
+    finally:
+        os.remove(path)
+
+
+def test_main_closes_database_on_no_windows_early_return():
+    path = _empty_ppg_db()
+    try:
+        result, con = _run_main_tracking_connection(path)
+        assert result == 1
+        _assert_connection_closed(con)
+    finally:
+        os.remove(path)
+
+
+def test_main_closes_database_when_query_raises():
+    path = _empty_ppg_db()
+    opened = []
+    real_connect = sqlite3.connect
+
+    def tracking_connect(*args, **kwargs):
+        con = real_connect(*args, **kwargs)
+        opened.append(con)
+        return con
+
+    argv = ["whoop_spot_hrv.py", "--db", path, "--device", "1"]
+    try:
+        with mock.patch.object(H.sqlite3, "connect", side_effect=tracking_connect), \
+                mock.patch.object(H, "_covered_windows", side_effect=RuntimeError("query failed")), \
+                mock.patch.object(sys, "argv", argv):
+            try:
+                H.main()
+            except RuntimeError as exc:
+                assert str(exc) == "query failed"
+            else:
+                raise AssertionError("expected query failure")
+        assert len(opened) == 1
+        _assert_connection_closed(opened[0])
+    finally:
+        os.remove(path)
 
 
 def _synth_ppg(fs, n_beats, ibi_ms, width_s=0.12):

--- a/Tools/linux-capture/test_whoop_sync.py
+++ b/Tools/linux-capture/test_whoop_sync.py
@@ -8,10 +8,15 @@ The whoop4 frame offsets exercised here (inner @ 4, meta_type @ 6, trim cursor @
 verified whoop5 offsets minus 4, and match the on-hardware HISTORY_END the strap serves.
 """
 
+import asyncio
 import os
 import sqlite3
+import sys
 import tempfile
+import threading
 import unittest
+from contextlib import suppress
+from unittest import mock
 
 import whoop_frame as wf
 import whoop_sync as ws
@@ -118,6 +123,69 @@ class WhoopDBTests(unittest.TestCase):
                 raise RuntimeError("boom")
         with self.assertRaises(sqlite3.ProgrammingError):
             con.execute("SELECT 1")
+
+    def test_constructor_closes_if_schema_initialization_fails(self):
+        opened = []
+        real_connect = sqlite3.connect
+
+        def tracking_connect(*args, **kwargs):
+            con = real_connect(*args, **kwargs)
+            opened.append(con)
+            return con
+
+        path = os.path.join(self.tmp, "init-error.db")
+        with mock.patch.object(ws.sqlite3, "connect", side_effect=tracking_connect), \
+                mock.patch.object(ws.decode_features, "apply_schema", side_effect=RuntimeError("boom")):
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                ws.WhoopDB(path)
+        self.assertEqual(len(opened), 1)
+        with self.assertRaises(sqlite3.ProgrammingError):
+            opened[0].execute("SELECT 1")
+
+    def test_database_outlives_cancelled_thread_commit(self):
+        """A cancelled to_thread await must not close SQLite while its worker still commits."""
+        started = threading.Event()
+        release = threading.Event()
+        errors = []
+        db_path = os.path.join(self.tmp, "cancelled-commit.db")
+        real_close = ws.WhoopDB.close
+
+        def close_then_release(db):
+            real_close(db)
+            release.set()
+
+        async def candidate_run(args, db):
+            did = db.upsert_device("AA:BB:CC:DD:EE:FF", model="whoop4")
+            frame = (1, "61080005", 47, 1000, 60, "aa01")
+
+            def delayed_commit():
+                started.set()
+                release.wait(timeout=0.3)
+                try:
+                    db.commit_chunk(did, [frame], trim=1, complete=False)
+                except Exception as exc:
+                    errors.append(exc)
+
+            task = asyncio.create_task(asyncio.to_thread(delayed_commit))
+
+            async def wait_until_started():
+                while not started.is_set():
+                    await asyncio.sleep(0.005)
+
+            await asyncio.wait_for(wait_until_started(), timeout=1.0)
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+
+        argv = ["whoop_sync.py", "sync", "--address", "AA:BB:CC:DD:EE:FF", "--db", db_path]
+        try:
+            with mock.patch.object(ws, "_run", side_effect=candidate_run), \
+                    mock.patch.object(ws.WhoopDB, "close", autospec=True, side_effect=close_then_release), \
+                    mock.patch.object(sys, "argv", argv):
+                ws.main()
+        finally:
+            release.set()
+        self.assertEqual(errors, [])
 
     def _frame(self, hexstr, t=47, unix=1000, hr=60):
         return (1, "61080005", t, unix, hr, hexstr)   # (recv_ms, char, inner_type, unix, hr, hex)

--- a/Tools/linux-capture/test_whoop_sync.py
+++ b/Tools/linux-capture/test_whoop_sync.py
@@ -9,6 +9,7 @@ verified whoop5 offsets minus 4, and match the on-hardware HISTORY_END the strap
 """
 
 import os
+import sqlite3
 import tempfile
 import unittest
 
@@ -98,6 +99,26 @@ class WhoopDBTests(unittest.TestCase):
         self.tmp = tempfile.mkdtemp()
         self.db = ws.WhoopDB(os.path.join(self.tmp, "t.db"))
 
+    def tearDown(self):
+        self.db.close()
+
+    def test_context_manager_closes_on_normal_exit(self):
+        path = os.path.join(self.tmp, "normal.db")
+        with ws.WhoopDB(path) as db:
+            con = db.db
+            con.execute("SELECT 1")
+        with self.assertRaises(sqlite3.ProgrammingError):
+            con.execute("SELECT 1")
+
+    def test_context_manager_closes_on_exception(self):
+        path = os.path.join(self.tmp, "error.db")
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            with ws.WhoopDB(path) as db:
+                con = db.db
+                raise RuntimeError("boom")
+        with self.assertRaises(sqlite3.ProgrammingError):
+            con.execute("SELECT 1")
+
     def _frame(self, hexstr, t=47, unix=1000, hr=60):
         return (1, "61080005", t, unix, hr, hexstr)   # (recv_ms, char, inner_type, unix, hr, hex)
 
@@ -138,7 +159,7 @@ class WhoopDBTests(unittest.TestCase):
         out = os.path.join(self.tmp, "o.json")
         n = self.db.export_json(did, out, only_type=47)
         self.assertEqual(n, 1)
-        with open(out) as f:
+        with open(out, encoding="utf-8") as f:
             recs = json.load(f)
         self.assertEqual(recs[0]["hex"], "aa01")
 
@@ -156,6 +177,9 @@ class DecodeWiringTests(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
         self.db = ws.WhoopDB(os.path.join(self.tmp, "t.db"))
+
+    def tearDown(self):
+        self.db.close()
 
     def _frame(self, hexstr, t=47, unix=1000, hr=60):
         return (1, "61080005", t, unix, hr, hexstr)   # (recv_ms, char, inner_type, unix, hr, hex)

--- a/Tools/linux-capture/validate_spo2_candidate.py
+++ b/Tools/linux-capture/validate_spo2_candidate.py
@@ -151,6 +151,14 @@ NOMINAL_DUTY_WINDOW_S = 30
 MIN_DISTINCT_INBAND = 5
 MIN_INBAND_STDEV = 0.5
 
+
+def configure_utf8_stdio() -> None:
+    """Keep Unicode diagnostics printable when the host defaults to a legacy code page."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            reconfigure(encoding="utf-8")
+
 # English + localized cycle headers → canonical keys (mirrors StrandImport HeaderNorm subset).
 HEADER_ALIASES = {
     # English (official export; lowercase after norm)
@@ -467,7 +475,7 @@ def load_frame_records(path: str, *, device_id: int = 2) -> List[dict]:
             )
         return [{"hex": r[0]} for r in rows]
 
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         capture = json.load(f)
     if not isinstance(capture, list):
         raise SystemExit(f"{path}: expected a JSON list of frame records, or a whoop_sync.py .db")
@@ -1205,7 +1213,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     results: List[dict] = []
 
     if args.batch:
-        with open(args.batch) as f:
+        with open(args.batch, encoding="utf-8") as f:
             batch = json.load(f)
         if not isinstance(batch, list) or not batch:
             print("batch file must be a non-empty JSON list", file=sys.stderr)
@@ -1253,4 +1261,5 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
 
 if __name__ == "__main__":
+    configure_utf8_stdio()
     sys.exit(main())

--- a/Tools/linux-capture/validate_spo2_candidate.py
+++ b/Tools/linux-capture/validate_spo2_candidate.py
@@ -1153,6 +1153,7 @@ def format_postable(results: Sequence[dict]) -> str:
 # --- CLI -------------------------------------------------------------------------------------------
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
+    configure_utf8_stdio()
     p = argparse.ArgumentParser(
         description="Validate WHOOP 5/MG v18 spo2_candidate_82 against a CSV export (#103)."
     )
@@ -1255,5 +1256,4 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
 
 if __name__ == "__main__":
-    configure_utf8_stdio()
     sys.exit(main())

--- a/Tools/linux-capture/validate_spo2_candidate.py
+++ b/Tools/linux-capture/validate_spo2_candidate.py
@@ -81,6 +81,7 @@ import zipfile
 from datetime import datetime, timezone
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
+from capture_io import configure_utf8_stdio
 import whoop_activity as wa
 import whoop_frame as wf
 
@@ -151,13 +152,6 @@ NOMINAL_DUTY_WINDOW_S = 30
 MIN_DISTINCT_INBAND = 5
 MIN_INBAND_STDEV = 0.5
 
-
-def configure_utf8_stdio() -> None:
-    """Keep Unicode diagnostics printable when the host defaults to a legacy code page."""
-    for stream in (sys.stdout, sys.stderr):
-        reconfigure = getattr(stream, "reconfigure", None)
-        if callable(reconfigure):
-            reconfigure(encoding="utf-8")
 
 # English + localized cycle headers → canonical keys (mirrors StrandImport HeaderNorm subset).
 HEADER_ALIASES = {

--- a/Tools/linux-capture/whoop_activity.py
+++ b/Tools/linux-capture/whoop_activity.py
@@ -157,20 +157,22 @@ DEFAULT_DB = "captures/whoop4.db"
 def records(db_path=DEFAULT_DB, device_id=2, start=None, end=None):
     """Decoded v18 records (time-ordered) from the frames table."""
     con = sqlite3.connect(db_path)
-    q = "SELECT hex FROM frames WHERE device_id=? AND inner_type=47"
-    args = [device_id]
-    if start is not None:
-        q += " AND unix>=?"; args.append(start)
-    if end is not None:
-        q += " AND unix<?"; args.append(end)
-    q += " ORDER BY unix"
-    out = []
-    for (hx,) in con.execute(q, args):
-        d = decode_v18(bytes.fromhex(hx))
-        if d is not None:
-            out.append(d)
-    con.close()
-    return out
+    try:
+        q = "SELECT hex FROM frames WHERE device_id=? AND inner_type=47"
+        args = [device_id]
+        if start is not None:
+            q += " AND unix>=?"; args.append(start)
+        if end is not None:
+            q += " AND unix<?"; args.append(end)
+        q += " ORDER BY unix"
+        out = []
+        for (hx,) in con.execute(q, args):
+            d = decode_v18(bytes.fromhex(hx))
+            if d is not None:
+                out.append(d)
+        return out
+    finally:
+        con.close()
 
 
 def _day_bounds(day):

--- a/Tools/linux-capture/whoop_activity.py
+++ b/Tools/linux-capture/whoop_activity.py
@@ -151,6 +151,8 @@ import argparse
 import json
 import datetime as _dt
 
+from capture_io import configure_utf8_stdio
+
 DEFAULT_DB = "captures/whoop4.db"
 
 
@@ -235,4 +237,5 @@ def main(argv=None):
 
 
 if __name__ == "__main__":
+    configure_utf8_stdio()
     main()

--- a/Tools/linux-capture/whoop_buzz.py
+++ b/Tools/linux-capture/whoop_buzz.py
@@ -40,6 +40,7 @@ import sys
 from bleak import BleakClient, BleakScanner
 from bleak.exc import BleakError
 
+from capture_io import configure_utf8_stdio
 import whoop_frame as wf
 
 log = logging.getLogger("whoop_buzz")
@@ -294,4 +295,5 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    configure_utf8_stdio()
     sys.exit(main())

--- a/Tools/linux-capture/whoop_capture.py
+++ b/Tools/linux-capture/whoop_capture.py
@@ -146,7 +146,7 @@ class Capture:
         if not self.records:
             return
         tmp = self.out_path + ".tmp"
-        with open(tmp, "w") as f:
+        with open(tmp, "w", encoding="utf-8") as f:
             json.dump(self.records, f, indent=1)
         import os
         os.replace(tmp, self.out_path)

--- a/Tools/linux-capture/whoop_capture.py
+++ b/Tools/linux-capture/whoop_capture.py
@@ -29,6 +29,7 @@ import time
 
 from bleak import BleakClient, BleakScanner
 
+from capture_io import configure_utf8_stdio
 import whoop_frame as wf
 
 # --- GATT UUIDs (from docs/BLE_REVERSE_ENGINEERING.md) ---------------------------------------------
@@ -496,4 +497,5 @@ def main():
 
 
 if __name__ == "__main__":
+    configure_utf8_stdio()
     main()

--- a/Tools/linux-capture/whoop_probe.py
+++ b/Tools/linux-capture/whoop_probe.py
@@ -16,6 +16,7 @@ import time
 
 from bleak import BleakClient, BleakScanner
 
+from capture_io import configure_utf8_stdio
 import whoop_frame as wf
 
 WHOOP4 = {
@@ -147,4 +148,5 @@ def main():
 
 
 if __name__ == "__main__":
+    configure_utf8_stdio()
     main()

--- a/Tools/linux-capture/whoop_setclock.py
+++ b/Tools/linux-capture/whoop_setclock.py
@@ -25,6 +25,7 @@ import time
 
 from bleak import BleakClient, BleakScanner
 
+from capture_io import configure_utf8_stdio
 import whoop_frame as wf
 
 FAMILIES = {
@@ -167,4 +168,5 @@ def main():
 
 
 if __name__ == "__main__":
+    configure_utf8_stdio()
     main()

--- a/Tools/linux-capture/whoop_spot_hrv.py
+++ b/Tools/linux-capture/whoop_spot_hrv.py
@@ -27,6 +27,7 @@ import sqlite3
 from collections import Counter
 from statistics import median, pstdev
 
+from capture_io import configure_utf8_stdio
 
 # ---------------------------------------------------------------- validated DSP (pure)
 
@@ -185,4 +186,5 @@ def _run(args, con):
 
 
 if __name__ == "__main__":
+    configure_utf8_stdio()
     raise SystemExit(main())

--- a/Tools/linux-capture/whoop_spot_hrv.py
+++ b/Tools/linux-capture/whoop_spot_hrv.py
@@ -159,7 +159,13 @@ def main():
     args = ap.parse_args()
     # Read-only: open the DB in immutable/ro mode so this analysis tool can never write to whoop.db.
     con = sqlite3.connect(f"file:{args.db}?mode=ro", uri=True)
+    try:
+        return _run(args, con)
+    finally:
+        con.close()
 
+
+def _run(args, con):
     windows = [(args.start, args.end)] if args.start and args.end else _covered_windows(con, args.device, args.channel)
     if not windows:
         print("no PPG-covered windows (need v26 optical bursts in feat_ppg for this device)")

--- a/Tools/linux-capture/whoop_sync.py
+++ b/Tools/linux-capture/whoop_sync.py
@@ -208,6 +208,15 @@ class WhoopDB:
         self.db.execute("PRAGMA synchronous=FULL")
         self.db.commit()
 
+    def close(self):
+        self.db.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
     def upsert_device(self, address, name=None, subject=None, model=None):
         address = address.upper()
         cur = self.db.cursor()
@@ -280,7 +289,7 @@ class WhoopDB:
         recs = [{"hex": h, "char": c, "ts_ms": (rm or 0), "hr": hr} for h, c, rm, hr in rows]
         os.makedirs(os.path.dirname(os.path.abspath(out_path)) or ".", exist_ok=True)
         tmp = out_path + ".tmp"
-        with open(tmp, "w") as f:
+        with open(tmp, "w", encoding="utf-8") as f:
             json.dump(recs, f, indent=1)
         os.replace(tmp, out_path)
         return len(recs)
@@ -682,13 +691,17 @@ async def _realtime_session(client, s, db, fam, args, stop_all, deadline):
 
 
 async def run_realtime(args):
+    with WhoopDB(args.db) as db:
+        return await _run_realtime(args, db)
+
+
+async def _run_realtime(args, db):
     """Capture the live realtime stream (HR + R-R + IMU) into the durable store, reconnecting on drops
     until --duration elapses, then decode → feat_rr so HRV/RSA can run. The realtime counterpart of the
     offload `run()`; reuses the same _acquire + MTU-negotiated reconnect loop + WhoopDB."""
     from bleak import BleakClient
     from bleak.exc import BleakError
     fam = Family(args.model)
-    db = WhoopDB(args.db)
     if not args.no_clock_check:
         await preflight_clock(fam, args)
     dev = await _acquire(args.address, tries=args.tries)
@@ -752,10 +765,14 @@ async def run_realtime(args):
 
 
 async def run(args):
+    with WhoopDB(args.db) as db:
+        return await _run(args, db)
+
+
+async def _run(args, db):
     from bleak import BleakClient
     from bleak.exc import BleakError
     fam = Family(args.model)
-    db = WhoopDB(args.db)
     if not args.no_clock_check:
         await preflight_clock(fam, args)
     dev = await _acquire(args.address, tries=args.tries)
@@ -781,7 +798,7 @@ async def run(args):
         s.emit = sys.stdout
         sys.stdout = sys.stderr               # subsequent print() diagnostics → stderr
     elif emit_target:
-        s.emit = open(emit_target, "w")
+        s.emit = open(emit_target, "w", encoding="utf-8")
     if s.emit is not None:
         s.emit.write(json.dumps({"_header": {"device_id": did, "address": info[0],
                                              "name": info[1], "model": args.model}}) + "\n")
@@ -989,38 +1006,42 @@ def main():
         except KeyboardInterrupt:
             pass
     elif cmd == "export":
-        db = WhoopDB(args.db); did = _need_device(db, args.address)
-        since = _parse_time(args.since) if args.since else None
-        print(f"exported {db.export_json(did, args.out, args.only_type, since)} frames → {args.out}")
+        with WhoopDB(args.db) as db:
+            did = _need_device(db, args.address)
+            since = _parse_time(args.since) if args.since else None
+            print(f"exported {db.export_json(did, args.out, args.only_type, since)} frames → {args.out}")
     elif cmd == "status":
-        db = WhoopDB(args.db); did = _need_device(db, args.address)
-        info = db.device_info(did); st = db.state(did); cov = db.coverage(did)
-        print(f"db: {args.db}")
-        print(f"  device: {info[0]} name={info[1]!r} subject={info[2]!r} model={info[3]}")
-        print(f"  cursor last_trim={st.get('last_trim','?')} history_complete={st.get('history_complete','0')}")
-        print(f"  coverage: {_fmt(cov[0])} → {_fmt(cov[1])}  ({cov[2] or 0} type-47)")
-        print(f"  counts by type: {db.counts(did)}")
-        labs = db.labels(did)
-        print(f"  labels ({len(labs)}):")
-        for s_, e_, a_, n_ in labs:
-            print(f"    {a_:12s} {_fmt(s_)} → {_fmt(e_)}  {n_ or ''}")
+        with WhoopDB(args.db) as db:
+            did = _need_device(db, args.address)
+            info = db.device_info(did); st = db.state(did); cov = db.coverage(did)
+            print(f"db: {args.db}")
+            print(f"  device: {info[0]} name={info[1]!r} subject={info[2]!r} model={info[3]}")
+            print(f"  cursor last_trim={st.get('last_trim','?')} history_complete={st.get('history_complete','0')}")
+            print(f"  coverage: {_fmt(cov[0])} → {_fmt(cov[1])}  ({cov[2] or 0} type-47)")
+            print(f"  counts by type: {db.counts(did)}")
+            labs = db.labels(did)
+            print(f"  labels ({len(labs)}):")
+            for s_, e_, a_, n_ in labs:
+                print(f"    {a_:12s} {_fmt(s_)} → {_fmt(e_)}  {n_ or ''}")
     elif cmd == "devices":
-        db = WhoopDB(args.db)
-        print(f"db: {args.db}")
-        for did, addr, nm, subj, mdl, n47, mn, mx in db.list_devices():
-            print(f"  [{did}] {addr} name={nm!r} subject={subj!r} model={mdl}  "
-                  f"{n47} type-47  {_fmt(mn)}→{_fmt(mx)}")
+        with WhoopDB(args.db) as db:
+            print(f"db: {args.db}")
+            for did, addr, nm, subj, mdl, n47, mn, mx in db.list_devices():
+                print(f"  [{did}] {addr} name={nm!r} subject={subj!r} model={mdl}  "
+                      f"{n47} type-47  {_fmt(mn)}→{_fmt(mx)}")
     elif cmd == "label":
-        db = WhoopDB(args.db); did = _need_device(db, args.address)
-        s_, e_ = _parse_time(args.start), _parse_time(args.end)
-        db.add_label(did, s_, e_, args.activity, args.note)
-        print(f"labeled {args.activity}: {_fmt(s_)} → {_fmt(e_)} for device {db.device_info(did)[0]}")
+        with WhoopDB(args.db) as db:
+            did = _need_device(db, args.address)
+            s_, e_ = _parse_time(args.start), _parse_time(args.end)
+            db.add_label(did, s_, e_, args.activity, args.note)
+            print(f"labeled {args.activity}: {_fmt(s_)} → {_fmt(e_)} for device {db.device_info(did)[0]}")
     elif cmd == "decode":
-        db = WhoopDB(args.db); did = _need_device(db, args.address)
-        res = decode_features.decode_new(db, did, full=args.full)
-        print(f"decode: {res['frames']} frames → feat_second updated "
-              f"({res['decoded']} decoded, {res['skipped']} skipped); "
-              f"cursor last_decoded_frame_id={res['cursor']}")
+        with WhoopDB(args.db) as db:
+            did = _need_device(db, args.address)
+            res = decode_features.decode_new(db, did, full=args.full)
+            print(f"decode: {res['frames']} frames → feat_second updated "
+                  f"({res['decoded']} decoded, {res['skipped']} skipped); "
+                  f"cursor last_decoded_frame_id={res['cursor']}")
 
 
 if __name__ == "__main__":

--- a/Tools/linux-capture/whoop_sync.py
+++ b/Tools/linux-capture/whoop_sync.py
@@ -61,8 +61,9 @@ import subprocess
 import sys
 import time
 
-import whoop_frame as wf
 import decode_features
+import whoop_frame as wf
+from capture_io import configure_utf8_stdio
 
 # `bleak` is imported lazily inside the BLE functions (run/_acquire) so this module's frame helpers,
 # Family, and WhoopDB can be imported and unit-tested with no third-party deps (like test_whoop_frame).
@@ -202,11 +203,15 @@ class WhoopDB:
     def __init__(self, path):
         os.makedirs(os.path.dirname(os.path.abspath(path)) or ".", exist_ok=True)
         self.db = sqlite3.connect(path, check_same_thread=False)
-        self.db.executescript(SCHEMA)
-        decode_features.apply_schema(self.db)
-        self.db.execute("PRAGMA journal_mode=WAL")
-        self.db.execute("PRAGMA synchronous=FULL")
-        self.db.commit()
+        try:
+            self.db.executescript(SCHEMA)
+            decode_features.apply_schema(self.db)
+            self.db.execute("PRAGMA journal_mode=WAL")
+            self.db.execute("PRAGMA synchronous=FULL")
+            self.db.commit()
+        except BaseException:
+            self.db.close()
+            raise
 
     def close(self):
         self.db.close()
@@ -690,9 +695,8 @@ async def _realtime_session(client, s, db, fam, args, stop_all, deadline):
     return outcome["v"], s.committed - start
 
 
-async def run_realtime(args):
-    with WhoopDB(args.db) as db:
-        return await _run_realtime(args, db)
+async def run_realtime(args, db):
+    return await _run_realtime(args, db)
 
 
 async def _run_realtime(args, db):
@@ -764,9 +768,8 @@ async def _run_realtime(args, db):
         print(f"  decode skipped ({e}); run `whoop_sync.py decode --db {args.db}`.", flush=True)
 
 
-async def run(args):
-    with WhoopDB(args.db) as db:
-        return await _run(args, db)
+async def run(args, db):
+    return await _run(args, db)
 
 
 async def _run(args, db):
@@ -997,12 +1000,14 @@ def main():
 
     if cmd == "sync":
         try:
-            asyncio.run(run(args))
+            with WhoopDB(args.db) as db:
+                asyncio.run(run(args, db))
         except KeyboardInterrupt:
             pass
     elif cmd == "realtime":
         try:
-            asyncio.run(run_realtime(args))
+            with WhoopDB(args.db) as db:
+                asyncio.run(run_realtime(args, db))
         except KeyboardInterrupt:
             pass
     elif cmd == "export":
@@ -1045,4 +1050,5 @@ def main():
 
 
 if __name__ == "__main__":
+    configure_utf8_stdio()
     main()


### PR DESCRIPTION
## What this PR does

Makes the Python capture tools work with non-UTF-8 host defaults. Text files use explicit UTF-8, and executable console entry points support Unicode diagnostics, including the validator's callable `main` entry point.

Closes SQLite connections on normal, early-return, initialization-error and command-error paths. Capture commands own the database outside `asyncio.run`, so its background executor finishes before the connection closes. Protocol frames, acknowledgement behavior and session logic are unchanged.

Adds native Windows Python 3.12 CI with UTF-8 mode disabled, strict cp1252 output and a minimum discovery/execution count.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / tooling

## How it was tested

- Failing regressions before the fixes covered console encoding and SQLite cleanup, including initialization errors and a cancelled background commit.
- Final independent `Tools/linux-capture` discovery with `PYTHONUTF8=0`, `PYTHONIOENCODING=cp1252:strict`, and `-W error::ResourceWarning`: 223 tests, one optional skip, passed.
- The exact new CI runner also passed locally on Python 3.12; failure/discovery-floor probes passed. The new native Windows lane and existing Linux lane both passed in [Tools Python CI](https://github.com/ryanbr/noop/actions/runs/33976917788).
- Database lifetime was exercised using real SQLite and the capture code with simulated Bluetooth transport. No physical strap was tested; this PR does not claim hardware qualification.

## Checklist

- Swift package tests: not applicable; no Swift changes.
- Android unit tests: not applicable; no Android changes.
- [x] No new Python resource warnings in the affected suite
- UI/design tokens: not applicable.
- [x] No protocol facts or frame bytes added to product code
- [x] Follows `docs/CONTRIBUTING.md`
- [x] No generated output, local analysis artifacts, metrics or secrets committed

## Related issues

Fixes bhelm/noop#15.
