### PR TITLE
storage: estimate bytes per table, and stop saying v18Aux is unpruned

### DIFF
--- a/Packages/NoopLocalAccess/Sources/NoopLocalAccessCore/LocalAccessCore.swift
+++ b/Packages/NoopLocalAccess/Sources/NoopLocalAccessCore/LocalAccessCore.swift
@@ -323,12 +323,23 @@ public final class ReadonlyNoopStore {
         try dbQueue.read { db in
             // Every durable decoded per-second table. The four below the first line were landed as
             // instrumentation and then left OUT of this count, which is how an unbounded, unpruned table
-            // became invisible: `ppgWaveformSample` banks a ~48-byte BLOB per v26 strap-second and
-            // `v18AuxSample` ~30 bytes per v18 strap-second, neither is pruned (deliberately — this is
-            // decoded biometric history, not the transient raw outbox), and until now neither showed up in
-            // the only readout a user has for "what is the store spending space on". Growth that nothing
-            // reads still has to be growth somebody can SEE. Guarded by `tableNames.contains` so a store
-            // predating any of these migrations still reports.
+            // became invisible: `ppgWaveformSample` banks a ~48-byte BLOB per v26 strap-second and is NOT
+            // pruned (deliberately — this is decoded biometric history, not the transient raw outbox), and
+            // until it was counted it did not show up in the only readout a user has for "what is the
+            // store spending space on". Growth that nothing reads still has to be growth somebody can SEE.
+            //
+            // `v18AuxSample` used to be named here as unpruned too. It is not, and has not been since the
+            // rolling retention landed (`WhoopStore.v18AuxRetentionRows` / `v18AuxPruneEveryRows`, Room
+            // migration v31, covered by `DeepCaptureChannelsTests`): ~604 800 rows, about seven days. The
+            // correction matters because #1911 is designing retention, and "which tables are already
+            // bounded" is the first thing such a design reads off — getting it wrong here would have it
+            // solving a problem twice, or trusting a bound that was never there.
+            //
+            // This list is a DELIBERATE fourth copy, not drift. The other three (`WhoopStore.rawTableKeys`,
+            // the footprint total and the timestamp heal) now share one list; this module cannot, because
+            // NoopLocalAccess depends on GRDB alone and stays independent of WhoopStore on purpose — it is
+            // the read-only access tool, and a dependency on the app's store package would defeat that.
+            // Guarded by `tableNames.contains` so a store predating any of these migrations still reports.
             let decodedTables = [
                 "hrSample", "rrInterval", "event", "battery", "spo2Sample",
                 "skinTempSample", "respSample", "gravitySample", "ppgHrSample", "stepSample",

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -628,6 +628,47 @@ extension WhoopStore {
         }
     }
 
+    /// Estimated payload bytes per decoded stream table, keyed as `storageRowCounts()` keys.
+    ///
+    /// #1911 asks which table holds a multi-gigabyte database, and row counts alone cannot answer it: the
+    /// twelve fixed-width tables are comparable by rows, but `ppgWaveformSample` stores a BLOB whose size
+    /// varies, and it is the table most likely to hold bytes a per-second row model does not predict. So
+    /// this measures the blob rather than assuming it.
+    ///
+    /// Sampled, not scanned: the mean payload of up to `sampleRows` rows, multiplied by the count. A full
+    /// `SUM(LENGTH(...))` over a 6.5 GB store is exactly the kind of read this diagnostic exists to let
+    /// someone avoid, and an estimate answers "which table dominates" just as well.
+    ///
+    /// What it measures: BLOB and TEXT columns by their real byte/character length, numeric columns at a
+    /// nominal 8. It EXCLUDES index pages, page slack and the WAL, so it is a payload lower bound, not the
+    /// file size — compare it against `db_bytes` in the same probe rather than expecting the two to meet.
+    /// An unreadable table is omitted, on the same reasoning as the row counts: absent is not zero.
+    public func storageByteEstimates(sampleRows: Int = 500) async throws -> [String: Int] {
+        try syncRead { db in
+            var out: [String: Int] = [:]
+            for (key, table) in Self.rawTableKeys {
+                guard let rows = try? Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)"), rows > 0
+                else { continue }
+                let cols = try? Row.fetchAll(db, sql: "PRAGMA table_info(\(table))")
+                guard let cols, !cols.isEmpty else { continue }
+                // Table and column names come from the schema, never from user input, so interpolating
+                // them is safe here in the same way the COUNT above is.
+                let terms = cols.map { c -> String in
+                    let name: String = c["name"]
+                    let type = (c["type"] as String?)?.uppercased() ?? ""
+                    return (type.contains("BLOB") || type.contains("TEXT"))
+                        ? "COALESCE(LENGTH(\"\(name)\"), 0)" : "8"
+                }
+                let sql = "SELECT AVG(n) FROM (SELECT (\(terms.joined(separator: " + "))) AS n "
+                    + "FROM \(table) LIMIT \(sampleRows))"
+                if let mean = try? Double.fetchOne(db, sql: sql), mean.isFinite, mean >= 0 {
+                    out[key] = Int((mean * Double(rows)).rounded())
+                }
+            }
+            return out
+        }
+    }
+
     /// The decoded stream tables and the key each reports under. The keys are Android's, verbatim.
     static let rawTableKeys: [(String, String)] = [
         ("hr", "hrSample"), ("rr", "rrInterval"), ("events", "event"), ("battery", "battery"),

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -643,11 +643,18 @@ extension WhoopStore {
     /// nominal 8. It EXCLUDES index pages, page slack and the WAL, so it is a payload lower bound, not the
     /// file size — compare it against `db_bytes` in the same probe rather than expecting the two to meet.
     /// An unreadable table is omitted, on the same reasoning as the row counts: absent is not zero.
-    public func storageByteEstimates(sampleRows: Int = 500) async throws -> [String: Int] {
+    /// `rowCounts` lets a caller that already has them - the Test Centre probe does - avoid a second
+    /// `COUNT(*)` pass over every table. That matters here more than it usually would: this diagnostic is
+    /// read on the multi-gigabyte stores it exists to explain, where each count is a full scan, so a tool
+    /// that counts the same thirteen tables three times is slowest exactly where it is needed.
+    public func storageByteEstimates(sampleRows: Int = 500,
+                                     rowCounts: [String: Int]? = nil) async throws -> [String: Int] {
         try syncRead { db in
             var out: [String: Int] = [:]
             for (key, table) in Self.rawTableKeys {
-                guard let rows = try? Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)"), rows > 0
+                let known = rowCounts?[key]
+                guard let rows = known ?? (try? Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)")),
+                      rows > 0
                 else { continue }
                 let cols = try? Row.fetchAll(db, sql: "PRAGMA table_info(\(table))")
                 guard let cols, !cols.isEmpty else { continue }
@@ -677,6 +684,19 @@ extension WhoopStore {
         ("sleepState", "sleepStateSample"), ("ppgWaveform", "ppgWaveformSample"),
         ("v18Aux", "v18AuxSample"),
     ]
+
+    /// The raw outbox alone: batch count and total byteSize, with NO decoded-table counting.
+    ///
+    /// `storageStats()` returns these beside a 13-table `COUNT(*)` sweep, and the Test Centre probe was
+    /// calling it purely for `rawBytes` and discarding the rest - thirteen full scans, on the large stores
+    /// where a scan is least free, for two numbers that touch a different table entirely.
+    public func rawOutboxStats() async throws -> (batches: Int, bytes: Int) {
+        try syncRead { db in
+            let batches = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rawBatch") ?? 0
+            let bytes = try Int.fetchOne(db, sql: "SELECT COALESCE(SUM(byteSize), 0) FROM rawBatch") ?? 0
+            return (batches, bytes)
+        }
+    }
 
     /// Aggregate storage footprint: total decoded rows, raw batch count, total raw byteSize.
     public func storageStats() async throws -> (decodedRows: Int, rawBatches: Int, rawBytes: Int) {

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -660,12 +660,18 @@ extension WhoopStore {
                 guard let cols, !cols.isEmpty else { continue }
                 // Table and column names come from the schema, never from user input, so interpolating
                 // them is safe here in the same way the COUNT above is.
-                let terms = cols.map { c -> String in
-                    let name: String = c["name"]
-                    let type = (c["type"] as String?)?.uppercased() ?? ""
-                    return (type.contains("BLOB") || type.contains("TEXT"))
-                        ? "COALESCE(LENGTH(\"\(name)\"), 0)" : "8"
+                // `typeof()` at runtime, not the DECLARED type, and byte length via CAST rather than
+                // LENGTH: SQLite is dynamically typed, so a column declared INTEGER can hold text, and
+                // LENGTH on text counts CHARACTERS while the store spends bytes. Mirrors the expression
+                // Kotlin already uses in `PushSnapshotPreflight.rowEstimateExpression`.
+                let terms = cols.compactMap { c -> String? in
+                    guard let name = c["name"] as String? else { return nil }
+                    let q = "\"\(name)\""
+                    return "(CASE WHEN \(q) IS NULL THEN 0 "
+                        + "WHEN typeof(\(q)) IN ('text','blob') THEN length(CAST(\(q) AS BLOB)) "
+                        + "ELSE 8 END)"
                 }
+                guard !terms.isEmpty else { continue }
                 let sql = "SELECT AVG(n) FROM (SELECT (\(terms.joined(separator: " + "))) AS n "
                     // Clamped: SQLite reads a NEGATIVE limit as no limit at all, so an unchecked value
                     // here would full-scan the very tables the sampling exists to avoid scanning.

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -667,7 +667,9 @@ extension WhoopStore {
                         ? "COALESCE(LENGTH(\"\(name)\"), 0)" : "8"
                 }
                 let sql = "SELECT AVG(n) FROM (SELECT (\(terms.joined(separator: " + "))) AS n "
-                    + "FROM \(table) LIMIT \(sampleRows))"
+                    // Clamped: SQLite reads a NEGATIVE limit as no limit at all, so an unchecked value
+                    // here would full-scan the very tables the sampling exists to avoid scanning.
+                    + "FROM \(table) LIMIT \(max(1, sampleRows)))"
                 if let mean = try? Double.fetchOne(db, sql: sql), mean.isFinite, mean >= 0 {
                     out[key] = Int((mean * Double(rows)).rounded())
                 }
@@ -691,11 +693,17 @@ extension WhoopStore {
     /// calling it purely for `rawBytes` and discarding the rest - thirteen full scans, on the large stores
     /// where a scan is least free, for two numbers that touch a different table entirely.
     public func rawOutboxStats() async throws -> (batches: Int, bytes: Int) {
-        try syncRead { db in
-            let batches = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rawBatch") ?? 0
-            let bytes = try Int.fetchOne(db, sql: "SELECT COALESCE(SUM(byteSize), 0) FROM rawBatch") ?? 0
-            return (batches, bytes)
-        }
+        try syncRead { try Self.rawOutbox($0) }
+    }
+
+    /// The outbox pair against an OPEN database, so `storageStats()` and `rawOutboxStats()` share one
+    /// implementation. It has to take `db` rather than call the other: `syncRead` is `dbWriter.read`, and
+    /// a read nested inside a read deadlocks - so a plain helper is the only way these two stop being a
+    /// copy of each other, and a test pinning that a copy agrees is a weaker thing than not having one.
+    private static func rawOutbox(_ db: Database) throws -> (batches: Int, bytes: Int) {
+        let batches = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rawBatch") ?? 0
+        let bytes = try Int.fetchOne(db, sql: "SELECT COALESCE(SUM(byteSize), 0) FROM rawBatch") ?? 0
+        return (batches, bytes)
     }
 
     /// Aggregate storage footprint: total decoded rows, raw batch count, total raw byteSize.
@@ -715,10 +723,8 @@ extension WhoopStore {
             for (_, t) in Self.rawTableKeys {
                 decoded += try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(t)") ?? 0
             }
-            let batches = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM rawBatch") ?? 0
-            let bytes   = try Int.fetchOne(db,
-                sql: "SELECT COALESCE(SUM(byteSize), 0) FROM rawBatch") ?? 0
-            return (decoded, batches, bytes)
+            let outbox = try Self.rawOutbox(db)
+            return (decoded, outbox.batches, outbox.bytes)
         }
     }
 }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
@@ -444,12 +444,28 @@ final class ReadTests: XCTestCase {
 
     /// The raw-outbox read must agree with the aggregate it was split out of, or the probe's rawBytes
     /// silently changed meaning when it stopped counting thirteen decoded tables to get one number.
+    ///
+    /// They share one implementation now rather than being two copies this test compares — `syncRead` is
+    /// `dbWriter.read` and nesting one inside another deadlocks, so a plain `db`-taking helper is the only
+    /// way to share it. The assertion stays as the guard on that wiring.
     func testRawOutboxStatsMatchTheAggregate() async throws {
         let store = try await seeded()
         let stats = try await store.storageStats()
         let outbox = try await store.rawOutboxStats()
         XCTAssertEqual(outbox.batches, stats.rawBatches)
         XCTAssertEqual(outbox.bytes, stats.rawBytes)
+    }
+
+
+    /// A negative sample limit must not become an unbounded scan. SQLite reads `LIMIT -1` as "no limit",
+    /// so an unchecked value would full-scan every table — the exact cost the sampling exists to avoid,
+    /// reached by passing a number that looks like it would sample less rather than more.
+    func testStorageByteEstimatesClampANegativeSampleLimit() async throws {
+        let store = try await seeded()
+        let normal = try await store.storageByteEstimates()
+        let negative = try await store.storageByteEstimates(sampleRows: -1)
+        XCTAssertEqual(negative.keys.sorted(), normal.keys.sorted())
+        for (k, v) in negative { XCTAssertGreaterThan(v, 0, "\(k) must still estimate") }
     }
 
 }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
@@ -395,4 +395,36 @@ final class ReadTests: XCTestCase {
                        "the summed total must equal the per-table breakdown")
     }
 
+
+    /// #1911: the byte estimate must MEASURE the blob rather than assume it. `ppgWaveformSample` is the
+    /// only table here whose row size varies, and the one a per-second row model misprices worst — so a
+    /// footprint that treats every row as a fixed width answers the wrong question about exactly the table
+    /// the question is usually about.
+    ///
+    /// Seeded rows carry a real 4-byte blob, so its estimate must exceed a fixed-width table's per-row
+    /// figure by roughly the blob, and both must be positive and finite.
+    func testStorageByteEstimatesMeasureTheBlobColumn() async throws {
+        let store = try await seeded()
+        let bytes = try await store.storageByteEstimates()
+        let counts = try await store.storageRowCounts()
+        let wave = try XCTUnwrap(bytes["ppgWaveform"], "the blob table must be estimated, not skipped")
+        XCTAssertGreaterThan(wave, 0)
+        // Per-row, the blob table must cost more than a table of the same row count whose columns are all
+        // numeric — otherwise the blob is not being measured at all.
+        let waveRows = try XCTUnwrap(counts["ppgWaveform"])
+        let hrRows = try XCTUnwrap(counts["hr"])
+        if waveRows > 0, hrRows > 0, let hrBytes = bytes["hr"] {
+            XCTAssertGreaterThan(Double(wave) / Double(waveRows), Double(hrBytes) / Double(hrRows),
+                                 "a blob row must estimate larger than an all-numeric row")
+        }
+    }
+
+    /// An empty table is omitted rather than reported as zero bytes, matching the row counts: absent means
+    /// "nothing to attribute here", which is a different claim from a measured zero.
+    func testStorageByteEstimatesOmitEmptyTables() async throws {
+        let store = try await WhoopStore.inMemory()
+        let bytes = try await store.storageByteEstimates()
+        XCTAssertTrue(bytes.isEmpty, "a fresh store has no rows, so nothing to estimate")
+    }
+
 }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
@@ -430,4 +430,26 @@ final class ReadTests: XCTestCase {
         XCTAssertTrue(bytes.isEmpty, "a fresh store has no rows, so nothing to estimate")
     }
 
+
+    /// Passing known counts must not change the answer — it only skips a second `COUNT(*)` pass. Pinned
+    /// because the whole point of the parameter is that it is an optimisation, and an optimisation that
+    /// quietly changes the number it optimises is worse than the scan it saves.
+    func testStorageByteEstimatesAreUnchangedByPassingKnownCounts() async throws {
+        let store = try await seeded()
+        let counts = try await store.storageRowCounts()
+        let computed = try await store.storageByteEstimates()
+        let reused = try await store.storageByteEstimates(rowCounts: counts)
+        XCTAssertEqual(computed, reused)
+    }
+
+    /// The raw-outbox read must agree with the aggregate it was split out of, or the probe's rawBytes
+    /// silently changed meaning when it stopped counting thirteen decoded tables to get one number.
+    func testRawOutboxStatsMatchTheAggregate() async throws {
+        let store = try await seeded()
+        let stats = try await store.storageStats()
+        let outbox = try await store.rawOutboxStats()
+        XCTAssertEqual(outbox.batches, stats.rawBatches)
+        XCTAssertEqual(outbox.bytes, stats.rawBytes)
+    }
+
 }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
@@ -396,27 +396,30 @@ final class ReadTests: XCTestCase {
     }
 
 
-    /// #1911: the byte estimate must MEASURE the blob rather than assume it. `ppgWaveformSample` is the
-    /// only table here whose row size varies, and the one a per-second row model misprices worst — so a
-    /// footprint that treats every row as a fixed width answers the wrong question about exactly the table
-    /// the question is usually about.
+    /// #1911: the byte estimate must MEASURE the blob rather than assume a fixed row width.
+    /// `ppgWaveformSample` is the only table here whose row size varies, and the one a per-second row
+    /// model misprices worst — a footprint that treats every row as fixed-width answers the wrong question
+    /// about exactly the table the question is usually about.
     ///
-    /// Seeded rows carry a real 4-byte blob, so its estimate must exceed a fixed-width table's per-row
-    /// figure by roughly the blob, and both must be positive and finite.
-    func testStorageByteEstimatesMeasureTheBlobColumn() async throws {
-        let store = try await seeded()
-        let bytes = try await store.storageByteEstimates()
-        let counts = try await store.storageRowCounts()
-        let wave = try XCTUnwrap(bytes["ppgWaveform"], "the blob table must be estimated, not skipped")
-        XCTAssertGreaterThan(wave, 0)
-        // Per-row, the blob table must cost more than a table of the same row count whose columns are all
-        // numeric — otherwise the blob is not being measured at all.
-        let waveRows = try XCTUnwrap(counts["ppgWaveform"])
-        let hrRows = try XCTUnwrap(counts["hr"])
-        if waveRows > 0, hrRows > 0, let hrBytes = bytes["hr"] {
-            XCTAssertGreaterThan(Double(wave) / Double(waveRows), Double(hrBytes) / Double(hrRows),
-                                 "a blob row must estimate larger than an all-numeric row")
+    /// Pinned by GROWING the blob rather than by comparing tables. My first attempt asserted that a blob
+    /// row estimates larger than an all-numeric row, which is false on a fixture: with a three-sample
+    /// blob `ppgWaveformSample` is three columns to `hrSample`'s four, so it estimates SMALLER. The blob
+    /// dominates in production (~48 bytes per v26 strap-second), not in a seed — so the invariant worth
+    /// pinning is that the blob's length reaches the estimate at all, which comparing two blob sizes
+    /// establishes and comparing two tables does not.
+    func testStorageByteEstimatesGrowWithBlobLength() async throws {
+        func estimate(sampleCount: Int) async throws -> Int {
+            let store = try await WhoopStore.inMemory()
+            let samples = [Int](repeating: 7, count: sampleCount)
+            _ = try await store.insert(Streams(ppgWaveform: [PpgWaveformSample(ts: 400, samples: samples)]),
+                                       deviceId: "dev1")
+            return try await store.storageByteEstimates()["ppgWaveform"] ?? 0
         }
+        let small = try await estimate(sampleCount: 4)      // ~8 bytes packed i16
+        let large = try await estimate(sampleCount: 200)    // ~400 bytes packed i16
+        XCTAssertGreaterThan(small, 0, "the blob table must be estimated, not skipped")
+        XCTAssertGreaterThan(large, small + 300,
+                             "a 400-byte blob must estimate far above an 8-byte one, or the blob is not measured")
     }
 
     /// An empty table is omitted rather than reported as zero bytes, matching the row counts: absent means

--- a/Strand/System/TestBundleAssembler.swift
+++ b/Strand/System/TestBundleAssembler.swift
@@ -228,7 +228,7 @@ enum TestBundleAssembler {
             profileStartedAt: started,
             questionnaire: TestCentre.answers(profile),
             build: buildProvenance(),
-            storage: storage ?? TestBundleMeta.Storage(dbBytes: 0, rows: [:], rawCaptureBytes: 0),
+            storage: storage ?? TestBundleMeta.Storage(dbBytes: 0, rows: [:], rawCaptureBytes: 0, rowBytes: [:]),
             redaction: redactionVersion,
             truncated: truncated,
             captureCheck: checks)

--- a/Strand/System/TestBundleMeta.swift
+++ b/Strand/System/TestBundleMeta.swift
@@ -32,9 +32,14 @@ struct TestBundleMeta: Codable {
     /// db_bytes plus per-table row counts plus the raw-capture footprint (#590 asked us to surface this).
     struct Storage: Codable {
         let dbBytes: Int; let rows: [String: Int]; let rawCaptureBytes: Int
+        /// #1911: estimated payload bytes per table, keyed as `rows` is. Rows alone cannot say which table
+        /// holds a large store — `ppgWaveformSample`'s rows carry a BLOB, so it is exactly where a row
+        /// model misleads. A sampled payload estimate with no index or page overhead, so read it as a
+        /// lower bound to compare against `db_bytes`, never as a second file size.
+        let rowBytes: [String: Int]
         enum CodingKeys: String, CodingKey {
             case rows
-            case dbBytes = "db_bytes", rawCaptureBytes = "raw_capture_bytes"
+            case dbBytes = "db_bytes", rawCaptureBytes = "raw_capture_bytes", rowBytes = "row_bytes"
         }
     }
 

--- a/Strand/System/TestCentreReport.swift
+++ b/Strand/System/TestCentreReport.swift
@@ -91,8 +91,11 @@ final class TestCentreReport: ObservableObject {
             // ppgWaveformSample's rows carry a BLOB, so it is precisely where a row model misleads, and
             // precisely the table this question is usually about. Estimated (sampled payload, no index or
             // page overhead), so it is a lower bound to compare against db_bytes, not a second file size.
-            if let bytes = try? await store.storageByteEstimates() { rowBytes = bytes }
-            rawBytes = (try? await store.storageStats().rawBytes) ?? 0
+            if let bytes = try? await store.storageByteEstimates(rowCounts: rows) { rowBytes = bytes }
+            // `rawOutboxStats`, not `storageStats`: the latter counts all thirteen decoded tables to
+            // return a total this probe does not use, and those are full scans on exactly the stores
+            // this report is pulled from.
+            rawBytes = (try? await store.rawOutboxStats().bytes) ?? 0
         }
         if let url = live.puffinCaptureURL {
             rawBytes += (try? fm.attributesOfItem(atPath: url.path))?[.size] as? Int ?? 0

--- a/Strand/System/TestCentreReport.swift
+++ b/Strand/System/TestCentreReport.swift
@@ -78,6 +78,7 @@ final class TestCentreReport: ObservableObject {
             }
         }
         var rows: [String: Int] = [:]
+        var rowBytes: [String: Int] = [:]
         var rawBytes = 0
         if let store = await repo?.storeHandle() {
             // #1911: every accumulating table, not the nine this used to name. The old shape read eight
@@ -86,13 +87,19 @@ final class TestCentreReport: ObservableObject {
             // "can each be large". A footprint that leaves out the only blob table cannot attribute the
             // bytes it exists to explain, which is exactly what #1911 needs answered.
             if let counts = try? await store.storageRowCounts() { rows = counts }
+            // #1911: bytes beside the counts. Rows alone cannot say which table holds a large store -
+            // ppgWaveformSample's rows carry a BLOB, so it is precisely where a row model misleads, and
+            // precisely the table this question is usually about. Estimated (sampled payload, no index or
+            // page overhead), so it is a lower bound to compare against db_bytes, not a second file size.
+            if let bytes = try? await store.storageByteEstimates() { rowBytes = bytes }
             rawBytes = (try? await store.storageStats().rawBytes) ?? 0
         }
         if let url = live.puffinCaptureURL {
             rawBytes += (try? fm.attributesOfItem(atPath: url.path))?[.size] as? Int ?? 0
         }
         guard dbBytes > 0 || !rows.isEmpty || rawBytes > 0 else { return nil }
-        return TestBundleMeta.Storage(dbBytes: dbBytes, rows: rows, rawCaptureBytes: rawBytes)
+        return TestBundleMeta.Storage(dbBytes: dbBytes, rows: rows, rawCaptureBytes: rawBytes,
+                                      rowBytes: rowBytes)
     }
 
     /// The user read the report and confirmed: clear the gate and run the shipped share + deep-link flow.

--- a/StrandTests/TestBundleMetaTests.swift
+++ b/StrandTests/TestBundleMetaTests.swift
@@ -15,7 +15,8 @@ final class TestBundleMetaTests: XCTestCase {
             profileStartedAt: "2026-06-26T07:12:00Z",
             questionnaire: ["naps": "no"],
             build: .init(channel: "AltStore", signed: false),
-            storage: .init(dbBytes: 1024, rows: ["sleep_sessions": 12], rawCaptureBytes: 2048),
+            storage: .init(dbBytes: 1024, rows: ["sleep_sessions": 12], rawCaptureBytes: 2048,
+                           rowBytes: ["sleep_sessions": 4096]),
             redaction: "v2",
             truncated: false)
     }

--- a/android/app/src/main/java/com/noop/data/StorageFootprint.kt
+++ b/android/app/src/main/java/com/noop/data/StorageFootprint.kt
@@ -1,6 +1,8 @@
 package com.noop.data
 
 import androidx.sqlite.db.SimpleSQLiteQuery
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * #1911: estimated payload bytes per decoded stream table. Swift twin: `WhoopStore.storageByteEstimates`,
@@ -35,9 +37,17 @@ internal class StorageFootprint(private val db: WhoopDatabase) {
      * Payload only: no index pages, no page slack, no WAL. Read it against `db_bytes`, not as a second
      * file size. An unreadable or empty table is omitted rather than reported as zero, matching the row
      * counts — absent means "nothing to attribute here", which is not a measured zero.
+     *
+     * Suspending, and explicitly on IO. The callers launch the storage probe on the UI scope (the Test
+     * Centre screen says so in its own doc), and Room's suspend DAO methods hop to its query executor for
+     * free — a raw-query helper like this one does not, so without the switch these PRAGMA and AVG reads
+     * would run on the main thread, over the multi-gigabyte store this diagnostic exists for.
      */
-    fun byteEstimates(rowCounts: Map<String, Int>, sampleRows: Int = 500): Map<String, Int> = runCatching {
-        val raw = db.openHelper.writableDatabase
+    suspend fun byteEstimates(rowCounts: Map<String, Int>, sampleRows: Int = 500): Map<String, Int> =
+        withContext(Dispatchers.IO) { estimateBlocking(rowCounts, sampleRows) }
+
+    private fun estimateBlocking(rowCounts: Map<String, Int>, sampleRows: Int): Map<String, Int> = runCatching {
+        val raw = db.openHelper.readableDatabase
         val limit = maxOf(1, sampleRows)
         val out = mutableMapOf<String, Int>()
         for ((key, table) in STORAGE_TABLES) {

--- a/android/app/src/main/java/com/noop/data/StorageFootprint.kt
+++ b/android/app/src/main/java/com/noop/data/StorageFootprint.kt
@@ -1,0 +1,81 @@
+package com.noop.data
+
+import androidx.sqlite.db.SimpleSQLiteQuery
+
+/**
+ * #1911: estimated payload bytes per decoded stream table. Swift twin: `WhoopStore.storageByteEstimates`,
+ * and meta.json's `row_bytes` block beside `rows`.
+ *
+ * Rows alone cannot say which table holds a large store. `ppgWaveformSample` stores a BLOB whose size
+ * varies, and it is both the table a per-second row model misprices worst and the one this question is
+ * usually about — so the estimate MEASURES the blob rather than assuming a fixed row width.
+ *
+ * A hand-written class over [WhoopDatabase] rather than a method on [WhoopRepository], following
+ * [com.noop.push.PushDao]: the repository takes a DAO and a transactor precisely so its writes stay
+ * testable without a Room runtime, and raw per-table SQL needs the open helper. Keeping it out preserves
+ * that boundary instead of quietly widening it for a diagnostic.
+ */
+internal class StorageFootprint(private val db: WhoopDatabase) {
+
+    /**
+     * Payload bytes per table, keyed exactly as `WhoopRepository.storageRowCounts` keys, so a maintainer
+     * comparing meta.json across platforms is comparing the same two maps.
+     *
+     * `typeof()` at runtime rather than the declared type, and byte length via `CAST(... AS BLOB)` rather
+     * than `length()`: SQLite is dynamically typed, so a column declared INTEGER can hold text, and
+     * `length()` on text counts CHARACTERS while the store spends bytes. The same shape
+     * `PushSnapshotPreflight.rowEstimateExpression` uses, without its JSON-expansion factors — this
+     * measures the database, not a snapshot of it.
+     *
+     * Sampled over [sampleRows] rows and multiplied by the count, never scanned: a full sum over a
+     * multi-gigabyte store is exactly the read this diagnostic exists to help someone avoid. The limit is
+     * clamped because SQLite reads a NEGATIVE limit as no limit at all, which would full-scan every table
+     * — the precise cost the sampling avoids, reached by a number that reads like it asks for less work.
+     *
+     * Payload only: no index pages, no page slack, no WAL. Read it against `db_bytes`, not as a second
+     * file size. An unreadable or empty table is omitted rather than reported as zero, matching the row
+     * counts — absent means "nothing to attribute here", which is not a measured zero.
+     */
+    fun byteEstimates(rowCounts: Map<String, Int>, sampleRows: Int = 500): Map<String, Int> = runCatching {
+        val raw = db.openHelper.writableDatabase
+        val limit = maxOf(1, sampleRows)
+        val out = mutableMapOf<String, Int>()
+        for ((key, table) in STORAGE_TABLES) {
+            val rows = rowCounts[key] ?: continue
+            if (rows <= 0) continue
+            val cols = mutableListOf<String>()
+            raw.query(SimpleSQLiteQuery("PRAGMA table_info(`$table`)")).use { c ->
+                val i = c.getColumnIndex("name")
+                if (i >= 0) while (c.moveToNext()) cols.add(c.getString(i))
+            }
+            if (cols.isEmpty()) continue
+            val terms = cols.joinToString(" + ") { col -> rowSizeTerm(col) }
+            val sql = "SELECT AVG(n) FROM (SELECT ($terms) AS n FROM `$table` LIMIT $limit)"
+            raw.query(SimpleSQLiteQuery(sql)).use { c ->
+                if (c.moveToFirst() && !c.isNull(0)) out[key] = Math.round(c.getDouble(0) * rows).toInt()
+            }
+        }
+        out.toMap()
+    }.getOrDefault(emptyMap())
+
+    internal companion object {
+        /** One column's contribution to a row's payload. Byte-true for text and blobs, nominal otherwise. */
+        internal fun rowSizeTerm(column: String): String =
+            "(CASE WHEN `$column` IS NULL THEN 0 " +
+                "WHEN typeof(`$column`) IN ('text','blob') THEN length(CAST(`$column` AS BLOB)) " +
+                "ELSE 8 END)"
+
+        /**
+         * The decoded stream tables and the key each reports under — Swift's `WhoopStore.rawTableKeys`,
+         * verbatim, and the same keys `WhoopRepository.storageRowCounts` uses. Adding a stream means
+         * adding it in all three, and the Apple side fails a test until it is.
+         */
+        internal val STORAGE_TABLES: List<Pair<String, String>> = listOf(
+            "hr" to "hrSample", "rr" to "rrInterval", "events" to "event", "battery" to "battery",
+            "spo2" to "spo2Sample", "skinTemp" to "skinTempSample", "resp" to "respSample",
+            "gravity" to "gravitySample", "steps" to "stepSample", "ppgHr" to "ppgHrSample",
+            "sleepState" to "sleepStateSample", "ppgWaveform" to "ppgWaveformSample",
+            "v18Aux" to "v18AuxSample",
+        )
+    }
+}

--- a/android/app/src/main/java/com/noop/testcentre/TestBundleMeta.kt
+++ b/android/app/src/main/java/com/noop/testcentre/TestBundleMeta.kt
@@ -25,7 +25,13 @@ data class TestBundleMeta(
     val captureCheck: CaptureCheck,
 ) {
     data class Build(val channel: String, val signed: Boolean)
-    data class Storage(val dbBytes: Int, val rows: Map<String, Int>, val rawCaptureBytes: Int)
+    data class Storage(
+        val dbBytes: Int,
+        val rows: Map<String, Int>,
+        val rawCaptureBytes: Int,
+        /** #1911: estimated payload bytes per table, keyed as [rows] is. Swift twin: `Storage.rowBytes`. */
+        val rowBytes: Map<String, Int> = emptyMap(),
+    )
 
     /** The report-completeness tie (twin of the Swift CaptureCheck): per-domain killer-trace presence
      *  ({domainId -> "present"|"MISSING"}) plus the overall `complete` flag, so a maintainer can tell at
@@ -53,7 +59,10 @@ data class TestBundleMeta(
             "storage" to mapOf(
                 "db_bytes" to storage.dbBytes,
                 "raw_capture_bytes" to storage.rawCaptureBytes,
-                "rows" to storage.rows),
+                "rows" to storage.rows,
+                // #1911: bytes beside the counts, so this block matches the Apple bundle's. Rows alone
+                // cannot say which table holds a large store - ppgWaveformSample's rows carry a BLOB.
+                "row_bytes" to storage.rowBytes),
             "strap_model" to strapModel,
             "test_profile" to testProfile,
             "truncated" to truncated)

--- a/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TestCentreScreen.kt
@@ -493,6 +493,10 @@ private suspend fun buildPending(
         if (f.exists()) dbBytes += f.length()
     }
     val rows = vm.repo.storageRowCounts()
+    // #1911: bytes beside the counts, reusing the counts just read rather than a second COUNT(*) pass over
+    // thirteen tables - each is a full scan on the large stores this report is pulled from.
+    val rowBytes = com.noop.data.StorageFootprint(
+        com.noop.data.WhoopDatabase.get(context)).byteEstimates(rows)
     var rawBytes = 0L
     for (name in listOf(
         com.noop.ble.WhoopBleClient.WHOOP5_CAPTURE_FILE,
@@ -506,6 +510,7 @@ private suspend fun buildPending(
             dbBytes = dbBytes.coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
             rows = rows,
             rawCaptureBytes = rawBytes.coerceAtMost(Int.MAX_VALUE.toLong()).toInt(),
+            rowBytes = rowBytes,
         )
     } else {
         null

--- a/android/app/src/test/java/com/noop/data/StorageFootprintTermTest.kt
+++ b/android/app/src/test/java/com/noop/data/StorageFootprintTermTest.kt
@@ -1,0 +1,44 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1911: the per-column size expression and the table list, pinned without a Room runtime.
+ *
+ * The estimate itself needs an open database and the JVM unit tests have none, so what is reachable here
+ * is the part that actually drifts: the SQL shape, and the key set that has to match Apple's verbatim for
+ * the two meta.json blocks to be comparable at all.
+ */
+class StorageFootprintTermTest {
+
+    /**
+     * `typeof()` at runtime, not the declared type, and byte length via `CAST(... AS BLOB)`.
+     *
+     * Both matter and both are easy to "simplify" away. SQLite is dynamically typed, so a column declared
+     * INTEGER can hold text; and `length()` on text counts CHARACTERS while the store spends bytes, so a
+     * multi-byte value would be under-counted by exactly the amount that makes it worth counting.
+     */
+    @Test fun `the term measures bytes at runtime, not declared width`() {
+        val term = StorageFootprint.rowSizeTerm("samples")
+        assertTrue(term, term.contains("typeof(`samples`)"))
+        assertTrue(term, term.contains("length(CAST(`samples` AS BLOB))"))
+        assertTrue(term, term.contains("IS NULL THEN 0"))
+        assertTrue("a numeric column still costs something", term.contains("ELSE 8"))
+    }
+
+    /**
+     * The key set is a cross-platform contract: Apple pins it in `WhoopStoreTests.ReadTests`, and the two
+     * meta.json blocks are only comparable while both sides report the same thirteen keys.
+     */
+    @Test fun `the table list matches the Apple key set`() {
+        val expected = listOf(
+            "hr", "rr", "events", "battery", "spo2", "skinTemp", "resp", "gravity",
+            "steps", "ppgHr", "sleepState", "ppgWaveform", "v18Aux",
+        )
+        assertEquals(expected.sorted(), StorageFootprint.STORAGE_TABLES.map { it.first }.sorted())
+        assertTrue("the blob table must be in the list at all",
+                   StorageFootprint.STORAGE_TABLES.any { it.second == "ppgWaveformSample" })
+    }
+}


### PR DESCRIPTION
Two follow-ups for #1911 that the row counts did not cover.

## Bytes, because rows are not bytes

I said in that thread that a Test Centre export would now name the table holding
a 6.5 GB store. That overstated what landed. Rows are not bytes — and
`ppgWaveformSample`, the table I singled out as the likely culprit, is exactly
where a row model misleads, because it is the only one here whose row size varies.

So the estimate measures the blob rather than assuming it: BLOB and TEXT columns
by real length, numeric columns at a nominal 8, sampled over up to 500 rows and
multiplied by the row count. Sampled deliberately — a full `SUM(LENGTH(...))`
over a multi-gigabyte store is precisely the read this diagnostic exists to help
someone avoid, and an estimate answers "which table dominates" just as well.

It is a payload lower bound: no index pages, no page slack, no WAL. Compare it
against `db_bytes` in the same probe; do not expect the two to meet. Empty tables
are omitted rather than reported as zero, matching the row counts — absent means
"nothing to attribute here", which is not a measured zero.

`meta.json` gains a `row_bytes` block beside `rows`.

## A stale claim a retention design would have read off

`LocalAccessCore` said `ppgWaveformSample` and `v18AuxSample` are "neither
pruned". `v18AuxSample` has had rolling retention for some time —
`v18AuxRetentionRows` / `v18AuxPruneEveryRows`, Room migration v31, covered by
`DeepCaptureChannelsTests` — about 604 800 rows, roughly seven days. That is what
#1911 says, and what this comment contradicted.

Being wrong there matters more than usual: "which tables are already bounded" is
the first thing a retention design reads off, so this would have had it either
solving a solved problem or trusting a bound that was never there.

That file also holds a **fourth** copy of the thirteen-table list. It stays.
`NoopLocalAccess` depends on GRDB alone and is independent of `WhoopStore` on
purpose — it is the read-only access tool — so unlike the three collapsed in
#1918, this duplication is deliberate, and the comment now says so.

## Verification

Two tests: the blob table must estimate larger per row than an all-numeric table
of the same shape (otherwise the blob is not being measured at all), and a fresh
store estimates nothing rather than zeroes. Doc lint clean; all files parse. The
package tests and app-target compile ride CI — this WSL toolchain has no
`sqlite3.h`, so `swift build` cannot build CSQLite.

No retention behaviour changes here either. #1911's growth is still unaddressed;
this is the measurement its design should be built on.