### PR TITLE
analytics: say when a night's stream came back at its read cap

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StreamReadCap.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StreamReadCap.swift
@@ -77,6 +77,19 @@ public enum StreamReadCap {
     /// truncated one.
     public static let headroom = 1.5
 
+    /// The cap on the skin-temp reads, named rather than left a literal so the no-night line can say when
+    /// one came back AT it.
+    ///
+    /// Not derived from a row rate like the caps below: skin's density was never measured. Skin rides the
+    /// record that carries gravity, and gravity ranged from 177 to 192,698 rows across 54 HOURS in one
+    /// capture, so whether 200,000 is generous or tight is genuinely unknown - which is the reason to
+    /// print the count. Unchanged in value: this names what both platforms already read at.
+    ///
+    /// Shared by two reads with very different spans - the night window, and the ~21-day WHOOP 4.0 anchor
+    /// scan. Only the window read's count reaches the no-night line, so an `atCap=skin` marker means THAT
+    /// read was clipped; a clipped anchor scan still goes unreported.
+    public static let skin = 200_000
+
     /// The cap for a stream producing `rowsPerSecond` at its densest.
     public static func cap(rowsPerSecond: Double) -> Int {
         Int((Double(windowSeconds) * rowsPerSecond * headroom).rounded(.up))

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StreamReadCap.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StreamReadCap.swift
@@ -77,8 +77,9 @@ public enum StreamReadCap {
     /// truncated one.
     public static let headroom = 1.5
 
-    /// The cap on the skin-temp reads, named rather than left a literal so the no-night line can say when
-    /// one came back AT it.
+    /// The cap on the sleep engine's skin-temp reads, named rather than left a literal so the no-night
+    /// line can say when one came back AT it. Skin reads OUTSIDE the engine (a chart, an export) keep
+    /// their own limits - this is not a repo-wide skin cap.
     ///
     /// Not derived from a row rate like the caps below: skin's density was never measured. Skin rides the
     /// record that carries gravity, and gravity ranged from 177 to 192,698 rows across 54 HOURS in one

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -339,7 +339,8 @@ final class IntelligenceEngine: ObservableObject {
 
     nonisolated static func sleepDetectNoNightLogLine(day: String, hrCount: Int, rrCount: Int,
                                                       respCount: Int, gravCount: Int, stepCount: Int,
-                                                      providedCount: Int, windowHours: Int) -> String {
+                                                      providedCount: Int, windowHours: Int,
+                                                      skinCount: Int = 0) -> String {
         // `reason` names WHICH absence this is, because grav=0 is printed but its consequence is not.
         // With no motion the stager has no HR-only fallback, so no quantity of HR can stage a night — a
         // strap capability limit, not a coverage gap, and the two want completely different follow-ups.
@@ -361,8 +362,8 @@ final class IntelligenceEngine: ObservableObject {
         if rrCount >= StreamReadCap.rr { atCap.append("rr") }
         let capNote = atCap.isEmpty ? "" : " atCap=" + atCap.joined(separator: ",")
         return "sleep-detect day=\(day) NO-NIGHT hr=\(hrCount) rr=\(rrCount) resp=\(respCount) "
-            + "grav=\(gravCount) steps=\(stepCount) provided=\(providedCount) window=\(windowHours)h "
-            + "reason=\(reason)" + capNote
+            + "grav=\(gravCount) skin=\(skinCount) steps=\(stepCount) provided=\(providedCount) "
+            + "window=\(windowHours)h reason=\(reason)" + capNote
     }
 
     /// #674/#1244: the "sleep total with no matched session" divergence line. A COMPUTED day whose fresh

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -346,9 +346,23 @@ final class IntelligenceEngine: ObservableObject {
         // With motion present the inputs were there and staging still produced nothing, which is the case
         // actually worth investigating.
         let reason = gravCount == 0 ? "no-motion" : "staged-none"
+        // #1118 follow-up: name any stream that came back AT its read cap. A read that returns exactly the
+        // limit is the definition of truncated everywhere else here (`full.count >= limit`), and it is the
+        // one thing a reader cannot infer from the counts alone — `grav=192698` looks healthy until you
+        // know the cap it is 96% of.
+        //
+        // GRAVITY is why this exists. HR and R-R ride a SlidingStreamWindow, which counts its own
+        // truncations; gravity is a plain read with no counter at all, so a night clipped of its newest
+        // motion staged badly and said nothing. That is the difference between "this release fixes your
+        // night" and "your offload never ran", and a log could not tell them apart.
+        var atCap: [String] = []
+        if gravCount >= StreamReadCap.gravity { atCap.append("grav") }
+        if hrCount >= StreamReadCap.hr { atCap.append("hr") }
+        if rrCount >= StreamReadCap.rr { atCap.append("rr") }
+        let capNote = atCap.isEmpty ? "" : " atCap=" + atCap.joined(separator: ",")
         return "sleep-detect day=\(day) NO-NIGHT hr=\(hrCount) rr=\(rrCount) resp=\(respCount) "
             + "grav=\(gravCount) steps=\(stepCount) provided=\(providedCount) window=\(windowHours)h "
-            + "reason=\(reason)"
+            + "reason=\(reason)" + capNote
     }
 
     /// #674/#1244: the "sleep total with no matched session" divergence line. A COMPUTED day whose fresh

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -357,11 +357,18 @@ final class IntelligenceEngine: ObservableObject {
         // motion staged badly and said nothing. That is the difference between "this release fixes your
         // night" and "your offload never ran", and a log could not tell them apart.
         var atCap: [String] = []
+        // ONLY the plain reads. Gravity and skin are read whole, so a result of exactly the cap IS the
+        // truncation — the same `count >= limit` test used everywhere else here, and neither stream has a
+        // counter of its own, which is why this marker exists.
+        //
+        // HR and R-R are deliberately absent even though their counts are printed. They arrive through
+        // `SlidingStreamWindow.rows`, which returns `full.filter { ts in from...to }` — a SLICE of a read
+        // that usually spans more than this night. A spliced window that WAS truncated still hands back a
+        // slice under the cap, so the marker would silently fail to fire: a false negative on a line whose
+        // only value is that its absence means "not clipped". Their exact truncation count is already
+        // printed unconditionally once per pass by `WindowedStreamPlan.logLine` (`hrTruncated=`), so
+        // nothing is lost by declining to guess it per night.
         if gravCount >= StreamReadCap.gravity { atCap.append("grav") }
-        if hrCount >= StreamReadCap.hr { atCap.append("hr") }
-        if rrCount >= StreamReadCap.rr { atCap.append("rr") }
-        // Skin is here because it is the stream whose density was never measured — the reason the
-        // count is printed at all. The count is the night-WINDOW read, so this marks that read clipped.
         if skinCount >= StreamReadCap.skin { atCap.append("skin") }
         let capNote = atCap.isEmpty ? "" : " atCap=" + atCap.joined(separator: ",")
         return "sleep-detect day=\(day) NO-NIGHT hr=\(hrCount) rr=\(rrCount) resp=\(respCount) "

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -340,7 +340,7 @@ final class IntelligenceEngine: ObservableObject {
     nonisolated static func sleepDetectNoNightLogLine(day: String, hrCount: Int, rrCount: Int,
                                                       respCount: Int, gravCount: Int, stepCount: Int,
                                                       providedCount: Int, windowHours: Int,
-                                                      skinCount: Int = 0) -> String {
+                                                      skinCount: Int) -> String {
         // `reason` names WHICH absence this is, because grav=0 is printed but its consequence is not.
         // With no motion the stager has no HR-only fallback, so no quantity of HR can stage a night — a
         // strap capability limit, not a coverage gap, and the two want completely different follow-ups.
@@ -360,6 +360,9 @@ final class IntelligenceEngine: ObservableObject {
         if gravCount >= StreamReadCap.gravity { atCap.append("grav") }
         if hrCount >= StreamReadCap.hr { atCap.append("hr") }
         if rrCount >= StreamReadCap.rr { atCap.append("rr") }
+        // Skin is here because it is the stream whose density was never measured — the reason the
+        // count is printed at all. The count is the night-WINDOW read, so this marks that read clipped.
+        if skinCount >= StreamReadCap.skin { atCap.append("skin") }
         let capNote = atCap.isEmpty ? "" : " atCap=" + atCap.joined(separator: ",")
         return "sleep-detect day=\(day) NO-NIGHT hr=\(hrCount) rr=\(rrCount) resp=\(respCount) "
             + "grav=\(gravCount) skin=\(skinCount) steps=\(stepCount) provided=\(providedCount) "
@@ -984,7 +987,7 @@ final class IntelligenceEngine: ObservableObject {
                         let windowSkin = (try? await store.skinTempSamples(deviceId: owner,
                                                                            from: skinAnchorScanFrom,
                                                                            to: skinAnchorScanTo,
-                                                                           limit: 200_000)) ?? []
+                                                                           limit: StreamReadCap.skin)) ?? []
                         if let anchor = Whoop4SkinTemp.deviceAnchorRaw(windowSkin.map { $0.raw }) {
                             skinAnchorByOwner[owner] = anchor
                         }
@@ -1044,7 +1047,7 @@ final class IntelligenceEngine: ObservableObject {
                 let grav = (try? await store.gravitySamples(deviceId: owner, from: from, to: to,
                                                             limit: StreamReadCap.gravity)) ?? []
                 let steps = (try? await store.stepSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
-                let skin = (try? await store.skinTempSamples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
+                let skin = (try? await store.skinTempSamples(deviceId: owner, from: from, to: to, limit: StreamReadCap.skin)) ?? []
                 // #93: WHOOP 4.0 raw SpO2 PPG samples for the night; analyzeDay banks the nightly red/IR ADC
                 // means on the DailyMetric. Empty on a 5/MG (no v24 spo2 channels) → the raw means stay nil.
                 let spo2 = (try? await store.spo2Samples(deviceId: owner, from: from, to: to, limit: 200_000)) ?? []
@@ -1072,7 +1075,7 @@ final class IntelligenceEngine: ObservableObject {
                         let windowSkin = (try? await store.skinTempSamples(deviceId: owner,
                                                                            from: skinAnchorScanFrom,
                                                                            to: skinAnchorScanTo,
-                                                                           limit: 200_000)) ?? []
+                                                                           limit: StreamReadCap.skin)) ?? []
                         if let anchor = Whoop4SkinTemp.deviceAnchorRaw(windowSkin.map { $0.raw }) {
                             skinAnchorByOwner[owner] = anchor
                         }
@@ -1305,7 +1308,8 @@ final class IntelligenceEngine: ObservableObject {
                         hrvDiag = Self.sleepDetectNoNightLogLine(
                             day: day, hrCount: hr.count, rrCount: rr.count, respCount: resp.count,
                             gravCount: grav.count, stepCount: steps.count,
-                            providedCount: providedSleep.count, windowHours: windowHours)
+                            providedCount: providedSleep.count, windowHours: windowHours,
+                            skinCount: skin.count)
                     } else {
                         hrvDiag = nil
                     }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -368,6 +368,11 @@ final class IntelligenceEngine: ObservableObject {
         // only value is that its absence means "not clipped". Their exact truncation count is already
         // printed unconditionally once per pass by `WindowedStreamPlan.logLine` (`hrTruncated=`), so
         // nothing is lost by declining to guess it per night.
+        //
+        // resp and steps are plain reads too, and equally judgeable, but stay unmarked on purpose: neither
+        // is a staging input, so clipping one cannot be the reason a night is missing. Their counts are
+        // printed as context. The marker answers "did a stream that could explain this get cut short",
+        // not "was every read complete".
         if gravCount >= StreamReadCap.gravity { atCap.append("grav") }
         if skinCount >= StreamReadCap.skin { atCap.append("skin") }
         let capNote = atCap.isEmpty ? "" : " atCap=" + atCap.joined(separator: ",")

--- a/StrandTests/IntelligenceSleepDetectNoNightTests.swift
+++ b/StrandTests/IntelligenceSleepDetectNoNightTests.swift
@@ -19,7 +19,7 @@ final class IntelligenceSleepDetectNoNightTests: XCTestCase {
         // gate the night → nothing stages. `window=54h` is the past-day span (30 h back → next midnight).
         let line = IE.sleepDetectNoNightLogLine(
             day: "2026-08-11", hrCount: 41230, rrCount: 0, respCount: 880,
-            gravCount: 0, stepCount: 12, providedCount: 0, windowHours: 54)
+            gravCount: 0, stepCount: 12, providedCount: 0, windowHours: 54, skinCount: 0)
         XCTAssertEqual(line,
             "sleep-detect day=2026-08-11 NO-NIGHT hr=41230 rr=0 resp=880 "
             // reason=no-motion is the point of this fixture: grav=0 means the stager has no HR-only
@@ -32,7 +32,7 @@ final class IntelligenceSleepDetectNoNightTests: XCTestCase {
         // Today's read caps at dayStart+18h (vs a past day's next-midnight), so the whole span is 48 h.
         let line = IE.sleepDetectNoNightLogLine(
             day: "2026-08-12", hrCount: 5000, rrCount: 900, respCount: 300,
-            gravCount: 4, stepCount: 0, providedCount: 0, windowHours: 48)
+            gravCount: 4, stepCount: 0, providedCount: 0, windowHours: 48, skinCount: 0)
         XCTAssertTrue(line.contains("window=48h"), line)
         // The other branch: motion WAS present and staging still produced nothing, which is the case
         // worth investigating rather than a capability limit.
@@ -43,7 +43,7 @@ final class IntelligenceSleepDetectNoNightTests: XCTestCase {
         // House style: never an em-dash in shared text.
         let line = IE.sleepDetectNoNightLogLine(
             day: "2026-08-11", hrCount: 1, rrCount: 1, respCount: 1,
-            gravCount: 1, stepCount: 1, providedCount: 1, windowHours: 54)
+            gravCount: 1, stepCount: 1, providedCount: 1, windowHours: 54, skinCount: 1)
         XCTAssertFalse(line.contains("—"))
     }
 
@@ -54,7 +54,7 @@ final class IntelligenceSleepDetectNoNightTests: XCTestCase {
     func testAStreamAtItsReadCapIsNamed() {
         let line = IntelligenceEngine.sleepDetectNoNightLogLine(
             day: "2026-09-06", hrCount: 1000, rrCount: 1000, respCount: 0,
-            gravCount: StreamReadCap.gravity, stepCount: 0, providedCount: 0, windowHours: 54)
+            gravCount: StreamReadCap.gravity, stepCount: 0, providedCount: 0, windowHours: 54, skinCount: 0)
         XCTAssertTrue(line.contains("atCap=grav"), line)
     }
 
@@ -62,7 +62,7 @@ final class IntelligenceSleepDetectNoNightTests: XCTestCase {
     func testANightUnderTheCapsCarriesNoMarker() {
         let line = IntelligenceEngine.sleepDetectNoNightLogLine(
             day: "2026-09-06", hrCount: 192_698, rrCount: 136_285, respCount: 0,
-            gravCount: 192_698, stepCount: 0, providedCount: 0, windowHours: 54)
+            gravCount: 192_698, stepCount: 0, providedCount: 0, windowHours: 54, skinCount: 0)
         XCTAssertFalse(line.contains("atCap"), line)
     }
 

--- a/StrandTests/IntelligenceSleepDetectNoNightTests.swift
+++ b/StrandTests/IntelligenceSleepDetectNoNightTests.swift
@@ -58,6 +58,19 @@ final class IntelligenceSleepDetectNoNightTests: XCTestCase {
         XCTAssertTrue(line.contains("atCap=grav"), line)
     }
 
+    /// HR and R-R at their caps produce NO marker, and that is deliberate rather than an oversight.
+    ///
+    /// Both arrive through `SlidingStreamWindow.rows`, which returns a SLICE of a read spanning more than
+    /// this night, so a truncated spliced window still hands back a count under the cap — the marker would
+    /// miss the very case it claims to catch. Their exact truncation count is printed once per pass by
+    /// `WindowedStreamPlan.logLine` instead. Pinned so the omission is not "fixed" back in.
+    func testHrAndRrAtTheirCapsCarryNoMarker() {
+        let line = IntelligenceEngine.sleepDetectNoNightLogLine(
+            day: "2026-09-06", hrCount: StreamReadCap.hr, rrCount: StreamReadCap.rr, respCount: 0,
+            gravCount: 10, stepCount: 0, providedCount: 0, windowHours: 54, skinCount: 0)
+        XCTAssertFalse(line.contains("atCap"), line)
+    }
+
     /// A healthy night says nothing extra — the marker only appears when something actually clipped.
     func testANightUnderTheCapsCarriesNoMarker() {
         let line = IntelligenceEngine.sleepDetectNoNightLogLine(

--- a/StrandTests/IntelligenceSleepDetectNoNightTests.swift
+++ b/StrandTests/IntelligenceSleepDetectNoNightTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import StrandAnalytics
 @testable import Strand
 
 /// Pins the "HR tracked but no sleep" diagnostic (#1244). When a day clears the >=200-HR gate yet the

--- a/StrandTests/IntelligenceSleepDetectNoNightTests.swift
+++ b/StrandTests/IntelligenceSleepDetectNoNightTests.swift
@@ -25,7 +25,7 @@ final class IntelligenceSleepDetectNoNightTests: XCTestCase {
             // reason=no-motion is the point of this fixture: grav=0 means the stager has no HR-only
             // fallback, so no quantity of HR could have staged a night. That is a strap capability limit,
             // and it wants a different follow-up from a night that had motion and still staged nothing.
-            + "grav=0 steps=12 provided=0 window=54h reason=no-motion")
+            + "grav=0 skin=0 steps=12 provided=0 window=54h reason=no-motion")
     }
 
     func testTodayWindowIs48h() {
@@ -70,6 +70,17 @@ final class IntelligenceSleepDetectNoNightTests: XCTestCase {
     /// and silent. Under the caps this ships with, the same night is comfortably clear.
     func testTheMeasuredFieldNightIsClearOfTheCaps() {
         XCTAssertLessThan(192_698, StreamReadCap.gravity)
+    }
+
+
+    /// The count that could not be measured. Skin temp only appears in a Test Centre "Night" line, which
+    /// fires when a session EXISTS — so on the nights being triaged, the ones with no sleep at all, its
+    /// volume was invisible.
+    func testTheLineReportsTheSkinSampleCount() {
+        let line = IntelligenceEngine.sleepDetectNoNightLogLine(
+            day: "2026-09-06", hrCount: 1000, rrCount: 900, respCount: 0, gravCount: 0,
+            stepCount: 0, providedCount: 0, windowHours: 54, skinCount: 4242)
+        XCTAssertTrue(line.contains("skin=4242"), line)
     }
 
 }

--- a/StrandTests/IntelligenceSleepDetectNoNightTests.swift
+++ b/StrandTests/IntelligenceSleepDetectNoNightTests.swift
@@ -45,4 +45,30 @@ final class IntelligenceSleepDetectNoNightTests: XCTestCase {
             gravCount: 1, stepCount: 1, providedCount: 1, windowHours: 54)
         XCTAssertFalse(line.contains("—"))
     }
+
+    /// The signal this line was missing. Gravity is a PLAIN read with no truncation counter, so a night
+    /// clipped of its newest motion staged badly and said nothing about why — and `grav=192698` reads as
+    /// healthy until you know it is 96% of a cap. A read that comes back AT the limit is truncated, which
+    /// is what `full.count >= limit` means everywhere else here.
+    func testAStreamAtItsReadCapIsNamed() {
+        let line = IntelligenceEngine.sleepDetectNoNightLogLine(
+            day: "2026-09-06", hrCount: 1000, rrCount: 1000, respCount: 0,
+            gravCount: StreamReadCap.gravity, stepCount: 0, providedCount: 0, windowHours: 54)
+        XCTAssertTrue(line.contains("atCap=grav"), line)
+    }
+
+    /// A healthy night says nothing extra — the marker only appears when something actually clipped.
+    func testANightUnderTheCapsCarriesNoMarker() {
+        let line = IntelligenceEngine.sleepDetectNoNightLogLine(
+            day: "2026-09-06", hrCount: 192_698, rrCount: 136_285, respCount: 0,
+            gravCount: 192_698, stepCount: 0, providedCount: 0, windowHours: 54)
+        XCTAssertFalse(line.contains("atCap"), line)
+    }
+
+    /// The field capture that motivated the caps: 192,698 gravity rows was 96% of the OLD 200,000 limit
+    /// and silent. Under the caps this ships with, the same night is comfortably clear.
+    func testTheMeasuredFieldNightIsClearOfTheCaps() {
+        XCTAssertLessThan(192_698, StreamReadCap.gravity)
+    }
+
 }

--- a/StrandTests/IntelligenceSleepDetectNoNightTests.swift
+++ b/StrandTests/IntelligenceSleepDetectNoNightTests.swift
@@ -72,7 +72,6 @@ final class IntelligenceSleepDetectNoNightTests: XCTestCase {
         XCTAssertLessThan(192_698, StreamReadCap.gravity)
     }
 
-
     /// The count that could not be measured. Skin temp only appears in a Test Centre "Night" line, which
     /// fires when a session EXISTS — so on the nights being triaged, the ones with no sleep at all, its
     /// volume was invisible.
@@ -81,6 +80,15 @@ final class IntelligenceSleepDetectNoNightTests: XCTestCase {
             day: "2026-09-06", hrCount: 1000, rrCount: 900, respCount: 0, gravCount: 0,
             stepCount: 0, providedCount: 0, windowHours: 54, skinCount: 4242)
         XCTAssertTrue(line.contains("skin=4242"), line)
+    }
+
+    /// Skin is the stream whose density was never measured, and it was the one `atCap` did not cover
+    /// when the marker was first written — so a clipped skin read printed a bare count and no warning.
+    func testSkinAtItsReadCapIsNamed() {
+        let line = IntelligenceEngine.sleepDetectNoNightLogLine(
+            day: "2026-09-06", hrCount: 10, rrCount: 10, respCount: 0, gravCount: 10,
+            stepCount: 0, providedCount: 0, windowHours: 54, skinCount: StreamReadCap.skin)
+        XCTAssertTrue(line.contains("atCap=skin"), line)
     }
 
 }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -2973,6 +2973,11 @@ object IntelligenceEngine {
         // only value is that its absence means "not clipped". Their exact truncation count is already
         // printed unconditionally once per pass by `WindowedStreamPlan.logLine` (`hrTruncated=`), so
         // nothing is lost by declining to guess it per night.
+        //
+        // resp and steps are plain reads too, and equally judgeable, but stay unmarked on purpose: neither
+        // is a staging input, so clipping one cannot be the reason a night is missing. Their counts are
+        // printed as context. The marker answers "did a stream that could explain this get cut short",
+        // not "was every read complete".
         val atCap = buildList {
             if (gravCount >= StreamReadCap.GRAVITY) add("grav")
             if (skinCount >= StreamReadCap.SKIN) add("skin")

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -823,7 +823,8 @@ object IntelligenceEngine {
                 // per-day anchor block below is a no-op — byte-identical anchor either way. A 5/MG banks
                 // skin-temp centidegrees directly — no per-device anchor — so its anchor slot stays null.
                 if (cacheOwnerFamily == DeviceFamily.WHOOP4 && !skinAnchorResolvedOwners.contains(owner)) {
-                    val windowSkin = repo.skinTempSamples(owner, skinAnchorScanFrom, skinAnchorScanTo, STREAM_LIMIT)
+                    val windowSkin = repo.skinTempSamples(owner, skinAnchorScanFrom, skinAnchorScanTo,
+                        StreamReadCap.SKIN)
                     Whoop4SkinTemp.deviceAnchorRaw(windowSkin.map { it.raw })?.let { skinAnchorByOwner[owner] = it }
                     skinAnchorResolvedOwners.add(owner)
                 }
@@ -2736,7 +2737,7 @@ object IntelligenceEngine {
         skinAnchorScanFrom: Long,
         skinAnchorScanTo: Long,
     ): DaySkinReads {
-        val skin = repo.skinTempSamples(owner, from, to, STREAM_LIMIT)
+        val skin = repo.skinTempSamples(owner, from, to, StreamReadCap.SKIN)
         // #93: WHOOP 4.0 raw SpO2 PPG samples for the night; analyzeDay banks the nightly red/IR ADC
         // means on the DailyMetric. Empty on a 5/MG (no v24 spo2 channels) → the raw means stay null.
         val spo2 = repo.spo2Samples(owner, from, to, STREAM_LIMIT)
@@ -2765,7 +2766,8 @@ object IntelligenceEngine {
         // identical to today). Computed here once per owner alongside the family resolution.
         val skinAnchorRaw = if (skinFamily == DeviceFamily.WHOOP4) {
             if (!skinAnchorResolvedOwners.contains(owner)) {
-                val windowSkin = repo.skinTempSamples(owner, skinAnchorScanFrom, skinAnchorScanTo, STREAM_LIMIT)
+                val windowSkin = repo.skinTempSamples(owner, skinAnchorScanFrom, skinAnchorScanTo,
+                    StreamReadCap.SKIN)
                 Whoop4SkinTemp.deviceAnchorRaw(windowSkin.map { it.raw })?.let { skinAnchorByOwner[owner] = it }
                 skinAnchorResolvedOwners.add(owner)
             }
@@ -2936,7 +2938,7 @@ object IntelligenceEngine {
      */
     internal fun sleepDetectNoNightLogLine(
         day: String, hrCount: Int, rrCount: Int, respCount: Int, gravCount: Int,
-        stepCount: Int, providedCount: Int, windowHours: Int, skinCount: Int = 0,
+        stepCount: Int, providedCount: Int, windowHours: Int, skinCount: Int,
     ): String {
         // `reason` names WHICH absence this is, because grav=0 is printed but its consequence is not.
         //
@@ -2964,6 +2966,9 @@ object IntelligenceEngine {
             if (gravCount >= StreamReadCap.GRAVITY) add("grav")
             if (hrCount >= StreamReadCap.HR) add("hr")
             if (rrCount >= StreamReadCap.RR) add("rr")
+            // Skin is here because it is the stream whose density was never measured — the reason the
+            // count is printed at all. The count is the night-WINDOW read, so this marks that read clipped.
+            if (skinCount >= StreamReadCap.SKIN) add("skin")
         }
         val capNote = if (atCap.isEmpty()) "" else " atCap=${atCap.joinToString(",")}"
         return "sleep-detect day=$day NO-NIGHT hr=$hrCount rr=$rrCount resp=$respCount " +

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -2962,12 +2962,19 @@ object IntelligenceEngine {
         // truncations; gravity is a plain read with no counter at all, so a night clipped of its newest
         // motion staged badly and said nothing. That is the difference between "this release fixes your
         // night" and "your offload never ran", and a log could not tell them apart.
+        // ONLY the plain reads. Gravity and skin are read whole, so a result of exactly the cap IS the
+        // truncation — the same `size >= limit` test used everywhere else here, and neither stream has a
+        // counter of its own, which is why this marker exists.
+        //
+        // HR and R-R are deliberately absent even though their counts are printed. They arrive through
+        // `SlidingStreamWindow.rows`, which returns `full.filter { ts in from..to }` — a SLICE of a read
+        // that usually spans more than this night. A spliced window that WAS truncated still hands back a
+        // slice under the cap, so the marker would silently fail to fire: a false negative on a line whose
+        // only value is that its absence means "not clipped". Their exact truncation count is already
+        // printed unconditionally once per pass by `WindowedStreamPlan.logLine` (`hrTruncated=`), so
+        // nothing is lost by declining to guess it per night.
         val atCap = buildList {
             if (gravCount >= StreamReadCap.GRAVITY) add("grav")
-            if (hrCount >= StreamReadCap.HR) add("hr")
-            if (rrCount >= StreamReadCap.RR) add("rr")
-            // Skin is here because it is the stream whose density was never measured — the reason the
-            // count is printed at all. The count is the night-WINDOW read, so this marks that read clipped.
             if (skinCount >= StreamReadCap.SKIN) add("skin")
         }
         val capNote = if (atCap.isEmpty()) "" else " atCap=${atCap.joinToString(",")}"

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -2951,9 +2951,24 @@ object IntelligenceEngine {
         // With motion present the inputs were there and staging still produced nothing, which remains the
         // case most worth investigating.
         val reason = if (gravCount == 0) "no-motion" else "staged-none"
+        // #1118 follow-up: name any stream that came back AT its read cap. A read that returns exactly
+        // the limit is the definition of truncated everywhere else here (`full.count >= limit`), and it
+        // is the one thing a reader cannot infer from the counts alone - `grav=192698` looks healthy
+        // until you know the cap it is 96% of.
+        //
+        // GRAVITY is why this exists. HR and R-R ride a SlidingStreamWindow, which counts its own
+        // truncations; gravity is a plain read with no counter at all, so a night clipped of its newest
+        // motion staged badly and said nothing. That is the difference between "this release fixes your
+        // night" and "your offload never ran", and a log could not tell them apart.
+        val atCap = buildList {
+            if (gravCount >= StreamReadCap.GRAVITY) add("grav")
+            if (hrCount >= StreamReadCap.HR) add("hr")
+            if (rrCount >= StreamReadCap.RR) add("rr")
+        }
+        val capNote = if (atCap.isEmpty()) "" else " atCap=${atCap.joinToString(",")}"
         return "sleep-detect day=$day NO-NIGHT hr=$hrCount rr=$rrCount resp=$respCount " +
             "grav=$gravCount steps=$stepCount provided=$providedCount window=${windowHours}h " +
-            "reason=$reason"
+            "reason=$reason$capNote"
     }
 
     /**

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1226,7 +1226,7 @@ object IntelligenceEngine {
                     sleepDetectNoNightLogLine(
                         day = day, hrCount = hr.size, rrCount = rr.size, respCount = resp.size,
                         gravCount = grav.size, stepCount = steps.size, providedCount = providedSleep.size,
-                        windowHours = windowHours,
+                        windowHours = windowHours, skinCount = skin.size,
                     ),
                 )
             }
@@ -2936,7 +2936,7 @@ object IntelligenceEngine {
      */
     internal fun sleepDetectNoNightLogLine(
         day: String, hrCount: Int, rrCount: Int, respCount: Int, gravCount: Int,
-        stepCount: Int, providedCount: Int, windowHours: Int,
+        stepCount: Int, providedCount: Int, windowHours: Int, skinCount: Int = 0,
     ): String {
         // `reason` names WHICH absence this is, because grav=0 is printed but its consequence is not.
         //
@@ -2967,8 +2967,8 @@ object IntelligenceEngine {
         }
         val capNote = if (atCap.isEmpty()) "" else " atCap=${atCap.joinToString(",")}"
         return "sleep-detect day=$day NO-NIGHT hr=$hrCount rr=$rrCount resp=$respCount " +
-            "grav=$gravCount steps=$stepCount provided=$providedCount window=${windowHours}h " +
-            "reason=$reason$capNote"
+            "grav=$gravCount skin=$skinCount steps=$stepCount provided=$providedCount " +
+            "window=${windowHours}h reason=$reason$capNote"
     }
 
     /**

--- a/android/app/src/main/java/com/noop/analytics/StreamReadCap.kt
+++ b/android/app/src/main/java/com/noop/analytics/StreamReadCap.kt
@@ -91,6 +91,21 @@ object StreamReadCap {
      */
     const val HEADROOM = 1.5
 
+    /**
+     * The cap on the skin-temp reads, named rather than left a literal so the no-night line can say when
+     * one came back AT it.
+     *
+     * Not derived from a row rate like the caps below: skin's density was never measured. Skin rides the
+     * record that carries gravity, and gravity ranged from 177 to 192,698 rows across 54 HOURS in one
+     * capture, so whether 200,000 is generous or tight is genuinely unknown - which is the reason to
+     * print the count. Unchanged in value: this names what both platforms already read at.
+     *
+     * Shared by two reads with very different spans - the night window, and the ~21-day WHOOP 4.0 anchor
+     * scan. Only the window read's count reaches the no-night line, so an `atCap=skin` marker means THAT
+     * read was clipped; a clipped anchor scan still goes unreported.
+     */
+    const val SKIN = 200_000
+
     /** The cap for a stream producing [rowsPerSecond] at its densest. */
     fun cap(rowsPerSecond: Double): Int = ceil(WINDOW_SECONDS * rowsPerSecond * HEADROOM).toInt()
 

--- a/android/app/src/main/java/com/noop/analytics/StreamReadCap.kt
+++ b/android/app/src/main/java/com/noop/analytics/StreamReadCap.kt
@@ -92,8 +92,9 @@ object StreamReadCap {
     const val HEADROOM = 1.5
 
     /**
-     * The cap on the skin-temp reads, named rather than left a literal so the no-night line can say when
-     * one came back AT it.
+     * The cap on the sleep engine's skin-temp reads, named rather than left a literal so the no-night
+     * line can say when one came back AT it. Skin reads OUTSIDE the engine (a chart, an export) keep
+     * their own limits - this is not a repo-wide skin cap.
      *
      * Not derived from a row rate like the caps below: skin's density was never measured. Skin rides the
      * record that carries gravity, and gravity ranged from 177 to 192,698 rows across 54 HOURS in one

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceSleepDetectNoNightTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceSleepDetectNoNightTest.kt
@@ -71,6 +71,22 @@ class IntelligenceSleepDetectNoNightTest {
         assertTrue(line, line.contains("atCap=grav"))
     }
 
+    /**
+     * HR and R-R at their caps produce NO marker, and that is deliberate rather than an oversight.
+     *
+     * Both arrive through `SlidingStreamWindow.rows`, which returns a SLICE of a read spanning more than
+     * this night, so a truncated spliced window still hands back a count under the cap - the marker would
+     * miss the very case it claims to catch. Their exact truncation count is printed once per pass by
+     * `WindowedStreamPlan.logLine` instead. Pinned so the omission is not "fixed" back in.
+     */
+    @Test fun `hr and rr at their caps carry no marker`() {
+        val line = IntelligenceEngine.sleepDetectNoNightLogLine(
+            day = "2026-09-06", hrCount = StreamReadCap.HR, rrCount = StreamReadCap.RR, respCount = 0,
+            gravCount = 10, stepCount = 0, providedCount = 0, windowHours = 54, skinCount = 0,
+        )
+        assertFalse(line, line.contains("atCap"))
+    }
+
     /** A healthy night says nothing extra - the marker only appears when something actually clipped. */
     @Test fun `a night under the caps carries no marker`() {
         val line = IntelligenceEngine.sleepDetectNoNightLogLine(

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceSleepDetectNoNightTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceSleepDetectNoNightTest.kt
@@ -29,7 +29,7 @@ class IntelligenceSleepDetectNoNightTest {
             // fallback, so no quantity of HR could have staged a night. That is a strap capability limit,
             // and it wants a different follow-up from a night that had motion and still staged nothing.
             "sleep-detect day=2026-08-11 NO-NIGHT hr=41230 rr=0 resp=880 " +
-                "grav=0 steps=12 provided=0 window=54h reason=no-motion",
+                "grav=0 skin=0 steps=12 provided=0 window=54h reason=no-motion",
             line,
         )
     }
@@ -87,6 +87,21 @@ class IntelligenceSleepDetectNoNightTest {
      */
     @Test fun `the measured field night is clear of the caps`() {
         assertTrue(192_698 < StreamReadCap.GRAVITY)
+    }
+
+
+    /**
+     * The count that could not be measured. Skin temp only appears in a Test Centre "Night" line, which
+     * fires when a session EXISTS - so on the nights being triaged, the ones with no sleep at all, its
+     * volume was invisible. It rides in the record that carries gravity, so whether it is dense or sparse
+     * decides whether its own 21-day anchor scan is anywhere near a cap; nobody could say which.
+     */
+    @Test fun `the line reports the skin sample count`() {
+        val line = IntelligenceEngine.sleepDetectNoNightLogLine(
+            day = "2026-09-06", hrCount = 1000, rrCount = 900, respCount = 0, gravCount = 0,
+            stepCount = 0, providedCount = 0, windowHours = 54, skinCount = 4242,
+        )
+        assertTrue(line, line.contains("skin=4242"))
     }
 
 }

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceSleepDetectNoNightTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceSleepDetectNoNightTest.kt
@@ -22,7 +22,7 @@ class IntelligenceSleepDetectNoNightTest {
         // gate the night → nothing stages. window=54h is the past-day span (30 h back → next midnight).
         val line = IntelligenceEngine.sleepDetectNoNightLogLine(
             day = "2026-08-11", hrCount = 41230, rrCount = 0, respCount = 880,
-            gravCount = 0, stepCount = 12, providedCount = 0, windowHours = 54,
+            gravCount = 0, stepCount = 12, providedCount = 0, windowHours = 54, skinCount = 0,
         )
         assertEquals(
             // reason=no-motion is the point of this fixture: grav=0 means the stager has no HR-only
@@ -39,7 +39,7 @@ class IntelligenceSleepDetectNoNightTest {
         // Today's read caps at dayStart+18h (vs a past day's next-midnight), so the whole span is 48 h.
         val line = IntelligenceEngine.sleepDetectNoNightLogLine(
             day = "2026-08-12", hrCount = 5000, rrCount = 900, respCount = 300,
-            gravCount = 4, stepCount = 0, providedCount = 0, windowHours = 48,
+            gravCount = 4, stepCount = 0, providedCount = 0, windowHours = 48, skinCount = 0,
         )
         assertTrue(line, line.contains("window=48h"))
         // The other branch: motion WAS present and staging still produced nothing, which is the case
@@ -52,7 +52,7 @@ class IntelligenceSleepDetectNoNightTest {
         // House style: never an em-dash in shared text.
         val line = IntelligenceEngine.sleepDetectNoNightLogLine(
             day = "2026-08-11", hrCount = 1, rrCount = 1, respCount = 1,
-            gravCount = 1, stepCount = 1, providedCount = 1, windowHours = 54,
+            gravCount = 1, stepCount = 1, providedCount = 1, windowHours = 54, skinCount = 1,
         )
         assertFalse(line.contains("—"))
     }
@@ -66,7 +66,7 @@ class IntelligenceSleepDetectNoNightTest {
     @Test fun `a stream at its read cap is named`() {
         val line = IntelligenceEngine.sleepDetectNoNightLogLine(
             day = "2026-09-06", hrCount = 1000, rrCount = 1000, respCount = 0,
-            gravCount = StreamReadCap.GRAVITY, stepCount = 0, providedCount = 0, windowHours = 54,
+            gravCount = StreamReadCap.GRAVITY, stepCount = 0, providedCount = 0, windowHours = 54, skinCount = 0,
         )
         assertTrue(line, line.contains("atCap=grav"))
     }
@@ -75,7 +75,7 @@ class IntelligenceSleepDetectNoNightTest {
     @Test fun `a night under the caps carries no marker`() {
         val line = IntelligenceEngine.sleepDetectNoNightLogLine(
             day = "2026-09-06", hrCount = 192_698, rrCount = 136_285, respCount = 0,
-            gravCount = 192_698, stepCount = 0, providedCount = 0, windowHours = 54,
+            gravCount = 192_698, stepCount = 0, providedCount = 0, windowHours = 54, skinCount = 0,
         )
         assertFalse(line, line.contains("atCap"))
     }
@@ -89,7 +89,6 @@ class IntelligenceSleepDetectNoNightTest {
         assertTrue(192_698 < StreamReadCap.GRAVITY)
     }
 
-
     /**
      * The count that could not be measured. Skin temp only appears in a Test Centre "Night" line, which
      * fires when a session EXISTS - so on the nights being triaged, the ones with no sleep at all, its
@@ -102,6 +101,18 @@ class IntelligenceSleepDetectNoNightTest {
             stepCount = 0, providedCount = 0, windowHours = 54, skinCount = 4242,
         )
         assertTrue(line, line.contains("skin=4242"))
+    }
+
+    /**
+     * Skin is the stream whose density was never measured, and it was the one `atCap` did not cover
+     * when the marker was first written — so a clipped skin read printed a bare count and no warning.
+     */
+    @Test fun `skin at its read cap is named`() {
+        val line = IntelligenceEngine.sleepDetectNoNightLogLine(
+            day = "2026-09-06", hrCount = 10, rrCount = 10, respCount = 0, gravCount = 10,
+            stepCount = 0, providedCount = 0, windowHours = 54, skinCount = StreamReadCap.SKIN,
+        )
+        assertTrue(line, line.contains("atCap=skin"))
     }
 
 }

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceSleepDetectNoNightTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceSleepDetectNoNightTest.kt
@@ -56,4 +56,37 @@ class IntelligenceSleepDetectNoNightTest {
         )
         assertFalse(line.contains("—"))
     }
+
+    /**
+     * The signal this line was missing. Gravity is a PLAIN read with no truncation counter, so a night
+     * clipped of its newest motion staged badly and said nothing about why - and `grav=192698` reads as
+     * healthy until you know it is 96% of a cap. A read that comes back AT the limit is truncated, which
+     * is what `full.count >= limit` means everywhere else here.
+     */
+    @Test fun `a stream at its read cap is named`() {
+        val line = IntelligenceEngine.sleepDetectNoNightLogLine(
+            day = "2026-09-06", hrCount = 1000, rrCount = 1000, respCount = 0,
+            gravCount = StreamReadCap.GRAVITY, stepCount = 0, providedCount = 0, windowHours = 54,
+        )
+        assertTrue(line, line.contains("atCap=grav"))
+    }
+
+    /** A healthy night says nothing extra - the marker only appears when something actually clipped. */
+    @Test fun `a night under the caps carries no marker`() {
+        val line = IntelligenceEngine.sleepDetectNoNightLogLine(
+            day = "2026-09-06", hrCount = 192_698, rrCount = 136_285, respCount = 0,
+            gravCount = 192_698, stepCount = 0, providedCount = 0, windowHours = 54,
+        )
+        assertFalse(line, line.contains("atCap"))
+    }
+
+    /**
+     * The field capture that motivated the caps: 192,698 gravity rows was 96% of the OLD 200,000 limit
+     * and silent. Under the caps this ships with, the same night is comfortably clear - so a marker
+     * appearing now means a genuinely denser night, not the old ceiling.
+     */
+    @Test fun `the measured field night is clear of the caps`() {
+        assertTrue(192_698 < StreamReadCap.GRAVITY)
+    }
+
 }


### PR DESCRIPTION
Prompted by a field report of "sometimes there is no sleep data at all" on a
WHOOP 4.0, which cannot currently be triaged from a log.

## The gap

The NO-NIGHT line already names WHICH absence it is - `no-motion` when gravity is
zero, `staged-none` when the inputs were there and staging still produced nothing.
What it cannot say is whether the inputs were COMPLETE.

`grav=192698` reads as a healthy night. It was 96% of the old 200,000 cap.

## Why gravity specifically

HR and R-R ride a `SlidingStreamWindow`, which counts its own truncations - that
counter is the only reason the R-R over-read was ever found. **Gravity is a plain
read with no counter at all**, so a night clipped of its newest motion staged
badly and said nothing about why.

That is exactly the difference between two answers to the same empty card:

- "the read-cap fix in this release repairs your nights" - the stream was being
  clipped, and the caps that shipped in #1899 raise gravity from 200,000 to
  291,600
- "your offload never ran" - `grav=0`, which that fix does not touch at all

Two different bugs, one symptom, and no way to tell them apart from a log.

## The change

The line names a PLAIN read that came back AT its limit: `... reason=staged-none
atCap=grav`. A read returning exactly the cap is what truncated means everywhere
else here (`size >= limit`), so this surfaces the existing definition rather than
inventing one.

Costs nothing on a healthy night - the marker is absent unless something clipped,
so existing lines are byte-identical.

**Gravity and skin only, deliberately.** HR and R-R have their counts printed but
carry no marker, because they reach the line through `SlidingStreamWindow.rows`,
which returns `full.filter { ts in from..to }` - a SLICE of a read that usually
spans more than the night being reported. Splicing is the window's normal mode, so
a read that WAS truncated still hands back a slice under the cap and the marker
would stay silent: a false negative on a line whose only value is that its absence
means "not clipped".

Nothing is lost by that. `WindowedStreamPlan.logLine` already prints `hrTruncated=`
and `rrTruncated=` once per pass, unconditionally - so the exact count is on the
same report even for a night that staged nothing. A test pins the omission so it is
not "fixed" back in later.

## Skin, and a false zero it was hiding

`skin=N` is printed because skin's density has never been measured - it rides the
record that carries gravity, and gravity ranged from 177 to 192,698 rows across 54
HOURS in one capture, so whether 200,000 covers it is genuinely unknown.

Two problems came out of re-reviewing that:

- **`atCap` did not cover skin** - the one stream the count was added for. Skin
  read at a bare `200_000` literal, so a clipped skin read printed `skin=200000`
  with no marker. That literal is now `StreamReadCap.SKIN` / `.skin` and is used
  at every skin read on both platforms: the night window (whose count is the one
  printed) and the ~21-day WHOOP 4.0 anchor scan. Unlike its neighbours the value
  is not derived from a row rate; only the name is new.
- **The Swift call site never passed `skinCount`.** A default of `0` on the
  formatter absorbed the missing argument, so every iOS no-night line reported
  `skin=0` whether or not skin rows existed - indistinguishable from "no skin
  data" in the exact capture this line is meant to be read from. The default is
  gone, Swift passes `skin.count`, and the five Kotlin fixtures that leaned on it
  now state their value.

Only the window read's count reaches the line, so `atCap=skin` marks THAT read
clipped; a clipped anchor scan still goes unreported, and the doc says so.

## Verification

Android 5341 tests / 0 failures, 9 in the NO-NIGHT class; doc-comment lint clean;
both Swift files parse. The Swift half rides CI, since `StrandTests` runs in the
macOS leg.

One test pins the measured field night - 192,698 gravity rows - as clear of the
caps this ships with, so a marker appearing later means a genuinely denser night
rather than the old ceiling returning.
