### PR TITLE
wind-down: pin the per-day nudge trigger to the nudge's day, not the wake's (#1863)

### DIFF
--- a/Strand/System/WindDownNudge.swift
+++ b/Strand/System/WindDownNudge.swift
@@ -95,6 +95,27 @@ enum WindDownNudge {
         return ((raw % day) + day) % day
     }
 
+    /// The day shift for a given weekday's nudge — 0 if the nudge lands on the same day as the wake,
+    /// -1 if it wraps to the previous evening. The minute-of-day wrap in `nudgeMinuteOfDay` silently
+    /// loses which day the nudge belongs to; this companion carries that information so the scheduler
+    /// can pin the trigger to the nudge's day, not the wake's. (#1863)
+    ///
+    /// `raw` is always in [-780, 1139] given the clamped inputs (wake ≤ 1439, sleepNeed ≥ 300, lead ≤ 120),
+    /// so the shift is always 0 or -1 — but the formula is general floor-division for safety.
+    static func nudgeDayShift(forWeekday weekday: Int) -> Int {
+        let raw = wakeMinutes(forWeekday: weekday) - sleepNeedMinutes - leadMinutes
+        let day = 24 * 60
+        // Floor division (Swift's `/` truncates toward zero, so adjust for negatives).
+        return raw < 0 ? -(((-raw - 1) / day) + 1) : raw / day
+    }
+
+    /// Shift a Calendar weekday (1=Sun…7=Sat) by a day count, wrapping through the week end. (#1863)
+    /// `shiftedWeekday(weekday: 1, by: -1)` → 7 (Sunday's evening-before nudge fires on Saturday).
+    static func shiftedWeekday(weekday: Int, by shift: Int) -> Int {
+        let zeroBased = weekday - 1 + shift
+        return ((zeroBased % 7) + 7) % 7 + 1
+    }
+
     // MARK: - Public API
 
     /// The result of enabling the nudge — lets the UI react instead of silently persisting an "on" toggle
@@ -190,11 +211,18 @@ enum WindDownNudge {
         if hasPerDayOverrides {
             for weekday in 1...7 {
                 let minute = nudgeMinuteOfDay(forWeekday: weekday)
+                // #1863 — an early wake (e.g. 03:30) wraps the nudge minute to the previous evening
+                // (19:00). The minute wrap alone loses which DAY that evening belongs to, so the trigger
+                // was pinned to the wake's own weekday — firing 8+ hours AFTER the wake it precedes.
+                // Derive the day shift and pin the trigger to the nudge's day, not the wake's.
+                let shift = nudgeDayShift(forWeekday: weekday)
                 var comps = DateComponents()
-                comps.weekday = weekday   // Calendar weekday 1=Sun…7=Sat → fires weekly on that day
+                comps.weekday = shiftedWeekday(weekday: weekday, by: shift)   // the nudge's day
                 comps.hour = minute / 60
                 comps.minute = minute % 60
                 let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: true)
+                // The request id stays keyed to the wake's weekday so toggling/clearing overrides
+                // always matches the ids `perDayRequestIds` enumerates.
                 center.add(UNNotificationRequest(identifier: "\(requestId)-wd\(weekday)",
                                                  content: content, trigger: trigger))
             }

--- a/StrandTests/WindDownPerDayOverrideTests.swift
+++ b/StrandTests/WindDownPerDayOverrideTests.swift
@@ -80,4 +80,60 @@ final class WindDownPerDayOverrideTests: XCTestCase {
         WindDownNudge.setWakeOverride(weekday: 9, minutes: 8 * 60)   // no weekday 9
         XCTAssertFalse(WindDownNudge.hasPerDayOverrides)
     }
+
+    // MARK: - #1863: day shift and weekday pinning
+
+    func testShiftedWeekday_wrapsThroughWeekEnd() {
+        // Sunday (1) − 1 → Saturday (7); Monday (2) − 1 → Sunday (1); no shift is identity.
+        XCTAssertEqual(WindDownNudge.shiftedWeekday(weekday: 1, by: -1), 7)
+        XCTAssertEqual(WindDownNudge.shiftedWeekday(weekday: 2, by: -1), 1)
+        XCTAssertEqual(WindDownNudge.shiftedWeekday(weekday: 3, by: -1), 2)
+        XCTAssertEqual(WindDownNudge.shiftedWeekday(weekday: 7, by: -1), 6)
+        for weekday in 1...7 {
+            XCTAssertEqual(WindDownNudge.shiftedWeekday(weekday: weekday, by: 0), weekday)
+        }
+    }
+
+    func testNudgeDayShift_earlyWake_isPreviousDay() {
+        // Tuesday 03:30 wake, default 8h need + 30m lead: raw = 210 − 480 − 30 = −300 → shift −1.
+        WindDownNudge.setWakeMinutes(7 * 60)
+        WindDownNudge.setWakeOverride(weekday: 3, minutes: 3 * 60 + 30)   // Tuesday 03:30
+        XCTAssertEqual(WindDownNudge.nudgeDayShift(forWeekday: 3), -1)
+        // The wrapped minute is 19:00 the previous evening.
+        XCTAssertEqual(WindDownNudge.nudgeMinuteOfDay(forWeekday: 3), 19 * 60)
+    }
+
+    func testNudgeDayShift_normalWake_isPreviousDay() {
+        // 07:00 wake, default 8h need + 30m lead: raw = 420 − 480 − 30 = −90 → shift −1.
+        WindDownNudge.setWakeMinutes(7 * 60)
+        XCTAssertEqual(WindDownNudge.nudgeDayShift(forWeekday: 3), -1)
+    }
+
+    func testNudgeDayShift_lateWake_isSameDay() {
+        // 09:00 wake, default 8h need + 30m lead: raw = 540 − 480 − 30 = 30 → shift 0.
+        WindDownNudge.setWakeMinutes(9 * 60)
+        XCTAssertEqual(WindDownNudge.nudgeDayShift(forWeekday: 3), 0)
+    }
+
+    func testEarlyWakeNudge_pinnedToPreviousDay() {
+        // #1863 scenario: Tuesday (weekday 3) 03:30 wake → nudge at 19:00 on Monday (weekday 2).
+        WindDownNudge.setWakeMinutes(7 * 60)
+        WindDownNudge.setWakeOverride(weekday: 3, minutes: 3 * 60 + 30)   // Tuesday 03:30
+        let shift = WindDownNudge.nudgeDayShift(forWeekday: 3)
+        let minute = WindDownNudge.nudgeMinuteOfDay(forWeekday: 3)
+        let nudgeWeekday = WindDownNudge.shiftedWeekday(weekday: 3, by: shift)
+        XCTAssertEqual(shift, -1)
+        XCTAssertEqual(minute, 19 * 60)            // 19:00
+        XCTAssertEqual(nudgeWeekday, 2)            // Monday, not Tuesday
+    }
+
+    func testEarlyWakeOnSunday_pinnedToSaturday() {
+        // Sunday (weekday 1) 03:30 wake → nudge at 19:00 on Saturday (weekday 7).
+        WindDownNudge.setWakeMinutes(7 * 60)
+        WindDownNudge.setWakeOverride(weekday: 1, minutes: 3 * 60 + 30)   // Sunday 03:30
+        let shift = WindDownNudge.nudgeDayShift(forWeekday: 1)
+        let nudgeWeekday = WindDownNudge.shiftedWeekday(weekday: 1, by: shift)
+        XCTAssertEqual(shift, -1)
+        XCTAssertEqual(nudgeWeekday, 7)            // Saturday, wrapping the week end
+    }
 }


### PR DESCRIPTION
## Summary

- Addresses #1863: the per-day wind-down nudge fired on the wrong weekday for an early wake
- `nudgeMinuteOfDay(forWeekday:)` wraps the nudge minute into [0, 1440) but silently loses which day that minute belongs to. The scheduler pinned the trigger to the wake's own weekday, so a Tuesday 03:30 wake scheduled its 19:00 nudge for Tuesday — 8.5 hours *after* the wake it exists to precede, pointing at Wednesday's wake instead
- Add `nudgeDayShift(forWeekday:)` (0 same-day, -1 previous-evening) and `shiftedWeekday(weekday:by:)` (wraps through the week end), and apply the shift to `comps.weekday` in `schedule()`
- The request id stays keyed to the wake's weekday so toggling/clearing overrides always matches `perDayRequestIds`
- Mirrors the Android reference from the issue: `floorDiv(wake - need - lead, 1440)` for the shift, `shiftWeekday` for the pin
- No UI change needed — `SmartAlarmView` reads the no-argument `nudgeMinuteOfDay()` (default wake), not the per-weekday version

#### Test plan

- [ ] `StrandTests` passes on the macOS/`Strand` leg of `app-build.yml` (includes the new `WindDownPerDayOverrideTests` cases)
- [ ] New tests verify: day shift is -1 for early/normal wakes, 0 for late wakes; `shiftedWeekday` wraps Sunday - 1 → Saturday; the #1863 scenario (Tuesday 03:30 → Monday 19:00) produces the correct nudge weekday
- [ ] Existing `WindDownPerDayOverrideTests` still pass (minute-of-day math unchanged)

Generated with [Devin](https://devin.ai)

