### PR TITLE
Require continuous effort for heart-rate recovery eligibility

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HeartRateRecovery.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HeartRateRecovery.swift
@@ -82,13 +82,23 @@ public enum HeartRateRecovery {
 
     private static func sustainedSeconds(atOrAbove threshold: Double, in samples: [HRSample]) -> Int {
         guard samples.count >= 2 else { return 0 }
-        var seconds = 0
+        var currentSeconds = 0
+        var longestSeconds = 0
         for i in 0..<(samples.count - 1) {
             let gap = samples[i + 1].ts - samples[i].ts
-            guard gap > 0, gap <= maximumContinuousGapSeconds else { continue }
-            if Double(samples[i].bpm) >= threshold { seconds += gap }
+            guard gap > 0 else { continue }
+            guard gap <= maximumContinuousGapSeconds else {
+                currentSeconds = 0
+                continue
+            }
+            guard Double(samples[i].bpm) >= threshold else {
+                currentSeconds = 0
+                continue
+            }
+            currentSeconds += gap
+            longestSeconds = max(longestSeconds, currentSeconds)
         }
-        return seconds
+        return longestSeconds
     }
 
     private static func median(_ values: [Int]) -> Int? {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HeartRateRecoveryTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HeartRateRecoveryTests.swift
@@ -15,6 +15,15 @@ final class HeartRateRecoveryTests: XCTestCase {
         return values.enumerated().map { i, bpm in HRSample(ts: target - values.count / 2 + i, bpm: bpm) }
     }
 
+    private func result(for eligibilitySamples: [HRSample]) -> HeartRateRecovery.Result? {
+        HeartRateRecovery.calculate(
+            samples: eligibilitySamples + window(minutes: 1, values: [140, 140, 140]),
+            workoutStart: end - 300,
+            workoutEnd: end,
+            maxHR: 200
+        )
+    }
+
     func testCalculatesOneTwoAndFiveMinuteDropsFromRobustReadings() {
         let samples = denseEligible()
             + window(minutes: 1, values: [146, 146, 220, 146, 146]) // optical spike cannot own the reading
@@ -40,6 +49,58 @@ final class HeartRateRecoveryTests: XCTestCase {
         let samples = sparse + window(minutes: 1, values: [140, 140, 140])
         XCTAssertNil(HeartRateRecovery.calculate(samples: samples, workoutStart: end - 300,
                                                  workoutEnd: end, maxHR: 200))
+    }
+
+    func testRejectsThreeSeparatedFortySecondHighIntensityRuns() {
+        let samples = [
+            HRSample(ts: end - 140, bpm: 170), HRSample(ts: end - 130, bpm: 170),
+            HRSample(ts: end - 120, bpm: 170), HRSample(ts: end - 110, bpm: 170),
+            HRSample(ts: end - 100, bpm: 120),
+            HRSample(ts: end - 90, bpm: 170), HRSample(ts: end - 80, bpm: 170),
+            HRSample(ts: end - 70, bpm: 170), HRSample(ts: end - 60, bpm: 170),
+            HRSample(ts: end - 50, bpm: 120),
+            HRSample(ts: end - 40, bpm: 170), HRSample(ts: end - 30, bpm: 170),
+            HRSample(ts: end - 20, bpm: 170), HRSample(ts: end - 10, bpm: 170),
+            HRSample(ts: end, bpm: 120),
+        ]
+
+        XCTAssertNil(result(for: samples))
+    }
+
+    func testGapExactlyAtCapUsesLeftSampleAndExactMinimumIsAccepted() {
+        let samples = stride(from: end - 120, through: end - 10, by: 10)
+            .map { HRSample(ts: $0, bpm: 170) }
+            + [HRSample(ts: end, bpm: 120)]
+
+        XCTAssertEqual(result(for: samples), .init(endHR: 170, after1Minute: 30,
+                                                  after2Minutes: nil, after5Minutes: nil))
+    }
+
+    func testGapOverCapResetsTheQualifyingRun() {
+        let beforeGap = stride(from: end - 180, through: end - 110, by: 10)
+            .map { HRSample(ts: $0, bpm: 170) }
+        let afterGap = stride(from: end - 99, through: end - 9, by: 10)
+            .map { HRSample(ts: $0, bpm: 170) }
+            + [HRSample(ts: end, bpm: 170)]
+
+        XCTAssertNil(result(for: beforeGap + afterGap))
+    }
+
+    func testBelowThresholdIntervalResetsTheQualifyingRun() {
+        let samples = stride(from: end - 130, through: end, by: 10).map { ts in
+            HRSample(ts: ts, bpm: ts == end - 60 ? 120 : 170)
+        }
+
+        XCTAssertNil(result(for: samples))
+    }
+
+    func testDuplicateTimestampDoesNotBreakAnOtherwiseContinuousRun() {
+        let samples = stride(from: end - 120, through: end, by: 10)
+            .map { HRSample(ts: $0, bpm: 170) }
+            + [HRSample(ts: end - 60, bpm: 120)]
+
+        XCTAssertEqual(result(for: samples), .init(endHR: 170, after1Minute: 30,
+                                                  after2Minutes: nil, after5Minutes: nil))
     }
 
     func testDoesNotCreditPreWorkoutHeartRateTowardEligibility() {

--- a/android/app/src/main/java/com/noop/analytics/HeartRateRecovery.kt
+++ b/android/app/src/main/java/com/noop/analytics/HeartRateRecovery.kt
@@ -66,14 +66,23 @@ object HeartRateRecovery {
 
     private fun sustainedSeconds(threshold: Double, samples: List<HrSample>): Long {
         if (samples.size < 2) return 0L
-        var seconds = 0L
+        var currentSeconds = 0L
+        var longestSeconds = 0L
         for (i in 0 until samples.lastIndex) {
             val gap = samples[i + 1].ts - samples[i].ts
-            if (gap in 1..maximumContinuousGapSeconds && samples[i].bpm.toDouble() >= threshold) {
-                seconds += gap
+            if (gap <= 0L) continue
+            if (gap > maximumContinuousGapSeconds) {
+                currentSeconds = 0L
+                continue
             }
+            if (samples[i].bpm.toDouble() < threshold) {
+                currentSeconds = 0L
+                continue
+            }
+            currentSeconds += gap
+            longestSeconds = maxOf(longestSeconds, currentSeconds)
         }
-        return seconds
+        return longestSeconds
     }
 
     private fun median(values: List<Int>): Int? {

--- a/android/app/src/test/java/com/noop/analytics/HeartRateRecoveryTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HeartRateRecoveryTest.kt
@@ -16,6 +16,11 @@ class HeartRateRecoveryTest {
         return values.mapIndexed { i, bpm -> HrSample("strap", target - values.size / 2 + i, bpm) }
     }
 
+    private fun result(eligibilitySamples: List<HrSample>): HeartRateRecovery.Result? =
+        HeartRateRecovery.calculate(
+            eligibilitySamples + window(1, listOf(140, 140, 140)), end - 300, end, 200.0,
+        )
+
     @Test
     fun calculatesOneTwoAndFiveMinuteDropsFromRobustReadings() {
         val samples = denseEligible() +
@@ -40,6 +45,57 @@ class HeartRateRecoveryTest {
     fun rejectsDisconnectedHighIntensityFragments() {
         val sparse = (end - 300..end step 15).map { HrSample("strap", it, 170) }
         assertNull(HeartRateRecovery.calculate(sparse + window(1, listOf(140, 140, 140)), end - 300, end, 200.0))
+    }
+
+    @Test
+    fun rejectsThreeSeparatedFortySecondHighIntensityRuns() {
+        val samples = listOf(
+            HrSample("strap", end - 140, 170), HrSample("strap", end - 130, 170),
+            HrSample("strap", end - 120, 170), HrSample("strap", end - 110, 170),
+            HrSample("strap", end - 100, 120),
+            HrSample("strap", end - 90, 170), HrSample("strap", end - 80, 170),
+            HrSample("strap", end - 70, 170), HrSample("strap", end - 60, 170),
+            HrSample("strap", end - 50, 120),
+            HrSample("strap", end - 40, 170), HrSample("strap", end - 30, 170),
+            HrSample("strap", end - 20, 170), HrSample("strap", end - 10, 170),
+            HrSample("strap", end, 120),
+        )
+
+        assertNull(result(samples))
+    }
+
+    @Test
+    fun gapExactlyAtCapUsesLeftSampleAndExactMinimumIsAccepted() {
+        val samples = (end - 120..end - 10 step 10).map { HrSample("strap", it, 170) } +
+            HrSample("strap", end, 120)
+
+        assertEquals(HeartRateRecovery.Result(170, 30, null, null), result(samples))
+    }
+
+    @Test
+    fun gapOverCapResetsTheQualifyingRun() {
+        val beforeGap = (end - 180..end - 110 step 10).map { HrSample("strap", it, 170) }
+        val afterGap = (end - 99..end - 9 step 10).map { HrSample("strap", it, 170) } +
+            HrSample("strap", end, 170)
+
+        assertNull(result(beforeGap + afterGap))
+    }
+
+    @Test
+    fun belowThresholdIntervalResetsTheQualifyingRun() {
+        val samples = (end - 130..end step 10).map { ts ->
+            HrSample("strap", ts, if (ts == end - 60) 120 else 170)
+        }
+
+        assertNull(result(samples))
+    }
+
+    @Test
+    fun duplicateTimestampDoesNotBreakAnOtherwiseContinuousRun() {
+        val samples = (end - 120..end step 10).map { HrSample("strap", it, 170) } +
+            HrSample("strap", end - 60, 120)
+
+        assertEquals(HeartRateRecovery.Result(170, 30, null, null), result(samples))
     }
 
     @Test


### PR DESCRIPTION
## What this PR does

Changes heart-rate recovery eligibility on Swift and Android to require one continuous qualifying effort of at least two minutes. Previously, separate high-heart-rate fragments could be added together and incorrectly qualify a workout.

The calculation keeps the existing threshold, left-sample interval attribution, 10-second gap cap, duplicate-timestamp handling, recovery windows, and score outputs.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- Matching Swift and Kotlin regressions failed before the calculation change for disconnected runs, a gap over the cap, and a below-threshold reset.
- Focused Swift tests pass 12/12 using the actual analytics source, tests, and `WhoopProtocol` dependency in a minimal Linux package.
- Focused Android `HeartRateRecoveryTest` passes through `testFullDebugUnitTest`.
- Boundary coverage includes a gap exactly at the 10-second cap, a gap over the cap, exactly 120 continuous qualifying seconds, left-sample attribution, and duplicate timestamps.
- A focused differential check of 22 shared HRR cases produced byte-identical Swift/Kotlin output, including the corrected null result for disconnected effort. This used an isolated adapted fork harness, not the full fork governance/coverage guard: an unrelated obsolete runner dispatch was excluded with an explicit error, and the pre-fix known-bug oracle was retired without changing the input cases. A missing-result negative control failed as expected.

This is a pure analytics change and does not touch BLE behavior. No physical strap was tested. Local focused verification ran on Linux; the complete Swift package suite subsequently passed on macOS in [Swift Packages CI](https://github.com/ryanbr/noop/actions/runs/33977518300), and the complete Android unit suite passed in [Android CI](https://github.com/ryanbr/noop/actions/runs/33977518279).

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — complete StrandAnalytics package tests passed in macOS CI.
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`) — complete unit suite passed in Android CI.
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no UI changes
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders — no protocol changes
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Fixes bhelm/noop#55.
