### PR TITLE
protocol: place a frame's R-R beats at the times they describe, not all at the frame

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/HistoricalStreams.swift
@@ -264,7 +264,11 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
                 out.hr.append(HRSample(ts: ts, bpm: bpm))
             }
             if let rrs = p["rr_intervals"]?.intArrayValue {
-                for rr in rrs { out.rr.append(RRInterval(ts: ts, rrMs: rr)) }
+                // #1118: the batch is spread across the time it describes — stamping every
+                // interval at the frame put ~1.5s of beats on 1s of clock. See RrBatchTimestamps.
+                for placed in RrBatchTimestamps.spread(frameTs: ts, rrMs: rrs) {
+                    out.rr.append(RRInterval(ts: placed.ts, rrMs: placed.rrMs))
+                }
             }
             if let red = p["spo2_red"]?.intValue {
                 out.spo2.append(SpO2Sample(ts: ts, red: red, ir: p["spo2_ir"]?.intValue ?? 0))
@@ -388,7 +392,11 @@ public func extractHistoricalStreams(_ parsed: [ParsedFrame],
                 out.hr.append(HRSample(ts: ts, bpm: bpm))
             }
             if let ts = rtTs, let rrs = p["rr_intervals"]?.intArrayValue {
-                for rr in rrs { out.rr.append(RRInterval(ts: ts, rrMs: rr)) }
+                // #1118: the batch is spread across the time it describes — stamping every
+                // interval at the frame put ~1.5s of beats on 1s of clock. See RrBatchTimestamps.
+                for placed in RrBatchTimestamps.spread(frameTs: ts, rrMs: rrs) {
+                    out.rr.append(RRInterval(ts: placed.ts, rrMs: placed.rrMs))
+                }
             }
         case "EVENT":
             // EVENT carries the strap RTC's real-unix seconds. Correct for a grossly-stale RTC

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/RrBatchTimestamps.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/RrBatchTimestamps.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Spread a frame's R-R array across the time it actually describes (#1118).
+///
+/// Every ingest path stamped EVERY interval in a frame's `rr_intervals` array with that frame's single
+/// timestamp:
+///
+///     for rr in rrs { out.rr.append(RRInterval(ts: ts, rrMs: rr)) }
+///
+/// A frame carrying two ~740 ms intervals therefore deposited ~1.5 seconds of beat-time onto one second
+/// of wall clock, and `rrCoverage` - which is exactly that ratio - read 1.5. A field capture measured
+/// `beatsPerSec=2.15` with `covExact=1.80` on a WHOOP 4.0 whose beats were entirely genuine.
+///
+/// ## This is not de-duplication
+///
+/// The beats are real and distinct; only their timestamps were collapsed. That is why removing exact
+/// `(ts,rrMs)` duplicates freed 0.3% of rows and left coverage at 1.80, and why a 40 ms same-second
+/// collapse reached 1.09-1.43 only by deleting real beats (beat accuracy fell to 0.57-0.66). There was
+/// never anything to remove.
+///
+/// ## The convention, and why the risk in it is small
+///
+/// The array is oldest-first and the MOST RECENT interval ends at the frame timestamp, following the
+/// Heart Rate Service shape these frames mirror (`rr_count` then the values, in 1/1024 s). So interval
+/// `i` is placed at `frameTs` minus the intervals that follow it.
+///
+/// If that is backwards and `frameTs` marks the START of the batch, every beat shifts by at most one
+/// batch width - under two seconds. That barely matters: RMSSD and SDNN are built from successive
+/// DIFFERENCES between interval values, which this does not touch, and coverage depends on the span the
+/// beats occupy rather than where the span sits. A whole-batch offset changes neither. What it could
+/// nudge is which sleep stage a beat at a stage boundary falls in, which is noise at this scale.
+///
+/// ## Safe where there is nothing to spread
+///
+/// A single-interval array returns unchanged, so a strap whose frames arrive at about its beat rate -
+/// the 5/MG, whose nights already read coverage ~1.0 - is byte-identical through this. Only a batching
+/// frame moves, which is the only case that was ever wrong.
+public enum RrBatchTimestamps {
+
+    /// The frame's intervals with a timestamp each, oldest first.
+    ///
+    /// Timestamps are whole seconds, so a sub-second step sometimes lands two beats in one second and
+    /// sometimes in adjacent ones. That is fine and is not an approximation worth avoiding: coverage is
+    /// measured across a night, where the spread's total is what counts, not any single pair.
+    public static func spread(frameTs: Int, rrMs: [Int]) -> [(ts: Int, rrMs: Int)] {
+        guard rrMs.count > 1 else { return rrMs.map { (ts: frameTs, rrMs: $0) } }
+        var out: [(ts: Int, rrMs: Int)] = []
+        out.reserveCapacity(rrMs.count)
+        // Walk backwards accumulating the intervals AFTER each one: the last ends at `frameTs`, the one
+        // before it a beat earlier, and so on.
+        var msAfter = 0
+        for value in rrMs.reversed() {
+            out.append((ts: frameTs - Int((Double(msAfter) / 1000.0).rounded()), rrMs: value))
+            msAfter += max(0, value)
+        }
+        return out.reversed()
+    }
+}

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Streams.swift
@@ -815,7 +815,11 @@ public func extractStreams(_ parsed: [ParsedFrame],
             }
             // Unlike Python, drop RR rows when timestamp is absent (a ts-less RR row is unstorable).
             if let ts = ts, let rrs = p["rr_intervals"]?.intArrayValue {
-                for rr in rrs { out.rr.append(RRInterval(ts: ts, rrMs: rr)) }
+                // #1118: the batch is spread across the time it describes — stamping every
+                // interval at the frame put ~1.5s of beats on 1s of clock. See RrBatchTimestamps.
+                for placed in RrBatchTimestamps.spread(frameTs: ts, rrMs: rrs) {
+                    out.rr.append(RRInterval(ts: placed.ts, rrMs: placed.rrMs))
+                }
             }
         case "EVENT":
             // EVENT timestamps are real RTC unix seconds — already wall-clock, NOT offset.

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/RrBatchTimestampsTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/RrBatchTimestampsTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import XCTest
+@testable import WhoopProtocol
+
+/// R-R batch timestamps (#1118) — twin of the Kotlin `RrBatchTimestampsTest`, same cases, same numbers.
+final class RrBatchTimestampsTests: XCTestCase {
+
+    /// The regression. Two ~740 ms beats used to share one second, so a frame deposited ~1.5 s of
+    /// beat-time onto 1 s of wall clock and coverage read 1.5. They must now occupy two seconds.
+    func testABatchIsSpreadAcrossTheTimeItDescribes() {
+        let out = RrBatchTimestamps.spread(frameTs: 1000, rrMs: [740, 745])
+        XCTAssertEqual(out.map(\.rrMs), [740, 745], "values are untouched — only timestamps move")
+        XCTAssertEqual(out.map(\.ts), [999, 1000])
+    }
+
+    /// The most recent interval ends AT the frame; earlier ones are back-dated by what follows them.
+    func testTheLastIntervalLandsOnTheFrameTimestamp() {
+        let out = RrBatchTimestamps.spread(frameTs: 5000, rrMs: [1000, 1000, 1000])
+        XCTAssertEqual(out.map(\.ts), [4998, 4999, 5000])
+    }
+
+    /// The property that makes this a fix rather than a trade: the beat-time a batch carries now matches
+    /// the wall-clock span it occupies, which IS what rrCoverage measures.
+    func testSpanMatchesTheBeatTimeCarried() {
+        let rr = [800, 820, 810, 790]
+        let out = RrBatchTimestamps.spread(frameTs: 10_000, rrMs: rr)
+        let span = out.last!.ts - out.first!.ts
+        let carriedSeconds = rr.dropLast().reduce(0, +) / 1000
+        XCTAssertEqual(span, carriedSeconds, accuracy: 1)
+    }
+
+    /// A strap that does not batch is byte-identical through this — the 5/MG's clean nights must not move.
+    func testASingleIntervalIsUnchanged() {
+        let out = RrBatchTimestamps.spread(frameTs: 777, rrMs: [812])
+        XCTAssertEqual(out.count, 1)
+        XCTAssertEqual(out[0].ts, 777)
+        XCTAssertEqual(out[0].rrMs, 812)
+    }
+
+    func testAnEmptyBatchYieldsNothing() {
+        XCTAssertTrue(RrBatchTimestamps.spread(frameTs: 1, rrMs: []).isEmpty)
+    }
+
+    /// No beat is invented or dropped — the count and the values survive exactly, in order.
+    func testNoBeatIsAddedOrLost() {
+        let rr = [700, 1200, 650, 900, 880]
+        let out = RrBatchTimestamps.spread(frameTs: 42_000, rrMs: rr)
+        XCTAssertEqual(out.map(\.rrMs), rr)
+    }
+
+    /// A nonsense value cannot drag a timestamp forwards past the frame.
+    func testANegativeValueCannotMoveTimeForwards() {
+        let out = RrBatchTimestamps.spread(frameTs: 100, rrMs: [-5000, 800])
+        XCTAssertTrue(out.allSatisfy { $0.ts <= 100 })
+    }
+}

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -851,7 +851,13 @@ fun extractHistoricalStreams(
                 p.intOrNull("heart_rate")?.let { bpm -> if (bpm != 0) hr.add(HrRow(ts, bpm)) }
 
                 @Suppress("UNCHECKED_CAST")
-                (p["rr_intervals"] as? List<Int>)?.forEach { rrMs -> rr.add(RrRow(ts, rrMs)) }
+                (p["rr_intervals"] as? List<Int>)?.let { rrs ->
+                    // #1118: spread across the time the batch describes, not all at the frame. `ts` is a
+                    // Long here and an Int in the sibling paths; epoch seconds fit either, and the shared
+                    // helper stays Int so it is byte-identical with the Swift twin.
+                    RrBatchTimestamps.spread(ts.toInt(), rrs)
+                        .forEach { rr.add(RrRow(it.ts.toLong(), it.rrMs)) }
+                }
 
                 p.intOrNull("spo2_red")?.let { red ->
                     spo2.add(Spo2Row(ts, red = red, ir = p.intOrNull("spo2_ir") ?: 0))
@@ -987,8 +993,9 @@ fun extractHistoricalStreams(
                 if (!plausible(ts.toLong())) { droppedImplausible++; continue }
                 parsed.parsed.intOrNull("heart_rate")?.let { bpm -> hr.add(HrRow(ts.toLong(), bpm)) }
                 @Suppress("UNCHECKED_CAST")
-                (parsed.parsed["rr_intervals"] as? List<Int>)?.forEach { rrMs ->
-                    rr.add(RrRow(ts.toLong(), rrMs))
+                (parsed.parsed["rr_intervals"] as? List<Int>)?.let { rrs ->
+                    // #1118: spread across the time the batch describes, not all at the frame.
+                    RrBatchTimestamps.spread(ts, rrs).forEach { rr.add(RrRow(it.ts.toLong(), it.rrMs)) }
                 }
             }
 

--- a/android/app/src/main/java/com/noop/protocol/RrBatchTimestamps.kt
+++ b/android/app/src/main/java/com/noop/protocol/RrBatchTimestamps.kt
@@ -1,0 +1,69 @@
+package com.noop.protocol
+
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+/**
+ * Spread a frame's R-R array across the time it actually describes (#1118).
+ *
+ * Every ingest path stamped EVERY interval in a frame's `rr_intervals` array with that frame's single
+ * timestamp:
+ *
+ * ```
+ * for (rr in rrs) out.rr.add(RrInterval(ts, rr))
+ * ```
+ *
+ * A frame carrying two ~740 ms intervals therefore deposited ~1.5 seconds of beat-time onto one second of
+ * wall clock, and `rrCoverage` - which is exactly that ratio - read 1.5. A field capture measured
+ * `beatsPerSec=2.15` with `covExact=1.80` on a WHOOP 4.0 whose beats were entirely genuine.
+ *
+ * ## This is not de-duplication
+ *
+ * The beats are real and distinct; only their timestamps were collapsed. That is why removing exact
+ * `(ts,rrMs)` duplicates freed 0.3% of rows and left coverage at 1.80, and why a 40 ms same-second
+ * collapse reached 1.09-1.43 only by deleting real beats (beat accuracy fell to 0.57-0.66). There was
+ * never anything to remove.
+ *
+ * ## The convention, and why the risk in it is small
+ *
+ * The array is oldest-first and the MOST RECENT interval ends at the frame timestamp, following the Heart
+ * Rate Service shape these frames mirror (`rr_count` then the values, in 1/1024 s). So interval `i` is
+ * placed at `frameTs` minus the intervals that follow it.
+ *
+ * If that is backwards and `frameTs` marks the START of the batch, every beat shifts by at most one batch
+ * width - under two seconds. That barely matters: RMSSD and SDNN are built from successive DIFFERENCES
+ * between interval values, which this does not touch, and coverage depends on the span the beats occupy
+ * rather than where the span sits. A whole-batch offset changes neither. What it could nudge is which
+ * sleep stage a beat at a stage boundary falls in, which is noise at this scale.
+ *
+ * ## Safe where there is nothing to spread
+ *
+ * A single-interval array returns unchanged, so a strap whose frames arrive at about its beat rate - the
+ * 5/MG, whose nights already read coverage ~1.0 - is byte-identical through this. Only a batching frame
+ * moves, which is the only case that was ever wrong. Swift twin: `RrBatchTimestamps`.
+ */
+object RrBatchTimestamps {
+
+    /** One interval with the timestamp it belongs at. */
+    data class Placed(val ts: Int, val rrMs: Int)
+
+    /**
+     * The frame's intervals with a timestamp each, oldest first.
+     *
+     * Timestamps are whole seconds, so a sub-second step sometimes lands two beats in one second and
+     * sometimes in adjacent ones. That is fine and is not an approximation worth avoiding: coverage is
+     * measured across a night, where the spread's total is what counts, not any single pair.
+     */
+    fun spread(frameTs: Int, rrMs: List<Int>): List<Placed> {
+        if (rrMs.size <= 1) return rrMs.map { Placed(frameTs, it) }
+        val out = ArrayList<Placed>(rrMs.size)
+        // Walk backwards accumulating the intervals AFTER each one: the last ends at `frameTs`, the one
+        // before it a beat earlier, and so on.
+        var msAfter = 0
+        for (value in rrMs.asReversed()) {
+            out.add(Placed(frameTs - (msAfter / 1000.0).roundToInt(), value))
+            msAfter += max(0, value)
+        }
+        return out.asReversed()
+    }
+}

--- a/android/app/src/main/java/com/noop/protocol/Streams.kt
+++ b/android/app/src/main/java/com/noop/protocol/Streams.kt
@@ -320,7 +320,7 @@ fun extractStreams(parsed: List<ParsedFrame>, deviceClockRef: Int, wallClockRef:
                     p.intOrNull("heart_rate")?.let { bpm -> out.hr.add(HrSample(ts, bpm)) }
                     // Drop RR rows when timestamp is absent (a ts-less RR row is unstorable).
                     p.intArrayOrNull("rr_intervals")?.let { rrs ->
-                        for (rr in rrs) out.rr.add(RrInterval(ts, rr))
+                        for (p2 in RrBatchTimestamps.spread(ts, rrs.toList())) out.rr.add(RrInterval(p2.ts, p2.rrMs))
                     }
                 }
             }

--- a/android/app/src/test/java/com/noop/protocol/FramingTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/FramingTest.kt
@@ -415,7 +415,11 @@ class FramingTest {
         assertEquals(1, streams.hr.size)
         assertEquals(HrSample(ts = 1700000000, bpm = 62), streams.hr[0])
         assertEquals(2, streams.rr.size)
-        assertEquals(RrInterval(ts = 1700000000, rrMs = 850), streams.rr[0])
+        // #1118: the frame carries TWO intervals, so they are spread across the time they describe
+        // rather than both stamped at the frame. The most recent ends at the frame timestamp; the
+        // earlier one is back-dated by the 870 ms that follows it. Values are untouched - this moved
+        // timestamps only, and no beat is added or lost.
+        assertEquals(RrInterval(ts = 1699999999, rrMs = 850), streams.rr[0])
         assertEquals(RrInterval(ts = 1700000000, rrMs = 870), streams.rr[1])
     }
 

--- a/android/app/src/test/java/com/noop/protocol/RrBatchTimestampsTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/RrBatchTimestampsTest.kt
@@ -1,0 +1,62 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+
+/** R-R batch timestamps (#1118) — twin of the Swift `RrBatchTimestampsTests`, same cases, same numbers. */
+class RrBatchTimestampsTest {
+
+    /**
+     * The regression. Two ~740 ms beats used to share one second, so a frame deposited ~1.5 s of
+     * beat-time onto 1 s of wall clock and coverage read 1.5. They must now occupy two seconds.
+     */
+    @Test fun `a batch is spread across the time it describes`() {
+        val out = RrBatchTimestamps.spread(1000, listOf(740, 745))
+        assertEquals(listOf(740, 745), out.map { it.rrMs })
+        assertEquals(listOf(999, 1000), out.map { it.ts })
+    }
+
+    /** The most recent interval ends AT the frame; earlier ones are back-dated by what follows them. */
+    @Test fun `the last interval lands on the frame timestamp`() {
+        val out = RrBatchTimestamps.spread(5000, listOf(1000, 1000, 1000))
+        assertEquals(listOf(4998, 4999, 5000), out.map { it.ts })
+    }
+
+    /**
+     * The property that makes this a fix rather than a trade: the beat-time a batch carries now matches
+     * the wall-clock span it occupies, which IS what rrCoverage measures.
+     */
+    @Test fun `span matches the beat-time carried`() {
+        val rr = listOf(800, 820, 810, 790)
+        val out = RrBatchTimestamps.spread(10_000, rr)
+        val span = out.last().ts - out.first().ts
+        val carriedSeconds = rr.dropLast(1).sum() / 1000
+        assertTrue("span=$span carried=$carriedSeconds", abs(span - carriedSeconds) <= 1)
+    }
+
+    /** A strap that does not batch is byte-identical through this — the 5/MG's clean nights must not move. */
+    @Test fun `a single interval is unchanged`() {
+        val out = RrBatchTimestamps.spread(777, listOf(812))
+        assertEquals(1, out.size)
+        assertEquals(777, out[0].ts)
+        assertEquals(812, out[0].rrMs)
+    }
+
+    @Test fun `an empty batch yields nothing`() {
+        assertTrue(RrBatchTimestamps.spread(1, emptyList()).isEmpty())
+    }
+
+    /** No beat is invented or dropped — the count and the values survive exactly, in order. */
+    @Test fun `no beat is added or lost`() {
+        val rr = listOf(700, 1200, 650, 900, 880)
+        assertEquals(rr, RrBatchTimestamps.spread(42_000, rr).map { it.rrMs })
+    }
+
+    /** A nonsense value cannot drag a timestamp forwards past the frame. */
+    @Test fun `a negative value cannot move time forwards`() {
+        val out = RrBatchTimestamps.spread(100, listOf(-5000, 800))
+        assertTrue(out.all { it.ts <= 100 })
+    }
+}


### PR DESCRIPTION
Traced from a field capture (Android staging 11.1.1 build 440, overnight
2026-09-06) in which a WHOOP 4.0's nights and a 5/MG's sit in the same pass and
only the 4.0 over-counts. See #1118 for the full trace.

## The cause

Every ingest path stamped EVERY interval in a frame's `rr_intervals` array with
that frame's single timestamp - live and offload, both platforms, seven sites:

```kotlin
for (rr in rrs) out.rr.add(RrInterval(ts, rr))
```

A frame carrying two ~740 ms intervals deposits ~1.5 seconds of beat-time onto
one second of wall clock, and `rrCoverage` is exactly that ratio.

## It is not duplication, and that matters

The beats are real and distinct; only their timestamps were collapsed. This
re-reads every number the de-dup candidates could not explain:

| observation | why |
|---|---|
| exact-dup collapse frees 0.3%, coverage stays 1.80 | nothing is duplicated |
| 40 ms collapse reaches 1.09-1.43, beat accuracy falls to 0.57-0.66 | it is deleting real beats |
| values within a second cluster tightly (`725,730,736,738,752,754`) | consecutive beats at a steady ~80 bpm |
| `multiMs=96%` | the values differ because they ARE different beats |
| always CROSS_SECOND | a batch straddles the boundary once its span exceeds a second |

## The change

Each interval sits at the frame timestamp minus the intervals that follow it, so
coverage falls out at ~1.0 by construction: the beat-time laid down equals the
wall-clock consumed. **No beat is added, dropped or altered** - values are
untouched, only `ts` moves. That is the difference between this and every
collapse candidate, each of which had to destroy real beats to make the number
look right.

A single-interval array returns unchanged, so a strap whose frames arrive at
about its beat rate is byte-identical through this - which is why the 5/MG's
nights already read ~1.0 and why this needs no family gate.

## The assumption in it

That the frame marks the END of the batch, following the Heart Rate Service shape
these frames mirror (`rr_count` then values in 1/1024 s). The capture does not
prove it. If it is backwards, every beat shifts by under two seconds and changes
neither RMSSD nor SDNN - both are built from differences between interval VALUES,
which this does not touch - nor coverage, which measures a span rather than where
it sits. The exposure is which sleep stage a boundary beat falls in.

## Verification

- Android 5323 tests / 0 failures; WhoopProtocol 683 / 0; doc lint clean.
- 7 new twinned tests, including the two properties that make this safe: the span
  a batch occupies now equals the beat-time it carries, and no beat is added or
  lost.
- `FramingTest`'s extractStreams case pinned the OLD behaviour, so it is repinned
  to the same shape rather than deleted. The Swift parity fixtures pass untouched,
  which says they carry single-interval frames.

**Not verified against a strap.** Nothing here has scored a real 4.0 night. The
check is a 4.0 capture reading `rrIntegrity` clean with coverage ~1.0 where it
read 1.5-2.4, and respiratory returning for those nights via the RSA gate.

## What this does not do

Re-derive history. Existing rows keep their collapsed timestamps, so the eleven
4.0 nights currently showing no breaths-per-minute stay that way until something
re-scores them from the frames. Worth deciding separately.