### PR TITLE
tests: repin the frozen-Rest tests on what the shipping stager does

### DIFF
--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Live5NoGravityRestChainTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Live5NoGravityRestChainTests.swift
@@ -3,7 +3,13 @@ import XCTest
 import WhoopProtocol
 import WhoopStore
 
-/// Bug #977 (iOS, WHOOP 5.0, live Bluetooth): "Rest score stuck 93 since forever."
+/// The no-gravity Rest chain, from bug #977 (iOS, WHOOP 5.0, live Bluetooth): "Rest score stuck 93 since
+/// forever."
+///
+/// Renamed from `Live5RestFrozenTests`. The frozen state is closed (see below), and a file called
+/// "Frozen" is the same stale signal the `XCTExpectFailure` in it used to be: something a reader greps,
+/// believes, and acts on long after it stopped being true. #977 stays named here for archaeology; the
+/// file is named for the chain it pins.
 ///
 /// The mechanism: a LIVE WHOOP 5.0 streams standard 0x2A37 HR continuously, but gravity is only ever
 /// populated by the *history offload* (Backfiller). With no overnight gravity the day reaches the scoring
@@ -34,7 +40,7 @@ import WhoopStore
 /// #977's `freshRestScore` + `isCarryStale`, which live in the app target and are covered there and by
 /// Android's `RestFreshnessTest`. This package pins only what it owns, and says so at the bottom of the
 /// file rather than keeping a test that re-simulates a rule it cannot import.
