### PR TITLE
today: the calibrating ring counts nights, so say nights

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Baselines.swift
@@ -279,6 +279,29 @@ public enum Baselines {
     /// from your strap for N days" when the baseline aged out silently instead of only "building your
     /// baseline". Pure and TZ-free (civil-day arithmetic); mirror EXACTLY in the Kotlin twin.
     /// `dayKeys`/`nightlyHrv` are parallel (same night per index); `today` is an ISO `yyyy-MM-dd` key.
+    /// Nights the app OBSERVED in the recent window, and how many of them carried no usable HRV.
+    ///
+    /// Distinct from both neighbours, and the gap between them. `calibrationNights` counts progress
+    /// toward a baseline; `nightsSinceNewestValidNight` measures a TOTAL drought and only speaks once it
+    /// passes `staleDays`. Neither says anything about the common case: nights arriving, but most of them
+    /// carrying nothing. A wearer five days in with three empty nights sits at "2 of 4" with no reason
+    /// given, which reads as a stuck counter rather than as missing data — that is the report this exists
+    /// to answer.
+    ///
+    /// Counts only days the app has a row for, so a new install is not charged for nights before it owned
+    /// the strap. Pure and TZ-free (civil-day arithmetic); mirror EXACTLY in the Kotlin twin.
+    public static func recentHrvCoverage(dayKeys: [String], nightlyHrv: [Double?], today: String,
+                                         window: Int = staleDays) -> (observed: Int, missing: Int) {
+        guard let t = isoEpochDay(today) else { return (0, 0) }
+        var observed = 0, missing = 0
+        for i in 0..<Swift.min(dayKeys.count, nightlyHrv.count) {
+            guard let d = isoEpochDay(dayKeys[i]), t - d >= 0, t - d < window else { continue }
+            observed += 1
+            if nightlyHrv[i] == nil { missing += 1 }
+        }
+        return (observed, missing)
+    }
+
     public static func nightsSinceNewestValidNight(dayKeys: [String], nightlyHrv: [Double?], today: String) -> Int? {
         var newest: String? = nil
         for i in 0..<Swift.min(dayKeys.count, nightlyHrv.count) where nightlyHrv[i] != nil {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BaselinesRecentHrvCoverageTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/BaselinesRecentHrvCoverageTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// The counts behind "N of the last M nights recorded no HRV".
+///
+/// The line only helps if both numbers are right, and both are Ints with the same units, so an inverted
+/// pair reads as "5 of the last 3 nights" — absurd to a person, invisible to a compiler. These pin the
+/// order as well as the arithmetic. Byte-identical twin: Kotlin `RecentHrvCoverageTest`.
+final class BaselinesRecentHrvCoverageTests: XCTestCase {
+
+    /// The reported shape: five observed nights, three of them empty.
+    func testCountsObservedNightsAndTheEmptyOnesAmongThem() {
+        let days = ["2026-09-02", "2026-09-03", "2026-09-04", "2026-09-05", "2026-09-06"]
+        let hrv: [Double?] = [44.0, nil, nil, 47.0, nil]
+        let cov = Baselines.recentHrvCoverage(dayKeys: days, nightlyHrv: hrv, today: "2026-09-06")
+        XCTAssertEqual(cov.observed, 5)
+        XCTAssertEqual(cov.missing, 3)
+    }
+
+    /// Only days the app has a row for, so a fresh install is not charged for nights it never saw.
+    func testADayOutsideTheWindowIsNotObserved() {
+        let cov = Baselines.recentHrvCoverage(dayKeys: ["2026-08-01", "2026-09-06"],
+                                              nightlyHrv: [nil, nil], today: "2026-09-06", window: 14)
+        XCTAssertEqual(cov.observed, 1, "the August night is 36 days back, outside the window")
+        XCTAssertEqual(cov.missing, 1)
+    }
+
+    /// A future-dated row cannot be a night that already happened.
+    func testADayAfterTodayIsIgnored() {
+        let cov = Baselines.recentHrvCoverage(dayKeys: ["2026-09-07"], nightlyHrv: [nil],
+                                              today: "2026-09-06")
+        XCTAssertEqual(cov.observed, 0)
+        XCTAssertEqual(cov.missing, 0)
+    }
+
+    /// Every night counted: the caller must then say nothing extra.
+    func testACompleteWindowReportsNothingMissing() {
+        let cov = Baselines.recentHrvCoverage(dayKeys: ["2026-09-05", "2026-09-06"],
+                                              nightlyHrv: [50.0, 51.0], today: "2026-09-06")
+        XCTAssertEqual(cov.observed, 2)
+        XCTAssertEqual(cov.missing, 0)
+    }
+
+    /// No rows, and an unparseable today, both yield zeroes rather than a fabricated count.
+    func testEmptyAndUnparseableInputsAreZero() {
+        XCTAssertEqual(Baselines.recentHrvCoverage(dayKeys: [], nightlyHrv: [], today: "2026-09-06").observed, 0)
+        XCTAssertEqual(Baselines.recentHrvCoverage(dayKeys: ["2026-09-06"], nightlyHrv: [nil],
+                                                   today: "not-a-day").observed, 0)
+    }
+}

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -1107,6 +1107,15 @@ struct LiquidTodayView: View {
                         Text(chargeDisplay.calibrationDetail ?? synthLine)
                             .font(StrandFont.body).foregroundStyle(StrandPalette.textPrimary)
                             .fixedSize(horizontal: false, vertical: true)
+                        // The reason the count is not moving, when nights are arriving empty. Sits under
+                        // the progress rather than replacing it: the wearer needs both the number and why.
+                        if let why = chargeDisplay.calibrationReason(
+                            dayKeys: repo.days.map(\.day), nightlyHrv: repo.days.map(\.avgHrv),
+                            today: Repository.logicalDayKey(Date())) {
+                            Text(why).font(StrandFont.caption)
+                                .foregroundStyle(StrandPalette.textSecondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
                         // #530 follow-up: the classic hero's "no cardio load yet" note (effortZeroNote),
                         // shown on a calm day so today's ~0 Effort explains itself instead of a bare 0.
                         if let note = effortZeroNote {
@@ -2475,6 +2484,15 @@ extension LiquidTodayView {
         var calibrationDetail: String? {
             guard case .calibrating(let nights) = self else { return nil }
             return String(localized: "Learning your baseline, \(nights) of \(Baselines.minNightsSeed) nights.")
+        }
+
+        /// The reason half, when nights are arriving but most carry no HRV (see `TodayView`'s twin). Nil
+        /// when every observed night counted, so a healthy calibration says nothing extra.
+        func calibrationReason(dayKeys: [String], nightlyHrv: [Double?], today: String) -> String? {
+            guard case .calibrating = self else { return nil }
+            let cov = Baselines.recentHrvCoverage(dayKeys: dayKeys, nightlyHrv: nightlyHrv, today: today)
+            guard cov.missing > 0, cov.observed > 0 else { return nil }
+            return String(localized: "\(cov.missing) of the last \(cov.observed) nights recorded no HRV. Check the strap is worn overnight and syncing.")
         }
 
         static func resolve(todayRecovery: Double?, priorScored: DailyMetric?,

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -210051,17 +210051,17 @@
         "zh-Hans": {"stringUnit": {"state": "translated", "value": "无法启动麦克风：%@"}},
         "zh-Hant": {"stringUnit": {"state": "translated", "value": "無法啟動麥克風：%@"}}
     } },
-    "%@ of %@ nights": { "localizations": {
-        "de": {"stringUnit": {"state": "translated", "value": "%@ von %@ Nächten"}},
-        "en": {"stringUnit": {"state": "translated", "value": "%@ of %@ nights"}},
-        "es": {"stringUnit": {"state": "translated", "value": "%@ de %@ noches"}},
-        "fr": {"stringUnit": {"state": "translated", "value": "%@ nuits sur %@"}},
-        "it": {"stringUnit": {"state": "translated", "value": "%@ di %@ notti"}},
-        "pl": {"stringUnit": {"state": "translated", "value": "%@ z %@ nocy"}},
-        "pt-PT": {"stringUnit": {"state": "translated", "value": "%@ de %@ noites"}},
-        "ru": {"stringUnit": {"state": "translated", "value": "%@ из %@ ночей"}},
-        "zh-Hans": {"stringUnit": {"state": "translated", "value": "%@ / %@ 晚"}},
-        "zh-Hant": {"stringUnit": {"state": "translated", "value": "%@ / %@ 晚"}}
+    "%lld of %lld nights": { "localizations": {
+        "de": {"stringUnit": {"state": "translated", "value": "%lld von %lld Nächten"}},
+        "en": {"stringUnit": {"state": "translated", "value": "%lld of %lld nights"}},
+        "es": {"stringUnit": {"state": "translated", "value": "%lld de %lld noches"}},
+        "fr": {"stringUnit": {"state": "translated", "value": "%lld nuits sur %lld"}},
+        "it": {"stringUnit": {"state": "translated", "value": "%lld di %lld notti"}},
+        "pl": {"stringUnit": {"state": "translated", "value": "%lld z %lld nocy"}},
+        "pt-PT": {"stringUnit": {"state": "translated", "value": "%lld de %lld noites"}},
+        "ru": {"stringUnit": {"state": "translated", "value": "%lld из %lld ночей"}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "%lld / %lld 晚"}},
+        "zh-Hant": {"stringUnit": {"state": "translated", "value": "%lld / %lld 晚"}}
     } }
   },
   "version": "1.0"

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -210050,6 +210050,18 @@
         "ru": {"stringUnit": {"state": "translated", "value": "Не удалось включить микрофон: %@"}},
         "zh-Hans": {"stringUnit": {"state": "translated", "value": "无法启动麦克风：%@"}},
         "zh-Hant": {"stringUnit": {"state": "translated", "value": "無法啟動麥克風：%@"}}
+    } },
+    "%@ of %@ nights": { "localizations": {
+        "de": {"stringUnit": {"state": "translated", "value": "%@ von %@ Nächten"}},
+        "en": {"stringUnit": {"state": "translated", "value": "%@ of %@ nights"}},
+        "es": {"stringUnit": {"state": "translated", "value": "%@ de %@ noches"}},
+        "fr": {"stringUnit": {"state": "translated", "value": "%@ nuits sur %@"}},
+        "it": {"stringUnit": {"state": "translated", "value": "%@ di %@ notti"}},
+        "pl": {"stringUnit": {"state": "translated", "value": "%@ z %@ nocy"}},
+        "pt-PT": {"stringUnit": {"state": "translated", "value": "%@ de %@ noites"}},
+        "ru": {"stringUnit": {"state": "translated", "value": "%@ из %@ ночей"}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "%@ / %@ 晚"}},
+        "zh-Hant": {"stringUnit": {"state": "translated", "value": "%@ / %@ 晚"}}
     } }
   },
   "version": "1.0"

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -210062,6 +210062,18 @@
         "ru": {"stringUnit": {"state": "translated", "value": "%lld из %lld ночей"}},
         "zh-Hans": {"stringUnit": {"state": "translated", "value": "%lld / %lld 晚"}},
         "zh-Hant": {"stringUnit": {"state": "translated", "value": "%lld / %lld 晚"}}
+    } },
+    "%lld of the last %lld nights recorded no HRV. Check the strap is worn overnight and syncing.": { "localizations": {
+        "de": {"stringUnit": {"state": "translated", "value": "%lld der letzten %lld Nächte haben keine HRV aufgezeichnet. Prüfe, ob der Strap nachts getragen wird und synchronisiert."}},
+        "en": {"stringUnit": {"state": "translated", "value": "%lld of the last %lld nights recorded no HRV. Check the strap is worn overnight and syncing."}},
+        "es": {"stringUnit": {"state": "translated", "value": "%lld de las últimas %lld noches no registraron HRV. Comprueba que llevas la banda por la noche y que se sincroniza."}},
+        "fr": {"stringUnit": {"state": "translated", "value": "%lld des %lld dernières nuits n’ont enregistré aucune VFC. Vérifiez que le bracelet est porté la nuit et se synchronise."}},
+        "it": {"stringUnit": {"state": "translated", "value": "%lld delle ultime %lld notti non hanno registrato HRV. Controlla che la fascia sia indossata di notte e si sincronizzi."}},
+        "pl": {"stringUnit": {"state": "translated", "value": "%lld z ostatnich %lld nocy nie zarejestrowało HRV. Sprawdź, czy opaska jest noszona w nocy i synchronizuje się."}},
+        "pt-PT": {"stringUnit": {"state": "translated", "value": "%lld das últimas %lld noites não registaram HRV. Verifica se usas a fita à noite e se sincroniza."}},
+        "ru": {"stringUnit": {"state": "translated", "value": "%lld из последних %lld ночей не записали ВСР. Проверьте, что ремешок надет ночью и синхронизируется."}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "最近 %2$lld 晚中有 %1$lld 晚未记录 HRV。请检查夜间是否佩戴并已同步。"}},
+        "zh-Hant": {"stringUnit": {"state": "translated", "value": "最近 %2$lld 晚中有 %1$lld 晚未記錄 HRV。請檢查夜間是否配戴並已同步。"}}
     } }
   },
   "version": "1.0"

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -1108,6 +1108,16 @@ struct TodayView: View {
            stale > Baselines.staleDays {
             return "No new nights from your strap for \(stale) days. Check it's connected and saving data."
         }
+        // #612 covers a TOTAL drought (nothing valid for staleDays). The common shape is the other one:
+        // nights arriving, most of them empty — five days in with three HRV-less nights sits at "2 of 4"
+        // with no reason given, which reads as a stuck counter. Name the missing nights so the wearer has
+        // something to act on instead of something to wait for.
+        let cov = Baselines.recentHrvCoverage(dayKeys: repo.days.map(\.day),
+                                              nightlyHrv: repo.days.map(\.avgHrv),
+                                              today: Repository.logicalDayKey(Date()))
+        if cov.missing > 0, cov.observed > 0 {
+            return "Learning your baseline, \(n) of \(Baselines.minNightsSeed) nights. \(cov.missing) of the last \(cov.observed) nights recorded no HRV. Check the strap is worn overnight and syncing."
+        }
         return "Learning your baseline, \(n) of \(Baselines.minNightsSeed) nights."
     }
 

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -3397,8 +3397,14 @@ struct TodayView: View {
                 // the same lineLimit/scaleFactor guard so it never wraps, then its "N of 4" subtitle below.
                 Text("Calibrating").font(StrandFont.headline).foregroundStyle(StrandPalette.textPrimary)
                     .lineLimit(1).minimumScaleFactor(0.7).fixedSize()
-                Text("\(n) of \(Baselines.minNightsSeed)").font(StrandFont.footnote).foregroundStyle(StrandPalette.textSecondary)
-                    .lineLimit(1)
+                // #1816's lesson on a second tile: a bare "2 of 4" under "Calibrating" is read as DAYS,
+                // and a wearer five days in reports it stuck. It counts NIGHTS THAT BANKED A USABLE HRV
+                // (`Baselines.update` only advances `nValid` for a non-nil in-range value), so a week of
+                // wear with three R-R-less nights genuinely sits at 2. Naming the unit is the whole fix:
+                // the number is right, the reader's unit was not.
+                Text("\(n) of \(Baselines.minNightsSeed) nights").font(StrandFont.footnote)
+                    .foregroundStyle(StrandPalette.textSecondary)
+                    .lineLimit(1).minimumScaleFactor(0.7)
             } else {
                 ringNoData(diameter: diameter)
             }

