### PR TITLE
coach: localize the voice controller's last two strings, pin CRLF on Kotlin too

### DIFF
--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -209987,6 +209987,42 @@
         "ru": {"stringUnit": {"state": "translated", "value": "Включите утреннюю сводку в настройках Коуча, чтобы видеть сегодняшнюю готовность здесь."}},
         "zh-Hans": {"stringUnit": {"state": "translated", "value": "在 Coach 设置中启用晨间简报以在此处查看今日准备度。"}},
         "zh-Hant": {"stringUnit": {"state": "translated", "value": "在 Coach 設定中啟用晨間簡報以在此處查看今日準備度。"}}
+    } },
+    "Voice input unavailable. Check microphone permission in Settings.": { "localizations": {
+        "de": {"stringUnit": {"state": "translated", "value": "Spracheingabe nicht verfügbar. Prüfe die Mikrofonberechtigung in den Einstellungen."}},
+        "en": {"stringUnit": {"state": "translated", "value": "Voice input unavailable. Check microphone permission in Settings."}},
+        "es": {"stringUnit": {"state": "translated", "value": "Entrada de voz no disponible. Comprueba el permiso del micrófono en Ajustes."}},
+        "fr": {"stringUnit": {"state": "translated", "value": "Saisie vocale indisponible. Vérifiez l'autorisation du microphone dans Réglages."}},
+        "it": {"stringUnit": {"state": "translated", "value": "Input vocale non disponibile. Controlla l'autorizzazione del microfono in Impostazioni."}},
+        "pl": {"stringUnit": {"state": "translated", "value": "Wprowadzanie głosowe niedostępne. Sprawdź uprawnienie mikrofonu w Ustawieniach."}},
+        "pt-PT": {"stringUnit": {"state": "translated", "value": "Entrada de voz indisponível. Verifica a permissão do microfone nas Definições."}},
+        "ru": {"stringUnit": {"state": "translated", "value": "Голосовой ввод недоступен. Проверьте разрешение микрофона в Настройках."}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "语音输入不可用。请在“设置”中检查麦克风权限。"}},
+        "zh-Hant": {"stringUnit": {"state": "translated", "value": "語音輸入無法使用。請在「設定」中檢查麥克風權限。"}}
+    } },
+    "On-device speech not available for %@.": { "localizations": {
+        "de": {"stringUnit": {"state": "translated", "value": "Geräteinterne Spracherkennung für %@ nicht verfügbar."}},
+        "en": {"stringUnit": {"state": "translated", "value": "On-device speech not available for %@."}},
+        "es": {"stringUnit": {"state": "translated", "value": "El reconocimiento de voz en el dispositivo no está disponible para %@."}},
+        "fr": {"stringUnit": {"state": "translated", "value": "La reconnaissance vocale sur l'appareil n'est pas disponible pour %@."}},
+        "it": {"stringUnit": {"state": "translated", "value": "Il riconoscimento vocale sul dispositivo non è disponibile per %@."}},
+        "pl": {"stringUnit": {"state": "translated", "value": "Rozpoznawanie mowy na urządzeniu jest niedostępne dla %@."}},
+        "pt-PT": {"stringUnit": {"state": "translated", "value": "O reconhecimento de voz no dispositivo não está disponível para %@."}},
+        "ru": {"stringUnit": {"state": "translated", "value": "Распознавание речи на устройстве недоступно для %@."}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "设备端语音识别不支持 %@。"}},
+        "zh-Hant": {"stringUnit": {"state": "translated", "value": "裝置端語音辨識不支援 %@。"}}
+    } },
+    "Couldn't start the microphone: %@": { "localizations": {
+        "de": {"stringUnit": {"state": "translated", "value": "Mikrofon konnte nicht gestartet werden: %@"}},
+        "en": {"stringUnit": {"state": "translated", "value": "Couldn't start the microphone: %@"}},
+        "es": {"stringUnit": {"state": "translated", "value": "No se pudo iniciar el micrófono: %@"}},
+        "fr": {"stringUnit": {"state": "translated", "value": "Impossible de démarrer le microphone : %@"}},
+        "it": {"stringUnit": {"state": "translated", "value": "Impossibile avviare il microfono: %@"}},
+        "pl": {"stringUnit": {"state": "translated", "value": "Nie udało się uruchomić mikrofonu: %@"}},
+        "pt-PT": {"stringUnit": {"state": "translated", "value": "Não foi possível iniciar o microfone: %@"}},
+        "ru": {"stringUnit": {"state": "translated", "value": "Не удалось включить микрофон: %@"}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "无法启动麦克风：%@"}},
+        "zh-Hant": {"stringUnit": {"state": "translated", "value": "無法啟動麥克風：%@"}}
     } }
   },
   "version": "1.0"

