### PR TITLE
today: stop the Liquid Effort tile calling a load index a percentage

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -1568,7 +1568,13 @@ struct LiquidTodayView: View {
         // — never a fabricated value. A navigated past day clears it.
         let liveStrainLocal: Double?
         if selectedDayOffset == 0 {
-            let todayHr = await repo.hrSamples(from: from, to: to)
+            // An EXPLICIT limit, not the 8000 default: that default is chart-sized, and this read is
+            // whole-window. `hrSamples` is `ORDER BY ts ASC LIMIT`, so truncation drops the NEWEST rows —
+            // at the ~18k HR rows a real day banks, the default covered roughly the first ten hours and the
+            // live score silently stopped climbing after that. It failed safe (`effectiveEffort` takes the
+            // max, so the stored row simply won) which is why it went unnoticed. 200_000 is what every
+            // other whole-window HR consumer already passes.
+            let todayHr = await repo.hrSamples(from: from, to: to, limit: 200_000)
             let maxHR = profile.age > 0 ? StrainScorer.tanakaHRmax(age: Double(profile.age)) : nil
             let restHR = day?.restingHr.map(Double.init) ?? StrainScorer.defaultRestingHR
             liveStrainLocal = StrainScorer.strain(todayHr, maxHR: maxHR, restingHR: restHR,

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -1273,7 +1273,12 @@ struct LiquidTodayView: View {
             // stays raw, matching the Effort hero, which correctly does not carry.
             ktile(String(localized: "Recovery"), icon: keyMetricIcon(metric), intText(chargeDisplay.pct), "%", StrandPalette.chargeColor, frac(chargeDisplay.pct), key: "recovery")
         case .effort:
-            ktile(String(localized: "Strain"), icon: keyMetricIcon(metric), intText(displayDay?.strain), "%", StrandPalette.effortColor, frac(displayDay?.strain), key: "strain")
+            // #492: Effort is a load index (0–100 NOOP / 0–21 WHOOP), NOT a percentage, and the unit was
+            // wrong on either axis. Fixed on Android and in `TodayView` at the time; THIS view kept the old
+            // form, so the tile also ignored the scale toggle — the hero ring above it read ~8 on the WHOOP
+            // axis while this read 38. `effortText` is the same shared formatter the ring and the workout
+            // rows use, so all three now agree by construction.
+            ktile(String(localized: "Strain"), icon: keyMetricIcon(metric), effortText(displayDay?.strain), "", StrandPalette.effortColor, frac(displayDay?.strain), key: "strain")
         case .rest:
             ktile(String(localized: "Rest"), icon: keyMetricIcon(metric), intText(restScore), "%", StrandPalette.restColor, frac(restScore), key: "sleep_performance")
         case .hrv:
@@ -1342,7 +1347,7 @@ struct LiquidTodayView: View {
 
     private func ktile(_ label: String, icon: String, _ value: String, _ unit: String, _ tint: Color, _ frac: Double?,
                        key: String? = nil, detailMetric: MetricDescriptor? = nil, caption: String? = nil) -> some View {
-        let displayValue = unit.isEmpty ? value : (unit == "%" ? value + unit : value + " " + unit)
+        let displayValue = Self.tileDisplayValue(value, unit: unit)
         let tile = VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 6) {
                 Image(systemName: icon)
@@ -1813,10 +1818,25 @@ struct LiquidTodayView: View {
 
     private func frac(_ v: Double?) -> Double? { v.map { max(0, min(1, $0 / 100)) } }
     private func fracOver(_ v: Double?, _ over: Double) -> Double? { v.map { max(0, min(1, $0 / over)) } }
-    private func intText(_ v: Double?) -> String { v.map { String(Int($0.rounded())) } ?? "–" }
+    /// What a tile shows when the metric has no value. One constant rather than a dash repeated at each
+    /// site, because the unit-suppression below has to recognise it.
+    static let noValueDash = "–"
+
+    /// Join a formatted tile value with its unit, dropping the unit when there is no value.
+    ///
+    /// #492 and the `–%` it left behind: a missing metric rendered its placeholder AND its unit, so an
+    /// empty Strain tile read `–%`, which parses as "minus percent" rather than "no data". Android has
+    /// had the guard all along (`unit = if (restScore != null) "%" else ""`, and `withUnit`'s NO_DATA
+    /// check); this is the iOS twin of it. `%` binds tight, every other unit takes a space.
+    static func tileDisplayValue(_ value: String, unit: String) -> String {
+        guard !unit.isEmpty, value != noValueDash else { return value }
+        return unit == "%" ? value + unit : value + " " + unit
+    }
+
+    private func intText(_ v: Double?) -> String { v.map { String(Int($0.rounded())) } ?? Self.noValueDash }
 
     private func unitText(_ v: Double?, _ unit: String, decimals: Int = 0) -> String {
-        guard let v else { return "–" }
+        guard let v else { return Self.noValueDash }
         let n = decimals > 0 ? String(format: "%.\(decimals)f", locale: AppLanguage.activeLocale, v) : String(Int(v.rounded()))
         return unit.isEmpty ? n : "\(n) \(unit)"
     }
@@ -1854,7 +1874,7 @@ struct LiquidTodayView: View {
     private var effortScale: EffortScale { UnitPrefs.resolveEffortScale(effortScaleRaw) }
 
     private func effortText(_ s: Double?) -> String {
-        guard let s else { return "–" }
+        guard let s else { return Self.noValueDash }
         // Route through the shared formatter instead of hardcoding *21: a default (0–100) user was shown the
         // WHOOP-scaled number here while the hero + Workouts table showed 0–100, two numbers for one workout.
         return UnitFormatter.effortDisplay(s, scale: effortScale)

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -103,6 +103,11 @@ struct LiquidTodayView: View {
     @State private var kSparks: [String: [(String, Double)]] = [:]
     private var enabledKeyMetrics: [KeyMetric] { KeyMetricPrefs.decodeEnabled(keyMetricsRaw) }
 
+    /// #1001: TODAY's in-progress Effort, scored live in `load()` over the same window this view already
+    /// resolves for its other reads. nil for a navigated past day, and nil when the scorer has too few
+    /// readings — every Effort read-out then falls back to the stored row rather than a fabricated value.
+    @State private var liveTodayStrain: Double?
+
     // day navigation (0 = today, 1 = yesterday, …)
     @State private var selectedDayOffset = 0
     @State private var showDayPicker = false
@@ -660,7 +665,7 @@ struct LiquidTodayView: View {
             // one decimal on the compressed 0–21 axis to match the app-wide `effortDisplay` convention
             // (12.6, not a rounded "13"); the 0–100 hero stays a whole number as before.
             HeroScoreCell(label: String(localized: "Effort"),
-                          score: displayDay?.strain.map { UnitFormatter.effortValue($0, scale: effortScale) },
+                          score: effortStrain(displayDay).map { UnitFormatter.effortValue($0, scale: effortScale) },
                           tint: StrandPalette.effortColor, animated: dataLoaded,
                           onGuide: { guideSection = .effort },
                           maxValue: effortScale == .whoop ? 21 : 100,
@@ -1047,7 +1052,7 @@ struct LiquidTodayView: View {
     /// card when today's Effort is ~0, so a calm day explains itself instead of a bare 0. Reuses classic's
     /// String Catalog entry verbatim — one key serves both Today screens.
     private var effortZeroNote: String? {
-        guard EffortDisplay.showsZeroNote(strain: displayDay?.strain, isToday: selectedDayOffset == 0) else { return nil }
+        guard EffortDisplay.showsZeroNote(strain: effortStrain(displayDay), isToday: selectedDayOffset == 0) else { return nil }
         return String(localized: "No cardio load yet. Effort builds once your heart rate climbs into your effort zone (around 50% of your heart-rate reserve). A calm day honestly reads near zero.")
     }
 
@@ -1278,7 +1283,7 @@ struct LiquidTodayView: View {
             // form, so the tile also ignored the scale toggle — the hero ring above it read ~8 on the WHOOP
             // axis while this read 38. `effortText` is the same shared formatter the ring and the workout
             // rows use, so all three now agree by construction.
-            ktile(String(localized: "Strain"), icon: keyMetricIcon(metric), effortText(displayDay?.strain), "", StrandPalette.effortColor, frac(displayDay?.strain), key: "strain")
+            ktile(String(localized: "Strain"), icon: keyMetricIcon(metric), effortText(effortStrain(displayDay)), "", StrandPalette.effortColor, frac(effortStrain(displayDay)), key: "strain")
         case .rest:
             ktile(String(localized: "Rest"), icon: keyMetricIcon(metric), intText(restScore), "%", StrandPalette.restColor, frac(restScore), key: "sleep_performance")
         case .hrv:
@@ -1556,6 +1561,22 @@ struct LiquidTodayView: View {
         let from = cycleMarkers.last(where: { $0.day == selectedDayKey }).map { Int($0.value) } ?? calendarFrom
         let toExclusive = cycleMarkers.last(where: { $0.day == nextDayKey }).map { Int($0.value) } ?? calendarTo
         let to = max(from, toExclusive - 1)
+        // #1001: in-progress Effort for TODAY, over the SAME window resolved just above (the day-cycle
+        // onset when that mode is on, else calendar midnight → now) with the identical params the daily
+        // pass uses, so the live number matches what the engine will eventually persist. Below
+        // `StrainScorer.minReadings` the scorer returns nil and the read-outs fall back to the stored row
+        // — never a fabricated value. A navigated past day clears it.
+        let liveStrainLocal: Double?
+        if selectedDayOffset == 0 {
+            let todayHr = await repo.hrSamples(from: from, to: to)
+            let maxHR = profile.age > 0 ? StrainScorer.tanakaHRmax(age: Double(profile.age)) : nil
+            let restHR = day?.restingHr.map(Double.init) ?? StrainScorer.defaultRestingHR
+            liveStrainLocal = StrainScorer.strain(todayHr, maxHR: maxHR, restingHR: restHR,
+                                                  method: PuffinExperiment.effortMethod, sex: profile.sex)
+        } else {
+            liveStrainLocal = nil
+        }
+        liveTodayStrain = liveStrainLocal
 
         async let restA = repo.exploreSeries(key: "sleep_performance", source: "my-whoop")
         async let stressA = repo.series(key: "stress", source: "my-whoop")
@@ -1818,6 +1839,7 @@ struct LiquidTodayView: View {
 
     private func frac(_ v: Double?) -> Double? { v.map { max(0, min(1, $0 / 100)) } }
     private func fracOver(_ v: Double?, _ over: Double) -> Double? { v.map { max(0, min(1, $0 / over)) } }
+
     /// What a tile shows when the metric has no value. One constant rather than a dash repeated at each
     /// site, because the unit-suppression below has to recognise it.
     static let noValueDash = "–"
@@ -1872,6 +1894,15 @@ struct LiquidTodayView: View {
     // preference the Workouts screen + Trends read, so a workout's Effort number is identical everywhere.
     @AppStorage(UnitPrefs.effortScaleKey) private var effortScaleRaw = EffortScale.hundred.rawValue
     private var effortScale: EffortScale { UnitPrefs.resolveEffortScale(effortScaleRaw) }
+
+    /// The Effort this view should show: the live in-progress score when it beats the stored row, else the
+    /// row (#1001). `StrainScorer.effectiveEffort` holds the never-drop floor and the live/stored
+    /// preference and is shared with the Kotlin twin, so the two platforms cannot resolve Effort
+    /// differently. `d` for today is always today's row or nil, never a prior day, so the floor cannot
+    /// resurrect a stale day — it only stops a read-out dropping below what today has already earned.
+    private func effortStrain(_ d: DailyMetric?) -> Double? {
+        StrainScorer.effectiveEffort(live: selectedDayOffset == 0 ? liveTodayStrain : nil, stored: d?.strain)
+    }
 
     private func effortText(_ s: Double?) -> String {
         guard let s else { return Self.noValueDash }
@@ -2351,9 +2382,9 @@ extension LiquidTodayView {
     /// The Effort hero's "no cardio load yet" honest note (#530 follow-up — Liquid parity with classic
     /// `TodayView.effortZeroNote`). Pure + static so the gate is testable with no view: the note shows
     /// ONLY for today when a strain value exists and is ~0 — a genuinely calm day reads near zero, while a
-    /// no-data day shows its own ring overlay and a past day is never annotated. Liquid reads
-    /// `displayDay?.strain` directly (it has no live-strain accumulator like classic's `liveTodayStrain`),
-    /// which is exactly the value its Effort hero draws.
+    /// no-data day shows its own ring overlay and a past day is never annotated. The caller passes
+    /// `effortStrain(displayDay)` — the SAME resolved value the Effort hero draws (#1001) — so the note
+    /// and the hero can never disagree about whether today is at zero.
     enum EffortDisplay {
         static func showsZeroNote(strain: Double?, isToday: Bool) -> Bool {
             guard isToday, let s = strain else { return false }

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -4777,7 +4777,14 @@ struct TodayView: View {
             let cycleOnset = dayCycleSeries.last(where: { $0.day <= selectedDayKey })
                 .map { Int($0.value.rounded()) }
             let effortStart = mode == .sleepOnset ? (cycleOnset ?? windowStart) : windowStart
-            let todayHr = await repo.hrSamples(from: effortStart, to: windowEndInclusive)
+            // An EXPLICIT limit, not the 8000 default: that default is chart-sized, and this read is
+            // whole-window. `hrSamples` is `ORDER BY ts ASC LIMIT`, so truncation drops the NEWEST rows —
+            // at the ~18k HR rows a real day banks, the default covered roughly the first ten hours and the
+            // live score silently stopped climbing after that. It failed safe (`effectiveEffort` takes the
+            // max, so the stored row simply won) which is why it went unnoticed. 200_000 is what every
+            // other whole-window HR consumer already passes.
+            let todayHr = await repo.hrSamples(from: effortStart, to: windowEndInclusive,
+                                               limit: 200_000)
             let maxHR = profile.age > 0 ? StrainScorer.tanakaHRmax(age: Double(profile.age)) : nil
             let restHR = displayDay?.restingHr.map(Double.init) ?? StrainScorer.defaultRestingHR
             liveStrainLocal = StrainScorer.strain(todayHr, maxHR: maxHR, restingHR: restHR,

--- a/StrandTests/LiquidTodayTileValueTests.swift
+++ b/StrandTests/LiquidTodayTileValueTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import Strand
+
+/// Pins the Key Metrics tile's value/unit join (#492, and the `–%` it left behind).
+///
+/// The reported symptom was an empty Strain tile reading `–%`: the placeholder kept its unit, so "no data"
+/// rendered as something that parses like a negative percentage. Android has always suppressed the unit on
+/// its no-data sentinel; these pin the iOS twin so the two cannot drift apart again.
+final class LiquidTodayTileValueTests: XCTestCase {
+
+    /// The reported bug, exactly: a missing metric must not carry a unit.
+    func testNoValuePlaceholderDropsItsUnit() {
+        XCTAssertEqual(LiquidTodayView.tileDisplayValue(LiquidTodayView.noValueDash, unit: "%"),
+                       LiquidTodayView.noValueDash)
+        XCTAssertEqual(LiquidTodayView.tileDisplayValue(LiquidTodayView.noValueDash, unit: "kcal"),
+                       LiquidTodayView.noValueDash)
+    }
+
+    /// A real value still gets its unit, and `%` binds tight where the others take a space — the existing
+    /// convention, unchanged by the guard above.
+    func testAValueKeepsItsUnitAndSpacing() {
+        XCTAssertEqual(LiquidTodayView.tileDisplayValue("93", unit: "%"), "93%")
+        XCTAssertEqual(LiquidTodayView.tileDisplayValue("1272", unit: "kcal"), "1272 kcal")
+    }
+
+    /// Effort passes an EMPTY unit now (it is a 0–100 / 0–21 load index, not a percentage), so the value
+    /// must come through untouched on both the present and the absent path.
+    func testAnEmptyUnitIsLeftAlone() {
+        XCTAssertEqual(LiquidTodayView.tileDisplayValue("38.9", unit: ""), "38.9")
+        XCTAssertEqual(LiquidTodayView.tileDisplayValue(LiquidTodayView.noValueDash, unit: ""),
+                       LiquidTodayView.noValueDash)
+    }
+}


### PR DESCRIPTION
Reported alongside #1898: the iOS Strain tile reads `–%`.

## Two bugs, one line apart

**The `%` should never have been there.** #492 established that Effort is a load
index (0–100 NOOP / 0–21 WHOOP), not a percentage, and that the unit was wrong on
either axis. Android and `TodayView` were fixed then; `LiquidTodayView` — the view
behind `liquidTodayEnabled`, and the one in the report — kept the old form.

Because it kept the old form it also kept reading the stored column directly
instead of the shared formatter, so the tile **ignored the effort-scale toggle**:
a user on the WHOOP 0–21 axis saw the hero ring read ~8 and the tile read 38 on
the same screen, and the tile rounded where every other read-out shows one
decimal. It now goes through `effortText` — the same formatter the ring and the
workout rows use — with no unit, matching Android's tile exactly, caption included
(it has none).

**The reported symptom was a second bug.** `ktile` appended the unit
unconditionally, so a missing metric rendered its placeholder AND its unit: an
empty Strain tile read `–%`, which parses as "minus percent" rather than "no
data". It hit Recovery, Rest and Blood Oxygen too, and would have shown `– kcal` /
`– ms` on the others. Android has always had the guard
(`unit = if (restScore != null) "%" else ""`, and `withUnit`'s NO_DATA check);
this is its iOS twin, extracted as a pure static so it is unit-tested rather than
buried in a view builder.

The no-data dash is now one constant instead of a literal repeated at each site,
because the suppression has to recognise it.

## The third bug: the number was stale as well as mislabelled

Chasing the unit turned up the bigger one. #1001 put the never-drop floor and the
live/stored preference in `StrainScorer.effectiveEffort`, shared with the Kotlin
twin so the platforms cannot resolve Effort differently. `TodayView` routes
through it. Android's tile does (`effortForDay ?: d.strain`, with the comment
"reading `d.strain` here is what left this tile behind the hero ring").

`LiquidTodayView` read the stored column for its hero, its Key Metrics tile AND
its zero-note gate. Nothing looked inconsistent on screen because all three read
the same stale source — but on an active day the whole view sat behind the
resolved value until the next scoring pass, against this file's own header claim
that every value binds to the same data classic TodayView reads.

The live score uses the window `load()` already derives for its other reads: the
day-cycle onset when that mode is on, else calendar midnight → now, with the same
params the daily pass uses. Below `StrainScorer.minReadings` the scorer returns
nil and every read-out falls back to the stored row, so it cannot fabricate a
value, and a navigated past day clears it.

The zero-note gate moves with the hero deliberately: had it kept reading the
stored column, "no cardio load yet" could appear beside a hero already showing a
live non-zero Effort. Its doc recorded the absence of a live accumulator here as
a fact, which is no longer true.

## What this still does NOT do

It does not make a missing Effort appear. In the report's iOS screenshot the hero
ring is empty and Charge reads 86 against Android's 93 — two devices holding
different data for the same day. That dash is missing data, not formatting.

## Verification

Doc lint clean; i18n audit clean (the fix removes a unit rather than adding copy,
so there is no new string). Three unit tests pin the join: placeholder drops its
unit, a real value keeps it with the existing `%`-binds-tight spacing, and an
empty unit passes through untouched. The Effort resolution itself stays in
`StrainScorer.effectiveEffort`, which `EffectiveEffortTests` already covers in
default CI. The app-target compile and those tests ride
the macOS build leg, since nothing local compiles that target.
