### PR TITLE
skin-temp: explorer leads with the absolute and honours the Settings choice (#1848)

### DIFF
--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -265,6 +265,32 @@ private let readingShortDateFormatter: DateFormatter = {
     return f
 }()
 
+// MARK: - Skin-temp explorer notes (#1847 / #1848)
+
+/// Whether the skin-temp explorer must explain that it fell back to deviations despite the
+/// user's Settings choice asking for temperatures. Twin of Android's `shouldExplainSkinTempFallback`.
+///
+/// True only when the user asked for absolute, the screen is NOT leading with absolutes, and NO
+/// night in the window carries one — so the fallback is total, not partial. A window with one
+/// stored temperature and twenty deltas still leads with temperatures (the #1850 window-wide rule),
+/// so this note stays silent there; it fires only when the setting genuinely cannot be honoured.
+func shouldExplainSkinTempFallback(prefer: SkinTempDisplay.Kind, leadsAbsolute: Bool,
+                                   anyAbsoluteInWindow: Bool) -> Bool {
+    prefer == .absolute && !leadsAbsolute && !anyAbsoluteInWindow
+}
+
+/// Whether the skin-temp explorer must explain that deviation-only nights were dropped from the
+/// series when leading with absolutes. Twin of Android's `shouldExplainShortenedSkinTempSeries`.
+///
+/// True ONLY when leading with the absolute — the deviation-led branch also drops rows (calibrating
+/// nights that have only an absolute, and the #622 bimodal partition), but those are the OPPOSITE
+/// kind, so this note's sentence would be precisely backwards there. True only when rows were
+/// actually dropped, so a complete series stays silent.
+func shouldExplainShortenedSkinTempSeries(leadsAbsolute: Bool, shownReadings: Int,
+                                          rowsWithEitherNumber: Int) -> Bool {
+    leadsAbsolute && shownReadings < rowsWithEitherNumber
+}
+
 // MARK: - Root: categorized list
 
 /// The "Explore" picker — categories as sections, metrics as rows, each pushing a
@@ -538,11 +564,18 @@ struct MetricDetailView: View {
     // Effort display scale (#268) — routes the Effort metric's numbers + unit; display-only, the plotted
     // series stays 0–100. Every other metric is scale-agnostic (see MetricDescriptor.format).
     @AppStorage(UnitPrefs.effortScaleKey) private var effortScaleRaw = EffortScale.hundred.rawValue
+    /// #1846/#1848: which skin-temp number the explorer leads with — absent/`""` = a temperature
+    /// (the default), or `SkinTempDisplay.Kind.deviation.rawValue` to lead with the ±baseline move.
+    /// Same key as Today/Health/Settings; display-only, nothing stored ever changes.
+    @AppStorage(UnitPrefs.skinTempDisplayKey) private var skinTempDisplayRaw = ""
     private var unitSystem: UnitSystem { UnitSystem(rawValue: unitSystemRaw) ?? .metric }
     private var temperatureUnit: TemperatureUnit {
         UnitPrefs.resolveTemperature(system: unitSystem, override: temperatureRaw)
     }
     private var effortScale: EffortScale { UnitPrefs.resolveEffortScale(effortScaleRaw) }
+    private var skinTempPreferred: SkinTempDisplay.Kind {
+        SkinTempDisplay.Kind(rawValue: skinTempDisplayRaw) ?? .absolute
+    }
     private func fmt(_ v: Double) -> String {
         metric.format(v, system: unitSystem, temperature: temperatureUnit, effortScale: effortScale)
     }
@@ -569,6 +602,13 @@ struct MetricDetailView: View {
     /// reads it, so it can lag the rest of the screen by a second without anyone noticing.
     @State private var correlationsLoaded = false
 
+    /// #1848: the skin-temp explorer's explanatory note (nil when none is needed). Set in `load()`
+    /// alongside the series, from the same `repo.days` scan that decides which kind to lead with.
+    /// Two notes, mutually exclusive: (1) the user asked for temperatures but the window has none,
+    /// so deviations are shown instead; (2) leading with absolutes dropped deviation-only nights
+    /// from the series. Both are real on Apple — the same two cases the Android twin carries.
+    @State private var skinTempNote: String? = nil
+
     /// Cached correlation scan, keyed by its inputs (selected range + the metric id),
     /// so the full cross-catalog Pearson sweep runs ONLY when those change — not on
     /// every body re-eval (hover / 1 Hz HR ticks / animation). Recomputed from
@@ -576,7 +616,7 @@ struct MetricDetailView: View {
     @State private var correlationCache: [CorrRow] = []
     /// The (metricID, range) the cache was built for; nil means "not yet computed".
     @State private var correlationKey: String? = nil
-    private var loadTaskID: String { "\(metric.id)|\(repo.refreshSeq)" }
+    private var loadTaskID: String { "\(metric.id)|\(repo.refreshSeq)|\(skinTempDisplayRaw)" }
 
     // MARK: Derived
 
@@ -746,6 +786,23 @@ struct MetricDetailView: View {
                     // with the range pill. Then the frosted chart / stat tiles / correlations.
                     heroHeader(effectiveRange: effRange, windowed: win, windowFellBack: fellBack)
                     heroChart(effectiveRange: effRange, windowed: win, windowFellBack: fellBack)
+                    // #1848: the skin-temp explorer's explanatory note (nil for every other metric and
+                    // for a skin-temp screen that needs no explanation). Sits between the chart and the
+                    // stats so it reads as context for the series just plotted, not as a generic banner.
+                    if let note = skinTempNote {
+                        NoopCard {
+                            HStack(alignment: .top, spacing: 10) {
+                                Image(systemName: "info.circle")
+                                    .font(.system(size: 14, weight: .medium))
+                                    .foregroundStyle(StrandPalette.textTertiary)
+                                    .accessibilityHidden(true)
+                                Text(note)
+                                    .font(StrandFont.footnote)
+                                    .foregroundStyle(StrandPalette.textSecondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                        }
+                    }
                     statRow(effectiveRange: effRange, windowed: win)
                     readingsTable(windowed: win)
                     correlationCard
@@ -850,6 +907,81 @@ struct MetricDetailView: View {
                     sourceByDay[point.day] = spo2CandidateAttributionSource
                 }
                 series = byDay.sorted { $0.key < $1.key }.map { (day: $0.key, value: $0.value) }
+            }
+        }
+        // #1848: skin-temp explorer — give it a skin-temp-specific branch mirroring the Android
+        // `buildVitalDetail` "skin" case, rather than the shared `dailyColumn` → `skinTempDevC` path.
+        //
+        // The shared mapper returns `skinTempDevC` only, so the explorer never leads with the measured
+        // absolute (`skinTempC`) and ignores the Settings choice (#1846). Repointing `dailyColumn`'s
+        // `skin_temp` case would change which series Trends plots and what the band is computed against
+        // (its callers include the trend series and the metric-catalog availability check), so the fix
+        // is a branch HERE, not a change to the shared mapper.
+        //
+        // The preference applies across the WINDOW (#1850), not just the newest row: a wearer with
+        // twenty stored temperatures and one recent night without saw twenty-three deltas — the setting
+        // says Temperature and the app HAS temperatures. `leadReading`'s rule lifted to the window: the
+        // chosen kind wins whenever any night carries it, the other is still the fallback, so a choice
+        // can never empty the screen.
+        //
+        // An absolute may live in EITHER column (#622: a WHOOP CSV import writes absolute °C into
+        // `skinTempDevC`), so both count here and in the series below.
+        skinTempNote = nil
+        if metric.key == "skin_temp" {
+            let days = repo.days
+            let anyAbsolute = days.contains { row in
+                row.skinTempC != nil
+                    || row.skinTempDevC.map(VitalBands.isAbsoluteSkinTemp) == true
+            }
+            let anyDeviation = days.contains { row in
+                row.skinTempDevC.map { !VitalBands.isAbsoluteSkinTemp($0) } == true
+            }
+            if anyAbsolute || anyDeviation {
+                let leadsAbsolute: Bool
+                switch skinTempPreferred {
+                case .absolute:   leadsAbsolute = anyAbsolute
+                case .deviation:  leadsAbsolute = !anyDeviation && anyAbsolute
+                }
+                if leadsAbsolute {
+                    // An absolute-led series takes EVERY absolute reading, whichever column holds it.
+                    // `skinTempC` is the on-device computed absolute; `skinTempDevC` may hold a CSV-imported
+                    // absolute (#622 bimodal). Mixing is only unsound ACROSS scales; these are the same scale.
+                    series = days.compactMap { row in
+                        let v = row.skinTempC
+                            ?? row.skinTempDevC.flatMap { VitalBands.isAbsoluteSkinTemp($0) ? $0 : nil }
+                        return v.map { (day: row.day, value: $0) }
+                    }.sorted { $0.day < $1.day }
+                } else {
+                    // Genuine deviations only — an imported absolute sitting in `skinTempDevC` belongs to
+                    // the other scale and is excluded, exactly as before.
+                    series = days.compactMap { row in
+                        row.skinTempDevC.flatMap { !VitalBands.isAbsoluteSkinTemp($0) ? $0 : nil }
+                            .map { (day: row.day, value: $0) }
+                    }.sorted { $0.day < $1.day }
+                }
+                // Rebuild sourceByDay for the new series. `DailyMetric` has no per-row deviceId on Apple
+                // (the merged cache doesn't carry one), so every reading attributes to the metric's own
+                // source — the same source the `exploreSeries` daily-column layer would have used.
+                sourceByDay = Dictionary(series.map { ($0.day, metric.source) },
+                                         uniquingKeysWith: { first, _ in first })
+                // The two #1847 notes — both cases exist on Apple too:
+                // (1) Settings asked for a temperature and none of these nights has one → say so, because
+                //     silently falling back is why the setting reads as broken. Nights scored before
+                //     `skinTempC` shipped kept only the deviation; a scoring pass refills them.
+                // (2) Leading with the absolute drops deviation-only nights from the series — which can
+                //     now include the most recent one. Say why rather than letting history look like it
+                //     vanished. (Deviation-led drops are the OPPOSITE kind, so the note is gated to
+                //     absolute-led only — see `shouldExplainShortenedSkinTempSeries`.)
+                let shownReadings = series.count
+                let rowsWithEither = days.count { $0.skinTempC != nil || $0.skinTempDevC != nil }
+                if shouldExplainSkinTempFallback(prefer: skinTempPreferred, leadsAbsolute: leadsAbsolute,
+                                                 anyAbsoluteInWindow: anyAbsolute) {
+                    skinTempNote = String(localized: "No measured temperature for these nights — showing the difference from your baseline instead. A re-score refills temperatures for nights that have one.")
+                } else if shouldExplainShortenedSkinTempSeries(leadsAbsolute: leadsAbsolute,
+                                                                shownReadings: shownReadings,
+                                                                rowsWithEitherNumber: rowsWithEither) {
+                    skinTempNote = String(localized: "Only nights with a measured temperature are shown — the others only have a baseline difference.")
+                }
             }
         }
         // #943 selection seam: a locked default (.month with under a week of history) no longer

--- a/StrandTests/SkinTempExplorerNoteTests.swift
+++ b/StrandTests/SkinTempExplorerNoteTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+import StrandAnalytics
+@testable import Strand
+
+/// #1848: the skin-temp explorer's two explanatory notes (#1847), pure-function twins of Android's
+/// `shouldExplainSkinTempFallback` and `shouldExplainShortenedSkinTempSeries`.
+///
+/// Both notes are gated so they fire ONLY when the sentence they carry is true — a note that says the
+/// opposite of what happened is worse than silence. The fallback note fires when the user asked for
+/// temperatures and the window has none; the shortened-series note fires when leading with absolutes
+/// dropped deviation-only nights. The deviation-led branch also drops rows (calibrating nights with
+/// only an absolute), but those are the OPPOSITE kind, so the shortened-series note is gated to
+/// absolute-led only.
+final class SkinTempExplorerNoteTests: XCTestCase {
+
+    // MARK: - shouldExplainSkinTempFallback
+
+    func testFallbackExplainedWhenUserAskedForAbsoluteButWindowHasNone() {
+        XCTAssertTrue(shouldExplainSkinTempFallback(
+            prefer: .absolute, leadsAbsolute: false, anyAbsoluteInWindow: false))
+    }
+
+    func testFallbackSilentWhenWindowHasAbsoluteEvenIfLatestLacksOne() {
+        // #1850: the preference applies across the window. A window with one stored temperature
+        // and twenty deltas still leads with temperatures, so the fallback note stays silent.
+        XCTAssertFalse(shouldExplainSkinTempFallback(
+            prefer: .absolute, leadsAbsolute: true, anyAbsoluteInWindow: true))
+    }
+
+    func testFallbackSilentWhenUserAskedForDeviation() {
+        // The user chose "vs baseline" — showing deviations is honouring the choice, not falling back.
+        XCTAssertFalse(shouldExplainSkinTempFallback(
+            prefer: .deviation, leadsAbsolute: false, anyAbsoluteInWindow: false))
+    }
+
+    func testFallbackSilentWhenLeadingAbsoluteAsRequested() {
+        XCTAssertFalse(shouldExplainSkinTempFallback(
+            prefer: .absolute, leadsAbsolute: true, anyAbsoluteInWindow: true))
+    }
+
+    // MARK: - shouldExplainShortenedSkinTempSeries
+
+    func testShortenedSeriesExplainedWhenAbsoluteLedDropsNights() {
+        XCTAssertTrue(shouldExplainShortenedSkinTempSeries(
+            leadsAbsolute: true, shownReadings: 21, rowsWithEitherNumber: 40))
+    }
+
+    func testShortenedSeriesSilentWhenEveryNightIsShown() {
+        XCTAssertFalse(shouldExplainShortenedSkinTempSeries(
+            leadsAbsolute: true, shownReadings: 23, rowsWithEitherNumber: 23))
+    }
+
+    func testShortenedSeriesSilentWhenNothingToShow() {
+        XCTAssertFalse(shouldExplainShortenedSkinTempSeries(
+            leadsAbsolute: true, shownReadings: 0, rowsWithEitherNumber: 0))
+    }
+
+    func testShortenedSeriesNeverExplainsWhenLeadingWithDeviation() {
+        // The deviation-led branch ALSO drops rows (calibrating nights with only an absolute), but
+        // those are the OPPOSITE kind — "only nights with a measured temperature are shown" would be
+        // precisely backwards. Ungated, this fired the moment a wearer picked "vs baseline" with any
+        // calibrating night in the window.
+        XCTAssertFalse(shouldExplainShortenedSkinTempSeries(
+            leadsAbsolute: false, shownReadings: 21, rowsWithEitherNumber: 40))
+    }
+}


### PR DESCRIPTION
## Summary

- Give `MetricExplorerView`'s `MetricDetailView` a skin-temp-specific branch mirroring Android's `buildVitalDetail` "skin" case, so the explorer honours the `units.skinTempDisplay` Settings choice instead of always leading with the deviation via the shared `Repository.dailyColumn` mapper.
- When leading absolute, source the series from `skinTempC` (plus bimodal absolutes from `skinTempDevC` per #622); when leading deviation, keep genuine deviations only. The shared `dailyColumn("skin_temp")` is unchanged — its callers include the trend series and the metric-catalog availability check.
- The preference applies across the WINDOW (#1850), not just the newest row: a wearer with twenty stored temperatures and one recent night without now leads with temperatures instead of twenty-three deltas.
- Carry the two #1847 notes: (1) the user asked for temperatures but the window has none → say so; (2) leading with absolutes dropped deviation-only nights → say why. Both are pure-function-gated (twins of Android's `shouldExplainSkinTempFallback` / `shouldExplainShortenedSkinTempSeries`) and pinned by `SkinTempExplorerNoteTests`.
- The preference is keyed into `loadTaskID` so flipping Settings reloads the series immediately.

Addresses #1848.

#### Test plan

- [ ] macOS Strand build passes (CI)
- [ ] iOS NOOPiOS build passes (CI)
- [ ] `check` passes (CI)
- [ ] `doc-comments` passes (CI)
- [ ] `SkinTempExplorerNoteTests` passes (part of StrandTests)
- [ ] Manual: with `units.skinTempDisplay = ""` (Temperature) and a window containing absolutes, the explorer leads with `°C` and the hero/chart/stats/readings table all use the absolute series
- [ ] Manual: with `units.skinTempDisplay = deviation` and a window containing only deviations, the explorer leads with `Δ°C` (unchanged from before)
- [ ] Manual: with Temperature selected and NO absolutes in the window, the fallback note appears
- [ ] Manual: with Temperature selected and a mix of absolutes + deviation-only nights, the shortened-series note appears

Generated with [Devin](https://devin.ai)

