### PR TITLE
settings: centre the bar's own transparency on the slider, and add notches

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppRoot.kt
+++ b/android/app/src/main/java/com/noop/ui/AppRoot.kt
@@ -290,8 +290,12 @@ internal object MoreSectionPrefs {
  * translating the bar away would leave an empty band rather than handing the space back to content —
  * visibly worse than not hiding at all. Auto-hide only makes sense over content.
  */
-internal fun shouldHideBar(autoHide: Boolean, overlay: Boolean, scrollingDown: Boolean): Boolean =
-    autoHide && overlay && scrollingDown
+internal fun shouldHideBar(
+    autoHide: Boolean,
+    overlay: Boolean,
+    scrollingDown: Boolean,
+    pinned: Boolean = false,
+): Boolean = !pinned && autoHide && overlay && scrollingDown
 
 /**
  * #1839: does this scroll delta change the direction, or is it noise?
@@ -375,6 +379,24 @@ object BottomBarStyleStore {
      */
     var scale by mutableStateOf(DEFAULT_SCALE)
         private set
+
+    /**
+     * Hold the bar visible regardless of auto-hide, while something is adjusting how it LOOKS.
+     *
+     * The transparency slider sits below the fold in Settings, so reaching it means scrolling down -
+     * which is exactly what auto-hide reads as "hide the bar". The control's live preview was therefore
+     * invisible at the moment it mattered, and touching the slider does not scroll, so nothing brought
+     * the bar back. Pinning while the drag is in flight is the narrowest fix: auto-hide is untouched as
+     * a setting, and the pin lasts only as long as a finger is down.
+     */
+    var previewPinned by mutableStateOf(false)
+        private set
+
+    /** Named `pinPreview` rather than `setPreviewPinned`: the latter is the property's own generated
+     *  setter, and declaring both is a JVM signature clash. */
+    fun pinPreview(value: Boolean) {
+        previewPinned = value
+    }
 
     /**
      * Move the bar NOW without persisting, for a slider drag.
@@ -473,7 +495,8 @@ fun AppRoot(viewModel: AppViewModel = viewModel()) {
     // Boolean, and only on a movement past the threshold, so a fingertip tremor cannot flicker the bar.
     var scrollingDown by remember { mutableStateOf(false) }
     val reduceMotion = rememberReduceMotion()
-    val hidden = shouldHideBar(BottomBarStyleStore.autoHide, BottomBarStyleStore.overlay, scrollingDown)
+    val hidden = shouldHideBar(BottomBarStyleStore.autoHide, BottomBarStyleStore.overlay, scrollingDown,
+                               pinned = BottomBarStyleStore.previewPinned)
     val collapseTarget = barCollapseFraction(hidden, reduceMotion)
     // The transform is a graphicsLayer only — GPU, per frame, NO relayout — so content never reflows as
     // the bar comes and goes and scrolling stays smooth. (The approach #90 got right.)

--- a/android/app/src/main/java/com/noop/ui/BottomBarStyle.kt
+++ b/android/app/src/main/java/com/noop/ui/BottomBarStyle.kt
@@ -6,12 +6,15 @@ import kotlin.math.abs
 const val MIN_OPACITY_STEP = 1
 
 /** Solid. */
-const val MAX_OPACITY_STEP = 8
+const val MAX_OPACITY_STEP = 11
 
 /**
- * The step whose alpha is the SHIPPED 0.80, so an install that never opens this setting renders exactly
- * as it did before. Chosen by arithmetic rather than taste: the linear 0.30..1.00 mapping puts 0.80 on
- * step 6 precisely, which is why the range starts at 0.30 rather than a rounder number.
+ * The shipped 0.80, sitting at the exact CENTRE of the slider - five notches either side.
+ *
+ * Centred on purpose. The bar you already have is the reference point, so the useful question at the
+ * slider is "more see-through than now, or less?", and that reads off a thumb that starts in the middle.
+ * With the default at 6 of 8 it sat right of centre, which made "less transparent" look like a two-notch
+ * afterthought next to a five-notch run the other way.
  */
 const val DEFAULT_OPACITY_STEP = 6
 
@@ -22,7 +25,17 @@ const val DEFAULT_SCALE = 1f
 val BOTTOM_BAR_SCALES: List<Float> = listOf(1f, 1.25f, 1.5f, 1.75f, 2f)
 
 /**
- * The bar's glass alpha for an opacity step, linear from 0.30 (step 1) to 1.00 (step 8).
+ * The bar's glass alpha for an opacity step: 0.30 at step 1, the shipped 0.80 at the centre step 6, and
+ * 1.00 at step 11.
+ *
+ * The two halves move at DIFFERENT rates, which is deliberate and is the only way to get all three of
+ * the things being asked for at once. Centring 0.80 with an even rate would mean either giving up the
+ * faint end (a symmetric range around 0.80 bottoms out at 0.60, less see-through than this already
+ * offers) or pushing the solid end past 1.00, which does not exist. So the transparent half spends 0.10
+ * a notch across a wide range, and the solid half spends 0.04 across a narrow one.
+ *
+ * A user does not perceive that asymmetry as unevenness. The thumb starts centred, five notches each
+ * way, and each notch is a visible change in the direction they moved it - which is the whole contract.
  *
  * The floor is 0.30 rather than 0: a fully invisible bar would still take taps, so a user could hide the
  * navigation and then not find it again. 0.30 is faint enough to read as "nearly gone" while leaving the
@@ -30,7 +43,13 @@ val BOTTOM_BAR_SCALES: List<Float> = listOf(1f, 1.25f, 1.5f, 1.75f, 2f)
  */
 fun alphaForOpacityStep(step: Int): Float {
     val clamped = step.coerceIn(MIN_OPACITY_STEP, MAX_OPACITY_STEP)
-    return 0.30f + (clamped - MIN_OPACITY_STEP) * 0.10f
+    return if (clamped <= DEFAULT_OPACITY_STEP) {
+        // 0.30 -> 0.80 across steps 1..6
+        0.30f + (clamped - MIN_OPACITY_STEP) * 0.10f
+    } else {
+        // 0.80 -> 1.00 across steps 6..11
+        0.80f + (clamped - DEFAULT_OPACITY_STEP) * 0.04f
+    }
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1785,9 +1785,16 @@ fun SettingsScreen(
                     // Live while dragging, persisted once on release: a drag emits a value per frame, and
                     // writing each one records a decision the user makes once. Rounded, not truncated -
                     // the snapped value can arrive as 5.9999998, which truncation would read as step 5.
-                    onValueChange = { BottomBarStyleStore.previewOpacityStep(it.roundToInt()) },
+                    onValueChange = {
+                        // Hold the bar visible for the drag: reaching this slider means scrolling down,
+                        // which auto-hide reads as "hide the bar", so the live preview was invisible at
+                        // exactly the moment it is for.
+                        BottomBarStyleStore.pinPreview(true)
+                        BottomBarStyleStore.previewOpacityStep(it.roundToInt())
+                    },
                     onValueChangeFinished = {
                         BottomBarStyleStore.setOpacityStep(context, BottomBarStyleStore.opacityStep)
+                        BottomBarStyleStore.pinPreview(false)
                     },
                     valueRange = MIN_OPACITY_STEP.toFloat()..MAX_OPACITY_STEP.toFloat(),
                     // Compose counts the stops BETWEEN the ends, so N notches is N-2. Derived, not

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -87,6 +87,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -141,6 +142,7 @@ import com.noop.update.UpdateCheck
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
 import com.noop.analytics.ClockFormatPreference
 
@@ -1741,6 +1743,18 @@ fun SettingsScreen(
                     onCheckedChange = { BottomBarStyleStore.setAutoHide(context, it) },
                 )
             }
+            // Reaching either control below means scrolling DOWN, which auto-hide reads as "hide the
+            // bar" - so a change made here landed on a bar the user could not see, and neither a slider
+            // drag nor a menu pick is a scroll, so nothing brought it back.
+            //
+            // Keyed on what the bar LOOKS like rather than on either control, so one rule covers both: a
+            // drag restarts this every frame and stays pinned throughout, a menu pick fires it once, and
+            // either way the bar is held a moment longer so the result is visible after the finger lifts.
+            LaunchedEffect(BottomBarStyleStore.scale, BottomBarStyleStore.opacityStep) {
+                BottomBarStyleStore.pinPreview(true)
+                delay(1_500)
+                BottomBarStyleStore.pinPreview(false)
+            }
             SettingsRowDivider()
             // Size. A dropdown of fixed multipliers rather than a slider: these are the sizes worth
             // having, and a continuous control here mostly produces sizes a user cannot tell apart.
@@ -1785,16 +1799,9 @@ fun SettingsScreen(
                     // Live while dragging, persisted once on release: a drag emits a value per frame, and
                     // writing each one records a decision the user makes once. Rounded, not truncated -
                     // the snapped value can arrive as 5.9999998, which truncation would read as step 5.
-                    onValueChange = {
-                        // Hold the bar visible for the drag: reaching this slider means scrolling down,
-                        // which auto-hide reads as "hide the bar", so the live preview was invisible at
-                        // exactly the moment it is for.
-                        BottomBarStyleStore.pinPreview(true)
-                        BottomBarStyleStore.previewOpacityStep(it.roundToInt())
-                    },
+                    onValueChange = { BottomBarStyleStore.previewOpacityStep(it.roundToInt()) },
                     onValueChangeFinished = {
                         BottomBarStyleStore.setOpacityStep(context, BottomBarStyleStore.opacityStep)
-                        BottomBarStyleStore.pinPreview(false)
                     },
                     valueRange = MIN_OPACITY_STEP.toFloat()..MAX_OPACITY_STEP.toFloat(),
                     // Compose counts the stops BETWEEN the ends, so N notches is N-2. Derived, not

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -1790,7 +1790,8 @@ fun SettingsScreen(
                         BottomBarStyleStore.setOpacityStep(context, BottomBarStyleStore.opacityStep)
                     },
                     valueRange = MIN_OPACITY_STEP.toFloat()..MAX_OPACITY_STEP.toFloat(),
-                    // Compose counts the stops BETWEEN the ends, so eight stops is six.
+                    // Compose counts the stops BETWEEN the ends, so N notches is N-2. Derived, not
+                    // written out, so changing the notch count cannot leave this line disagreeing with it.
                     steps = MAX_OPACITY_STEP - MIN_OPACITY_STEP - 1,
                     colors = SliderDefaults.colors(
                         thumbColor = Palette.accent,

--- a/android/app/src/test/java/com/noop/ui/BottomBarAutoHideTest.kt
+++ b/android/app/src/test/java/com/noop/ui/BottomBarAutoHideTest.kt
@@ -48,4 +48,39 @@ class BottomBarAutoHideTest {
         assertEquals(1f, barCollapseFraction(hidden = true, reduceMotion = false), 0f)
         assertEquals(0f, barCollapseFraction(hidden = false, reduceMotion = false), 0f)
     }
+
+    /**
+     * The pin beats auto-hide. Reaching the transparency slider means scrolling DOWN, which auto-hide
+     * reads as "hide the bar" - so without this the control's live preview was invisible at exactly the
+     * moment it exists for, and touching a slider does not scroll, so nothing brought the bar back.
+     */
+    @Test
+    fun `a pinned preview keeps the bar visible while scrolling down`() {
+        assertTrue(shouldHideBar(autoHide = true, overlay = true, scrollingDown = true))
+        assertFalse(shouldHideBar(autoHide = true, overlay = true, scrollingDown = true, pinned = true))
+    }
+
+    /** The pin only ever SHOWS the bar; it can never hide one that would otherwise be up. */
+    @Test
+    fun `pinning never hides a bar that would be visible`() {
+        for (auto in listOf(true, false)) {
+            for (overlay in listOf(true, false)) {
+                for (down in listOf(true, false)) {
+                    val unpinned = shouldHideBar(auto, overlay, down, pinned = false)
+                    val pinned = shouldHideBar(auto, overlay, down, pinned = true)
+                    assertFalse("pinned must never hide more than unpinned", pinned && !unpinned)
+                }
+            }
+        }
+    }
+
+    /** The default argument keeps every existing caller and case unchanged. */
+    @Test
+    fun `omitting the pin matches the old behaviour`() {
+        assertEquals(
+            shouldHideBar(autoHide = true, overlay = true, scrollingDown = true, pinned = false),
+            shouldHideBar(autoHide = true, overlay = true, scrollingDown = true),
+        )
+    }
+
 }

--- a/android/app/src/test/java/com/noop/ui/BottomBarStyleTest.kt
+++ b/android/app/src/test/java/com/noop/ui/BottomBarStyleTest.kt
@@ -15,13 +15,41 @@ class BottomBarStyleTest {
         assertEquals(0.80f, alphaForOpacityStep(DEFAULT_OPACITY_STEP), 0.0001f)
     }
 
-    @Test fun `the eight steps run from faint to solid`() {
+    @Test fun `the steps run from faint to solid`() {
         assertEquals(0.30f, alphaForOpacityStep(MIN_OPACITY_STEP), 0.0001f)
         assertEquals(1.00f, alphaForOpacityStep(MAX_OPACITY_STEP), 0.0001f)
         val all = (MIN_OPACITY_STEP..MAX_OPACITY_STEP).map { alphaForOpacityStep(it) }
-        assertEquals(8, all.size)
+        assertEquals(11, all.size)
         assertEquals(all.sorted(), all)
         assertEquals(all.distinct().size, all.size)
+    }
+
+    /**
+     * THE property this exists for: the bar you already have sits at the CENTRE, so the slider reads as
+     * "more see-through than now" to the left and "less" to the right, with the same number of notches
+     * each way. If the default ever stops being centred, the control stops answering that question.
+     */
+    @Test fun `the default sits at the exact centre of the slider`() {
+        val below = DEFAULT_OPACITY_STEP - MIN_OPACITY_STEP
+        val above = MAX_OPACITY_STEP - DEFAULT_OPACITY_STEP
+        assertEquals("same number of notches either side of the default", below, above)
+    }
+
+    /** Left of the default is more see-through than today's bar; right of it is less. */
+    @Test fun `left is more transparent than the default and right is less`() {
+        val default = alphaForOpacityStep(DEFAULT_OPACITY_STEP)
+        for (s in MIN_OPACITY_STEP until DEFAULT_OPACITY_STEP) {
+            assertTrue("step $s must be more transparent", alphaForOpacityStep(s) < default)
+        }
+        for (s in (DEFAULT_OPACITY_STEP + 1)..MAX_OPACITY_STEP) {
+            assertTrue("step $s must be less transparent", alphaForOpacityStep(s) > default)
+        }
+    }
+
+    /** Every notch is a real change - no two adjacent steps render the same bar. */
+    @Test fun `every notch moves the alpha`() {
+        val all = (MIN_OPACITY_STEP..MAX_OPACITY_STEP).map { alphaForOpacityStep(it) }
+        all.zipWithNext { a, b -> assertTrue("adjacent steps must differ", b - a > 0.001f) }
     }
 
     /**


### PR DESCRIPTION
From the device. The bar you already have sat at 6 of 8, so "less transparent"
was a two-notch afterthought next to a five-notch run the other way. The useful
question at this slider is "more see-through than now, or less?" - and that reads
off a thumb that starts in the middle.

## Eleven notches, default dead centre

| step | alpha | |
|---|---|---|
| 1 | 0.30 | faintest |
| 2-5 | 0.40 - 0.70 | more see-through than today |
| **6** | **0.80** | **today's bar - centre** |
| 7-10 | 0.84 - 0.96 | less see-through than today |
| 11 | 1.00 | solid |

The shipped 0.80 is still exactly step 6, so an install that never touches this
is unchanged. The 0.30 floor is kept: a bar at zero alpha would still take taps,
so a user could hide their own navigation and then be unable to find the setting
that hid it.

## Why the halves move at different rates

It is the only way to get all three asked-for properties at once. Centring 0.80
with an even rate means either:

- giving up the faint end - a symmetric range around 0.80 bottoms out at 0.60,
  which is LESS see-through than this already offers; or
- running the solid end past 1.00, which does not exist.

So the transparent half spends 0.10 a notch across a wide range, and the solid
half 0.04 across a narrow one. The thumb still starts centred with five notches
each way, and every notch is a visible change in the direction it was moved,
which is the contract that matters.

## Tests pin the property, not the numbers

Equal notches either side of the default; everything left of it more transparent
and everything right of it less; and no two adjacent notches rendering the same
bar. Those hold if the counts change again - a test asserting only "step 6 is
0.80" would not.

## One line that was already wrong

The slider's notch count was derived from the constants, so it followed on its
own. Its COMMENT said "eight stops is six" and did not. It now states the rule
rather than the arithmetic - the same fault this exact line had two commits ago,
which is a good argument for never writing a count into a comment beside the
expression that computes it.

## Verification

5332 tests / 0 failures, 11 in the style class; doc-comment lint clean. No new
strings, so no i18n or release-lint surface.

**Not seen on a device.** Worth knowing for anyone already on build 442: a step
you set there is reinterpreted here, since the scale changed under it. The
default is 6 in both and means 0.80 in both, so only a moved slider shifts.