### PR TITLE
settings: give the bottom bar its own card, with a size and a transparency

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -376,6 +376,18 @@ object BottomBarStyleStore {
     var scale by mutableStateOf(DEFAULT_SCALE)
         private set
 
+    /**
+     * Move the bar NOW without persisting, for a slider drag.
+     *
+     * Separate from [setOpacityStep] because a drag emits a value per frame: persisting each one would
+     * write SharedPreferences dozens of times to record a decision the user makes once, on release. The
+     * card-opacity slider already splits it this way; this is the same split, not a new idea.
+     */
+    fun previewOpacityStep(step: Int) {
+        opacityStep = step.coerceIn(MIN_OPACITY_STEP, MAX_OPACITY_STEP)
+    }
+
+    /** Set and persist - for a committed choice, i.e. the end of a drag. */
     fun setOpacityStep(ctx: Context, step: Int) {
         val clamped = step.coerceIn(MIN_OPACITY_STEP, MAX_OPACITY_STEP)
         opacityStep = clamped

--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -351,6 +351,45 @@ object BottomBarStyleStore {
      */
     fun barHeightForContent(): Dp = if (overlay) barHeight else 0.dp
 
+    /**
+     * How see-through the bar's glass is, in EIGHT steps: 1 the most transparent, 8 solid.
+     *
+     * A step rather than a raw float so the two ends are reachable and every stop is repeatable - a
+     * continuous slider on a bar this small mostly produces values a user cannot tell apart or return to.
+     * The mapping is linear from 0.30 to 1.00, which puts the SHIPPED 0.80 exactly on step 6, so an
+     * install that never touches this is byte-identical to before.
+     */
+    var opacityStep by mutableStateOf(DEFAULT_OPACITY_STEP)
+        private set
+
+    /** The alpha for [opacityStep]. Step 1 = 0.30 ... step 6 = 0.80 (the shipped value) ... step 8 = 1.00. */
+    val barAlpha: Float get() = alphaForOpacityStep(opacityStep)
+
+    /**
+     * How much bigger the bar is drawn, from 1x to 2x.
+     *
+     * Scales the bar's CONTENT - icon, label and the padding around them - rather than applying a
+     * graphics scale to the finished bar, which would blur it and leave the touch targets where they
+     * were. The bar's height is measured and republished either way ([barHeight]), so screens keep
+     * clearing it correctly at any size without a second number to maintain.
+     */
+    var scale by mutableStateOf(DEFAULT_SCALE)
+        private set
+
+    fun setOpacityStep(ctx: Context, step: Int) {
+        val clamped = step.coerceIn(MIN_OPACITY_STEP, MAX_OPACITY_STEP)
+        opacityStep = clamped
+        NoopPrefs.of(ctx.applicationContext).edit()
+            .putInt(NoopPrefs.KEY_BOTTOM_BAR_OPACITY_STEP, clamped).apply()
+    }
+
+    fun setScale(ctx: Context, value: Float) {
+        val clamped = nearestScale(value)
+        scale = clamped
+        NoopPrefs.of(ctx.applicationContext).edit()
+            .putFloat(NoopPrefs.KEY_BOTTOM_BAR_SCALE, clamped).apply()
+    }
+
     /** #1839: hide the overlay bar while scrolling down, bring it back on scrolling up. Default ON. */
     var autoHide by mutableStateOf(true)
         private set
@@ -362,10 +401,14 @@ object BottomBarStyleStore {
     }
 
     fun load(ctx: Context) {
-        overlay = NoopPrefs.of(ctx.applicationContext)
-            .getBoolean(NoopPrefs.KEY_OVERLAY_BOTTOM_BAR, true)
-        autoHide = NoopPrefs.of(ctx.applicationContext)
-            .getBoolean(NoopPrefs.KEY_BOTTOM_BAR_AUTO_HIDE, true)
+        val prefs = NoopPrefs.of(ctx.applicationContext)
+        overlay = prefs.getBoolean(NoopPrefs.KEY_OVERLAY_BOTTOM_BAR, true)
+        autoHide = prefs.getBoolean(NoopPrefs.KEY_BOTTOM_BAR_AUTO_HIDE, true)
+        // Both are read through the same clamps the setters use, so a hand-edited or downgraded pref
+        // cannot put the bar in a state the UI has no way to leave.
+        opacityStep = prefs.getInt(NoopPrefs.KEY_BOTTOM_BAR_OPACITY_STEP, DEFAULT_OPACITY_STEP)
+            .coerceIn(MIN_OPACITY_STEP, MAX_OPACITY_STEP)
+        scale = nearestScale(prefs.getFloat(NoopPrefs.KEY_BOTTOM_BAR_SCALE, DEFAULT_SCALE))
     }
 
     fun set(ctx: Context, value: Boolean) {
@@ -1001,7 +1044,9 @@ private fun GlassBottomBar(
             // "Glass": a translucent raised surface — a frosted island, not a hard slab. Compose has no
             // cheap blur, so translucency (≈0.80) + a hairline rim is the Liquid-Glass stand-in. A soft,
             // low drop shadow reads as floating without a glow.
-            color = Palette.surfaceRaised.copy(alpha = 0.80f),
+            // The glass alpha is the user's transparency step; 0.80 was the shipped constant and remains
+            // the default (step 6), so an untouched install is unchanged.
+            color = Palette.surfaceRaised.copy(alpha = BottomBarStyleStore.barAlpha),
             tonalElevation = 2.dp,
             shadowElevation = 4.dp,
             modifier = Modifier
@@ -1013,7 +1058,11 @@ private fun GlassBottomBar(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 8.dp, vertical = 7.dp),
+                    // Scaling the PADDING and the slot contents grows the bar honestly - the touch
+                    // targets grow with it, and `barHeight` is measured afterwards so screens keep
+                    // clearing the bar at any size. A graphics scale would blur it and leave the hit
+                    // areas behind.
+                    .padding(horizontal = 8.dp, vertical = 7.dp * BottomBarStyleStore.scale),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(2.dp),
             ) {
@@ -1070,16 +1119,19 @@ private fun BarSlot(
                 indication = null,
                 onClick = onClick,
             )
-            .padding(vertical = 3.dp)
+            .padding(vertical = 3.dp * BottomBarStyleStore.scale)
             .semantics { contentDescription = label },
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(3.dp),
     ) {
-        Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(Metrics.iconSmall))
+        // Icon and label scale together with the padding above, so the slot grows as one piece rather
+        // than a bigger box around the same small glyph.
+        Icon(icon, contentDescription = null, tint = tint,
+             modifier = Modifier.size(Metrics.iconSmall * BottomBarStyleStore.scale))
         Text(
             label,
             style = NoopType.footnote.copy(
-                fontSize = 10.sp,
+                fontSize = 10.sp * BottomBarStyleStore.scale,
                 fontWeight = if (active) FontWeight.SemiBold else FontWeight.Medium,
             ),
             color = tint,

--- a/android/app/src/main/java/com/noop/ui/BottomBarStyle.kt
+++ b/android/app/src/main/java/com/noop/ui/BottomBarStyle.kt
@@ -1,0 +1,47 @@
+package com.noop.ui
+
+import kotlin.math.abs
+
+/** The most transparent step. */
+const val MIN_OPACITY_STEP = 1
+
+/** Solid. */
+const val MAX_OPACITY_STEP = 8
+
+/**
+ * The step whose alpha is the SHIPPED 0.80, so an install that never opens this setting renders exactly
+ * as it did before. Chosen by arithmetic rather than taste: the linear 0.30..1.00 mapping puts 0.80 on
+ * step 6 precisely, which is why the range starts at 0.30 rather than a rounder number.
+ */
+const val DEFAULT_OPACITY_STEP = 6
+
+/** Unscaled - the shipped bar. */
+const val DEFAULT_SCALE = 1f
+
+/** The offered sizes. A short fixed list, not a slider: these are the sizes worth having. */
+val BOTTOM_BAR_SCALES: List<Float> = listOf(1f, 1.25f, 1.5f, 1.75f, 2f)
+
+/**
+ * The bar's glass alpha for an opacity step, linear from 0.30 (step 1) to 1.00 (step 8).
+ *
+ * The floor is 0.30 rather than 0: a fully invisible bar would still take taps, so a user could hide the
+ * navigation and then not find it again. 0.30 is faint enough to read as "nearly gone" while leaving the
+ * capsule's rim visible.
+ */
+fun alphaForOpacityStep(step: Int): Float {
+    val clamped = step.coerceIn(MIN_OPACITY_STEP, MAX_OPACITY_STEP)
+    return 0.30f + (clamped - MIN_OPACITY_STEP) * 0.10f
+}
+
+/**
+ * The nearest offered scale to [value].
+ *
+ * Snaps rather than clamps so a stored value from a build with a DIFFERENT set of sizes - or a
+ * hand-edited pref - lands on something offerable instead of a size the dropdown cannot show or leave.
+ */
+fun nearestScale(value: Float): Float =
+    BOTTOM_BAR_SCALES.minByOrNull { abs(it - value) } ?: DEFAULT_SCALE
+
+/** The dropdown's label for a scale, e.g. "1.25x". Not translated - it is a number and a multiplier. */
+fun scaleLabel(value: Float): String =
+    if (value == value.toInt().toFloat()) "${value.toInt()}x" else "${value}x"

--- a/android/app/src/main/java/com/noop/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/noop/ui/MainActivity.kt
@@ -718,6 +718,12 @@ object NoopPrefs {
      *  ON (#1841). Only meaningful with the overlay layout, where the bar sits over content. */
     const val KEY_BOTTOM_BAR_AUTO_HIDE = "noop.bottomBarAutoHide"
 
+    /** #1836 follow-up: the bar's glass alpha, as one of eight steps. See [com.noop.ui.alphaForOpacityStep]. */
+    const val KEY_BOTTOM_BAR_OPACITY_STEP = "noop.bottomBarOpacityStep"
+
+    /** #1836 follow-up: how much bigger the bar is drawn, one of [com.noop.ui.BOTTOM_BAR_SCALES]. */
+    const val KEY_BOTTOM_BAR_SCALE = "noop.bottomBarScale"
+
     /** #1836: draw the bottom bar as an overlay (glass over the screen's backdrop) instead of a reserved
      *  Scaffold slot. Default ON (#1841), after the overlay was confirmed on a device. */
     const val KEY_OVERLAY_BOTTOM_BAR = "noop.overlayBottomBar"

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1707,12 +1707,6 @@ fun SettingsScreen(
             }
         }
 
-        // --- Background image (#custom-background) ---
-        // An optional custom photo drawn full-bleed behind EVERY tab (including More), in place of the
-        // day-cycle sky (precedence: image > sky > flat canvas). Pick from Photos or Browse the files; the
-        // image is downscaled + kept on this phone only (NOOP is offline, so it's never uploaded), and left
-        // out of the .noopbak backup like the avatar. Reads BackgroundImageStore snapshot state, so the
-        // controls + the live backdrop update the instant an image is set, removed, or re-scaled.
         // The bar's own card. These four options are all about one piece of app-shell chrome, and living
         // among the theme controls in Appearance meant two of them sat between unrelated rows while the
         // other two had nowhere to go. Grouped, the size and transparency read as what they are: choices
@@ -1805,6 +1799,12 @@ fun SettingsScreen(
                 )
             }
         }
+        // --- Background image (#custom-background) ---
+        // An optional custom photo drawn full-bleed behind EVERY tab (including More), in place of the
+        // day-cycle sky (precedence: image > sky > flat canvas). Pick from Photos or Browse the files; the
+        // image is downscaled + kept on this phone only (NOOP is offline, so it's never uploaded), and left
+        // out of the .noopbak backup like the avatar. Reads BackgroundImageStore snapshot state, so the
+        // controls + the live backdrop update the instant an image is set, removed, or re-scaled.
         SettingsCard(
             icon = Icons.Outlined.Image,
             title = "Background image",

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1788,9 +1788,15 @@ fun SettingsScreen(
                 Text(uiString(R.string.l10n_settings_screen_how_see_through_the_bar_is_ddb0c208), style = NoopType.footnote, color = Palette.textTertiary)
                 Slider(
                     value = BottomBarStyleStore.opacityStep.toFloat(),
-                    onValueChange = { BottomBarStyleStore.setOpacityStep(context, it.toInt()) },
+                    // Live while dragging, persisted once on release: a drag emits a value per frame, and
+                    // writing each one records a decision the user makes once. Rounded, not truncated -
+                    // the snapped value can arrive as 5.9999998, which truncation would read as step 5.
+                    onValueChange = { BottomBarStyleStore.previewOpacityStep(it.roundToInt()) },
+                    onValueChangeFinished = {
+                        BottomBarStyleStore.setOpacityStep(context, BottomBarStyleStore.opacityStep)
+                    },
                     valueRange = MIN_OPACITY_STEP.toFloat()..MAX_OPACITY_STEP.toFloat(),
-                    // 8 stops means 7 gaps between them.
+                    // Compose counts the stops BETWEEN the ends, so eight stops is six.
                     steps = MAX_OPACITY_STEP - MIN_OPACITY_STEP - 1,
                     colors = SliderDefaults.colors(
                         thumbColor = Palette.accent,

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.BatteryStd
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.Brightness6
+import androidx.compose.material.icons.filled.ViewAgenda
 import androidx.compose.material.icons.filled.Campaign
 import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.Download
@@ -1375,32 +1376,6 @@ fun SettingsScreen(
                 )
             }
             SettingsRowDivider()
-            // #1836: which bottom-bar layout to draw. Default OFF — the shipped reserved slot. The
-            // overlay lets a screen's own backdrop show through the bar's glass, which is what it was
-            // built for, but it is app-shell layout no test can judge, so it ships switchable.
-            SettingsFormRow(label = uiString(R.string.l10n_settings_screen_bottom_bar_overlay_f257c96f)) {
-                Switch(
-                    checked = BottomBarStyleStore.overlay,
-                    onCheckedChange = { BottomBarStyleStore.set(context, it) },
-                )
-            }
-            SettingsRowDivider()
-            // #1839: hide the bar while scrolling down, bring it back on scrolling up. Only does anything
-            // with the overlay on, because in the slot layout the space is reserved and hiding the bar
-            // would leave an empty band — so the row is disabled rather than silently inert.
-            // Reduce Motion pins the bar visible (a bar that vanishes without animation reads as a
-            // glitch), so with it on the toggle would flip and change nothing. A switch that silently
-            // does nothing is worse than one that is plainly unavailable, so it greys out for the same
-            // reason it does without the overlay.
-            val autoHideAvailable = BottomBarStyleStore.overlay && !rememberReduceMotion()
-            SettingsFormRow(label = uiString(R.string.l10n_settings_screen_hide_bar_when_scrolling_b077d9f3)) {
-                Switch(
-                    checked = BottomBarStyleStore.autoHide,
-                    enabled = autoHideAvailable,
-                    onCheckedChange = { BottomBarStyleStore.setAutoHide(context, it) },
-                )
-            }
-            SettingsRowDivider()
             // #1821: Clock format. Sits with Language because it is an app-owned display CONVENTION, and
             // like Language it offers "System default" - which here means the device's own 12/24h switch,
             // not the region default that was silently deciding this for everyone. Twin of the Apple row.
@@ -1738,6 +1713,92 @@ fun SettingsScreen(
         // image is downscaled + kept on this phone only (NOOP is offline, so it's never uploaded), and left
         // out of the .noopbak backup like the avatar. Reads BackgroundImageStore snapshot state, so the
         // controls + the live backdrop update the instant an image is set, removed, or re-scaled.
+        // The bar's own card. These four options are all about one piece of app-shell chrome, and living
+        // among the theme controls in Appearance meant two of them sat between unrelated rows while the
+        // other two had nowhere to go. Grouped, the size and transparency read as what they are: choices
+        // about the same bar the toggles above them move and hide.
+        SettingsCard(
+            icon = Icons.Filled.ViewAgenda,
+            title = uiString(R.string.l10n_settings_screen_bottom_bar_f84098a9),
+            blurb = uiString(R.string.l10n_settings_screen_how_the_navigation_bar_looks_f186b099),
+        ) {
+            // #1836: which bottom-bar layout to draw. Default OFF — the shipped reserved slot. The
+            // overlay lets a screen's own backdrop show through the bar's glass, which is what it was
+            // built for, but it is app-shell layout no test can judge, so it ships switchable.
+            SettingsFormRow(label = uiString(R.string.l10n_settings_screen_bottom_bar_overlay_f257c96f)) {
+                Switch(
+                    checked = BottomBarStyleStore.overlay,
+                    onCheckedChange = { BottomBarStyleStore.set(context, it) },
+                )
+            }
+            SettingsRowDivider()
+            // #1839: hide the bar while scrolling down, bring it back on scrolling up. Only does anything
+            // with the overlay on, because in the slot layout the space is reserved and hiding the bar
+            // would leave an empty band — so the row is disabled rather than silently inert.
+            // Reduce Motion pins the bar visible (a bar that vanishes without animation reads as a
+            // glitch), so with it on the toggle would flip and change nothing. A switch that silently
+            // does nothing is worse than one that is plainly unavailable, so it greys out for the same
+            // reason it does without the overlay.
+            val autoHideAvailable = BottomBarStyleStore.overlay && !rememberReduceMotion()
+            SettingsFormRow(label = uiString(R.string.l10n_settings_screen_hide_bar_when_scrolling_b077d9f3)) {
+                Switch(
+                    checked = BottomBarStyleStore.autoHide,
+                    enabled = autoHideAvailable,
+                    onCheckedChange = { BottomBarStyleStore.setAutoHide(context, it) },
+                )
+            }
+            SettingsRowDivider()
+            // Size. A dropdown of fixed multipliers rather than a slider: these are the sizes worth
+            // having, and a continuous control here mostly produces sizes a user cannot tell apart.
+            var sizeMenuOpen by remember { mutableStateOf(false) }
+            SettingsFormRow(label = uiString(R.string.l10n_settings_screen_bar_size_2304bfbb)) {
+                Box {
+                    Row(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(999.dp))
+                            .clickable { sizeMenuOpen = true }
+                            .background(Palette.surfaceInset)
+                            .padding(horizontal = 14.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        Text(scaleLabel(BottomBarStyleStore.scale), style = NoopType.subhead,
+                             color = Palette.textPrimary)
+                        Icon(Icons.Filled.ArrowDropDown, contentDescription = null,
+                             tint = Palette.textSecondary)
+                    }
+                    DropdownMenu(expanded = sizeMenuOpen, onDismissRequest = { sizeMenuOpen = false }) {
+                        BOTTOM_BAR_SCALES.forEach { option ->
+                            DropdownMenuItem(
+                                text = { Text(scaleLabel(option), color = Palette.textPrimary) },
+                                onClick = {
+                                    sizeMenuOpen = false
+                                    BottomBarStyleStore.setScale(context, option)
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+            SettingsRowDivider()
+            // Transparency, in the eight steps the store defines. The slider writes on every change so the
+            // bar updates live underneath the sheet - the whole point is seeing it against your own screen.
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(uiString(R.string.l10n_settings_screen_bar_transparency_3f648fbb), style = NoopType.subhead, color = Palette.textPrimary)
+                Text(uiString(R.string.l10n_settings_screen_how_see_through_the_bar_is_ddb0c208), style = NoopType.footnote, color = Palette.textTertiary)
+                Slider(
+                    value = BottomBarStyleStore.opacityStep.toFloat(),
+                    onValueChange = { BottomBarStyleStore.setOpacityStep(context, it.toInt()) },
+                    valueRange = MIN_OPACITY_STEP.toFloat()..MAX_OPACITY_STEP.toFloat(),
+                    // 8 stops means 7 gaps between them.
+                    steps = MAX_OPACITY_STEP - MIN_OPACITY_STEP - 1,
+                    colors = SliderDefaults.colors(
+                        thumbColor = Palette.accent,
+                        activeTrackColor = Palette.accent,
+                    ),
+                )
+            }
+        }
         SettingsCard(
             icon = Icons.Outlined.Image,
             title = "Background image",

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2691,4 +2691,9 @@
     <string name="settings_day_cycle_midnight">00:00</string>
     <string name="settings_day_cycle_sleep_description">Standard. Der Zyklus folgt dem Beginn deines erkannten Hauptschlafs. Bei fehlenden oder unzuverlässigen Schlafdaten verwendet NOOP ersatzweise die lokale Mitternacht.</string>
     <string name="settings_day_cycle_midnight_description">Verwendet einen herkömmlichen lokalen Kalendertag von 00:00 bis 00:00 Uhr.</string>
+    <string name="l10n_settings_screen_bottom_bar_f84098a9">Untere Leiste</string>
+    <string name="l10n_settings_screen_how_the_navigation_bar_looks_f186b099">Wie die Navigationsleiste aussieht – ihre Größe und wie viel vom Bildschirm durchscheint.</string>
+    <string name="l10n_settings_screen_bar_size_2304bfbb">Leistengröße</string>
+    <string name="l10n_settings_screen_bar_transparency_3f648fbb">Transparenz der Leiste</string>
+    <string name="l10n_settings_screen_how_see_through_the_bar_is_ddb0c208">Wie durchsichtig die Leiste ist. Die schwächste Stufe zeigt weiterhin ihren Rand, damit sie immer auffindbar bleibt.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2678,4 +2678,9 @@
     <string name="settings_day_cycle_midnight">00:00</string>
     <string name="settings_day_cycle_sleep_description">Predeterminado. El ciclo sigue el inicio del sueño principal detectado. Si faltan datos de sueño o no son fiables, se usa la medianoche local.</string>
     <string name="settings_day_cycle_midnight_description">Usa un día natural local convencional de 00:00 a 00:00.</string>
+    <string name="l10n_settings_screen_bottom_bar_f84098a9">Barra inferior</string>
+    <string name="l10n_settings_screen_how_the_navigation_bar_looks_f186b099">El aspecto de la barra de navegación: su tamaño y cuánto se ve de la pantalla a través de ella.</string>
+    <string name="l10n_settings_screen_bar_size_2304bfbb">Tamaño de la barra</string>
+    <string name="l10n_settings_screen_bar_transparency_3f648fbb">Transparencia de la barra</string>
+    <string name="l10n_settings_screen_how_see_through_the_bar_is_ddb0c208">Cuánto se transparenta la barra. El nivel más tenue sigue mostrando su borde, así que siempre se puede encontrar.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2677,4 +2677,9 @@
     <string name="settings_day_cycle_midnight">00:00</string>
     <string name="settings_day_cycle_sleep_description">Par défaut. Le cycle suit le début du sommeil principal détecté. Si les données de sommeil sont absentes ou peu fiables, l’heure locale de minuit est utilisée.</string>
     <string name="settings_day_cycle_midnight_description">Utilise une journée civile locale classique de 00:00 à 00:00.</string>
+    <string name="l10n_settings_screen_bottom_bar_f84098a9">Barre inférieure</string>
+    <string name="l10n_settings_screen_how_the_navigation_bar_looks_f186b099">L’apparence de la barre de navigation : sa taille et la part de l’écran visible au travers.</string>
+    <string name="l10n_settings_screen_bar_size_2304bfbb">Taille de la barre</string>
+    <string name="l10n_settings_screen_bar_transparency_3f648fbb">Transparence de la barre</string>
+    <string name="l10n_settings_screen_how_see_through_the_bar_is_ddb0c208">À quel point la barre est transparente. Le niveau le plus faible affiche encore son contour, elle reste donc toujours repérable.</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2682,4 +2682,9 @@
     <string name="settings_day_cycle_midnight">00:00</string>
     <string name="settings_day_cycle_sleep_description">Domyślnie. Cykl rozpoczyna się wraz z wykrytym głównym snem. Gdy brakuje wiarygodnych danych o śnie, używana jest lokalna północ.</string>
     <string name="settings_day_cycle_midnight_description">Używa zwykłego lokalnego dnia kalendarzowego od 00:00 do 00:00.</string>
+    <string name="l10n_settings_screen_bottom_bar_f84098a9">Dolny pasek</string>
+    <string name="l10n_settings_screen_how_the_navigation_bar_looks_f186b099">Wygląd paska nawigacji — jego rozmiar i to, ile ekranu przez niego prześwituje.</string>
+    <string name="l10n_settings_screen_bar_size_2304bfbb">Rozmiar paska</string>
+    <string name="l10n_settings_screen_bar_transparency_3f648fbb">Przezroczystość paska</string>
+    <string name="l10n_settings_screen_how_see_through_the_bar_is_ddb0c208">Jak bardzo pasek jest przezroczysty. Najsłabszy stopień nadal pokazuje jego obramowanie, więc zawsze można go znaleźć.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2670,4 +2670,9 @@
     <string name="settings_day_cycle_midnight">00:00</string>
     <string name="settings_day_cycle_sleep_description">Predefinição. O ciclo segue o início do sono principal detetado. Se os dados de sono estiverem em falta ou não forem fiáveis, é usada a meia-noite local.</string>
     <string name="settings_day_cycle_midnight_description">Usa um dia civil local convencional das 00:00 às 00:00.</string>
+    <string name="l10n_settings_screen_bottom_bar_f84098a9">Barra inferior</string>
+    <string name="l10n_settings_screen_how_the_navigation_bar_looks_f186b099">O aspeto da barra de navegação — o seu tamanho e quanto do ecrã se vê através dela.</string>
+    <string name="l10n_settings_screen_bar_size_2304bfbb">Tamanho da barra</string>
+    <string name="l10n_settings_screen_bar_transparency_3f648fbb">Transparência da barra</string>
+    <string name="l10n_settings_screen_how_see_through_the_bar_is_ddb0c208">Quão transparente é a barra. O nível mais ténue continua a mostrar o contorno, por isso pode sempre ser encontrada.</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -2562,4 +2562,9 @@
     <string name="settings_day_cycle_midnight">00:00</string>
     <string name="settings_day_cycle_sleep_description">По умолчанию цикл начинается с обнаруженного основного сна. Если данные о сне отсутствуют или ненадёжны, используется местная полночь.</string>
     <string name="settings_day_cycle_midnight_description">Используется обычный местный календарный день с 00:00 до 00:00.</string>
+    <string name="l10n_settings_screen_bottom_bar_f84098a9">Нижняя панель</string>
+    <string name="l10n_settings_screen_how_the_navigation_bar_looks_f186b099">Как выглядит панель навигации — её размер и насколько сквозь неё виден экран.</string>
+    <string name="l10n_settings_screen_bar_size_2304bfbb">Размер панели</string>
+    <string name="l10n_settings_screen_bar_transparency_3f648fbb">Прозрачность панели</string>
+    <string name="l10n_settings_screen_how_see_through_the_bar_is_ddb0c208">Насколько панель прозрачна. На самом слабом шаге её контур всё ещё виден, поэтому её всегда можно найти.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2591,4 +2591,9 @@
     <string name="settings_day_cycle_midnight">00:00</string>
     <string name="settings_day_cycle_sleep_description">默认。周期从检测到的主要睡眠开始。睡眠数据缺失或不可靠时，将使用当地午夜。</string>
     <string name="settings_day_cycle_midnight_description">使用从 00:00 到次日 00:00 的常规当地日历日。</string>
+    <string name="l10n_settings_screen_bottom_bar_f84098a9">底部栏</string>
+    <string name="l10n_settings_screen_how_the_navigation_bar_looks_f186b099">导航栏的外观——它的大小，以及透过它能看到多少屏幕内容。</string>
+    <string name="l10n_settings_screen_bar_size_2304bfbb">栏大小</string>
+    <string name="l10n_settings_screen_bar_transparency_3f648fbb">栏透明度</string>
+    <string name="l10n_settings_screen_how_see_through_the_bar_is_ddb0c208">底部栏的透明程度。即使在最淡的一档也会保留边框，因此始终能找到它。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2704,4 +2704,9 @@
     <string name="settings_day_cycle_midnight">00:00</string>
     <string name="settings_day_cycle_sleep_description">Default. The cycle follows the beginning of your detected main sleep. Before a main sleep is detected, local midnight is used.</string>
     <string name="settings_day_cycle_midnight_description">Uses a conventional local calendar day from 00:00 to 00:00.</string>
+    <string name="l10n_settings_screen_bottom_bar_f84098a9">Bottom bar</string>
+    <string name="l10n_settings_screen_how_the_navigation_bar_looks_f186b099">How the navigation bar looks — its size, and how much of the screen shows through it.</string>
+    <string name="l10n_settings_screen_bar_size_2304bfbb">Bar size</string>
+    <string name="l10n_settings_screen_bar_transparency_3f648fbb">Bar transparency</string>
+    <string name="l10n_settings_screen_how_see_through_the_bar_is_ddb0c208">How see-through the bar is. The faintest step still shows its rim, so it can always be found.</string>
 </resources>

--- a/android/app/src/test/java/com/noop/ui/BottomBarStyleTest.kt
+++ b/android/app/src/test/java/com/noop/ui/BottomBarStyleTest.kt
@@ -58,4 +58,15 @@ class BottomBarStyleTest {
         assertEquals("1.25x", scaleLabel(1.25f))
         assertEquals("2x", scaleLabel(2f))
     }
+
+    /**
+     * The rounding the slider relies on. A snapped slider value can arrive as 5.9999998; truncation
+     * reads that as step 5, so the bar lands one stop below where the thumb is sitting.
+     */
+    @Test fun `a snapped slider value rounds to its own step`() {
+        assertEquals(6, 5.9999998f.let { Math.round(it) })
+        assertEquals(alphaForOpacityStep(6), alphaForOpacityStep(Math.round(5.9999998f)), 0.0001f)
+        assertEquals(alphaForOpacityStep(5), alphaForOpacityStep(Math.round(5.4f)), 0.0001f)
+    }
+
 }

--- a/android/app/src/test/java/com/noop/ui/BottomBarStyleTest.kt
+++ b/android/app/src/test/java/com/noop/ui/BottomBarStyleTest.kt
@@ -1,0 +1,61 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The bottom bar's size and transparency options. */
+class BottomBarStyleTest {
+
+    /**
+     * The property that makes this safe to ship: the DEFAULT step reproduces the alpha the bar has
+     * always drawn, so an install that never opens the setting looks identical.
+     */
+    @Test fun `the default step is the shipped alpha`() {
+        assertEquals(0.80f, alphaForOpacityStep(DEFAULT_OPACITY_STEP), 0.0001f)
+    }
+
+    @Test fun `the eight steps run from faint to solid`() {
+        assertEquals(0.30f, alphaForOpacityStep(MIN_OPACITY_STEP), 0.0001f)
+        assertEquals(1.00f, alphaForOpacityStep(MAX_OPACITY_STEP), 0.0001f)
+        val all = (MIN_OPACITY_STEP..MAX_OPACITY_STEP).map { alphaForOpacityStep(it) }
+        assertEquals(8, all.size)
+        assertEquals(all.sorted(), all)
+        assertEquals(all.distinct().size, all.size)
+    }
+
+    /**
+     * A bar can never become invisible-but-tappable, which would hide the navigation with no way back
+     * to the setting that hid it.
+     */
+    @Test fun `the faintest step is still visible`() {
+        assertTrue(alphaForOpacityStep(MIN_OPACITY_STEP) >= 0.30f)
+    }
+
+    /** Out-of-range input is clamped, not honoured - including values a downgrade could leave behind. */
+    @Test fun `steps outside the range clamp`() {
+        assertEquals(alphaForOpacityStep(MIN_OPACITY_STEP), alphaForOpacityStep(-4), 0.0001f)
+        assertEquals(alphaForOpacityStep(MAX_OPACITY_STEP), alphaForOpacityStep(99), 0.0001f)
+    }
+
+    @Test fun `the offered sizes are the requested ones`() {
+        assertEquals(listOf(1f, 1.25f, 1.5f, 1.75f, 2f), BOTTOM_BAR_SCALES)
+    }
+
+    /**
+     * A stored size from another build - or a hand-edited pref - snaps to something the dropdown can
+     * show, so the UI can always leave the state it is in.
+     */
+    @Test fun `an unoffered size snaps to the nearest offered one`() {
+        assertEquals(1.25f, nearestScale(1.3f), 0.0001f)
+        assertEquals(2f, nearestScale(5f), 0.0001f)
+        assertEquals(1f, nearestScale(0f), 0.0001f)
+        assertTrue(nearestScale(1.37f) in BOTTOM_BAR_SCALES)
+    }
+
+    @Test fun `scale labels read as multipliers`() {
+        assertEquals("1x", scaleLabel(1f))
+        assertEquals("1.25x", scaleLabel(1.25f))
+        assertEquals("2x", scaleLabel(2f))
+    }
+}


### PR DESCRIPTION
Two new bottom-bar options, in their own settings card with the two that already
existed.

## Its own card

The overlay and auto-hide toggles were living among the theme controls in
Appearance - fine when there was nowhere else, less so once size and transparency
join them. Four settings about one piece of chrome now sit together, so the size
and transparency read as choices about the same bar the toggles above them move
and hide.

## Transparency: eight steps, not a free slider

On a bar this small a continuous control mostly produces values nobody can tell
apart or return to. Eight stops are each reachable and repeatable.

The mapping is linear from 0.30 to 1.00, which puts the **shipped 0.80 exactly on
step 6** - so an install that never opens this setting renders byte-identically
to before. That is why the range starts at 0.30 rather than a rounder number.

The floor is 0.30 rather than 0 deliberately: a fully invisible bar still takes
taps, so a user could hide their own navigation and then be unable to find the
setting that hid it. At 0.30 the capsule's rim is still visible.

## Size: 1x / 1.25x / 1.5x / 1.75x / 2x

A dropdown, because these are the sizes worth having.

It scales the bar's CONTENT - icon, label and the padding around them - rather
than applying a graphics scale to the finished bar. A graphics scale would blur
it and leave the touch targets at their original size. `barHeight` is measured
after layout and republished, so every screen keeps clearing the bar correctly at
any size without a second number to maintain.

## Both fail safe

Each reads through the same clamps its setter uses, so a hand-edited or
downgraded preference cannot leave the bar in a state the UI has no way to leave.
An unoffered size snaps to the nearest offered one rather than being honoured, so
a value from a build with different sizes still lands somewhere the dropdown can
show.

## Verification

- 5323 tests / 0 failures, 7 new. The one that matters asserts the default step
  reproduces the shipped alpha, so this cannot silently restyle every install.
- Doc-comment lint clean; i18n audit green; `lintVitalFullRelease
  -PstagingRelease` clean after the strings.xml edits.
- Copy translated into all seven locales rather than left English. The gate only
  enforces three, but shipping five English strings into the other four is
  exactly how the drift it exists to shrink gets added to.

**Not seen on a device.** The whole point of these two is how they look, and
nothing here has rendered - 2x in particular wants checking against a small
screen, where the bar could crowd content even with the measured inset following
it.

## Android only

Apple's tab bar is a different construction with its own layout rules; this is
app-shell chrome, which is platform-specific by contract. Worth its own change if
it is wanted there.