--- a/android/app/src/main/java/com/noop/analytics/Baselines.kt
+++ b/android/app/src/main/java/com/noop/analytics/Baselines.kt
@@ -234,6 +234,11 @@ object Baselines {
         return BaselineStatus.TRUSTED
     }
 
+    /** Named rather than a `Pair`: the two numbers are both Ints with the same units, so `first`/`second`
+     *  at a call site is a coin toss that no test would catch — "5 of the last 3 nights" is absurd to a
+     *  reader and invisible to a compiler. Mirrors the Swift twin's `(observed:missing:)` labels. */
+    data class HrvCoverage(val observed: Int, val missing: Int)
+
     /**
      * Nights the app OBSERVED in the recent window, and how many carried no usable HRV. Swift twin:
      * `Baselines.recentHrvCoverage`.
@@ -247,11 +252,6 @@ object Baselines {
      * Counts only days the app has a row for, so a new install is not charged for nights before it owned
      * the strap. Pure and TZ-free (civil-day arithmetic).
      */
-    /** Named rather than a `Pair`: the two numbers are both Ints with the same units, so `first`/`second`
-     *  at a call site is a coin toss that no test would catch — "5 of the last 3 nights" is absurd to a
-     *  reader and invisible to a compiler. Mirrors the Swift twin's `(observed:missing:)` labels. */
-    data class HrvCoverage(val observed: Int, val missing: Int)
-
     fun recentHrvCoverage(
         dayKeys: List<String>,
         nightlyHrv: List<Double?>,

--- a/android/app/src/main/java/com/noop/analytics/Baselines.kt
+++ b/android/app/src/main/java/com/noop/analytics/Baselines.kt
@@ -247,13 +247,18 @@ object Baselines {
      * Counts only days the app has a row for, so a new install is not charged for nights before it owned
      * the strap. Pure and TZ-free (civil-day arithmetic).
      */
+    /** Named rather than a `Pair`: the two numbers are both Ints with the same units, so `first`/`second`
+     *  at a call site is a coin toss that no test would catch — "5 of the last 3 nights" is absurd to a
+     *  reader and invisible to a compiler. Mirrors the Swift twin's `(observed:missing:)` labels. */
+    data class HrvCoverage(val observed: Int, val missing: Int)
+
     fun recentHrvCoverage(
         dayKeys: List<String>,
         nightlyHrv: List<Double?>,
         today: String,
         window: Int = staleDays,
-    ): Pair<Int, Int> {
-        val t = isoEpochDay(today) ?: return 0 to 0
+    ): HrvCoverage {
+        val t = isoEpochDay(today) ?: return HrvCoverage(0, 0)
         var observed = 0
         var missing = 0
         for (i in 0 until minOf(dayKeys.size, nightlyHrv.size)) {
@@ -262,7 +267,7 @@ object Baselines {
             observed++
             if (nightlyHrv[i] == null) missing++
         }
-        return observed to missing
+        return HrvCoverage(observed, missing)
     }
 
     /** #612: calendar days since the newest night that carried a usable HRV reading (the baseline's input),

--- a/android/app/src/main/java/com/noop/analytics/Baselines.kt
+++ b/android/app/src/main/java/com/noop/analytics/Baselines.kt
@@ -234,6 +234,37 @@ object Baselines {
         return BaselineStatus.TRUSTED
     }
 
+    /**
+     * Nights the app OBSERVED in the recent window, and how many carried no usable HRV. Swift twin:
+     * `Baselines.recentHrvCoverage`.
+     *
+     * Distinct from both neighbours, and the gap between them. `calibrationNights` counts progress toward
+     * a baseline; [nightsSinceNewestValidNight] measures a TOTAL drought and only speaks once it passes
+     * [staleDays]. Neither says anything about the common case: nights arriving, but most of them carrying
+     * nothing. A wearer five days in with three empty nights sits at "2 of 4" with no reason given, which
+     * reads as a stuck counter rather than as missing data — that is the report this exists to answer.
+     *
+     * Counts only days the app has a row for, so a new install is not charged for nights before it owned
+     * the strap. Pure and TZ-free (civil-day arithmetic).
+     */
+    fun recentHrvCoverage(
+        dayKeys: List<String>,
+        nightlyHrv: List<Double?>,
+        today: String,
+        window: Int = staleDays,
+    ): Pair<Int, Int> {
+        val t = isoEpochDay(today) ?: return 0 to 0
+        var observed = 0
+        var missing = 0
+        for (i in 0 until minOf(dayKeys.size, nightlyHrv.size)) {
+            val d = isoEpochDay(dayKeys[i]) ?: continue
+            if (t - d < 0 || t - d >= window) continue
+            observed++
+            if (nightlyHrv[i] == null) missing++
+        }
+        return observed to missing
+    }
+
     /** #612: calendar days since the newest night that carried a usable HRV reading (the baseline's input),
      *  or null when there is none / a key can't be parsed. DISTINCT from `calibrationNights` (which counts
      *  progress TOWARD a usable baseline) — this measures staleness, so a surface can say "no new nights from

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2938,7 +2938,22 @@ private fun SynthesisHeroCard(
             } else {
                 // Comma (not the old em-dash) to match the Swift canonical synthesis copy VERBATIM
                 // (TodayView "Learning your baseline, N of M nights.") and the no-em-dash standing rule.
-                uiString(R.string.today_synthesis_learning_baseline, recoveryCalibration, Baselines.minNightsSeed)
+                // #612 above covers a TOTAL drought. The common shape is the other one: nights arriving,
+                // most of them empty. Five days in with three HRV-less nights sits at "2 of 4" with no
+                // reason given, which reads as a stuck counter rather than as missing data. Name the
+                // missing nights so a wearer has something to act on instead of something to wait for.
+                // Swift twin: TodayView.calibrationDetail.
+                val cov = Baselines.recentHrvCoverage(
+                    days.map { it.day }, days.map { it.avgHrv }, logicalDayKeyNow(),
+                )
+                val base = uiString(
+                    R.string.today_synthesis_learning_baseline, recoveryCalibration, Baselines.minNightsSeed,
+                )
+                if (cov.second > 0 && cov.first > 0) {
+                    base + " " + uiString(R.string.today_synthesis_nights_without_hrv, cov.second, cov.first)
+                } else {
+                    base
+                }
             }
         } else if (carriedDay != null) {
             // Carried prior-day read, summarise that day + stamp it so it isn't passed off as today's.

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3013,6 +3013,17 @@ private fun SynthesisHeroCard(
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                         )
+                        // While calibrating, the detail carries the progress AND, when nights are arriving
+                        // empty, the reason. Collapsed used to show only "Calibrating", which is the state
+                        // the field report was taken in: the explanation existed one tap away and the
+                        // wearer had no way to know it was there. iOS never gated this line; matching it.
+                        if (recoveryCalibration != null) {
+                            Text(
+                                detail,
+                                style = NoopType.caption,
+                                color = Palette.textSecondary,
+                            )
+                        }
                     }
                     Icon(
                         Icons.Filled.KeyboardArrowDown,

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2949,8 +2949,8 @@ private fun SynthesisHeroCard(
                 val base = uiString(
                     R.string.today_synthesis_learning_baseline, recoveryCalibration, Baselines.minNightsSeed,
                 )
-                if (cov.second > 0 && cov.first > 0) {
-                    base + " " + uiString(R.string.today_synthesis_nights_without_hrv, cov.second, cov.first)
+                if (cov.missing > 0 && cov.observed > 0) {
+                    base + " " + uiString(R.string.today_synthesis_nights_without_hrv, cov.missing, cov.observed)
                 } else {
                     base
                 }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2354,6 +2354,7 @@
     <string name="today_steps_headline_more_days">Noch %1$d Tage mit Smartphone-Schritten nötig</string>
     <string name="today_steps_headline_no_motion">Noch keine Bewegungsdaten synchronisiert</string>
     <string name="today_synthesis_learning_baseline">Dein Basiswert wird gelernt, %1$d von %2$d Nächten.</string>
+    <string name="today_synthesis_nights_without_hrv">%1$d der letzten %2$d Nächte haben keine HRV aufgezeichnet. Prüfe, ob der Strap nachts getragen wird und synchronisiert.</string>
     <string name="today_last_night_date">Letzte Nacht · %1$s</string>
     <string name="today_hr_min">Min.</string>
     <string name="today_hr_avg">Ø</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -970,7 +970,7 @@
     <string name="l10n_today_screen_arrange_today_6b699147">Heute vereinbaren</string>
     <string name="l10n_today_screen_calibrating_37c2c9bd">Kalibrierung</string>
     <string name="l10n_today_screen_no_new_nights_from_your_strap_for_stale_days_8863bcfe">Seit %1$d Tagen keine neuen Nächte von deinem Strap. Prüfe, ob er verbunden ist und Daten speichert.</string>
-    <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s von %2$s</string>
+    <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s von %2$s Nächten</string>
     <string name="l10n_today_screen_choose_which_cards_show_on_today_f79942e1">Wählen Sie, welche Karten auf Heute angezeigt werden, und ordnen Sie sie mit den Pfeilen neu an.</string>
     <string name="l10n_today_screen_close_bbfa773e">Schließen</string>
     <string name="l10n_today_screen_customise_your_cards_2428d761">Passe deine Karten an</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -770,7 +770,7 @@
     <string name="l10n_today_screen_arrange_today_6b699147">Arregla hoy</string>
     <string name="l10n_today_screen_calibrating_37c2c9bd">Calibrando</string>
     <string name="l10n_today_screen_no_new_nights_from_your_strap_for_stale_days_8863bcfe">Sin nuevas noches de tu strap desde hace %1$d días. Comprueba que esté conectado y guardando datos.</string>
-    <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s de %2$s</string>
+    <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s de %2$s noches</string>
     <string name="l10n_today_screen_choose_which_cards_show_on_today_f79942e1">Elija qué tarjetas muestran en Hoy y reordenarlos con las flechas.</string>
     <string name="l10n_today_screen_close_bbfa773e">Cerrar</string>
     <string name="l10n_today_screen_customise_your_cards_2428d761">Personaliza tus tarjetas</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2341,6 +2341,7 @@
     <string name="today_steps_headline_more_days">Faltan %1$d días contabilizados también por el teléfono</string>
     <string name="today_steps_headline_no_motion">Aún no se han sincronizado datos de movimiento</string>
     <string name="today_synthesis_learning_baseline">Creando tu referencia, %1$d de %2$d noches.</string>
+    <string name="today_synthesis_nights_without_hrv">%1$d de las últimas %2$d noches no registraron HRV. Comprueba que llevas la banda por la noche y que se sincroniza.</string>
     <string name="today_last_night_date">Anoche · %1$s</string>
     <string name="today_hr_min">Mín.</string>
     <string name="today_hr_avg">Media</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -788,7 +788,7 @@
     <string name="l10n_today_screen_arrange_today_6b699147">Arrange aujourd\'hui</string>
     <string name="l10n_today_screen_calibrating_37c2c9bd">Calibration en cours</string>
     <string name="l10n_today_screen_no_new_nights_from_your_strap_for_stale_days_8863bcfe">Aucune nouvelle nuit de votre strap depuis %1$d jours. Vérifiez qu\'il est connecté et enregistre les données.</string>
-    <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s de %2$s</string>
+    <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s nuits sur %2$s</string>
     <string name="l10n_today_screen_choose_which_cards_show_on_today_f79942e1">Choisissez les cartes affichées sur Today et réarrangez-les avec les flèches.</string>
     <string name="l10n_today_screen_close_bbfa773e">Fermer</string>
     <string name="l10n_today_screen_customise_your_cards_2428d761">Personnalisez vos cartes</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2340,6 +2340,7 @@
     <string name="today_steps_headline_more_days">Encore %1$d jours également comptés par le téléphone</string>
     <string name="today_steps_headline_no_motion">Aucune donnée de mouvement synchronisée pour l\'instant</string>
     <string name="today_synthesis_learning_baseline">Création de votre référence, %1$d nuits sur %2$d.</string>
+    <string name="today_synthesis_nights_without_hrv">%1$d des %2$d dernières nuits n\'ont enregistré aucune VFC. Vérifiez que le bracelet est porté la nuit et se synchronise.</string>
     <string name="today_last_night_date">Nuit dernière · %1$s</string>
     <string name="today_hr_min">Min.</string>
     <string name="today_hr_avg">Moy.</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -921,7 +921,7 @@
     <string name="l10n_today_screen_arrange_today_6b699147">Umów się już dziś</string>
     <string name="l10n_today_screen_calibrating_37c2c9bd">Kalibracja</string>
     <string name="l10n_today_screen_no_new_nights_from_your_strap_for_stale_days_8863bcfe">Żadnych nowych nocy z Twojego paska przez %1$d dni. Sprawdź, czy jest podłączony i zapisuje dane.</string>
-    <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s lub %2$s</string>
+    <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s z %2$s nocy</string>
     <string name="l10n_today_screen_choose_which_cards_show_on_today_f79942e1">Wybierz, które karty mają być wyświetlane w Dzisiaj i zmień ich kolejność za pomocą strzałek.</string>
     <string name="l10n_today_screen_close_bbfa773e">Zamknij</string>
     <string name="l10n_today_screen_customise_your_cards_2428d761">Dostosuj swoje karty</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2333,6 +2333,7 @@
     <string name="today_steps_headline_more_days">Potrzeba jeszcze %1$d dni z krokami telefonu</string>
     <string name="today_steps_headline_no_motion">Brak zsynchronizowanych danych o ruchu</string>
     <string name="today_synthesis_learning_baseline">Tworzenie bazy: %1$d z %2$d nocy.</string>
+    <string name="today_synthesis_nights_without_hrv">%1$d z ostatnich %2$d nocy nie zarejestrowało HRV. Sprawdź, czy opaska jest noszona w nocy i synchronizuje się.</string>
     <string name="today_last_night_date">Ostatnia noc · %1$s</string>
     <string name="today_hr_min">Min.</string>
     <string name="today_hr_avg">Śr.</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2333,6 +2333,7 @@
     <string name="today_steps_headline_more_days">Faltam %1$d dias também contados pelo telemóvel</string>
     <string name="today_steps_headline_no_motion">Ainda sem dados de movimento sincronizados</string>
     <string name="today_synthesis_learning_baseline">A criar a sua referência, %1$d de %2$d noites.</string>
+    <string name="today_synthesis_nights_without_hrv">%1$d das últimas %2$d noites não registaram HRV. Verifica se usas a fita à noite e se sincroniza.</string>
     <string name="today_last_night_date">Noite passada · %1$s</string>
     <string name="today_hr_min">Mín.</string>
     <string name="today_hr_avg">Méd.</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -935,7 +935,7 @@
     <string name="l10n_today_screen_arrange_today_6b699147">Organize hoje</string>
     <string name="l10n_today_screen_calibrating_37c2c9bd">A calibrar</string>
     <string name="l10n_today_screen_no_new_nights_from_your_strap_for_stale_days_8863bcfe">Nenhuma noite nova na tua bracelete durante %1$d dias. Verifique se está ligado e a guardar dados.</string>
-    <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s de %2$s</string>
+    <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s de %2$s noites</string>
     <string name="l10n_today_screen_choose_which_cards_show_on_today_f79942e1">Escolha quais os cartões que serão apresentados no Hoje e reordene-os com as setas. </string>
     <string name="l10n_today_screen_close_bbfa773e">Fechar</string>
     <string name="l10n_today_screen_customise_your_cards_2428d761">Personalize os teus cartões</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -2287,6 +2287,7 @@
     <string name="today_steps_headline_more_days">Нужно ещё %1$d дней, когда ваш телефон тоже считал шаги</string>
     <string name="today_steps_headline_no_motion">Данные о движении ещё не синхронизированы</string>
     <string name="today_synthesis_learning_baseline">Изучаем вашу норму, %1$d из %2$d ночей.</string>
+    <string name="today_synthesis_nights_without_hrv">%1$d из последних %2$d ночей не записали ВСР. Проверьте, что ремешок надет ночью и синхронизируется.</string>
     <string name="today_last_night_date">Прошлая ночь · %1$s</string>
     <string name="today_hr_min">Мин.</string>
     <string name="today_hr_avg">Сред.</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -967,7 +967,7 @@
     <string name="l10n_today_screen_arrange_today_6b699147">Настроить «Сегодня»</string>
     <string name="l10n_today_screen_calibrating_37c2c9bd">Калибровка</string>
     <string name="l10n_today_screen_no_new_nights_from_your_strap_for_stale_days_8863bcfe">Нет новых ночей с вашего браслета уже %1$d дней. Проверьте, что он подключён и сохраняет данные.</string>
-    <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s из %2$s</string>
+    <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s из %2$s ночей</string>
     <string name="l10n_today_screen_choose_which_cards_show_on_today_f79942e1">Выберите, какие карточки показывать на «Сегодня», и меняйте их порядок стрелками. </string>
     <string name="l10n_today_screen_close_bbfa773e">Закрыть</string>
     <string name="l10n_today_screen_customise_your_cards_2428d761">Настройте свои карточки</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2268,6 +2268,7 @@
     <string name="today_steps_headline_more_days">还需 %1$d 天由手机同时记录步数</string>
     <string name="today_steps_headline_no_motion">尚未同步运动数据</string>
     <string name="today_synthesis_learning_baseline">正在建立基线：%1$d/%2$d 晚。</string>
+    <string name="today_synthesis_nights_without_hrv">最近 %2$d 晚中有 %1$d 晚未记录 HRV。请检查夜间是否佩戴并已同步。</string>
     <string name="today_last_night_date">昨晚 · %1$s</string>
     <string name="today_hr_min">最低</string>
     <string name="today_hr_avg">平均</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1055,7 +1055,7 @@
     <string name="l10n_today_screen_arrange_today_6b699147">Arrange Today</string>
     <string name="l10n_today_screen_calibrating_37c2c9bd">Calibrating</string>
     <string name="l10n_today_screen_no_new_nights_from_your_strap_for_stale_days_8863bcfe">No new nights from your strap for %1$d days. Check it\'s connected and saving data.</string>
-    <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s of %2$s</string>
+    <string name="l10n_today_screen_calibratingnights_of_baselines_minnightsseed_3b76e55c">%1$s of %2$s nights</string>
     <string name="l10n_today_screen_choose_which_cards_show_on_today_f79942e1">Choose which cards show on Today and reorder them with the arrows. </string>
     <string name="l10n_today_screen_close_bbfa773e">Close</string>
     <string name="l10n_today_screen_customise_your_cards_2428d761">Customise your cards</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2453,6 +2453,7 @@
     <string name="today_steps_headline_more_days">Need %1$d more days where your phone also counted steps</string>
     <string name="today_steps_headline_no_motion">No motion synced yet</string>
     <string name="today_synthesis_learning_baseline">Learning your baseline, %1$d of %2$d nights.</string>
+    <string name="today_synthesis_nights_without_hrv">%1$d of the last %2$d nights recorded no HRV. Check the strap is worn overnight and syncing.</string>
     <string name="today_last_night_date">Last night · %1$s</string>
     <string name="today_hr_min">Min</string>
     <string name="today_hr_avg">Avg</string>

--- a/android/app/src/test/java/com/noop/analytics/RecentHrvCoverageTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RecentHrvCoverageTest.kt
@@ -1,0 +1,53 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #1853-adjacent: the counts behind "N of the last M nights recorded no HRV".
+ *
+ * The line only helps if both numbers are right, and both are Ints with the same units, so an inverted
+ * pair reads as "5 of the last 3 nights" — absurd to a person, invisible to a compiler. These pin the
+ * order as well as the arithmetic. Byte-identical twin: Swift `BaselinesRecentHrvCoverageTests`.
+ */
+class RecentHrvCoverageTest {
+
+    /** The reported shape: five observed nights, three of them empty. */
+    @Test fun `counts observed nights and the empty ones among them`() {
+        val days = listOf("2026-09-02", "2026-09-03", "2026-09-04", "2026-09-05", "2026-09-06")
+        val hrv = listOf(44.0, null, null, 47.0, null)
+        val cov = Baselines.recentHrvCoverage(days, hrv, "2026-09-06")
+        assertEquals(5, cov.observed)
+        assertEquals(3, cov.missing)
+    }
+
+    /** Only days the app has a row for, so a fresh install is not charged for nights it never saw. */
+    @Test fun `a day outside the window is not observed`() {
+        val days = listOf("2026-08-01", "2026-09-06")
+        val hrv = listOf<Double?>(null, null)
+        val cov = Baselines.recentHrvCoverage(days, hrv, "2026-09-06", window = 14)
+        assertEquals("the August night is 36 days back, outside the window", 1, cov.observed)
+        assertEquals(1, cov.missing)
+    }
+
+    /** A future-dated row cannot be a night that already happened. */
+    @Test fun `a day after today is ignored`() {
+        val cov = Baselines.recentHrvCoverage(listOf("2026-09-07"), listOf(null), "2026-09-06")
+        assertEquals(0, cov.observed)
+        assertEquals(0, cov.missing)
+    }
+
+    /** Every night counted: the caller must then say nothing extra. */
+    @Test fun `a complete window reports nothing missing`() {
+        val days = listOf("2026-09-05", "2026-09-06")
+        val cov = Baselines.recentHrvCoverage(days, listOf(50.0, 51.0), "2026-09-06")
+        assertEquals(2, cov.observed)
+        assertEquals(0, cov.missing)
+    }
+
+    /** No rows, and an unparseable today, both yield zeroes rather than a fabricated count. */
+    @Test fun `empty and unparseable inputs are zero`() {
+        assertEquals(0, Baselines.recentHrvCoverage(emptyList(), emptyList(), "2026-09-06").observed)
+        assertEquals(0, Baselines.recentHrvCoverage(listOf("2026-09-06"), listOf(null), "not-a-day").observed)
+    }
+}


### PR DESCRIPTION
From a field report: *"It has been 5 days already but the charge has not calibrated yet"*, against a Charge ring reading **2 of 4**.

## The count is right; the unit was missing

`RecoveryScorer.calibrationNights` counts nights that banked a **usable HRV**, not days elapsed — `Baselines.update` only advances `nValid` for a non-nil value inside `cfg.minVal…maxVal`, and a nil night holds the baseline without counting. So five days of wear with three R-R-less nights genuinely sits at 2.

A bare "2 of 4" under "Calibrating" is read as days, and a number that has not moved in five of them is read as broken. The reporter's own screenshot shows why those nights were empty — **Effort and Strain both "No data"** while Rest reads 90%: sleep is staging, the R-R that HRV needs is not landing. The calibration counter was reporting that faithfully.

## The same shape as #1816

That one merged an hour ago: the steps caption counted down phone-step days while the strap had banked no motion, and sent a reporter to enter Apple Health steps by hand expecting calibration to start. Here the identical shape sends one to wait. Both fix the same way — **name the quantity, do not change the number**.

The detail line already said it (`Learning your baseline, 2 of 4 nights`), but it lives in the Synthesis card, collapsed in the report. The explanation existed and the reader could not see it.

## Two things found while translating

- **Polish said "or".** The string read `%1$s lub %2$s` — `lub` is the conjunction, so the ring said "2 **or** 4". Now `%1$s z %2$s nocy`.
- **Chinese already carried 晚** (nights), so it keeps its original wording rather than being rewritten to match the others.

## Truncation

The iOS footnote had `lineLimit(1)` and no shrink, so a longer string would have truncated to `2 of 4 nig…`. It gains `minimumScaleFactor(0.7)`; Android's `AutoSizeValue` already shrinks at `0.6`.

## Two deliberate choices, recorded rather than assumed

**The Android key keeps its old hash.** Keys here are `l10n_<screen>_<slug>_<sha1[:8]>`, and the suffix `3b76e55c` encodes the *previous* English value. Changing the value in place leaves the hash describing something that is no longer there. The alternative — a new key — means editing eight locale files plus the call site to rename an identifier nothing reads as text, and the audit does not verify the hash. I took the smaller change; flagging it because it is a real, if minor, convention deviation rather than an oversight.

**The catalog key is `%lld`, not `%@`.** Both interpolated values are `Int`, so Swift extracts `%lld of %lld nights`. I keyed it `%@` first, which would have matched nothing and shipped English in all ten locales — silently, since the audit checks un-extracted literals and gaps in existing keys, not whether an extracted string has an entry at all. The catalog's own 279 `%lld` keys settled it.

## Verification

`Tools/i18n_audit.py --ci` clean, doc lint clean, `lintVitalFullRelease -PstagingRelease` clean (the new Android value stays on its existing key, so no `ExtraTranslation`). The new iOS string is in `Localizable.xcstrings` for all ten locales rather than shipping English-only.

## Not addressed here

Why those nights bank no R-R is a data question, not a copy one. The pills elsewhere (`Calibrating, 2 of 4`, `TodayView:2843/2851`, `HealthView:510`) carry the same ambiguity and are left alone — but not for the reason I first gave. I said "tighter space" without checking; `ScoreStatePill`'s `Text` has no `lineLimit`, no `minimumScaleFactor` and no `fixedSize`, so it cannot truncate. It can WRAP, and that is the actual risk: `TodayView:24-30` records a reported overlap glitch caused by exactly this block growing taller than a fixed 150pt frame once a ring showed a `SourceBadge` + `ScoreStatePill` together. Lengthening a pill in that row is a layout change wanting a device check, not a copy change — which is why it is a follow-up rather than part of this.