--- a/StrandiOS/App/CoachVoiceInput.swift
+++ b/StrandiOS/App/CoachVoiceInput.swift
@@ -111,8 +111,8 @@ final class CoachVoiceInput: ObservableObject {
         #if canImport(UIKit)
         guard canUseVoice else {
             statusMessage = Self.localeSupportsOnDevice
-                ? "Voice input unavailable. Check microphone permission in Settings."
-                : "On-device speech not available for \(Locale.current.identifier)."
+                ? String(localized: "Voice input unavailable. Check microphone permission in Settings.")
+                : String(localized: "On-device speech not available for \(Locale.current.identifier).")
             return
         }
         stopTranscribing(completion: { _ in })
@@ -173,7 +173,7 @@ final class CoachVoiceInput: ObservableObject {
         self.recognitionRequest = request
 
         guard let recognizer = SFSpeechRecognizer(locale: Locale.current) else {
-            statusMessage = "On-device speech not available for \(Locale.current.identifier)."
+            statusMessage = String(localized: "On-device speech not available for \(Locale.current.identifier).")
             return
         }
 
@@ -207,7 +207,7 @@ final class CoachVoiceInput: ObservableObject {
             try audioEngine.start()
             isRecording = true
         } catch {
-            statusMessage = "Couldn't start the microphone: \(error.localizedDescription)"
+            statusMessage = String(localized: "Couldn't start the microphone: \(error.localizedDescription)")
             finishSession(completion: { _ in })
         }
     }

--- a/android/app/src/main/java/com/noop/ui/CoachScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachScreen.kt
@@ -962,14 +962,13 @@ private fun CoachPrimaryButton(label: String, enabled: Boolean, onClick: () -> U
  * Mirrors the iOS `CoachView.composer` + `micButton` twin. The mic button:
  *  - requests RECORD_AUDIO at runtime on first tap (via [rememberLauncherForActivityResult]),
  *  - starts/stops [CoachVoiceInput], which uses `createOnDeviceSpeechRecognizer` behind an
- *    `isOnDeviceRecognitionAvailable` gate (API 31+) and hides the mic entirely below that, so audio
- *    cannot reach a server. This line used to say EXTRA_PREFER_OFFLINE, which was a PREFERENCE the
- *    platform could ignore; that is the weaker mechanism the review replaced, and a doc still naming
- *    it would have this screen vouching for a guarantee the code no longer relies on,
+ *    `isOnDeviceRecognitionAvailable` gate (API 31+); below that the button is not composed at all,
  *  - streams the partial transcript into the text field live,
  *  - on stop, appends the finalized transcript to the draft (not replace, so it composes with
  *    typed text).
- * Only the resulting TEXT ever reaches the AI provider — no new network path, no audio egress.
+ * Only the resulting TEXT ever reaches the AI provider — no new network path, no audio egress. That
+ * is a guarantee rather than a preference: `createOnDeviceSpeechRecognizer` cannot fall back to a
+ * server, where the `EXTRA_PREFER_OFFLINE` this line used to name was a hint the platform could ignore.
  */
 @Composable
 private fun MicComposerRow(

--- a/android/app/src/main/java/com/noop/ui/CoachScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachScreen.kt
@@ -961,7 +961,11 @@ private fun CoachPrimaryButton(label: String, enabled: Boolean, onClick: () -> U
  * K4: The composer row with a mic button (on-device voice input) between the text field and Send.
  * Mirrors the iOS `CoachView.composer` + `micButton` twin. The mic button:
  *  - requests RECORD_AUDIO at runtime on first tap (via [rememberLauncherForActivityResult]),
- *  - starts/stops [CoachVoiceInput] (Android platform SpeechRecognizer, EXTRA_PREFER_OFFLINE),
+ *  - starts/stops [CoachVoiceInput], which uses `createOnDeviceSpeechRecognizer` behind an
+ *    `isOnDeviceRecognitionAvailable` gate (API 31+) and hides the mic entirely below that, so audio
+ *    cannot reach a server. This line used to say EXTRA_PREFER_OFFLINE, which was a PREFERENCE the
+ *    platform could ignore; that is the weaker mechanism the review replaced, and a doc still naming
+ *    it would have this screen vouching for a guarantee the code no longer relies on,
  *  - streams the partial transcript into the text field live,
  *  - on stop, appends the finalized transcript to the draft (not replace, so it composes with
  *    typed text).

--- a/android/app/src/main/java/com/noop/ui/CoachVoiceInput.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachVoiceInput.kt
@@ -79,11 +79,11 @@ class CoachVoiceInput(
     fun start() {
         if (isRecording) return
         if (!isAvailable()) {
-            onError("On-device speech recognition is not available on this device or locale.")
+            onError(context.getString(R.string.coach_voice_error_unavailable))
             return
         }
         if (!isPermissionGranted()) {
-            onError("Microphone permission not granted.")
+            onError(context.getString(R.string.coach_voice_error_permission))
             return
         }
         // SpeechRecognizer must be created on the main thread; this class is called from Compose

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2733,6 +2733,7 @@
     <string name="coach_voice_error_permission">Mikrofonberechtigung verweigert.</string>
     <string name="coach_voice_error_generic">Spracheingabe fehlgeschlagen. Versuchen Sie es erneut.</string>
     <string name="coach_voice_error_server">On-Device-Spracherkennung für diese Sprache nicht verfügbar.</string>
+    <string name="coach_voice_error_unavailable">On-Device-Spracherkennung ist auf diesem Gerät oder für diese Sprache nicht verfügbar.</string>
     <string name="coach_voice_unavailable">On-Device-Spracherkennung ist auf diesem Gerät oder für diese Sprache nicht verfügbar.</string>
     <string name="coach_voice_permission_denied">Mikrofonberechtigung verweigert. Aktivieren Sie sie in den Einstellungen, um die Spracheingabe zu nutzen.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2720,6 +2720,7 @@
     <string name="coach_voice_error_permission">Permiso de micrófono denegado.</string>
     <string name="coach_voice_error_generic">Error de entrada de voz. Inténtelo de nuevo.</string>
     <string name="coach_voice_error_server">El reconocimiento de voz en el dispositivo no está disponible para este idioma.</string>
+    <string name="coach_voice_error_unavailable">El reconocimiento de voz en el dispositivo no está disponible en este dispositivo o idioma.</string>
     <string name="coach_voice_unavailable">El reconocimiento de voz en el dispositivo no está disponible en este dispositivo o idioma.</string>
     <string name="coach_voice_permission_denied">Permiso de micrófono denegado. Actívalo en Configuración para usar la entrada de voz.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2719,6 +2719,7 @@
     <string name="coach_voice_error_permission">Autorisation du microphone refusée.</string>
     <string name="coach_voice_error_generic">Échec de la saisie vocale. Réessayez.</string>
     <string name="coach_voice_error_server">La reconnaissance vocale sur l\'appareil n\'est pas disponible pour cette langue.</string>
+    <string name="coach_voice_error_unavailable">La reconnaissance vocale sur l\'appareil n\'est pas disponible sur cet appareil ou pour cette langue.</string>
     <string name="coach_voice_unavailable">La reconnaissance vocale sur l\'appareil n\'est pas disponible sur cet appareil ou pour cette langue.</string>
     <string name="coach_voice_permission_denied">Autorisation du microphone refusée. Activez-la dans les Paramètres pour utiliser la saisie vocale.</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2724,6 +2724,7 @@
     <string name="coach_voice_error_permission">Odmowa uprawnień do mikrofonu.</string>
     <string name="coach_voice_error_generic">Wprowadzanie głosowe nie powiodło się. Spróbuj ponownie.</string>
     <string name="coach_voice_error_server">Rozpoznawanie mowy na urządzeniu jest niedostępne dla tego języka.</string>
+    <string name="coach_voice_error_unavailable">Rozpoznawanie mowy na urządzeniu jest niedostępne na tym urządzeniu lub dla tego języka.</string>
     <string name="coach_voice_unavailable">Rozpoznawanie mowy na urządzeniu nie jest dostępne na tym urządzeniu lub w tym języku.</string>
     <string name="coach_voice_permission_denied">Odmowa uprawnień do mikrofonu. Włącz je w Ustawieniach, aby używać wprowadzania głosowego.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2712,6 +2712,7 @@
     <string name="coach_voice_error_permission">Permissão de microfone negada.</string>
     <string name="coach_voice_error_generic">Falha na entrada de voz. Tente novamente.</string>
     <string name="coach_voice_error_server">O reconhecimento de voz no dispositivo não está disponível para este idioma.</string>
+    <string name="coach_voice_error_unavailable">O reconhecimento de voz no dispositivo não está disponível neste dispositivo ou idioma.</string>
     <string name="coach_voice_unavailable">O reconhecimento de voz no dispositivo não está disponível neste dispositivo ou idioma.</string>
     <string name="coach_voice_permission_denied">Permissão de microfone negada. Ative-a nas Configurações para usar a entrada de voz.</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -1387,6 +1387,7 @@
     <string name="coach_voice_error_permission">Разрешение на микрофон отклонено.</string>
     <string name="coach_voice_error_generic">Ошибка голосового ввода. Попробуйте снова.</string>
     <string name="coach_voice_error_server">Распознавание речи на устройстве недоступно для этого языка.</string>
+    <string name="coach_voice_error_unavailable">Распознавание речи на устройстве недоступно на этом устройстве или для этого языка.</string>
     <string name="coach_voice_unavailable">Распознавание речи на устройстве недоступно на этом устройстве или для этого языка.</string>
     <string name="coach_voice_permission_denied">Разрешение на микрофон отклонено. Включите его в Настройках, чтобы использовать голосовой ввод.</string>
     <string name="l10n_compare_screen_remove_title_ddb5361c">Удалить %1$s</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2633,6 +2633,7 @@
     <string name="coach_voice_error_permission">麦克风权限被拒绝。</string>
     <string name="coach_voice_error_generic">语音输入失败。请重试。</string>
     <string name="coach_voice_error_server">此语言不支持设备端语音识别。</string>
+    <string name="coach_voice_error_unavailable">此设备或语言不支持设备端语音识别。</string>
     <string name="coach_voice_unavailable">此设备或语言不支持设备端语音识别。</string>
     <string name="coach_voice_permission_denied">麦克风权限被拒绝。请在设置中启用以使用语音输入。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2749,6 +2749,7 @@
     <string name="coach_voice_error_permission">Microphone permission denied.</string>
     <string name="coach_voice_error_generic">Voice input failed. Try again.</string>
     <string name="coach_voice_error_server">On-device speech is unavailable for this locale.</string>
+    <string name="coach_voice_error_unavailable">On-device speech recognition is not available on this device or locale.</string>
     <string name="coach_voice_unavailable">On-device speech recognition is not available on this device or locale.</string>
     <string name="coach_voice_permission_denied">Microphone permission denied. Enable it in Settings to use voice input.</string>
 </resources>

--- a/android/app/src/test/java/com/noop/analytics/SseDeltasTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SseDeltasTest.kt
@@ -268,4 +268,24 @@ class SseDeltasTest {
         }
         assertEquals("ok", sb.toString())
     }
+
+    // ── CRLF parity ──────────────────────────────────────────────────────────────────────────
+    //
+    // The Swift twin trims `.whitespacesAndNewlines`; Kotlin's `trim()` already strips \r. These
+    // pin that, because the divergence they guard against was real: Swift used `.whitespaces`
+    // (space and tab only), so on a CRLF stream `isDone("[DONE]\r")` was false on iOS and true
+    // here, and iOS never saw the end-of-stream sentinel. Fixing one side without pinning the
+    // other leaves it free to drift straight back.
+
+    /** A CRLF stream leaves a trailing \r after splitting on \n. It must not hide the sentinel. */
+    @Test fun `isDone strips CRLF`() {
+        assertTrue(SseDeltas.isDone("[DONE]\r"))
+        assertTrue(SseDeltas.isDone("[DONE]\r\n"))
+    }
+
+    /** The same trailing \r must not end up inside the JSON payload handed to the parsers. */
+    @Test fun `dataPayload strips CRLF`() {
+        assertEquals("{\"hello\":1}", SseDeltas.dataPayload("data: {\"hello\":1}\r"))
+    }
+
 }


### PR DESCRIPTION
The two residuals from the K1-K15 review, done here so @evoveotech did not have
to rebase a 5,600-line branch a third time for them.

## Two strings the audit structurally cannot see

`CoachVoiceInput` routed its `mapError` cases through resources but still passed
two English literals straight to `onError`:

```
onError("On-device speech recognition is not available on this device or locale.")
onError("Microphone permission not granted.")
```

The first one is **new** — the unavailability path added by the on-device
recognizer fix.

To correct something I claimed while writing this: that message is **not** what
pre-API-31 devices see. `CoachScreen` composes the mic inside
`if (voiceInput.isAvailable())`, so on those devices there is no button to tap and
the message is unreachable through the UI. The string is still right to have — a
defensive guard should not emit English if it ever fires — but the justification I
first gave for it was wrong.

Neither is visible to `Tools/i18n_audit.py`: they sit in a plain class rather than
a `@Composable`, which is the audit's known blind spot, so CI was green on both.

The permission message reuses the existing `coach_voice_error_permission`
("Microphone permission denied.") rather than adding a near-duplicate for seven
translators to render twice. The unavailability message is a new key,
`coach_voice_error_unavailable`, present in all eight locale files.

## The same defect on iOS, four times

Checking parity on the Android fix turned up the Swift twin, which was worse:
`CoachVoiceInput.swift` had **four** user-facing strings and **zero**
`String(localized:)`, all shown as the composer's `statusMessage`, in an app that
ships ten iOS locales.

They are invisible to the audit for the mirror image of the Android reason. Its
Apple detector keys on `Text(...)`-style view initializers the way its Android one
is `@Composable`-scoped; these are assignments to a `@Published var statusMessage`
rendered elsewhere. So the Coach feature landed unlocalized copy through the same
structural gap on both platforms — two on Android, four on iOS — and my first
review caught only the Android pair, because I read the Kotlin and never opened
the Swift twin.

Three unique keys after dedup, two carrying `%@` (the locale identifier and the
underlying error), spliced into `Localizable.xcstrings` as text for all ten
locales rather than round-tripped through a JSON writer.

## CRLF was pinned on one side of a parity bug

The original finding was a divergence: Swift trimmed `.whitespaces`, which does
not include `\r`, so on a CRLF stream `isDone("[DONE]\r")` was **false on iOS and
true on Android** — iOS never saw the end-of-stream sentinel. The fix corrected
Swift and added five `\r` cases there; Kotlin got none.

Kotlin's `trim()` is correct today, but a parity bug pinned on one side only
leaves the other free to drift back into it — a later "tidy" to `trimEnd(' ')`
would reopen it silently. The same two cases are now pinned here.

## A doc still vouching for the replaced mechanism

Found re-reading this: `CoachVoiceInput` moved to `createOnDeviceSpeechRecognizer`,
but `CoachScreen`'s composer doc still described the mic as using
`EXTRA_PREFER_OFFLINE`. It was the only place left in the tree naming it.

That is worse than an ordinary stale comment. `EXTRA_PREFER_OFFLINE` is a
preference the platform may ignore, and the gap between it and the stated
guarantee was the single blocking finding on the Coach review — so a doc still
naming it left this screen asserting the exact thing that was not true, on the
screen someone reads first when checking whether the mic can reach a server.

## Verification

Android 5395 tests / 0 failures, `SseDeltasTest` 35. Doc lint clean. `Tools/i18n_audit.py --ci`
clean. `lintVitalFullRelease -PstagingRelease` clean — the new key exists in every
locale, so no `ExtraTranslation`.
