### PR TITLE
Close the final resting-HR bin on the window end so an admitted endpoint sample is not dropped

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer.swift
@@ -247,7 +247,7 @@ public enum RecoveryScorer {
     /// the night's true floor. Returns nil when there are no HR samples in window.
     ///
     /// The window is CLOSED at both ends, so the binning is too: bins are `[t, t + windowS)`
-    /// except the final one, which is `[t, end]` (#39). Half-open bins alone would admit a
+    /// except the final one, which is `[t, end]`. Half-open bins alone would admit a
     /// sample sitting exactly on an aligned `end` through the prefilter and then place it in no
     /// bin — counted as data, silently ignored. A zero-length window (`start == end`) is that
     /// single closed bin.
@@ -327,7 +327,7 @@ public enum RecoveryScorer {
         var points: [(tHours: Double, meanBpm: Double)] = []
         var t = start
         repeat {
-            // Final bin closes on `end` — same closed-window rule as restingHR (#39), so an
+            // Final bin closes on `end` — same closed-window rule as restingHR, so an
             // endpoint sample counts toward the bin gate instead of vanishing after admission.
             let isFinal = t + restingHRWindowS >= end
             let win = seg.filter { $0.ts >= t && (isFinal || $0.ts < t + restingHRWindowS) }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer.swift
@@ -246,6 +246,12 @@ public enum RecoveryScorer {
     /// samples whose ts ∈ [start, end]. Rejects single-beat dips while capturing
     /// the night's true floor. Returns nil when there are no HR samples in window.
     ///
+    /// The window is CLOSED at both ends, so the binning is too: bins are `[t, t + windowS)`
+    /// except the final one, which is `[t, end]` (#39). Half-open bins alone would admit a
+    /// sample sitting exactly on an aligned `end` through the prefilter and then place it in no
+    /// bin — counted as data, silently ignored. A zero-length window (`start == end`) is that
+    /// single closed bin.
+    ///
     /// Artifact hardening (#686): a bin may only WIN the floor when it is BOTH well-populated
     /// (≥ `restingHRMinBinSamples`, so one lone artifact beat can't be a bin "mean") AND
     /// physiologically plausible (mean ≥ `restingHRMinPlausibleBpm`, rejecting dropout-driven
@@ -260,8 +266,13 @@ public enum RecoveryScorer {
         var means: [Double] = []          // every bin mean (legacy floor, the fallback)
         var qualified: [Double] = []       // bins eligible to WIN the floor (#686)
         var t = start
-        while t < end {
-            let win = seg.filter { $0.ts >= t && $0.ts < t + restingHRWindowS }
+        repeat {
+            // The last bin (its half-open end reaches or passes `end`) closes on `end` instead,
+            // catching an endpoint sample the prefilter already admitted. `seg` holds nothing
+            // past `end`, so "everything from t onwards" IS [t, end]. `repeat` runs once for a
+            // zero-length window, where that single closed bin is the whole window.
+            let isFinal = t + restingHRWindowS >= end
+            let win = seg.filter { $0.ts >= t && (isFinal || $0.ts < t + restingHRWindowS) }
             if !win.isEmpty {
                 let mean = Double(win.reduce(0) { $0 + $1.bpm }) / Double(win.count)
                 means.append(mean)
@@ -272,7 +283,7 @@ public enum RecoveryScorer {
                 }
             }
             t += restingHRWindowS
-        }
+        } while t < end
         let floor: Double
         if let m = qualified.min() {
             floor = m
@@ -300,7 +311,9 @@ public enum RecoveryScorer {
     ///
     /// Computed as the least-squares slope of the SAME non-overlapping 5-minute HR bin means
     /// `restingHR` uses (`restingHRWindowS`) against each bin's midpoint time (hours from
-    /// `start`). NEGATIVE = declining (HR falling through the night — the physiologically
+    /// `start`, and for the final closed bin still its half-open midpoint `t + windowS / 2`, so a
+    /// partial or endpoint-only last bin keeps the same time axis as every other bin).
+    /// NEGATIVE = declining (HR falling through the night — the physiologically
     /// expected, good pattern); POSITIVE = rising (restlessness, illness, alcohol, a late
     /// stimulant). Returns nil when fewer than `recoveryIndexMinBins` bins have data (too
     /// little of the window to fit a trend) or there are no samples at all — it never
@@ -313,15 +326,18 @@ public enum RecoveryScorer {
         // underlying series, one as a floor, one as a trend across it.
         var points: [(tHours: Double, meanBpm: Double)] = []
         var t = start
-        while t < end {
-            let win = seg.filter { $0.ts >= t && $0.ts < t + restingHRWindowS }
+        repeat {
+            // Final bin closes on `end` — same closed-window rule as restingHR (#39), so an
+            // endpoint sample counts toward the bin gate instead of vanishing after admission.
+            let isFinal = t + restingHRWindowS >= end
+            let win = seg.filter { $0.ts >= t && (isFinal || $0.ts < t + restingHRWindowS) }
             if !win.isEmpty {
                 let mean = Double(win.reduce(0) { $0 + $1.bpm }) / Double(win.count)
                 let midpointS = Double(t - start) + Double(restingHRWindowS) / 2.0
                 points.append((tHours: midpointS / 3600.0, meanBpm: mean))
             }
             t += restingHRWindowS
-        }
+        } while t < end
         guard points.count >= recoveryIndexMinBins else { return nil }
 
         // Least-squares slope: Σ((t-t̄)(y-ȳ)) / Σ((t-t̄)²), bpm per hour.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTests.swift
@@ -366,6 +366,41 @@ final class RecoveryScorerTests: XCTestCase {
         XCTAssertEqual(slope, -27.428571428571423, accuracy: 1e-9)
     }
 
+    func testRestingHREndpointSweepMatchesOracle() {
+        // Twin of the Kotlin RecoveryScorerWindowEndpointTest sweep: `end` walks a whole bin width
+        // and beyond, in 25 s steps, against a dense 70 bpm opening bin plus five endpoint beats at
+        // 60. Same 37 literals, from the same standalone-oracle stdout, so the oracle guards BOTH
+        // directions — a Swift-side drift fails here rather than waiting for two field logs to
+        // disagree. Note end = 300: the single closed bin holds BOTH groups (mean 69.8 → 70).
+        let expected = [62, 68, 69, 69, 70, 70, 70, 70, 70, 70, 70, 70, 70,
+                        60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60,
+                        60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60]
+        var i = 0
+        var endTs = 0
+        while endTs <= 900 {
+            var hr: [HRSample] = (0..<300).map { HRSample(ts: $0, bpm: 70) }
+            hr.append(contentsOf: (0..<5).map { _ in HRSample(ts: endTs, bpm: 60) })
+            XCTAssertEqual(RecoveryScorer.restingHR(hr, start: 0, end: endTs), expected[i],
+                           "restingHR.end=\(endTs)")
+            i += 1
+            endTs += 25
+        }
+    }
+
+    func testRecoveryIndexSlopeFullNightUnchanged() throws {
+        // Twin of the Kotlin full-night pin: a 6 h night has no sample on `end`, so the endpoint
+        // rule must not move it — the oracle's slope for a −2 bpm/hour synthetic night, to the
+        // last digit.
+        var hr: [HRSample] = []
+        var s = 0
+        while s < 6 * 3600 {
+            hr.append(HRSample(ts: s, bpm: Int((62.0 - 2.0 * Double(s) / 3600.0).rounded())))
+            s += 30
+        }
+        let slope = try XCTUnwrap(RecoveryScorer.recoveryIndexSlope(hr, start: 0, end: 6 * 3600))
+        XCTAssertEqual(slope, -2.0071001350569166, accuracy: 1e-9)
+    }
+
     // MARK: - Recovery Index / Activity-Balance folded into recovery(...)
 
     func testRecoveryIndexAndActivityBalanceDefaultNilByteIdenticalToBefore() {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTests.swift
@@ -294,7 +294,7 @@ final class RecoveryScorerTests: XCTestCase {
     // cannot be mistaken for a change to trailing partial bins.
 
     func testRestingHRAlignedEndpointSampleReachesABin() {
-        // Issue #39's minimal case: start = 0, end = 300 (exactly one bin wide), five samples on
+        // The minimal case: start = 0, end = 300 (exactly one bin wide), five samples on
         // the endpoint. They pass the prefilter, so they must also populate the final bin — and
         // five is exactly restingHRMinBinSamples, so the bin qualifies for the floor. This case
         // already returned 60 before the fix, but only because NO bin held anything and the
@@ -333,7 +333,7 @@ final class RecoveryScorerTests: XCTestCase {
     }
 
     func testRecoveryIndexSlopeAlignedEndpointCompletesTheBinGate() throws {
-        // Issue #39's second case: six samples over an aligned 30-minute window, the last exactly
+        // The bin-gate case: six samples over an aligned 30-minute window, the last exactly
         // on `end`. Dropping it left five bins — one short of recoveryIndexMinBins — so the gate
         // turned a complete window into nil. With the final bin closed there are six bins and a
         // slope. Expected value from the Swift oracle in Tools-free standalone form (see the

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTests.swift
@@ -284,6 +284,88 @@ final class RecoveryScorerTests: XCTestCase {
         XCTAssertLessThan(flatSlope!, risingSlope!)
     }
 
+    // MARK: - Window endpoint: the closed [start, end] window has a closed FINAL bin
+
+    // Both `restingHR` and `recoveryIndexSlope` prefilter ts ∈ [start, end], so a sample sitting
+    // exactly ON `end` is admitted. With bins shaped [t, t+300) and a loop that stops at `end`, an
+    // ALIGNED end (end - start a multiple of the bin width) left that admitted sample in no bin at
+    // all: it was counted as data and then silently ignored. The final bin is therefore closed at
+    // `end`. The paired non-aligned cases pin the behaviour that was already correct, so the fix
+    // cannot be mistaken for a change to trailing partial bins.
+
+    func testRestingHRAlignedEndpointSampleReachesABin() {
+        // Issue #39's minimal case: start = 0, end = 300 (exactly one bin wide), five samples on
+        // the endpoint. They pass the prefilter, so they must also populate the final bin — and
+        // five is exactly restingHRMinBinSamples, so the bin qualifies for the floor. This case
+        // already returned 60 before the fix, but only because NO bin held anything and the
+        // all-sample fallback stepped in; it now flows through the bin path like any other
+        // window. testRestingHREndpointSampleLandsInFinalBinOnly is where the fallback cannot
+        // hide the dropped sample.
+        let hr = (0..<5).map { _ in HRSample(ts: 300, bpm: 60) }
+        XCTAssertEqual(RecoveryScorer.restingHR(hr, start: 0, end: 300), 60,
+                       "a sample exactly on an aligned end must belong to the final bin")
+    }
+
+    func testRestingHRNonAlignedEndpointSampleReachesABin() {
+        // Paired non-aligned case: end = 450 falls mid-bin, so the endpoint sample was always
+        // inside the trailing partial bin. Same answer, before and after the fix.
+        let hr = (0..<5).map { _ in HRSample(ts: 450, bpm: 60) }
+        XCTAssertEqual(RecoveryScorer.restingHR(hr, start: 0, end: 450), 60,
+                       "a sample on a non-aligned end stays in the trailing partial bin")
+    }
+
+    func testRestingHREndpointSampleLandsInFinalBinOnly() {
+        // The endpoint must join the LAST bin, not leak into earlier ones: a dense 70 bpm first
+        // bin plus five endpoint beats at 40 gives a floor of 40 (the endpoint bin), while the
+        // 70 bpm bin is untouched. A rule that admitted ts == end into every bin would drag the
+        // first bin's mean down instead.
+        var hr: [HRSample] = (0..<300).map { HRSample(ts: $0, bpm: 70) }
+        hr.append(contentsOf: (0..<5).map { _ in HRSample(ts: 600, bpm: 40) })
+        XCTAssertEqual(RecoveryScorer.restingHR(hr, start: 0, end: 600), 40,
+                       "the endpoint sample belongs to the final bin only")
+    }
+
+    func testRestingHRDegenerateZeroLengthWindow() {
+        // start == end: the single instant is one closed bin. Five samples clear the count bar,
+        // so the floor is their mean — the same number the all-sample fallback produced before.
+        let hr = (0..<5).map { _ in HRSample(ts: 1000, bpm: 58) }
+        XCTAssertEqual(RecoveryScorer.restingHR(hr, start: 1000, end: 1000), 58)
+    }
+
+    func testRecoveryIndexSlopeAlignedEndpointCompletesTheBinGate() throws {
+        // Issue #39's second case: six samples over an aligned 30-minute window, the last exactly
+        // on `end`. Dropping it left five bins — one short of recoveryIndexMinBins — so the gate
+        // turned a complete window into nil. With the final bin closed there are six bins and a
+        // slope. Expected value from the Swift oracle in Tools-free standalone form (see the
+        // Kotlin twin, which pins the same literal).
+        let hr = [HRSample(ts: 0, bpm: 66), HRSample(ts: 300, bpm: 64),
+                  HRSample(ts: 600, bpm: 62), HRSample(ts: 900, bpm: 60),
+                  HRSample(ts: 1200, bpm: 58), HRSample(ts: 1800, bpm: 54)]
+        let slope = try XCTUnwrap(RecoveryScorer.recoveryIndexSlope(hr, start: 0, end: 1800),
+                                  "an admitted endpoint sample must count toward the bin gate")
+        XCTAssertEqual(slope, -27.428571428571423, accuracy: 1e-9)
+    }
+
+    func testRecoveryIndexSlopeStillNilWithOnlyFiveBins() {
+        // The gate itself is unchanged: the same window without the endpoint sample has five
+        // bins and must stay nil. Closing the final bin adds no bin where there is no sample.
+        let hr = [HRSample(ts: 0, bpm: 66), HRSample(ts: 300, bpm: 64),
+                  HRSample(ts: 600, bpm: 62), HRSample(ts: 900, bpm: 60),
+                  HRSample(ts: 1200, bpm: 58)]
+        XCTAssertNil(RecoveryScorer.recoveryIndexSlope(hr, start: 0, end: 1800))
+    }
+
+    func testRecoveryIndexSlopeNonAlignedEndpointCompletesTheBinGate() throws {
+        // Paired non-aligned case: end = 1750 sits mid-bin, so the endpoint sample was already in
+        // the trailing partial bin and the gate was already satisfied. Pinned so the fix is
+        // visibly confined to the aligned case.
+        let hr = [HRSample(ts: 0, bpm: 66), HRSample(ts: 300, bpm: 64),
+                  HRSample(ts: 600, bpm: 62), HRSample(ts: 900, bpm: 60),
+                  HRSample(ts: 1200, bpm: 58), HRSample(ts: 1750, bpm: 54)]
+        let slope = try XCTUnwrap(RecoveryScorer.recoveryIndexSlope(hr, start: 0, end: 1750))
+        XCTAssertEqual(slope, -27.428571428571423, accuracy: 1e-9)
+    }
+
     // MARK: - Recovery Index / Activity-Balance folded into recovery(...)
 
     func testRecoveryIndexAndActivityBalanceDefaultNilByteIdenticalToBefore() {

--- a/android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt
+++ b/android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt
@@ -290,7 +290,7 @@ object RecoveryScorer {
      * the night's true floor. Returns null when there are no HR samples in window.
      *
      * The window is CLOSED at both ends, so the binning is too: bins are `[t, t + windowS)` except
-     * the final one, which is `[t, end]` (#39). Half-open bins alone would admit a sample sitting
+     * the final one, which is `[t, end]`. Half-open bins alone would admit a sample sitting
      * exactly on an aligned `end` through the prefilter and then place it in no bin — counted as
      * data, silently ignored. A zero-length window (`start == end`) is that single closed bin.
      *
@@ -375,7 +375,7 @@ object RecoveryScorer {
         val points = ArrayList<Pair<Double, Double>>() // (tHours, meanBpm)
         var t = start
         do {
-            // Final bin closes on `end` — same closed-window rule as restingHR (#39), so an
+            // Final bin closes on `end` — same closed-window rule as restingHR, so an
             // endpoint sample counts toward the bin gate instead of vanishing after admission.
             val binEnd = t + restingHRWindowS
             val isFinal = binEnd >= end

--- a/android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt
+++ b/android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt
@@ -289,6 +289,11 @@ object RecoveryScorer {
      * samples whose ts ∈ [start, end]. Rejects single-beat dips while capturing
      * the night's true floor. Returns null when there are no HR samples in window.
      *
+     * The window is CLOSED at both ends, so the binning is too: bins are `[t, t + windowS)` except
+     * the final one, which is `[t, end]` (#39). Half-open bins alone would admit a sample sitting
+     * exactly on an aligned `end` through the prefilter and then place it in no bin — counted as
+     * data, silently ignored. A zero-length window (`start == end`) is that single closed bin.
+     *
      * Artifact hardening (#686): a bin may only WIN the floor when it is BOTH well-populated
      * (≥ [restingHRMinBinSamples], so one lone artifact beat can't be a bin "mean") AND
      * physiologically plausible (mean ≥ [restingHRMinPlausibleBpm], rejecting dropout-driven
@@ -306,9 +311,14 @@ object RecoveryScorer {
         val means = ArrayList<Double>()      // every bin mean (legacy floor, the fallback)
         val qualified = ArrayList<Double>()  // bins eligible to WIN the floor (#686)
         var t = start
-        while (t < end) {
+        do {
+            // The last bin (its half-open end reaches or passes `end`) closes on `end` instead,
+            // catching an endpoint sample the prefilter already admitted. `seg` holds nothing past
+            // `end`, so "everything from t onwards" IS [t, end]. `do` runs once for a zero-length
+            // window, where that single closed bin is the whole window.
             val binEnd = t + restingHRWindowS
-            val win = seg.filter { it.ts >= t && it.ts < binEnd }
+            val isFinal = binEnd >= end
+            val win = seg.filter { it.ts >= t && (isFinal || it.ts < binEnd) }
             if (win.isNotEmpty()) {
                 val mean = win.sumOf { it.bpm }.toDouble() / win.size.toDouble()
                 means.add(mean)
@@ -319,7 +329,7 @@ object RecoveryScorer {
                 }
             }
             t += restingHRWindowS
-        }
+        } while (t < end)
         val floor: Double = qualified.minOrNull()
             ?: means.minOrNull()
             ?: (seg.sumOf { it.bpm }.toDouble() / seg.size.toDouble())
@@ -346,7 +356,9 @@ object RecoveryScorer {
      *
      * Computed as the least-squares slope of the SAME non-overlapping 5-minute HR bin means
      * [restingHR] uses ([restingHRWindowS]) against each bin's midpoint time (hours from
-     * `start`). NEGATIVE = declining (HR falling through the night — the physiologically
+     * `start`, and for the final closed bin still its half-open midpoint `t + windowS / 2`, so a
+     * partial or endpoint-only last bin keeps the same time axis as every other bin).
+     * NEGATIVE = declining (HR falling through the night — the physiologically
      * expected, good pattern); POSITIVE = rising (restlessness, illness, alcohol, a late
      * stimulant). Returns null when fewer than [recoveryIndexMinBins] bins have data (too
      * little of the window to fit a trend) or there are no samples at all — it never
@@ -362,16 +374,19 @@ object RecoveryScorer {
         // underlying series, one as a floor, one as a trend across it.
         val points = ArrayList<Pair<Double, Double>>() // (tHours, meanBpm)
         var t = start
-        while (t < end) {
+        do {
+            // Final bin closes on `end` — same closed-window rule as restingHR (#39), so an
+            // endpoint sample counts toward the bin gate instead of vanishing after admission.
             val binEnd = t + restingHRWindowS
-            val win = seg.filter { it.ts >= t && it.ts < binEnd }
+            val isFinal = binEnd >= end
+            val win = seg.filter { it.ts >= t && (isFinal || it.ts < binEnd) }
             if (win.isNotEmpty()) {
                 val mean = win.sumOf { it.bpm }.toDouble() / win.size.toDouble()
                 val midpointS = (t - start).toDouble() + restingHRWindowS / 2.0
                 points.add((midpointS / 3600.0) to mean)
             }
             t += restingHRWindowS
-        }
+        } while (t < end)
         if (points.size < recoveryIndexMinBins) return null
 
         // Least-squares slope: Σ((t−t̄)(y−ȳ)) / Σ((t−t̄)²), bpm per hour.

--- a/android/app/src/test/java/com/noop/analytics/RecoveryScorerWindowEndpointTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RecoveryScorerWindowEndpointTest.kt
@@ -1,0 +1,147 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Tests the closed-window binning of RecoveryScorer.restingHR and RecoveryScorer.recoveryIndexSlope
+ * (#39). Both prefilter ts ∈ [start, end] but binned as [t, t+300) up to `end`, so a sample sitting
+ * exactly on an ALIGNED end was admitted and then belonged to no bin. The final bin now closes on
+ * `end`.
+ *
+ * Parity: the expected values are the verbatim stdout of the standalone Swift oracle built from the
+ * fixed Swift source (CLAUDE.md's byte-identical-by-oracle rule), not values read off this Kotlin
+ * implementation. RecoveryScorerTests.swift pins the same scenarios on the Swift side.
+ */
+class RecoveryScorerWindowEndpointTest {
+
+    private val dev = "test"
+
+    private fun hr(ts: Long, bpm: Int) = HrSample(deviceId = dev, ts = ts, bpm = bpm)
+
+    @Test
+    fun alignedEndpointSampleReachesABin() {
+        // Issue #39's minimal case: start = 0, end = 300 (exactly one bin wide), five samples on
+        // the endpoint. This already returned 60 before the fix, but only because NO bin held
+        // anything and the all-sample fallback stepped in; it now flows through the bin path.
+        val samples = (0 until 5).map { hr(300L, 60) }
+        assertEquals(
+            "a sample exactly on an aligned end must belong to the final bin",
+            60, RecoveryScorer.restingHR(samples, 0L, 300L)
+        )
+    }
+
+    @Test
+    fun nonAlignedEndpointSampleReachesABin() {
+        // Paired non-aligned case: end = 450 falls mid-bin, so the endpoint sample was always
+        // inside the trailing partial bin. Same answer, before and after the fix.
+        val samples = (0 until 5).map { hr(450L, 60) }
+        assertEquals(
+            "a sample on a non-aligned end stays in the trailing partial bin",
+            60, RecoveryScorer.restingHR(samples, 0L, 450L)
+        )
+    }
+
+    @Test
+    fun endpointSampleLandsInFinalBinOnly() {
+        // The endpoint must join the LAST bin, not leak into earlier ones: a dense 70 bpm first bin
+        // plus five endpoint beats at 40 gives a floor of 40, while the 70 bpm bin is untouched.
+        // Before the fix the endpoint beats vanished and the floor read 70.
+        val samples = ArrayList<HrSample>()
+        for (i in 0 until 300) samples.add(hr(i.toLong(), 70))
+        for (i in 0 until 5) samples.add(hr(600L, 40))
+        assertEquals(
+            "the endpoint sample belongs to the final bin only",
+            40, RecoveryScorer.restingHR(samples, 0L, 600L)
+        )
+    }
+
+    @Test
+    fun degenerateZeroLengthWindow() {
+        // start == end: the single instant is one closed bin, and its mean is the same number the
+        // all-sample fallback produced before.
+        val samples = (0 until 5).map { hr(1000L, 58) }
+        assertEquals(58, RecoveryScorer.restingHR(samples, 1000L, 1000L))
+    }
+
+    @Test
+    fun restingHrEndpointSweepMatchesSwiftOracle() {
+        // `end` walks a whole bin width and beyond, in 25 s steps, against a dense 70 bpm opening
+        // bin plus five endpoint beats at 60. Verbatim Swift oracle stdout — this is the check that
+        // catches drift the eye does not, including the aligned end = 300 case where the single
+        // closed bin holds BOTH groups (mean 69.8 → 70).
+        val expected = listOf(
+            62, 68, 69, 69, 70, 70, 70, 70, 70, 70, 70, 70, 70,
+            60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60,
+            60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60
+        )
+        var i = 0
+        var endTs = 0L
+        while (endTs <= 900L) {
+            val samples = ArrayList<HrSample>()
+            for (s in 0 until 300) samples.add(hr(s.toLong(), 70))
+            for (s in 0 until 5) samples.add(hr(endTs, 60))
+            assertEquals(
+                "restingHR.end=$endTs", expected[i], RecoveryScorer.restingHR(samples, 0L, endTs)
+            )
+            i++
+            endTs += 25L
+        }
+    }
+
+    @Test
+    fun restingHrNullWithoutSamples() {
+        assertNull(RecoveryScorer.restingHR(emptyList(), 0L, 1000L))
+    }
+
+    @Test
+    fun recoveryIndexSlopeAlignedEndpointCompletesTheBinGate() {
+        // Issue #39's second case: six samples over an aligned 30-minute window, the last exactly
+        // on `end`. Dropping it left five bins — one short of recoveryIndexMinBins — so the gate
+        // turned a complete window into null.
+        val samples = listOf(
+            hr(0L, 66), hr(300L, 64), hr(600L, 62), hr(900L, 60), hr(1200L, 58), hr(1800L, 54)
+        )
+        val slope = RecoveryScorer.recoveryIndexSlope(samples, 0L, 1800L)
+        assertNotNull("an admitted endpoint sample must count toward the bin gate", slope)
+        assertEquals(-27.428571428571423, slope!!, 1e-9)
+    }
+
+    @Test
+    fun recoveryIndexSlopeStillNullWithOnlyFiveBins() {
+        // The gate itself is unchanged: the same window without the endpoint sample has five bins
+        // and must stay null. Closing the final bin adds no bin where there is no sample.
+        val samples = listOf(hr(0L, 66), hr(300L, 64), hr(600L, 62), hr(900L, 60), hr(1200L, 58))
+        assertNull(RecoveryScorer.recoveryIndexSlope(samples, 0L, 1800L))
+    }
+
+    @Test
+    fun recoveryIndexSlopeNonAlignedEndpointCompletesTheBinGate() {
+        // Paired non-aligned case: end = 1750 sits mid-bin, so the endpoint sample was already in
+        // the trailing partial bin. Same slope as the aligned case (identical bin midpoints).
+        val samples = listOf(
+            hr(0L, 66), hr(300L, 64), hr(600L, 62), hr(900L, 60), hr(1200L, 58), hr(1750L, 54)
+        )
+        val slope = RecoveryScorer.recoveryIndexSlope(samples, 0L, 1750L)
+        assertNotNull(slope)
+        assertEquals(-27.428571428571423, slope!!, 1e-9)
+    }
+
+    @Test
+    fun recoveryIndexSlopeFullNightUnchanged() {
+        // A full 6 h night has no sample on `end`, so the endpoint rule must not move it: the
+        // oracle's slope for a −2 bpm/hour synthetic night, to the last digit.
+        val samples = ArrayList<HrSample>()
+        var s = 0L
+        while (s < 6 * 3600L) {
+            samples.add(hr(s, Math.round(62.0 - 2.0 * s.toDouble() / 3600.0).toInt()))
+            s += 30L
+        }
+        val slope = RecoveryScorer.recoveryIndexSlope(samples, 0L, 6 * 3600L)
+        assertNotNull(slope)
+        assertEquals(-2.0071001350569166, slope!!, 1e-9)
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/RecoveryScorerWindowEndpointTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RecoveryScorerWindowEndpointTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 
 /**
  * Tests the closed-window binning of RecoveryScorer.restingHR and RecoveryScorer.recoveryIndexSlope
- * (#39). Both prefilter ts ∈ [start, end] but binned as [t, t+300) up to `end`, so a sample sitting
+ * Both prefilter ts ∈ [start, end] but binned as [t, t+300) up to `end`, so a sample sitting
  * exactly on an ALIGNED end was admitted and then belonged to no bin. The final bin now closes on
  * `end`.
  *
@@ -24,7 +24,7 @@ class RecoveryScorerWindowEndpointTest {
 
     @Test
     fun alignedEndpointSampleReachesABin() {
-        // Issue #39's minimal case: start = 0, end = 300 (exactly one bin wide), five samples on
+        // The minimal case: start = 0, end = 300 (exactly one bin wide), five samples on
         // the endpoint. This already returned 60 before the fix, but only because NO bin held
         // anything and the all-sample fallback stepped in; it now flows through the bin path.
         val samples = (0 until 5).map { hr(300L, 60) }
@@ -99,7 +99,7 @@ class RecoveryScorerWindowEndpointTest {
 
     @Test
     fun recoveryIndexSlopeAlignedEndpointCompletesTheBinGate() {
-        // Issue #39's second case: six samples over an aligned 30-minute window, the last exactly
+        // The bin-gate case: six samples over an aligned 30-minute window, the last exactly
         // on `end`. Dropping it left five bins — one short of recoveryIndexMinBins — so the gate
         // turned a complete window into null.
         val samples = listOf(

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -190,7 +190,7 @@ HRV is the dominant driver, and NOOP needs a few nights to learn your personal b
 
 ### Resting HR (`restingHR`)
 
-"Lowest sustained HR" during the in-bed window = the **minimum of 5-minute non-overlapping bin means** of HR samples in `[start, end]`. This rejects single-beat dips while capturing the night's true floor.
+"Lowest sustained HR" during the in-bed window = the **minimum of 5-minute non-overlapping bin means** of HR samples in `[start, end]`. This rejects single-beat dips while capturing the night's true floor. The window is closed at both ends, so the bins are `[t, t + 300)` except the last one, which closes on `end` — a sample sitting exactly on an aligned `end` belongs to that final bin.
 
 ---
 


### PR DESCRIPTION
`RecoveryScorer.restingHR` and `RecoveryScorer.recoveryIndexSlope` document and prefilter a closed `[start, end]` window but bin it as `[t, t + 300)` with a loop that stops at `end`. A sample sitting exactly on an aligned `end` passes the prefilter and then belongs to no bin: counted as data, silently ignored. For the Recovery Index that can leave the six-bin gate one bin short and turn a complete 30-minute window into `nil`/`null`.

The final bin now closes on `end` on both platforms (`[t, t + 300)` for every bin except the last, which is `[t, end]`); a zero-length window is that single closed bin. Bin midpoints, the #686 artifact gate and `recoveryIndexMinBins` are unchanged, so nothing moves except a sample on an aligned endpoint. Doc comments and `docs/ANALYTICS.md` state the rule.

Scope note: these two helpers are library API with no in-app caller today, so this change moves no shipped number. The resting HR the apps display comes from `SleepStager.sessionRestingHR`, whose window loop has the same shape; that is a separate concern and not part of this PR.

Verification (Linux, no macOS): paired Swift and Kotlin tests for the aligned and non-aligned endpoint, the endpoint landing only in the final bin, the zero-length window, and the five/six-bin gate. Red before the fix on both platforms (`restingHR` floor 70 instead of 40; `recoveryIndexSlope` nil instead of a slope), green after. Kotlin expectations, including a 37-point endpoint sweep, are the verbatim stdout of a standalone Swift oracle built from the fixed helpers; Swift pins the same sweep so the oracle guards both directions. `swift test` for `StrandAnalytics` and `testFullDebugUnitTest` for Android passed locally; `doc_comment_lint` clean. An independent read-only review found no code defect. App targets were not compiled here (no Xcode); no app-target source is touched.

Addresses https://github.com/bhelm/noop/issues/39. Kept as draft for maintainer review; no merge performed.