### PR TITLE
storage: let the Apple footprint name the tables that can actually be large

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -614,7 +614,8 @@ extension WhoopStore {
     /// row-count model misprices worst, since `ppgWaveformSample` is the only blob table here. A footprint
     /// that omits the blob table cannot attribute the bytes it was collected to explain.
     ///
-    /// Shares `rawTables` with `storageStats()` so a table added to one is counted by both. Best-effort
+    /// Shares `rawTableKeys` with `storageStats()` and `TimestampHeal` so a table added to one is seen by
+    /// all three — counted in the total, named in the breakdown, and healed. Best-effort
     /// per table: an unreadable count is omitted rather than reported as zero, because a zero here reads
     /// as "this table is empty" and that is a different claim from "this table could not be read".
     public func storageRowCounts() async throws -> [String: Int] {
@@ -639,14 +640,15 @@ extension WhoopStore {
     /// Aggregate storage footprint: total decoded rows, raw batch count, total raw byteSize.
     public func storageStats() async throws -> (decodedRows: Int, rawBatches: Int, rawBytes: Int) {
         try syncRead { db in
-            // The COMPLETE set of accumulating decoded raw streams — KEEP IN SYNC with
-            // `TimestampHeal.rawTables` (its per-timestamp purge is the canonical list) and the Android
-            // `WhoopRepository.storageRowCounts`. The list now lives in `rawTableKeys`, shared with
-            // `storageRowCounts()` above, so the total and the per-table breakdown cannot disagree about
-            // which tables exist. Summed by iterating the list rather than a hand-written
-            // expression, because the old fixed sum silently under-reported: it omitted stepSample,
-            // ppgHrSample, sleepStateSample, ppgWaveformSample, rawImuSample and v18AuxSample — and a 4.0
-            // with PPG (ppgHrSample/ppgWaveformSample) or IMU capture (rawImuSample) banks millions of rows.
+            // The COMPLETE set of accumulating decoded raw streams, from `rawTableKeys` — no longer a
+            // "keep in sync with TimestampHeal" instruction, because that copy is gone and the heal now
+            // reads the same list. Android's `WhoopRepository.storageRowCounts` is the one that still has
+            // to be kept in step by hand; the note there says so.
+            //
+            // Summed by iterating the list rather than a hand-written expression, because the old fixed
+            // sum silently under-reported: it omitted stepSample, ppgHrSample, sleepStateSample,
+            // ppgWaveformSample, rawImuSample and v18AuxSample — and a 4.0 with PPG banks millions of
+            // rows. (rawImuSample has since been dropped outright, in `v41-drop-raw-imu-sample`.)
             // Table names are compile-time constants (never user input), so the interpolation is safe.
             var decoded = 0
             for (_, t) in Self.rawTableKeys {

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -605,22 +605,51 @@ extension WhoopStore {
         }
     }
 
+    /// Per-table row counts for every accumulating decoded stream, keyed identically to Android's
+    /// `WhoopRepository.storageRowCounts` so a maintainer reads the SAME map from either platform.
+    ///
+    /// #1911 wants to know WHICH table holds a multi-gigabyte database, and the answer was unavailable on
+    /// Apple: the Test Centre probe emitted nine keys and left out `ppgHr`, `sleepState`, `ppgWaveform`
+    /// and `v18Aux` — the four Android's own comment singles out as "can each be large", and the ones a
+    /// row-count model misprices worst, since `ppgWaveformSample` is the only blob table here. A footprint
+    /// that omits the blob table cannot attribute the bytes it was collected to explain.
+    ///
+    /// Shares `rawTables` with `storageStats()` so a table added to one is counted by both. Best-effort
+    /// per table: an unreadable count is omitted rather than reported as zero, because a zero here reads
+    /// as "this table is empty" and that is a different claim from "this table could not be read".
+    public func storageRowCounts() async throws -> [String: Int] {
+        try syncRead { db in
+            var out: [String: Int] = [:]
+            for (key, table) in Self.rawTableKeys {
+                if let n = try? Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)") { out[key] = n }
+            }
+            return out
+        }
+    }
+
+    /// The decoded stream tables and the key each reports under. The keys are Android's, verbatim.
+    static let rawTableKeys: [(String, String)] = [
+        ("hr", "hrSample"), ("rr", "rrInterval"), ("events", "event"), ("battery", "battery"),
+        ("spo2", "spo2Sample"), ("skinTemp", "skinTempSample"), ("resp", "respSample"),
+        ("gravity", "gravitySample"), ("steps", "stepSample"), ("ppgHr", "ppgHrSample"),
+        ("sleepState", "sleepStateSample"), ("ppgWaveform", "ppgWaveformSample"),
+        ("v18Aux", "v18AuxSample"),
+    ]
+
     /// Aggregate storage footprint: total decoded rows, raw batch count, total raw byteSize.
     public func storageStats() async throws -> (decodedRows: Int, rawBatches: Int, rawBytes: Int) {
         try syncRead { db in
             // The COMPLETE set of accumulating decoded raw streams — KEEP IN SYNC with
             // `TimestampHeal.rawTables` (its per-timestamp purge is the canonical list) and the Android
-            // `WhoopRepository.storageRowCounts`. Summed by iterating the list rather than a hand-written
+            // `WhoopRepository.storageRowCounts`. The list now lives in `rawTableKeys`, shared with
+            // `storageRowCounts()` above, so the total and the per-table breakdown cannot disagree about
+            // which tables exist. Summed by iterating the list rather than a hand-written
             // expression, because the old fixed sum silently under-reported: it omitted stepSample,
             // ppgHrSample, sleepStateSample, ppgWaveformSample, rawImuSample and v18AuxSample — and a 4.0
             // with PPG (ppgHrSample/ppgWaveformSample) or IMU capture (rawImuSample) banks millions of rows.
             // Table names are compile-time constants (never user input), so the interpolation is safe.
-            let rawTables = ["hrSample", "rrInterval", "event", "battery",
-                             "spo2Sample", "skinTempSample", "respSample", "gravitySample",
-                             "stepSample", "ppgHrSample", "sleepStateSample", "ppgWaveformSample",
-                             "v18AuxSample"]
             var decoded = 0
-            for t in rawTables {
+            for (_, t) in Self.rawTableKeys {
                 decoded += try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(t)") ?? 0
             }
             let batches = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rawBatch") ?? 0

--- a/Packages/WhoopStore/Sources/WhoopStore/TimestampHeal.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/TimestampHeal.swift
@@ -52,12 +52,13 @@ extension WhoopStore {
             // legacy-rows gap rather than an ongoing one (the #547 ingest gate now rejects an implausible
             // ts before it is banked), which is exactly why it went unnoticed. Guarded by the same
             // out-of-bounds predicate as everything else — a plausible row is never touched.
-            let rawTables = ["hrSample", "rrInterval", "event", "battery",
-                             "spo2Sample", "skinTempSample", "respSample",
-                             "gravitySample", "stepSample", "ppgHrSample",
-                             "sleepStateSample", "ppgWaveformSample", "v18AuxSample"]
+            // The SAME list the storage footprint reports, rather than a third copy of it. This one was
+            // called canonical while `storageStats` kept its own and the Apple probe a shorter one again,
+            // and that drift is not hypothetical: `storageStats`' comment records its old fixed sum
+            // omitting six of these tables. One list means a stream added later is healed AND counted AND
+            // named in the breakdown, or none of the three - never silently one of them.
             var rawDeleted = 0
-            for table in rawTables {
+            for (_, table) in WhoopStore.rawTableKeys {
                 try db.execute(sql: "DELETE FROM \(table) WHERE ts < ? OR ts > ?",
                                arguments: [lo, hi])
                 rawDeleted += db.changesCount

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
@@ -364,4 +364,35 @@ final class ReadTests: XCTestCase {
         XCTAssertEqual(stats.rawBytes, 4)
 #endif
     }
+
+    /// #1911: the footprint must name EVERY accumulating table, including the four the Apple probe used
+    /// to omit — `ppgHr`, `sleepState`, `ppgWaveform`, `v18Aux`. Those are the ones a row-count model
+    /// misprices worst (`ppgWaveformSample` is the only blob table), so leaving them out made the
+    /// footprint unable to attribute the bytes it was collected to explain.
+    ///
+    /// Pinned against the Android key set verbatim: a maintainer comparing meta.json across platforms is
+    /// comparing the same map, and a table added to one side without the other shows up here.
+    func testStorageRowCountsNamesEveryAccumulatingTable() async throws {
+        let store = try await WhoopStore.inMemory()
+        let counts = try await store.storageRowCounts()
+        let expected = ["hr", "rr", "events", "battery", "spo2", "skinTemp", "resp", "gravity",
+                        "steps", "ppgHr", "sleepState", "ppgWaveform", "v18Aux"]
+        XCTAssertEqual(Set(counts.keys), Set(expected),
+                       "key set must match Android's WhoopRepository.storageRowCounts exactly")
+        for k in expected {
+            XCTAssertEqual(counts[k], 0, "\(k) starts empty in a fresh store")
+        }
+    }
+
+    /// The total and the breakdown are derived from ONE list, so they cannot disagree about which tables
+    /// exist. Pinned because they used to be two hand-maintained lists, and the older one had already
+    /// drifted once — the comment on `storageStats` records it omitting six tables.
+    func testStorageStatsTotalAgreesWithTheBreakdown() async throws {
+        let store = try await seeded()
+        let counts = try await store.storageRowCounts()
+        let stats = try await store.storageStats()
+        XCTAssertEqual(stats.decodedRows, counts.values.reduce(0, +),
+                       "the summed total must equal the per-table breakdown")
+    }
+
 }

--- a/Strand/System/TestCentreReport.swift
+++ b/Strand/System/TestCentreReport.swift
@@ -80,11 +80,12 @@ final class TestCentreReport: ObservableObject {
         var rows: [String: Int] = [:]
         var rawBytes = 0
         if let store = await repo?.storeHandle() {
-            if let c = try? await store.storageStats_rowCountsForTest() {
-                rows = ["hr": c.hr, "rr": c.rr, "events": c.events, "battery": c.battery,
-                        "spo2": c.spo2, "skinTemp": c.skinTemp, "resp": c.resp, "gravity": c.gravity]
-            }
-            if let steps = try? await store.stepCountForTest() { rows["steps"] = steps }
+            // #1911: every accumulating table, not the nine this used to name. The old shape read eight
+            // counts out of a test helper and bolted `steps` on beside them, which silently omitted
+            // ppgHr, sleepState, ppgWaveform and v18Aux — the four Android already reports and flags as
+            // "can each be large". A footprint that leaves out the only blob table cannot attribute the
+            // bytes it exists to explain, which is exactly what #1911 needs answered.
+            if let counts = try? await store.storageRowCounts() { rows = counts }
             rawBytes = (try? await store.storageStats().rawBytes) ?? 0
         }
         if let url = live.puffinCaptureURL {

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1707,6 +1707,15 @@ class WhoopRepository(
      * the Phase-1 zeros. Keys mirror the Swift probe (TestCentreReport.storageProbe) so a maintainer
      * reads the same map from either platform. Best-effort: a read failure returns empty (the caller's
      * zeroed fallback stays an honest "unreadable"), never a fabricated figure.
+     *
+     * THE KEY SET IS A CROSS-PLATFORM CONTRACT. Apple pins it in `WhoopStoreTests.ReadTests`
+     * (`testStorageRowCountsNamesEveryAccumulatingTable`) against this exact list, so adding a table
+     * there fails loudly until both sides agree. There is no equivalent pin on this side: these counts
+     * need a DAO, and the JVM unit tests have no in-memory Room, so a key added HERE and not there goes
+     * unnoticed. Add it to `WhoopStore.rawTableKeys` in the same change - the Apple probe reads that list
+     * for both its total and its breakdown, so a table missing from it is invisible in the footprint,
+     * which is how ppgWaveform - the only blob table, and the one a row-count model misprices worst -
+     * stayed unreported on Apple until #1911 asked which table was large.
      */
     suspend fun storageRowCounts(): Map<String, Int> = runCatching {
         mapOf(


### PR DESCRIPTION
Prompted by #1911, which asks which table holds a multi-gigabyte database. On
Apple that question could not be answered.

## The gap

`TestCentreReport.storageProbe` read eight counts out of
`storageStats_rowCountsForTest()`, bolted `steps` on beside them, and emitted
**nine** keys. Android's `WhoopRepository.storageRowCounts` emits **thirteen** —
and the four Apple was missing are `ppgHr`, `sleepState`, `ppgWaveform` and
`v18Aux`, which Android's own comment singles out as *"can each be large"*.

Both platforms' comments claim the keys mirror each other. They did not.

The omission is worst exactly where it matters. `ppgWaveformSample` is the only
blob table in the set, so it is the one a per-second row-count model misprices
most — and the most likely candidate for bytes such a model cannot explain. A
footprint that leaves out the blob table cannot attribute the bytes it exists to
attribute.

## The change

`WhoopStore.storageRowCounts()` returns the full map, keyed verbatim as Android
keys it, so a maintainer comparing `meta.json` across platforms is comparing the
same map. Best-effort per table: an unreadable count is **omitted** rather than
reported as zero, because a zero reads as "this table is empty", which is a
different claim from "this table could not be read".

There were **three** copies of the same thirteen tables in Swift: `TimestampHeal`'s
local list (which `storageStats`' own comment called canonical), `storageStats`'
own, and the probe's shorter nine. All three now read `rawTableKeys`, so a stream
added later is healed **and** counted **and** named in the breakdown — or none of
the three, never silently one of them, which is how `ppgWaveform` came to be
purged correctly while going unreported.

That drift is not hypothetical: `storageStats`' comment records its old fixed sum
omitting six tables. A test pins the summed total against the breakdown, and the
heal's list is byte-identical in set and order to what it had, so its behaviour is
unchanged (`TimestampHealTests` covers it).

The "KEEP IN SYNC with `TimestampHeal.rawTables`" instruction retires with the
copy it referred to, and the note that `rawImuSample` was among the omissions now
records that it was dropped outright in `v41-drop-raw-imu-sample`.

Production code also stops calling a `…ForTest` helper.

## Why this first

#1911 proposes tiered storage, rollup, cold tiers and retention as one shippable
unit. Its sizing model assumes 1 Hz for seven tables; measured against a 54-hour
field capture, `gravitySample` matches (0.99×) but `hrSample` runs 0.21× and
`respSample` 0.005× of the modelled rate. The model's total and the reported
6.5 GB agree, but if several tables are overstated by 5–200× then that agreement
is coincidental and something not in the model holds a large share of the bytes.

Which tiers to build, and at what granularity, depends on knowing that. This PR
is the measurement, and it changes no retention behaviour.

## The pin is one-sided, deliberately

Apple's key set is pinned by a test. Android's is not, and I could not pin it
without inventing test infrastructure: those counts need a DAO and the JVM unit
tests have no in-memory Room. That is the same asymmetry I objected to in the
Coach CRLF fix earlier — with the difference that there the twin was a pure
function and the test was trivially writable.

So the contract is documented where the next editor of the Android side will be
standing, naming the Apple test that enforces it and the list to add to. Weaker
than a test, and not pretending otherwise.

## Verification

Two new tests in `WhoopStoreTests`: the key set matches Android's verbatim, and
the summed total equals the breakdown. Doc lint clean; both files parse. The
package tests and the app-target compile ride CI — nothing local builds them
(this WSL toolchain has no `sqlite3.h`, so `swift build` cannot build CSQLite).
