### PR TITLE
ci: only run the Python tools workflow when the Python tools change

### DIFF
--- a/.github/workflows/tools-python.yml
+++ b/.github/workflows/tools-python.yml
@@ -21,10 +21,20 @@
 name: Tools Python CI
 
 on:
+  # Path-filtered like android.yml / swift-packages.yml / app-build.yml. Without this the workflow ran on
+  # EVERY pull request and every push to main, including the many that touch no Python at all - and with a
+  # Windows runner now in it, billed at twice a Linux minute, that is a real cost for a job whose inputs
+  # cannot have changed. The workflow file itself is included so a change to the job still tests itself.
   pull_request:
     branches: [main]
+    paths:
+      - 'Tools/**'
+      - '.github/workflows/tools-python.yml'
   push:
     branches: [main]
+    paths:
+      - 'Tools/**'
+      - '.github/workflows/tools-python.yml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Follow-up to #1900, which added a Windows job to `tools-python.yml`.

That workflow has no path filter, so it runs on every pull request and every push
to main regardless of what changed. Six PRs merged today touched analytics, BLE,
settings and docs - `linux-capture` ran on all of them and could not have learned
anything from any of them.

Already waste; no longer free. Windows minutes bill at twice Linux, so with a
Windows job in the workflow every unrelated PR now pays for a runner whose inputs
have not moved.

Filtered to `Tools/**` plus the workflow file itself - the file included so a
change to the job still exercises the job. This matches `android.yml`,
`swift-packages.yml` and `app-build.yml`, which all filter this way; this
workflow was the one that did not.

**Net effect is less CI than before the Windows job existed**, not more.

Both jobs are otherwise untouched, including the `windows-capture` guard that
fails when discovery finds fewer than 200 tests - which is a good guard and
worth keeping.

Verified: the YAML parses and both triggers carry the filter. The workflow cannot
self-test this change before merge, since a filtered workflow that excluded its
own file would not run on the PR that changed it - which is exactly why the file
is in the filter.