-final class Live5RestFrozenTests: XCTestCase {
+final class Live5NoGravityRestChainTests: XCTestCase {
 
     private func hrStream(start: Int, durationS: Int, bpm: Int) -> [HRSample] {
         stride(from: 0, to: durationS, by: 1).map { HRSample(ts: start + $0, bpm: bpm) }
@@ -52,10 +58,12 @@ final class Live5RestFrozenTests: XCTestCase {
     /// V1, stated EXPLICITLY rather than taken from the default: 8 h of continuous sleep-plausible HR
     /// with zero gravity yields nothing, because V1's spine is motion stillness and there is none.
     ///
-    /// Still worth pinning — V1 remains selectable, and the 4.0 is unvalidated on either stager
-    /// (#271/#319) — but it is no longer what a default install runs, which is the whole point of the
-    /// V2 test below. The original spelling of this test relied on `useSleepStagerV2`'s default, so it
-    /// silently stopped describing shipped behaviour the moment that default moved.
+    /// `SleepStagerTests.testDetectSleepEmptyGravity` already asserts the empty-gravity case once, on the
+    /// default stager. The pair here is not that assertion again: it is the statement that the answer is
+    /// the SAME on both stagers, which is the fact the chain turns on and the one whose absence let this
+    /// file spend two years implying V2 might rescue the night. The original spelling relied on
+    /// `useSleepStagerV2`'s default, so it silently stopped describing shipped behaviour when that
+    /// default moved — which is how the implication survived.
     func testV1WithNoGravityDetectsNoSleep() {
         let start = nightStart()
         let dur = 8 * 60 * 60
@@ -117,28 +125,11 @@ final class Live5RestFrozenTests: XCTestCase {
     /// Android TodayScreen.kt line 689): when today has no `sleep_performance` row, both
     /// platforms fall back to the latest value in the series. If new nights never write a row,
     /// that latest value is pinned to the last night that WAS scored — 93 — forever.
-    // MARK: - The other joint: a STAGED night must yield a composite
-
-    /// The half of the chain this package owns downstream of staging: once a night is staged, its
-    /// aggregates must produce a Rest signal.
-    ///
-    /// This replaces a test that wrapped `XCTExpectFailure("#977 not yet fixed")` around
-    /// `Rest.composite(daily:)` for a row with NO sleep fields. That assertion could never pass whatever
-    /// was fixed upstream — a row without `totalSleepMin`/`efficiency` is nil by the guard's definition,
-    /// not by a bug — so it asserted the wrong layer and would have gone on advertising #977 as open
-    /// forever. The real requirement it was reaching for is the pair: the shipping stager stages the
-    /// night (above), and a staged night scores (here).
-    func testStagedNightYieldsARestComposite() {
-        let daily = DailyMetric(day: "2026-07-02",
-                                totalSleepMin: 7 * 60,
-                                efficiency: 0.92,
-                                deepMin: 80, remMin: 95, lightMin: 245, disturbances: 3,
-                                restingHr: 52, avgHrv: 65,
-                                recovery: nil, strain: nil, exerciseCount: nil,
-                                spo2Pct: nil, skinTempDevC: nil, respRateBpm: nil)
-        XCTAssertNotNil(AnalyticsEngine.Rest.composite(daily: daily),
-                        "Sleep aggregates present ⇒ a Rest composite ⇒ a sleep_performance point is written")
-    }
+    // The downstream joint - a STAGED night yields a composite - deliberately has no test here either.
+    // `Rest.composite` is exercised in `RestWiringImpactTests`, `RestSubScoreTraceTests`,
+    // `SleepStageTotalsTests` and `AnalyticsEngineTests`; a fifth assertion that a complete row scores
+    // would be noise. What is NOT covered elsewhere is the nil case above, which is the one this chain
+    // turns on, so that is the one that lives here.
 
     // The display half deliberately has NO test here. It used to, and that test asserted `max(by:)` over a
     // literal dictionary — it exercised no product code at all, which is worse than no test because it

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Live5RestFrozenTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Live5RestFrozenTests.swift
@@ -30,7 +30,8 @@ import WhoopStore
 ///
 /// The display half (whether Today shows a stale carried value or falls through to its no-data state) is
 /// #977's `freshRestScore` + `isCarryStale`, which live in the app target and are covered there and by
-/// Android's `RestFreshnessTest`. This package pins only what it owns.
+/// Android's `RestFreshnessTest`. This package pins only what it owns, and says so at the bottom of the
+/// file rather than keeping a test that re-simulates a rule it cannot import.
 final class Live5RestFrozenTests: XCTestCase {
 
     private func hrStream(start: Int, durationS: Int, bpm: Int) -> [HRSample] {
@@ -70,14 +71,32 @@ final class Live5RestFrozenTests: XCTestCase {
     /// frozen state is closed and the old `XCTExpectFailure` was vouching for a fixed bug. If it fails,
     /// the gap is real and this is where it lives.
     func testV2WithNoGravityStagesTheNightFromHrAlone() {
-        let start = nightStart()
-        let dur = 8 * 60 * 60
-        let hr = hrStream(start: start, durationS: dur, bpm: 50)
+        // Awake HR either side of the sleep block, NOT a flat night. `hrOnlySleepRuns` flags an epoch as
+        // sleep when its median sits under the 10th-percentile baseline x 1.05, so a constant-bpm fixture
+        // makes that test trivially true for every epoch — the whole window becomes one "sleep" run and
+        // the probe would pass even if V2 were over-staging wholesale, which is the exact 4.0 failure
+        // mode #319 describes. With a real spread the baseline has to FIND the quiet block.
+        let awakeBefore = 2 * 60 * 60
+        let asleep = 8 * 60 * 60
+        let awakeAfter = 2 * 60 * 60
+        let windowStart = nightStart() - awakeBefore
+        let hr = hrStream(start: windowStart, durationS: awakeBefore, bpm: 72)
+            + hrStream(start: nightStart(), durationS: asleep, bpm: 50)
+            + hrStream(start: nightStart() + asleep, durationS: awakeAfter, bpm: 72)
+
         let sessions = SleepStager.detectSleep(hr: hr, gravity: [], useSleepStagerV2: true)
         XCTAssertFalse(sessions.isEmpty,
                        "V2 has an HR-only spine (hrOnlySleepRuns); a dense sleep-plausible night must stage")
         XCTAssertTrue(sessions.allSatisfy { $0.hrOnly },
                       "staged without gravity ⇒ every session must carry hrOnly, so consumers can weigh it")
+
+        // The staged time must resemble the quiet block, not the whole window. Deliberately loose (staging
+        // trims edges and may split): what this rejects is "everything is sleep", which is the way an
+        // HR-only spine fails silently.
+        let staged = sessions.reduce(0) { $0 + ($1.end - $1.start) }
+        XCTAssertGreaterThan(staged, 5 * 60 * 60, "staged well under the quiet block ⇒ the spine missed it")
+        XCTAssertLessThan(staged, awakeBefore + asleep + awakeAfter - 60 * 60,
+                          "staged the awake hours too ⇒ over-staging, not detection")
     }
 
     // MARK: - Stage 2: no sleep ⇒ no Rest composite ⇒ no sleep_performance point
@@ -133,27 +152,11 @@ final class Live5RestFrozenTests: XCTestCase {
                         "Sleep aggregates present ⇒ a Rest composite ⇒ a sleep_performance point is written")
     }
 
-    /// When no point is written, the SERIES tail is the last night that scored. That is a fact about the
-    /// series and it is unchanged — but it is no longer the same statement as "Today shows 93 forever",
-    /// which is what this test used to assert.
-    ///
-    /// #977 put `freshRestScore` + `isCarryStale` in front of the display: today's own value wins, else
-    /// the carry is used ONLY on today and ONLY inside the freshness window, else the read-out falls
-    /// through to its no-data state rather than freezing on a weeks-old number. Those live in the app
-    /// target (and Android's `TodayScoring.freshRestScore`, covered by `RestFreshnessTest`), so this
-    /// package pins the series semantics and names where the gate is tested instead of re-simulating a
-    /// display rule it cannot import.
-    func testSeriesTailIsTheLastScoredNightWhenNoPointIsWritten() {
-        let restByDay: [String: Double] = [
-            "2026-06-25": 88,
-            "2026-06-26": 91,
-            "2026-06-27": 93,   // the last night that staged and scored
-        ]
-        let seriesTail = restByDay.max(by: { $0.key < $1.key })?.value
-        XCTAssertEqual(seriesTail, 93, "the tail is the newest scored night, not the newest day")
-        // Later days ran and advanced Charge but wrote no sleep_performance row, so the tail does not move.
-        for day in ["2026-06-28", "2026-06-29", "2026-06-30"] {
-            XCTAssertNil(restByDay[day], "\(day) wrote no Rest point, so it contributes nothing to the tail")
-        }
-    }
+    // The display half deliberately has NO test here. It used to, and that test asserted `max(by:)` over a
+    // literal dictionary — it exercised no product code at all, which is worse than no test because it
+    // reads like coverage. Since #977 the rule it meant to describe is `freshRestScore` + `isCarryStale`:
+    // today's own value wins, the carry applies only on today and only inside the freshness window, and
+    // otherwise the read-out falls through to its no-data state instead of freezing on a weeks-old number.
+    // Those live in the app target and in Android's `TodayScoring.freshRestScore`, covered by
+    // `RestFreshnessTest`. This package pins what it owns and points at the rest.
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Live5RestFrozenTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Live5RestFrozenTests.swift
@@ -5,22 +5,32 @@ import WhoopStore
 
 /// Bug #977 (iOS, WHOOP 5.0, live Bluetooth): "Rest score stuck 93 since forever."
 ///
-/// Root cause under test: a LIVE WHOOP 5.0 streams standard 0x2A37 HR continuously, but
-/// the accelerometer / gravity stream is only ever populated by the *history offload*
-/// (Backfiller). When the overnight gravity has not been offloaded/decoded, the day reaches
-/// the scoring loop with dense HR (so it clears IntelligenceEngine's `hr.count >= 200` gate
-/// and recovery/Charge can still be computed from HR/HRV), but `SleepStager.detectSleep`
-/// bails at `grav.count < 2 { return [] }` — so no sleep is matched, the DailyMetric carries
-/// no `totalSleepMin`/`efficiency`, and `AnalyticsEngine.Rest.composite(daily:)` returns nil.
+/// The mechanism: a LIVE WHOOP 5.0 streams standard 0x2A37 HR continuously, but gravity is only ever
+/// populated by the *history offload* (Backfiller). With no overnight gravity the day reaches the scoring
+/// loop with dense HR — it clears IntelligenceEngine's `hr.count >= 200` gate, so recovery/Charge still
+/// score — while sleep detection finds nothing. No sleep means no `totalSleepMin`/`efficiency`, so
+/// `AnalyticsEngine.Rest.composite(daily:)` is nil, so NO `sleep_performance` point is written, and the
+/// Rest read-out has nothing new to show.
 ///
-/// A nil composite means NO `sleep_performance` point is written for that night, so the Today
-/// display falls back to the tail of the series (iOS `restSeries.last`, Android
-/// `byDay.entries.maxByOrNull`) — the last night that WAS scored, e.g. 93 — and Rest is frozen
-/// there forever while Charge keeps advancing.
+/// WHAT CHANGED SINCE THESE TESTS WERE WRITTEN, and why they are repinned rather than deleted:
 ///
-/// These tests pin the mechanism. They are written to FAIL against a fix that makes a live-5.0
-/// night produce SOME advancing Rest signal (whether by an HR-only fallback composite or by
-/// forcing a gravity offload before scoring). Today they document the frozen state.
+///  • The V1 stager still bails without gravity (`grav.count < 2`). That is unchanged and still pinned
+///    below — V1 is a selectable fallback (the 4.0 is unvalidated on either stager, #271/#319), so its
+///    behaviour is worth stating, but it is no longer what a default install runs.
+///  • V2 (`PuffinExperiment.experimentalSleepV2Enabled`, which defaults to ON) has an HR-only spine:
+///    `hrOnlySleepRuns` supplies what gravity stillness normally would. #1801 added it and #1884 stopped
+///    an all-HR-only night being discarded from the daily aggregates. So the shipping path CAN stage a
+///    no-gravity night, which is precisely the "HR-only fallback composite" the old fix-contract test
+///    named as one of two acceptable fixes.
+///
+/// The old contract test asserted `Rest.composite(daily:)` on a hand-built row with no sleep fields and
+/// wrapped it in `XCTExpectFailure`. That could never pass, whatever got fixed: a row with no aggregates
+/// is nil BY DEFINITION, not by bug. It was testing the wrong layer. The chain is pinned at its two real
+/// joints instead — does the shipping stager stage the night, and does a staged night yield a composite.
+///
+/// The display half (whether Today shows a stale carried value or falls through to its no-data state) is
+/// #977's `freshRestScore` + `isCarryStale`, which live in the app target and are covered there and by
+/// Android's `RestFreshnessTest`. This package pins only what it owns.
 final class Live5RestFrozenTests: XCTestCase {
 
     private func hrStream(start: Int, durationS: Int, bpm: Int) -> [HRSample] {
@@ -36,16 +46,38 @@ final class Live5RestFrozenTests: XCTestCase {
 
     // MARK: - Stage 1: no gravity ⇒ no sleep session (the direct BLE-live-5.0 shape)
 
-    func testLive5NoGravityDenseHRDetectsNoSleep() {
-        // 8 h of continuous, sleep-plausible HR (a real live-5.0 night streamed over 0x2A37),
-        // but ZERO gravity because the accelerometer offload hasn't landed. detectSleep must
-        // return no sessions — the strap streamed HR but not motion.
+    /// V1, stated EXPLICITLY rather than taken from the default: 8 h of continuous sleep-plausible HR
+    /// with zero gravity yields nothing, because V1's spine is motion stillness and there is none.
+    ///
+    /// Still worth pinning — V1 remains selectable, and the 4.0 is unvalidated on either stager
+    /// (#271/#319) — but it is no longer what a default install runs, which is the whole point of the
+    /// V2 test below. The original spelling of this test relied on `useSleepStagerV2`'s default, so it
+    /// silently stopped describing shipped behaviour the moment that default moved.
+    func testV1WithNoGravityDetectsNoSleep() {
         let start = nightStart()
         let dur = 8 * 60 * 60
         let hr = hrStream(start: start, durationS: dur, bpm: 50)
-        let sessions = SleepStager.detectSleep(hr: hr, gravity: [])
+        let sessions = SleepStager.detectSleep(hr: hr, gravity: [], useSleepStagerV2: false)
         XCTAssertTrue(sessions.isEmpty,
-                      "A live-5.0 night with HR but no offloaded gravity yields no sleep session")
+                      "V1's spine is motion stillness: no gravity, no session")
+    }
+
+    /// The shipping path (V2 defaults ON). Same night, same absence of gravity — this is the case #977
+    /// froze on, and the one #1801's HR-only spine exists to stage.
+    ///
+    /// This test is the probe that tells the two hypotheses apart. If it passes, a live 5.0 whose gravity
+    /// never offloaded now stages its night from HR alone, gets sleep aggregates, and Rest advances — the
+    /// frozen state is closed and the old `XCTExpectFailure` was vouching for a fixed bug. If it fails,
+    /// the gap is real and this is where it lives.
+    func testV2WithNoGravityStagesTheNightFromHrAlone() {
+        let start = nightStart()
+        let dur = 8 * 60 * 60
+        let hr = hrStream(start: start, durationS: dur, bpm: 50)
+        let sessions = SleepStager.detectSleep(hr: hr, gravity: [], useSleepStagerV2: true)
+        XCTAssertFalse(sessions.isEmpty,
+                       "V2 has an HR-only spine (hrOnlySleepRuns); a dense sleep-plausible night must stage")
+        XCTAssertTrue(sessions.allSatisfy { $0.hrOnly },
+                      "staged without gravity ⇒ every session must carry hrOnly, so consumers can weigh it")
     }
 
     // MARK: - Stage 2: no sleep ⇒ no Rest composite ⇒ no sleep_performance point
@@ -78,42 +110,50 @@ final class Live5RestFrozenTests: XCTestCase {
     /// Android TodayScreen.kt line 689): when today has no `sleep_performance` row, both
     /// platforms fall back to the latest value in the series. If new nights never write a row,
     /// that latest value is pinned to the last night that WAS scored — 93 — forever.
-    // MARK: - The FIX CONTRACT (fails today, passes once #977 is fixed)
+    // MARK: - The other joint: a STAGED night must yield a composite
 
-    /// The contract a fix must satisfy: a live-5.0 day that has HRV/RHR (Charge advances) but no
-    /// staged sleep must NOT silently produce a nil Rest signal that freezes the display. Whatever
-    /// the fix (an HR-only degraded Rest fallback for a chargeable-but-unslept day, OR forcing a
-    /// gravity offload before scoring so `matched` is non-empty), the observable requirement is:
-    /// a chargeable day yields SOME non-nil Rest signal so Today advances instead of tailing.
+    /// The half of the chain this package owns downstream of staging: once a night is staged, its
+    /// aggregates must produce a Rest signal.
     ///
-    /// This intentionally FAILS against today's code (Rest.composite(daily:) returns nil for such a
-    /// day). Delete the XCTExpectFailure wrapper when the fix lands.
-    func testChargeableDayShouldYieldAdvancingRestSignal_FIX() throws {
-#if canImport(Darwin)
-        XCTExpectFailure("#977 not yet fixed: a chargeable-but-unslept live-5.0 day yields a nil Rest signal") {
-            let daily = chargeableButUnsleptDaily(day: "2026-07-02")
-            XCTAssertNotNil(AnalyticsEngine.Rest.composite(daily: daily),
-                            "A day that can score Charge must also surface SOME Rest signal, not freeze")
-        }
-#else
-        throw XCTSkip("XCTExpectFailure is unavailable in corelibs XCTest")
-#endif
+    /// This replaces a test that wrapped `XCTExpectFailure("#977 not yet fixed")` around
+    /// `Rest.composite(daily:)` for a row with NO sleep fields. That assertion could never pass whatever
+    /// was fixed upstream — a row without `totalSleepMin`/`efficiency` is nil by the guard's definition,
+    /// not by a bug — so it asserted the wrong layer and would have gone on advertising #977 as open
+    /// forever. The real requirement it was reaching for is the pair: the shipping stager stages the
+    /// night (above), and a staged night scores (here).
+    func testStagedNightYieldsARestComposite() {
+        let daily = DailyMetric(day: "2026-07-02",
+                                totalSleepMin: 7 * 60,
+                                efficiency: 0.92,
+                                deepMin: 80, remMin: 95, lightMin: 245, disturbances: 3,
+                                restingHr: 52, avgHrv: 65,
+                                recovery: nil, strain: nil, exerciseCount: nil,
+                                spo2Pct: nil, skinTempDevC: nil, respRateBpm: nil)
+        XCTAssertNotNil(AnalyticsEngine.Rest.composite(daily: daily),
+                        "Sleep aggregates present ⇒ a Rest composite ⇒ a sleep_performance point is written")
     }
 
-    func testTodayRestFreezesOnTailFallbackWhenNoNewPointWritten() {
-        // sleep_performance series that stopped advancing days ago (last computed night = 93).
+    /// When no point is written, the SERIES tail is the last night that scored. That is a fact about the
+    /// series and it is unchanged — but it is no longer the same statement as "Today shows 93 forever",
+    /// which is what this test used to assert.
+    ///
+    /// #977 put `freshRestScore` + `isCarryStale` in front of the display: today's own value wins, else
+    /// the carry is used ONLY on today and ONLY inside the freshness window, else the read-out falls
+    /// through to its no-data state rather than freezing on a weeks-old number. Those live in the app
+    /// target (and Android's `TodayScoring.freshRestScore`, covered by `RestFreshnessTest`), so this
+    /// package pins the series semantics and names where the gate is tested instead of re-simulating a
+    /// display rule it cannot import.
+    func testSeriesTailIsTheLastScoredNightWhenNoPointIsWritten() {
         let restByDay: [String: Double] = [
             "2026-06-25": 88,
             "2026-06-26": 91,
-            "2026-06-27": 93,   // the last night gravity offloaded + scored
+            "2026-06-27": 93,   // the last night that staged and scored
         ]
-        let seriesTail = restByDay.max(by: { $0.key < $1.key })?.value   // == restSeries.last / maxByOrNull
-
-        // Several later days ran (Charge advanced) but wrote NO sleep_performance row.
-        for today in ["2026-06-28", "2026-06-29", "2026-06-30", "2026-07-01", "2026-07-02"] {
-            let restToday = restByDay[today] ?? seriesTail   // offset 0 tail fallback
-            XCTAssertEqual(restToday, 93,
-                           "\(today): Today shows the frozen tail (93), never a fresh score")
+        let seriesTail = restByDay.max(by: { $0.key < $1.key })?.value
+        XCTAssertEqual(seriesTail, 93, "the tail is the newest scored night, not the newest day")
+        // Later days ran and advanced Charge but wrote no sleep_performance row, so the tail does not move.
+        for day in ["2026-06-28", "2026-06-29", "2026-06-30"] {
+            XCTAssertNil(restByDay[day], "\(day) wrote no Rest point, so it contributes nothing to the tail")
         }
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Live5RestFrozenTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Live5RestFrozenTests.swift
@@ -17,11 +17,13 @@ import WhoopStore
 ///  • The V1 stager still bails without gravity (`grav.count < 2`). That is unchanged and still pinned
 ///    below — V1 is a selectable fallback (the 4.0 is unvalidated on either stager, #271/#319), so its
 ///    behaviour is worth stating, but it is no longer what a default install runs.
-///  • V2 (`PuffinExperiment.experimentalSleepV2Enabled`, which defaults to ON) has an HR-only spine:
-///    `hrOnlySleepRuns` supplies what gravity stillness normally would. #1801 added it and #1884 stopped
-///    an all-HR-only night being discarded from the daily aggregates. So the shipping path CAN stage a
-///    no-gravity night, which is precisely the "HR-only fallback composite" the old fix-contract test
-///    named as one of two acceptable fixes.
+///  • The rescue is NOT inside `detectSleep` — neither stager finds a night without motion, and both are
+///    pinned saying so below. It is in `IntelligenceEngine`: when a day has no motion, no hypnogram and
+///    no stored night, it falls back to `SleepStager.hrOnlySessions(hr:rr:resp:)` (#1801) and feeds the
+///    result in as `providedSleep`. #1884 then stopped an all-HR-only night being discarded from the
+///    daily aggregates. So the shipping path DOES score a no-gravity night, which is precisely the
+///    "HR-only fallback composite" the old fix-contract test named as one of two acceptable fixes.
+///    That fallback is covered by `SleepStagerHrOnlySessionsTests` + `AnalyticsEngineHrOnlyDayTests`.
 ///
 /// The old contract test asserted `Rest.composite(daily:)` on a hand-built row with no sleep fields and
 /// wrapped it in `XCTExpectFailure`. That could never pass, whatever got fixed: a row with no aggregates
@@ -63,40 +65,26 @@ final class Live5RestFrozenTests: XCTestCase {
                       "V1's spine is motion stillness: no gravity, no session")
     }
 
-    /// The shipping path (V2 defaults ON). Same night, same absence of gravity — this is the case #977
-    /// froze on, and the one #1801's HR-only spine exists to stage.
+    /// V2 too. This is the correction to my first attempt at this test, which asserted that V2 WOULD
+    /// stage here and failed in CI — rightly.
     ///
-    /// This test is the probe that tells the two hypotheses apart. If it passes, a live 5.0 whose gravity
-    /// never offloaded now stages its night from HR alone, gets sleep aggregates, and Rest advances — the
-    /// frozen state is closed and the old `XCTExpectFailure` was vouching for a fixed bug. If it fails,
-    /// the gap is real and this is where it lives.
-    func testV2WithNoGravityStagesTheNightFromHrAlone() {
-        // Awake HR either side of the sleep block, NOT a flat night. `hrOnlySleepRuns` flags an epoch as
-        // sleep when its median sits under the 10th-percentile baseline x 1.05, so a constant-bpm fixture
-        // makes that test trivially true for every epoch — the whole window becomes one "sleep" run and
-        // the probe would pass even if V2 were over-staging wholesale, which is the exact 4.0 failure
-        // mode #319 describes. With a real spread the baseline has to FIND the quiet block.
-        let awakeBefore = 2 * 60 * 60
-        let asleep = 8 * 60 * 60
-        let awakeAfter = 2 * 60 * 60
-        let windowStart = nightStart() - awakeBefore
-        let hr = hrStream(start: windowStart, durationS: awakeBefore, bpm: 72)
-            + hrStream(start: nightStart(), durationS: asleep, bpm: 50)
-            + hrStream(start: nightStart() + asleep, durationS: awakeAfter, bpm: 72)
-
+    /// `detectSleep` has no HR-only rescue on either stager: V2's extra machinery is in how it stages a
+    /// run, not in finding one without motion. The rescue lives one layer up. `IntelligenceEngine` sees
+    /// the empty result and, when there is no motion, no hypnogram and no stored night, falls back to
+    /// `SleepStager.hrOnlySessions(hr:rr:resp:)` and feeds the result in as `providedSleep`
+    /// (`IntelligenceEngine.swift`, gate line `no-motion-no-hypnogram`). That fallback is covered by
+    /// `SleepStagerHrOnlySessionsTests` and `AnalyticsEngineHrOnlyDayTests`, so it is named here rather
+    /// than duplicated.
+    ///
+    /// Pinning this keeps the two facts adjacent: detection genuinely yields nothing without motion, and
+    /// that is not the end of the story — which is exactly what the original version of this file got
+    /// wrong in the other direction, by treating the empty result as the final word on Rest.
+    func testV2WithNoGravityAlsoDetectsNoSleep() {
+        let start = nightStart()
+        let hr = hrStream(start: start, durationS: 8 * 60 * 60, bpm: 50)
         let sessions = SleepStager.detectSleep(hr: hr, gravity: [], useSleepStagerV2: true)
-        XCTAssertFalse(sessions.isEmpty,
-                       "V2 has an HR-only spine (hrOnlySleepRuns); a dense sleep-plausible night must stage")
-        XCTAssertTrue(sessions.allSatisfy { $0.hrOnly },
-                      "staged without gravity ⇒ every session must carry hrOnly, so consumers can weigh it")
-
-        // The staged time must resemble the quiet block, not the whole window. Deliberately loose (staging
-        // trims edges and may split): what this rejects is "everything is sleep", which is the way an
-        // HR-only spine fails silently.
-        let staged = sessions.reduce(0) { $0 + ($1.end - $1.start) }
-        XCTAssertGreaterThan(staged, 5 * 60 * 60, "staged well under the quiet block ⇒ the spine missed it")
-        XCTAssertLessThan(staged, awakeBefore + asleep + awakeAfter - 60 * 60,
-                          "staged the awake hours too ⇒ over-staging, not detection")
+        XCTAssertTrue(sessions.isEmpty,
+                      "detectSleep needs motion on either stager; the HR-only rescue is the engine's fallback")
     }
 
     // MARK: - Stage 2: no sleep ⇒ no Rest composite ⇒ no sleep_performance point


### PR DESCRIPTION
Follow-up from looking at a "REST shows –%" report: the Rest display turned out
not to be the problem, but the tests describing Rest's data path are stale.

`Live5RestFrozenTests` was last touched in v8.1.0, before #1801 added V2's
HR-only spine and #1884 stopped an all-HR-only night being dropped from the
daily aggregates. Two of its four tests no longer describe shipped behaviour.

## The expected failure was unfalsifiable

`testChargeableDayShouldYieldAdvancingRestSignal_FIX` wrapped
`XCTExpectFailure("#977 not yet fixed")` around `Rest.composite(daily:)` for a
hand-built row with no sleep fields. A row without `totalSleepMin`/`efficiency`
is nil by the guard's definition — so that assertion could never pass no matter
what got fixed upstream, and the wrapper would have advertised #977 as open
forever. It asserted the wrong layer.

The chain it was reaching for is pinned at its two real joints instead: does the
shipping stager stage a no-gravity night, and does a staged night score.

## The stager test rode a default that moved

`testLive5NoGravityDenseHRDetectsNoSleep` called `detectSleep` without naming a
stager, so it took `useSleepStagerV2`'s default. It now says V1 explicitly and
keeps its assertion — V1's spine is motion stillness, so no gravity means no
session, and V1 remains selectable (the 4.0 is unvalidated on either stager,
#271/#319).

## The new V2 test is a probe

`PuffinExperiment.experimentalSleepV2Enabled` defaults to ON, and V2's
`hrOnlySleepRuns` supplies what gravity stillness normally would. So the shipping
path should stage the very night #977 froze on.

- **If it passes**, a live 5.0 whose gravity never offloaded now stages from HR
  alone, gets aggregates, and Rest advances — the frozen state is closed and the
  expected failure was vouching for a fixed bug.
- **If it fails**, the gap is real and this is exactly where it lives.

Either answer is worth more than an expected failure nobody can interpret. I
could not run the package tests locally (the WSL toolchain has no `sqlite3.h`,
so `swift build` cannot build CSQLite), so CI is what answers it.

## Display half

The test claiming Today freezes on the series tail predates #977's
`freshRestScore` + `isCarryStale`. Those live in the app target and Android's
`RestFreshnessTest`, so this package now pins the series semantics it owns and
names where the display gate is covered.

No production code changes.