### PR TITLE
Bound ppgWaveformSample with rolling newest-N retention

### DIFF
--- a/Packages/NoopLocalAccess/Sources/NoopLocalAccessCore/LocalAccessCore.swift
+++ b/Packages/NoopLocalAccess/Sources/NoopLocalAccessCore/LocalAccessCore.swift
@@ -323,17 +323,19 @@ public final class ReadonlyNoopStore {
         try dbQueue.read { db in
             // Every durable decoded per-second table. The four below the first line were landed as
             // instrumentation and then left OUT of this count, which is how an unbounded, unpruned table
-            // became invisible: `ppgWaveformSample` banks a ~48-byte BLOB per v26 strap-second and is NOT
-            // pruned (deliberately — this is decoded biometric history, not the transient raw outbox), and
-            // until it was counted it did not show up in the only readout a user has for "what is the
-            // store spending space on". Growth that nothing reads still has to be growth somebody can SEE.
+            // became invisible: `ppgWaveformSample` banks a ~48-byte BLOB per v26 strap-second, and until
+            // it was counted it did not show up in the only readout a user has for "what is the store
+            // spending space on". Growth that nothing reads still has to be growth somebody can SEE.
             //
-            // `v18AuxSample` used to be named here as unpruned too. It is not, and has not been since the
-            // rolling retention landed (`WhoopStore.v18AuxRetentionRows` / `v18AuxPruneEveryRows`, Room
-            // migration v31, covered by `DeepCaptureChannelsTests`): ~604 800 rows, about seven days. The
-            // correction matters because #1911 is designing retention, and "which tables are already
-            // bounded" is the first thing such a design reads off — getting it wrong here would have it
-            // solving a problem twice, or trusting a bound that was never there.
+            // BOTH blob tables are now bounded, and neither claim below is safe to let go stale, because
+            // "which tables are already bounded" is the first thing a retention design reads off — getting
+            // it wrong has such a design solving a problem twice, or trusting a bound that was never
+            // there. `v18AuxSample`: rolling retention since `WhoopStore.v18AuxRetentionRows` /
+            // `v18AuxPruneEveryRows` (Room migration v31, covered by `DeepCaptureChannelsTests`).
+            // `ppgWaveformSample`: rolling retention since #1911 (`WhoopStore.ppgWaveformRetentionRows` /
+            // `ppgWaveformPruneEveryRows`, covered by `PpgWaveformSampleTests`). Both keep ~604,800 NEWEST
+            // rows per device — a row cap, NOT an age cutoff, so a sporadic wearer keeps a full working
+            // set. Every other decoded per-second table listed here is still genuinely unpruned.
             //
             // This list is a DELIBERATE fourth copy, not drift. The other three (`WhoopStore.rawTableKeys`,
             // the footprint total and the timestamp heal) now share one list; this module cannot, because

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -538,12 +538,19 @@ extension WhoopStore {
         // That keeps a v26-heavy night to roughly the same order of magnitude as ONE extra per-second
         // stream (≈50 bytes/row), not 24x that. Additive only, a NEW table, no existing row touched.
         //
-        // Retention: no pruning, matching every other durable per-second table (hrSample, spo2Sample, …
-        // are never pruned either) — this is decoded biometric history, not the transient raw outbox.
-        // `PrunePolicy`'s ~50 MB cap governs ONLY `rawBatch` (raw, pre-decode frames kept for re-decode /
-        // re-sync); it is untouched by and unrelated to this table. Growth here is bounded by how much
-        // v26 data a strap actually emits (firmware chooses v26 vs v18 per second, not every night is
-        // v26-heavy), not by an artificial cap.
+        // Retention: CAPPED at `WhoopStore.ppgWaveformRetentionRows` newest rows per device (#1911), swept
+        // amortised on insert exactly like `v18AuxSample`. This table is the ONE exception to "no durable
+        // per-second table is pruned" (hrSample, spo2Sample, … are still never pruned), because it is the
+        // only one storing a blob rather than a scalar: ~120 B/row against ~30 B, and #1911 measured the
+        // decoded streams at ~93 MB/day with this table the fastest-growing per byte. `PrunePolicy`'s
+        // ~50 MB cap governs ONLY `rawBatch` (raw, pre-decode frames kept for re-decode / re-sync); it is
+        // untouched by and unrelated to this table.
+        //
+        // The cap is NEWEST-N-ROWS, not an age-based drop, and that distinction is load-bearing for the
+        // consumer note below: a sporadic wearer's v26 seconds are spread thin over months, so deleting by
+        // wall-clock age would empty the table for exactly the user a future estimator needs most, while
+        // newest-N always leaves a full working set. See `ppgWaveformRetentionRows` for the byte maths and
+        // for why #1911's "diagnostic-only, drop after the hot window" framing was not followed.
         //
         // CONSUMER STATUS — deliberately none, and stated here so nobody has to re-derive it. The writer is
         // live on both platforms (offload + archive replay + the Android capture importer), but the reader

--- a/Packages/WhoopStore/Sources/WhoopStore/Database.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Database.swift
@@ -541,8 +541,9 @@ extension WhoopStore {
         // Retention: CAPPED at `WhoopStore.ppgWaveformRetentionRows` newest rows per device (#1911), swept
         // amortised on insert exactly like `v18AuxSample`. This table is the ONE exception to "no durable
         // per-second table is pruned" (hrSample, spo2Sample, … are still never pruned), because it is the
-        // only one storing a blob rather than a scalar: ~120 B/row against ~30 B, and #1911 measured the
-        // decoded streams at ~93 MB/day with this table the fastest-growing per byte. `PrunePolicy`'s
+        // only one storing a blob rather than a scalar: ~120 B/row against ~30 B. It is the worst ROW, not
+        // the biggest table — v26 runs only in optical windows (~28,800 rows/day) where `rrInterval` banks
+        // ~100,000/day, so most of #1911's ~93 MB/day is still unbounded elsewhere. `PrunePolicy`'s
         // ~50 MB cap governs ONLY `rawBatch` (raw, pre-decode frames kept for re-decode / re-sync); it is
         // untouched by and unrelated to this table.
         //

--- a/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
@@ -59,8 +59,13 @@ extension WhoopStore {
     }
 
     /// Rolling retention for the v27 PPG waveform table (twin of Kotlin `PPG_WAVEFORM_RETENTION_ROWS`),
-    /// added for #1911. This table was previously the only UNBOUNDED blob table, and at ~1 row/second
-    /// through a v26-heavy night it is the fastest-growing table per byte in the store.
+    /// added for #1911. This table was previously the only UNBOUNDED blob table, and it carries by far the
+    /// largest PER-ROW cost of any decoded stream: ~120 B against ~30 B for a scalar row.
+    ///
+    /// It is NOT the store's fastest-growing table, and this note must not be read as saying so. v26 runs
+    /// only in optical windows, roughly 28,800 rows/day by #1911's own figures, where `rrInterval` banks
+    /// ~100,000/day and remains the higher-volume table by bytes. Capping this one bounds the worst row,
+    /// not the bulk of #1911's ~93 MB/day.
     ///
     /// **A NEWEST-N-ROWS CAP, DELIBERATELY NOT A TIME-WINDOW DROP.** #1911 proposes "dropped after the hot
     /// window", justifying it as "diagnostic-only". That justification is wrong, and the migration note on
@@ -75,10 +80,12 @@ extension WhoopStore {
     /// 604,800 = 7 × 86,400, matching the aux cap's "a week of strap-seconds" semantic and #1911's own
     /// 7-day hot window. The ceiling is larger than the aux table's because the row is: ~120 B/row (a 48 B
     /// packed-i16 blob for 24 samples, plus row and primary-key-index overhead) puts it at a **~70 MB hard
-    /// ceiling** per device, against ~50 MB for aux. In practice v26 is a fraction of the strap's seconds,
-    /// so occupancy is far below that and the window spans considerably longer than a week in wall-clock
-    /// terms. Retuning is a one-constant change with no migration once a device `row_bytes` measurement
-    /// lands, and RELAXING a cap is always cheaper than imposing one on a user with a year of history.
+    /// ceiling** per device, against ~50 MB for aux. That ceiling is the bound worth quoting; the wall-clock
+    /// span is longer than the arithmetic suggests, because v26 only runs in optical windows. At #1911's
+    /// ~28,800 rows/day the cap holds about **three weeks** of typical wear, and proportionally more for a
+    /// sporadic wearer, which is exactly the population an age-based cutoff would have emptied. Retuning is
+    /// a one-constant change with no migration once a device `row_bytes` measurement lands, and RELAXING a
+    /// cap is always cheaper than imposing one on a user with a year of history.
     public static let ppgWaveformRetentionRows = 604_800
 
     /// Rows to bank before sweeping `ppgWaveformSample` again, same amortisation as

--- a/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
@@ -79,8 +79,8 @@ extension WhoopStore {
     ///
     /// 604,800 = 7 × 86,400, matching the aux cap's "a week of strap-seconds" semantic and #1911's own
     /// 7-day hot window. The ceiling is larger than the aux table's because the row is: ~120 B/row (a 48 B
-    /// packed-i16 blob for 24 samples, plus row and primary-key-index overhead) puts it at a **~70 MB hard
-    /// ceiling** per device, against ~50 MB for aux. That ceiling is the bound worth quoting; the wall-clock
+    /// packed-i16 blob for 24 samples, plus row and primary-key-index overhead) puts it at **~70 MB per
+    /// device**, against ~50 MB for aux. That is the bound worth quoting; the wall-clock
     /// span is longer than the arithmetic suggests, because v26 only runs in optical windows. At #1911's
     /// ~28,800 rows/day the cap holds about **three weeks** of typical wear, and proportionally more for a
     /// sporadic wearer, which is exactly the population an age-based cutoff would have emptied. Retuning is
@@ -92,7 +92,17 @@ extension WhoopStore {
     /// `v18AuxPruneEveryRows` below and the same magnitude for the same reason: the sweep walks up to
     /// `ppgWaveformRetentionRows` index entries, so running it per insert batch is the cost. The table may
     /// sit this many rows (plus the crossing batch) above the cap in exchange, roughly a MB against its
-    /// ~70 MB ceiling.
+    /// ~70 MB bound.
+    ///
+    /// WHAT THIS BUDGET DOES NOT GUARANTEE, and the reason the cap above is stated as a size rather than a
+    /// "hard ceiling": the counter is in-memory and per store instance, so a process restart resets it.
+    /// The sweep is the ONLY thing enforcing retention on this table — `Collector.prune` covers the raw
+    /// outbox alone, and the `*ByTs` deletes belong to `TimestampHeal`, not to retention — so a store that
+    /// never banks this many rows in one process lifetime never sweeps at all. It is not a concern for the
+    /// normal shape (the budget accumulates across every batch of a session, and one night's offload banks
+    /// ~28,800 rows, crossing it twice over), but a store fed only short bursts between app kills can drift
+    /// above the cap indefinitely. `v18AuxPruneEveryRows` below has the identical property; a sweep forced
+    /// once per session would close it for both, and belongs in a change that covers both.
     public static let ppgWaveformPruneEveryRows = 10_000
 
     /// v31 rolling retention for the v18 aux-slot table (twin of Kotlin `V18_AUX_RETENTION_ROWS`).

--- a/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StreamStore.swift
@@ -58,6 +58,36 @@ extension WhoopStore {
         return out
     }
 
+    /// Rolling retention for the v27 PPG waveform table (twin of Kotlin `PPG_WAVEFORM_RETENTION_ROWS`),
+    /// added for #1911. This table was previously the only UNBOUNDED blob table, and at ~1 row/second
+    /// through a v26-heavy night it is the fastest-growing table per byte in the store.
+    ///
+    /// **A NEWEST-N-ROWS CAP, DELIBERATELY NOT A TIME-WINDOW DROP.** #1911 proposes "dropped after the hot
+    /// window", justifying it as "diagnostic-only". That justification is wrong, and the migration note on
+    /// `ppgWaveformSample` in `Database.swift` is the authority: these rows are kept precisely so a better
+    /// estimator, HRV-from-PPG, or a waveform viewer can later run over the ORIGINAL samples rather than
+    /// the derived bpm. Deleting by wall-clock age would empty the table for exactly the user a future
+    /// estimator needs most — a sporadic wearer, whose v26 seconds are spread thin over months — and a
+    /// waveform, unlike an HR series, has no aggregate that survives it. Newest-N instead bounds the bytes
+    /// while ALWAYS leaving a full working set to analyse, which is the same trade `v18AuxRetentionRows`
+    /// below makes for the same reason.
+    ///
+    /// 604,800 = 7 × 86,400, matching the aux cap's "a week of strap-seconds" semantic and #1911's own
+    /// 7-day hot window. The ceiling is larger than the aux table's because the row is: ~120 B/row (a 48 B
+    /// packed-i16 blob for 24 samples, plus row and primary-key-index overhead) puts it at a **~70 MB hard
+    /// ceiling** per device, against ~50 MB for aux. In practice v26 is a fraction of the strap's seconds,
+    /// so occupancy is far below that and the window spans considerably longer than a week in wall-clock
+    /// terms. Retuning is a one-constant change with no migration once a device `row_bytes` measurement
+    /// lands, and RELAXING a cap is always cheaper than imposing one on a user with a year of history.
+    public static let ppgWaveformRetentionRows = 604_800
+
+    /// Rows to bank before sweeping `ppgWaveformSample` again, same amortisation as
+    /// `v18AuxPruneEveryRows` below and the same magnitude for the same reason: the sweep walks up to
+    /// `ppgWaveformRetentionRows` index entries, so running it per insert batch is the cost. The table may
+    /// sit this many rows (plus the crossing batch) above the cap in exchange, roughly a MB against its
+    /// ~70 MB ceiling.
+    public static let ppgWaveformPruneEveryRows = 10_000
+
     /// v31 rolling retention for the v18 aux-slot table (twin of Kotlin `V18_AUX_RETENTION_ROWS`).
     ///
     /// Raw instrumentation must be capped rather than unbounded. Nothing reads these rows yet, so a cap is far
@@ -109,7 +139,9 @@ extension WhoopStore {
             spo2: Int, skinTemp: Int, resp: Int, gravity: Int) {
         try await insert(streams, deviceId: deviceId,
                          v18AuxRetentionRows: WhoopStore.v18AuxRetentionRows,
-                         v18AuxPruneEveryRows: WhoopStore.v18AuxPruneEveryRows)
+                         v18AuxPruneEveryRows: WhoopStore.v18AuxPruneEveryRows,
+                         ppgWaveformRetentionRows: WhoopStore.ppgWaveformRetentionRows,
+                         ppgWaveformPruneEveryRows: WhoopStore.ppgWaveformPruneEveryRows)
     }
 
     /// `insert(_:deviceId:)` with the v31 aux-table cap made explicit. Internal and a SEPARATE overload
@@ -117,13 +149,21 @@ extension WhoopStore {
     /// require `insert(_:deviceId:)` exactly, and a Swift witness must match the requirement's parameter
     /// list — a default argument does not satisfy it. Exists so a test can prove the rolling delete with a
     /// small cap instead of writing 600k rows; every production caller goes through the wrapper above.
+    ///
+    /// The two v18-aux caps are required because eleven existing call sites already pass them; the two
+    /// ppg-waveform caps added for #1911 are DEFAULTED so those same call sites keep compiling untouched.
+    /// A default is fine on this overload (unlike the public entry point, per the note above) because
+    /// nothing witnesses it against a protocol requirement.
     @discardableResult
     func insert(_ streams: Streams, deviceId: String, v18AuxRetentionRows: Int,
-                v18AuxPruneEveryRows: Int) async throws
+                v18AuxPruneEveryRows: Int,
+                ppgWaveformRetentionRows: Int = WhoopStore.ppgWaveformRetentionRows,
+                ppgWaveformPruneEveryRows: Int = WhoopStore.ppgWaveformPruneEveryRows) async throws
         -> (hr: Int, rr: Int, events: Int, battery: Int,
             spo2: Int, skinTemp: Int, resp: Int, gravity: Int) {
         // Banked rows, accumulated across batches so the sweep does not run on every one.
         var v18Written = 0
+        var ppgWaveformWritten = 0
         let result: (Int, Int, Int, Int, Int, Int, Int, Int) = try syncWrite { db in
             var hr = 0, rr = 0, ev = 0, bat = 0
             var spo2 = 0, skin = 0, resp = 0, grav = 0
@@ -309,6 +349,7 @@ extension WhoopStore {
                 for s in streams.ppgWaveform {
                     try stmt.execute(arguments: [deviceId, s.ts, WhoopStore.packPpgSamples(s.samples),
                                                  s.burstIndex])
+                    ppgWaveformWritten += 1
                 }
             }
             // Every remaining v18 slot (v31), one compact blob per strap-second. Persist-only, same as
@@ -351,6 +392,25 @@ extension WhoopStore {
                        """, arguments: [deviceId, deviceId, v18AuxRetentionRows])
                }) != nil {
                 v18AuxRowsSincePrune[deviceId] = 0
+            }
+        }
+        // #1911 rolling retention for the waveform blobs, amortised and best-effort on exactly the same
+        // terms as the aux sweep above (see `ppgWaveformRetentionRows` for why this is a newest-N cap and
+        // not an age-based drop). Its own counter and its own transaction: a batch routinely writes one of
+        // these two tables and not the other, and a failed sweep here must not fail an insert whose rows
+        // are already committed — leaving the budget unspent simply retries on the next batch.
+        if ppgWaveformWritten > 0 {
+            let banked = (ppgWaveformRowsSincePrune[deviceId] ?? 0) + ppgWaveformWritten
+            ppgWaveformRowsSincePrune[deviceId] = banked
+            if banked >= ppgWaveformPruneEveryRows,
+               (try? syncWrite { db in
+                   try db.execute(sql: """
+                       DELETE FROM ppgWaveformSample WHERE deviceId = ? AND ts < (
+                           SELECT MIN(ts) FROM (
+                               SELECT ts FROM ppgWaveformSample WHERE deviceId = ? ORDER BY ts DESC LIMIT ?))
+                       """, arguments: [deviceId, deviceId, ppgWaveformRetentionRows])
+               }) != nil {
+                ppgWaveformRowsSincePrune[deviceId] = 0
             }
         }
         return result

--- a/Packages/WhoopStore/Sources/WhoopStore/WhoopStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/WhoopStore.swift
@@ -59,6 +59,12 @@ private actor StoreOpenGate {
 /// data or the query results.
 public actor WhoopStore {
 
+    /// PPG waveform rows banked since its retention sweep last ran, PER DEVICE, for the same reason as
+    /// `v18AuxRowsSincePrune` below: the sweep is per device, so a shared counter would let one strap
+    /// spend another's budget. Separate counter from the v18 aux one because the two caps differ and a
+    /// batch commonly writes one table and not the other. See `StreamStore`.
+    var ppgWaveformRowsSincePrune: [String: Int] = [:]
+
     /// v18 aux rows banked since the retention sweep last ran, PER DEVICE — the sweep is per device too,
     /// so a shared counter would let one strap spend another's budget. See `StreamStore`.
     var v18AuxRowsSincePrune: [String: Int] = [:]

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/PpgWaveformSampleTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/PpgWaveformSampleTests.swift
@@ -204,6 +204,35 @@ final class PpgWaveformSampleTests: XCTestCase {
         XCTAssertEqual(rows.map(\.ts), [100])
     }
 
+    /// One strap's sweep must not evict ANOTHER strap's rows. Distinct from the budget test above, which
+    /// only proves the two devices bank separately: this pins the DELETE's own device scoping, and it is
+    /// the reason the older strap's rows sit BELOW the sweeping strap's cutoff. With `dev2` newer than the
+    /// cutoff (as in the budget test) the rows survive even a DELETE that has lost its `deviceId` filter,
+    /// so that arrangement cannot see the bug. Dropping the outer filter is silent cross-device data loss
+    /// on a multi-strap install, and nothing else in the suite catches it.
+    func testRetentionSweepDoesNotEvictAnotherDevicesRows() async throws {
+        let s = try await retentionStore()
+        try await s.upsertDevice(id: "dev2", mac: nil, name: nil)
+        for ts in [500, 501] {
+            _ = try await s.insert(waveform(ts), deviceId: "dev2",
+                                   v18AuxRetentionRows: WhoopStore.v18AuxRetentionRows,
+                                   v18AuxPruneEveryRows: WhoopStore.v18AuxPruneEveryRows,
+                                   ppgWaveformRetentionRows: 10, ppgWaveformPruneEveryRows: 50)
+        }
+        // dev1's rows are all NEWER than dev2's, so dev1's cutoff sits above every dev2 row.
+        for ts in 1_000...1_003 {
+            _ = try await s.insert(waveform(ts), deviceId: "dev1",
+                                   v18AuxRetentionRows: WhoopStore.v18AuxRetentionRows,
+                                   v18AuxPruneEveryRows: WhoopStore.v18AuxPruneEveryRows,
+                                   ppgWaveformRetentionRows: 1, ppgWaveformPruneEveryRows: 1)
+        }
+        let d1 = try await s.ppgWaveformSamples(deviceId: "dev1", from: 0, to: 10_000)
+        let d2 = try await s.ppgWaveformSamples(deviceId: "dev2", from: 0, to: 10_000)
+        XCTAssertEqual(d1.map(\.ts), [1_003], "dev1 is swept to its own cap")
+        XCTAssertEqual(d2.map(\.ts), [500, 501],
+                       "dev2's older rows must survive dev1's sweep — the DELETE is per device")
+    }
+
     /// The production cap must stay a WEEK-SCALE newest-N row count, not an age-based drop. Pins the
     /// constant so a future "just make it 7 days" edit has to confront `ppgWaveformRetentionRows`' note.
     func testProductionRetentionCapIsAWeekOfStrapSeconds() {

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/PpgWaveformSampleTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/PpgWaveformSampleTests.swift
@@ -108,4 +108,106 @@ final class PpgWaveformSampleTests: XCTestCase {
         data.append(0xFF)
         XCTAssertEqual(WhoopStore.unpackPpgSamples(data), [1, 2, 3])
     }
+
+    // MARK: - #1911 rolling retention
+
+    private func retentionStore() async throws -> WhoopStore {
+        let s = try await WhoopStore.inMemory()
+        try await s.upsertDevice(id: "dev1", mac: nil, name: nil)
+        return s
+    }
+
+    private func waveform(_ ts: Int) -> Streams {
+        Streams(ppgWaveform: [PpgWaveformSample(ts: ts, samples: realSamples, burstIndex: 0)])
+    }
+
+    /// The cap keeps the NEWEST rows. This is the property the whole design rests on — an age-based drop
+    /// would instead empty the table for a sporadic wearer, whom a future PPG estimator needs most.
+    func testRetentionKeepsTheNewestRows() async throws {
+        let s = try await retentionStore()
+        for ts in 100...105 {
+            _ = try await s.insert(waveform(ts), deviceId: "dev1",
+                                   v18AuxRetentionRows: WhoopStore.v18AuxRetentionRows,
+                                   v18AuxPruneEveryRows: WhoopStore.v18AuxPruneEveryRows,
+                                   ppgWaveformRetentionRows: 2, ppgWaveformPruneEveryRows: 1)
+        }
+        let rows = try await s.ppgWaveformSamples(deviceId: "dev1", from: 0, to: 1_000)
+        XCTAssertEqual(rows.map(\.ts), [104, 105], "newest-N, not oldest-N and not everything")
+    }
+
+    /// Under the sweep threshold nothing is evicted — the overshoot is deliberate amortisation.
+    func testRetentionDoesNotSweepUnderTheThreshold() async throws {
+        let s = try await retentionStore()
+        for ts in 100...104 {
+            _ = try await s.insert(waveform(ts), deviceId: "dev1",
+                                   v18AuxRetentionRows: WhoopStore.v18AuxRetentionRows,
+                                   v18AuxPruneEveryRows: WhoopStore.v18AuxPruneEveryRows,
+                                   ppgWaveformRetentionRows: 2, ppgWaveformPruneEveryRows: 50)
+        }
+        let rows = try await s.ppgWaveformSamples(deviceId: "dev1", from: 0, to: 1_000)
+        XCTAssertEqual(rows.count, 5, "under the threshold the sweep must not run — overshoot is the point")
+    }
+
+    /// The counter resets after each sweep, so a long offload sweeps repeatedly rather than latching once.
+    func testRetentionCounterResetsAfterEachSweep() async throws {
+        let s = try await retentionStore()
+        for ts in 100...111 {
+            _ = try await s.insert(waveform(ts), deviceId: "dev1",
+                                   v18AuxRetentionRows: WhoopStore.v18AuxRetentionRows,
+                                   v18AuxPruneEveryRows: WhoopStore.v18AuxPruneEveryRows,
+                                   ppgWaveformRetentionRows: 2, ppgWaveformPruneEveryRows: 4)
+        }
+        let rows = try await s.ppgWaveformSamples(deviceId: "dev1", from: 0, to: 1_000)
+        XCTAssertEqual(rows.map(\.ts), [110, 111],
+                       "a second sweep must happen; the counter cannot latch after the first")
+    }
+
+    /// The budget is per device, because the delete is — one strap must not spend another's.
+    func testRetentionBudgetIsNotSharedBetweenDevices() async throws {
+        let s = try await retentionStore()
+        try await s.upsertDevice(id: "dev2", mac: nil, name: nil)
+        for ts in 100...102 {
+            _ = try await s.insert(waveform(ts), deviceId: "dev1",
+                                   v18AuxRetentionRows: WhoopStore.v18AuxRetentionRows,
+                                   v18AuxPruneEveryRows: WhoopStore.v18AuxPruneEveryRows,
+                                   ppgWaveformRetentionRows: 1, ppgWaveformPruneEveryRows: 4)
+        }
+        // With a SHARED counter dev2's single row crosses the threshold and sweeps; because the delete is
+        // scoped to dev2 it would evict nothing from dev1 while zeroing dev1's budget.
+        _ = try await s.insert(waveform(200), deviceId: "dev2",
+                               v18AuxRetentionRows: WhoopStore.v18AuxRetentionRows,
+                               v18AuxPruneEveryRows: WhoopStore.v18AuxPruneEveryRows,
+                               ppgWaveformRetentionRows: 1, ppgWaveformPruneEveryRows: 4)
+        _ = try await s.insert(waveform(103), deviceId: "dev1",
+                               v18AuxRetentionRows: WhoopStore.v18AuxRetentionRows,
+                               v18AuxPruneEveryRows: WhoopStore.v18AuxPruneEveryRows,
+                               ppgWaveformRetentionRows: 1, ppgWaveformPruneEveryRows: 4)
+        let d1 = try await s.ppgWaveformSamples(deviceId: "dev1", from: 0, to: 1_000)
+        XCTAssertEqual(d1.map(\.ts), [103],
+                       "dev1's own fourth row must trigger dev1's sweep — dev2 cannot spend its budget")
+    }
+
+    /// A batch with no waveform row must not sweep at all: a WHOOP 4.0 offload, or any non-v26 second,
+    /// never pays for the index scan and never evicts. Guards against banking the budget off other streams.
+    func testNoWaveformRowsMeansNoRetentionSweep() async throws {
+        let s = try await retentionStore()
+        _ = try await s.insert(waveform(100), deviceId: "dev1",
+                               v18AuxRetentionRows: WhoopStore.v18AuxRetentionRows,
+                               v18AuxPruneEveryRows: WhoopStore.v18AuxPruneEveryRows,
+                               ppgWaveformRetentionRows: 5, ppgWaveformPruneEveryRows: 1)
+        // An HR-only batch banks nothing here, so the cap of 1 must NOT evict the waveform row above.
+        _ = try await s.insert(Streams(hr: [HRSample(ts: 200, bpm: 60)]), deviceId: "dev1",
+                               v18AuxRetentionRows: WhoopStore.v18AuxRetentionRows,
+                               v18AuxPruneEveryRows: WhoopStore.v18AuxPruneEveryRows,
+                               ppgWaveformRetentionRows: 1, ppgWaveformPruneEveryRows: 1)
+        let rows = try await s.ppgWaveformSamples(deviceId: "dev1", from: 0, to: 1_000)
+        XCTAssertEqual(rows.map(\.ts), [100])
+    }
+
+    /// The production cap must stay a WEEK-SCALE newest-N row count, not an age-based drop. Pins the
+    /// constant so a future "just make it 7 days" edit has to confront `ppgWaveformRetentionRows`' note.
+    func testProductionRetentionCapIsAWeekOfStrapSeconds() {
+        XCTAssertEqual(WhoopStore.ppgWaveformRetentionRows, 604_800)
+        XCTAssertEqual(WhoopStore.ppgWaveformPruneEveryRows, 10_000)
+    }
 }

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -669,6 +669,13 @@ data class CoachMessageRow(
  * PK (deviceId, ts) mirrors every other per-second stream; a truncated frame can decode fewer than 24
  * samples. Fields are declared in the SAME order as the GRDB schema
  * (deviceId, ts, samples, burstIndex) so Room's generated shape stays byte-identical.
+ *
+ * CAPPED, not unbounded (#1911): [WhoopRepository.PPG_WAVEFORM_RETENTION_ROWS] rolling rows per device,
+ * the same shape [V18AuxSampleEntity] uses. The cap is NEWEST-N ROWS, never an age cutoff, and that is
+ * load-bearing for the paragraph above: a sporadic wearer's v26 seconds are spread thin over months, so
+ * dropping by wall-clock age would empty the table for exactly the user a future re-analysis needs most,
+ * and a waveform has no aggregate that survives it. Bounding the bytes while always leaving a full working
+ * set is the whole point. Swift twin: `WhoopStore.ppgWaveformRetentionRows`.
  */
 @Entity(tableName = "ppgWaveformSample", primaryKeys = ["deviceId", "ts"])
 data class PpgWaveformSampleEntity(

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -197,6 +197,19 @@ interface WhoopDao : DeviceRegistryDao {
     suspend fun insertV18Aux(rows: List<V18AuxSampleEntity>): List<Long>
 
     /**
+     * Bound the PPG waveform table to the newest [keep] rows for [deviceId] (#1911 rolling retention).
+     * Same shape as [pruneV18Aux] below, and deliberately the same NEWEST-N semantic rather than an
+     * age-based delete: see `WhoopRepository.PPG_WAVEFORM_RETENTION_ROWS`. Swift twin: the DELETE at the
+     * end of `WhoopStore.insert`.
+     */
+    @Query(
+        "DELETE FROM ppgWaveformSample WHERE deviceId = :deviceId AND ts < " +
+            "(SELECT MIN(ts) FROM (SELECT ts FROM ppgWaveformSample WHERE deviceId = :deviceId " +
+            "ORDER BY ts DESC LIMIT :keep))",
+    )
+    suspend fun prunePpgWaveform(deviceId: String, keep: Int)
+
+    /**
      * Bound the v18 aux table to the newest [keep] rows for [deviceId] (rolling retention, v31). Same
      * shape as [pruneRawImu] — this is instrumentation nothing reads yet, so it is capped rather than
      * unbounded. Swift twin: the DELETE at the end of `WhoopStore.insert`.

--- a/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDatabase.kt
@@ -548,6 +548,12 @@ abstract class WhoopDatabase : RoomDatabase() {
          * BLOB (2 bytes/sample, little-endian i16, [StreamPersistence.packPpgSamples]) rather than 24 scalar
          * rows.
          *
+         * Retention: `ppgWaveformSample` is CAPPED at [WhoopRepository.PPG_WAVEFORM_RETENTION_ROWS] rolling
+         * rows per device (#1911), the same shape `v18AuxSample` uses. The cap is NEWEST-N ROWS and never an
+         * age cutoff: v26 seconds are spread thin over months for a sporadic wearer, so dropping by
+         * wall-clock age would empty the table for exactly the user a future re-analysis needs most, and a
+         * waveform has no aggregate that survives it. Swift twin: the `v27-ppg-waveform` migration note.
+         *
          * CREATE TABLE only (no existing data touched), so already-offloaded raw streams survive. The SQL MUST
          * match Room's generated schema for [PpgWaveformSampleEntity] exactly: deviceId TEXT NOT NULL, ts
          * INTEGER NOT NULL, samples BLOB NOT NULL (all Kotlin non-null, no SQL DEFAULT), composite PRIMARY KEY

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -2164,8 +2164,13 @@ class WhoopRepository(
 
         /**
          * #1911: rolling retention for the v27 PPG waveform table (Swift twin
-         * `WhoopStore.ppgWaveformRetentionRows`). Previously the only UNBOUNDED blob table, and at
-         * ~1 row/second through a v26-heavy night the fastest-growing table per byte in the store.
+         * `WhoopStore.ppgWaveformRetentionRows`). Previously the only UNBOUNDED blob table, and it carries
+         * by far the largest PER-ROW cost of any decoded stream: ~120 B against ~30 B for a scalar row.
+         *
+         * It is NOT the store's fastest-growing table, and this note must not be read as saying so. v26
+         * runs only in optical windows, roughly 28,800 rows/day by #1911's own figures, where `rrInterval`
+         * banks ~100,000/day and remains the higher-volume table by bytes. Capping this one bounds the
+         * worst row, not the bulk of #1911's ~93 MB/day.
          *
          * A NEWEST-N-ROWS CAP, DELIBERATELY NOT A TIME-WINDOW DROP. #1911 proposes "dropped after the hot
          * window", calling the waveform "diagnostic-only". That framing is wrong: the migration note on
@@ -2179,8 +2184,11 @@ class WhoopRepository(
          * 604,800 = 7 × 86,400, matching the aux cap's "week of strap-seconds" semantic and #1911's own
          * 7-day hot window. The ceiling is larger than aux's because the row is: ~120 B/row (a 48 B
          * packed-i16 blob for 24 samples plus row and primary-key-index overhead) gives a ~70 MB hard
-         * ceiling per device against ~50 MB for aux. In practice v26 is a fraction of the strap's seconds,
-         * so occupancy sits far below that. Retuning is one constant with no migration.
+         * ceiling per device against ~50 MB for aux. That ceiling is the bound worth quoting; the wall-clock
+         * span is longer than the arithmetic suggests, because v26 only runs in optical windows. At #1911's
+         * ~28,800 rows/day the cap holds about three weeks of typical wear, and proportionally more for a
+         * sporadic wearer, which is exactly the population an age-based cutoff would have emptied. Retuning
+         * is one constant with no migration.
          */
         const val PPG_WAVEFORM_RETENTION_ROWS = 604_800
 

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -2183,8 +2183,8 @@ class WhoopRepository(
          *
          * 604,800 = 7 × 86,400, matching the aux cap's "week of strap-seconds" semantic and #1911's own
          * 7-day hot window. The ceiling is larger than aux's because the row is: ~120 B/row (a 48 B
-         * packed-i16 blob for 24 samples plus row and primary-key-index overhead) gives a ~70 MB hard
-         * ceiling per device against ~50 MB for aux. That ceiling is the bound worth quoting; the wall-clock
+         * packed-i16 blob for 24 samples plus row and primary-key-index overhead) gives ~70 MB per device
+         * against ~50 MB for aux. That is the bound worth quoting; the wall-clock
          * span is longer than the arithmetic suggests, because v26 only runs in optical windows. At #1911's
          * ~28,800 rows/day the cap holds about three weeks of typical wear, and proportionally more for a
          * sporadic wearer, which is exactly the population an age-based cutoff would have emptied. Retuning
@@ -2196,7 +2196,17 @@ class WhoopRepository(
          *  [V18_AUX_PRUNE_EVERY_ROWS] below, for the same reason: the sweep walks up to
          *  [PPG_WAVEFORM_RETENTION_ROWS] index entries, so running it per insert batch is the cost. The
          *  table may sit this many rows (plus the crossing batch) above the cap, roughly a MB against its
-         *  ~70 MB ceiling. Swift twin: `WhoopStore.ppgWaveformPruneEveryRows`. */
+         *  ~70 MB bound. Swift twin: `WhoopStore.ppgWaveformPruneEveryRows`.
+         *
+         *  WHAT THIS BUDGET DOES NOT GUARANTEE, and why the cap above is stated as a size and not a "hard
+         *  ceiling": the counter is in-memory and per repository instance, so process death resets it. The
+         *  sweep is the ONLY thing enforcing retention on this table (the `*ByTs` deletes belong to the
+         *  timestamp heal, not to retention), so a repository that never banks this many rows in one
+         *  process lifetime never sweeps. Not a concern for the normal shape, since the budget accumulates
+         *  across every batch of a session and one night's offload banks ~28,800 rows, but a repository fed
+         *  only short bursts between app kills can drift above the cap indefinitely.
+         *  [V18_AUX_PRUNE_EVERY_ROWS] has the identical property; forcing a sweep once per session would
+         *  close it for both, and belongs in a change that covers both. */
         const val PPG_WAVEFORM_PRUNE_EVERY_ROWS = 10_000
 
         /**

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -430,6 +430,12 @@ class WhoopRepository(
         suspend fun <R> run(block: suspend () -> R): R
     }
 
+    /** PPG waveform rows banked since its retention sweep last ran, PER DEVICE, for the same reason as
+     *  [v18AuxRowsSincePrune] below: the sweep is per device, so a shared counter would let one strap
+     *  spend another's budget. A separate counter because the two caps differ and a batch commonly writes
+     *  one table and not the other. Swift twin: `WhoopStore.ppgWaveformRowsSincePrune`. */
+    private val ppgWaveformRowsSincePrune = mutableMapOf<String, Int>()
+
     /** v18 aux rows banked since the retention sweep last ran, PER DEVICE — the sweep is per device too,
      *  so a shared counter would let one strap spend another's budget. Only the single-threaded offload
      *  path banks v18 rows, so a plain map is enough. Swift twin: `WhoopStore.v18AuxRowsSincePrune`. */
@@ -498,6 +504,8 @@ class WhoopRepository(
         // shipped constants. (#888)
         v18AuxRetentionRows: Int = V18_AUX_RETENTION_ROWS,
         v18AuxPruneEveryRows: Int = V18_AUX_PRUNE_EVERY_ROWS,
+        ppgWaveformRetentionRows: Int = PPG_WAVEFORM_RETENTION_ROWS,
+        ppgWaveformPruneEveryRows: Int = PPG_WAVEFORM_PRUNE_EVERY_ROWS,
     ): InsertCounts {
         if (streams.isEmpty) return InsertCounts()
 
@@ -507,6 +515,8 @@ class WhoopRepository(
                 deviceId = deviceId,
                 v18AuxRetentionRows = v18AuxRetentionRows,
                 v18AuxPruneEveryRows = v18AuxPruneEveryRows,
+                ppgWaveformRetentionRows = ppgWaveformRetentionRows,
+                ppgWaveformPruneEveryRows = ppgWaveformPruneEveryRows,
             )
         }
         val counts = result.counts
@@ -539,6 +549,8 @@ class WhoopRepository(
         deviceId: String,
         v18AuxRetentionRows: Int,
         v18AuxPruneEveryRows: Int,
+        ppgWaveformRetentionRows: Int,
+        ppgWaveformPruneEveryRows: Int,
     ): InsertResult {
         val hrIds = if (streams.hr.isEmpty()) emptyList() else
             dao.insertHr(streams.hr.map { HrSample(deviceId, it.ts, it.bpm) })
@@ -593,6 +605,19 @@ class WhoopRepository(
                         it.burstIndex)
                 },
             )
+            // #1911 rolling retention, amortised and best-effort on exactly the same terms as the v18-aux
+            // sweep below (see [PPG_WAVEFORM_RETENTION_ROWS] for why this is newest-N and not an age-based
+            // drop). Its own counter: a batch routinely writes one of these two tables and not the other.
+            val bankedPpg = (ppgWaveformRowsSincePrune[deviceId] ?: 0) + streams.ppgWaveform.size
+            ppgWaveformRowsSincePrune[deviceId] = bankedPpg
+            if (bankedPpg >= ppgWaveformPruneEveryRows) {
+                runCatching { dao.prunePpgWaveform(deviceId, ppgWaveformRetentionRows) }
+                    .onSuccess { ppgWaveformRowsSincePrune[deviceId] = 0 }
+                    // prunePpgWaveform is a suspend call, so a scope cancellation arrives here as a
+                    // CancellationException that runCatching would otherwise swallow, leaving the caller
+                    // running inside a cancelled coroutine. Same rethrow as the v18-aux sweep below.
+                    .onFailure { if (it is kotlin.coroutines.cancellation.CancellationException) throw it }
+            }
         }
 
         // Every remaining v18 slot (v31), one compact blob per strap-second. Persist-only, same as
@@ -2136,6 +2161,35 @@ class WhoopRepository(
 
         /** Default row cap on range reads. Matches the Swift call sites' bounded scans. */
         const val DEFAULT_LIMIT = 100_000
+
+        /**
+         * #1911: rolling retention for the v27 PPG waveform table (Swift twin
+         * `WhoopStore.ppgWaveformRetentionRows`). Previously the only UNBOUNDED blob table, and at
+         * ~1 row/second through a v26-heavy night the fastest-growing table per byte in the store.
+         *
+         * A NEWEST-N-ROWS CAP, DELIBERATELY NOT A TIME-WINDOW DROP. #1911 proposes "dropped after the hot
+         * window", calling the waveform "diagnostic-only". That framing is wrong: the migration note on
+         * `ppgWaveformSample` is the authority, and these rows are kept so a better estimator,
+         * HRV-from-PPG, or a waveform viewer can later run over the ORIGINAL samples rather than the
+         * derived bpm. Deleting by wall-clock age would empty the table for exactly the user such an
+         * estimator needs most (a sporadic wearer, whose v26 seconds are spread thin over months), and a
+         * waveform has no aggregate that survives it. Newest-N bounds the bytes while always leaving a
+         * full working set — the same trade [V18_AUX_RETENTION_ROWS] below makes.
+         *
+         * 604,800 = 7 × 86,400, matching the aux cap's "week of strap-seconds" semantic and #1911's own
+         * 7-day hot window. The ceiling is larger than aux's because the row is: ~120 B/row (a 48 B
+         * packed-i16 blob for 24 samples plus row and primary-key-index overhead) gives a ~70 MB hard
+         * ceiling per device against ~50 MB for aux. In practice v26 is a fraction of the strap's seconds,
+         * so occupancy sits far below that. Retuning is one constant with no migration.
+         */
+        const val PPG_WAVEFORM_RETENTION_ROWS = 604_800
+
+        /** Rows to bank before sweeping `ppgWaveformSample` again — same amortisation and magnitude as
+         *  [V18_AUX_PRUNE_EVERY_ROWS] below, for the same reason: the sweep walks up to
+         *  [PPG_WAVEFORM_RETENTION_ROWS] index entries, so running it per insert batch is the cost. The
+         *  table may sit this many rows (plus the crossing batch) above the cap, roughly a MB against its
+         *  ~70 MB ceiling. Swift twin: `WhoopStore.ppgWaveformPruneEveryRows`. */
+        const val PPG_WAVEFORM_PRUNE_EVERY_ROWS = 10_000
 
         /**
          * v31: rolling retention for the v18 aux-slot table (Swift twin `WhoopStore.v18AuxRetentionRows`).

--- a/android/app/src/test/java/com/noop/data/PpgWaveformMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/PpgWaveformMigrationTest.kt
@@ -133,4 +133,108 @@ class PpgWaveformMigrationTest {
         // And it unpacks back to the original samples.
         assertEquals(realSamples, StreamPersistence.unpackPpgSamples(rows[0].samples))
     }
+
+    // MARK: - #1911 rolling retention (twin of Swift PpgWaveformSampleTests' retention block)
+
+    private fun waveformRow(ts: Long) = PpgWaveformRow(ts = ts, samples = listOf(1, -2, 3), burstIndex = 0)
+
+    /** Records every `prunePpgWaveform(deviceId, keep)` the repository makes. */
+    private fun sweepRecordingDao(sweeps: MutableList<Pair<String, Int>>): WhoopDao =
+        Proxy.newProxyInstance(
+            WhoopDao::class.java.classLoader,
+            arrayOf(WhoopDao::class.java),
+        ) { _, method, args ->
+            when (method.name) {
+                "insertPpgWaveform" -> listOf(1L)
+                "insertV18Aux" -> listOf(1L)
+                "pruneV18Aux" -> Unit
+                "prunePpgWaveform" -> { sweeps.add((args[0] as String) to (args[1] as Int)); Unit }
+                else -> throw UnsupportedOperationException("unexpected DAO call ${method.name}")
+            }
+        } as WhoopDao
+
+    /** Under the sweep threshold nothing is evicted — the overshoot is deliberate amortisation. */
+    @Test
+    fun waveformRetention_doesNotSweepUnderTheThreshold(): Unit = runBlocking {
+        val sweeps = mutableListOf<Pair<String, Int>>()
+        val repo = WhoopRepository(sweepRecordingDao(sweeps))
+        repeat(3) { i ->
+            repo.insert(
+                StreamBatch(ppgWaveform = listOf(waveformRow(1_780_917_232L + i))),
+                "my-whoop",
+                ppgWaveformPruneEveryRows = 5_000,
+            )
+        }
+        assertEquals("three rows must not reach a 5 000-row budget", 0, sweeps.size)
+    }
+
+    /**
+     * Once the banked count crosses the threshold the sweep runs, and the counter resets so the next
+     * window has to earn its own sweep. It must also pass the RETENTION cap as `keep`, not the budget.
+     */
+    @Test
+    fun waveformRetention_sweepsOnThresholdThenResets(): Unit = runBlocking {
+        val sweeps = mutableListOf<Pair<String, Int>>()
+        val repo = WhoopRepository(sweepRecordingDao(sweeps))
+        // Two rows per batch against a budget of 3: banked=2 (no sweep), 4 (sweep, reset), 2 (no sweep).
+        repeat(3) { i ->
+            repo.insert(
+                StreamBatch(ppgWaveform = listOf(
+                    waveformRow(1_780_917_232L + i * 2), waveformRow(1_780_917_233L + i * 2),
+                )),
+                "my-whoop",
+                ppgWaveformPruneEveryRows = 3,
+                ppgWaveformRetentionRows = 99,
+            )
+        }
+        assertEquals("exactly one sweep — the counter must reset after it", 1, sweeps.size)
+        assertEquals("my-whoop" to 99, sweeps[0])
+    }
+
+    /** The budget is per device, because the delete is — one strap must not spend another's. */
+    @Test
+    fun waveformRetention_budgetIsNotSharedBetweenDevices(): Unit = runBlocking {
+        val sweeps = mutableListOf<Pair<String, Int>>()
+        val repo = WhoopRepository(sweepRecordingDao(sweeps))
+        repeat(3) { i ->
+            repo.insert(StreamBatch(ppgWaveform = listOf(waveformRow(1_780_917_232L + i))),
+                "strap-a", ppgWaveformPruneEveryRows = 4)
+        }
+        // With a SHARED counter this fourth banked row would cross the threshold and sweep strap-b,
+        // evicting nothing from strap-a while zeroing strap-a's budget.
+        repo.insert(StreamBatch(ppgWaveform = listOf(waveformRow(1_780_918_000L))),
+            "strap-b", ppgWaveformPruneEveryRows = 4)
+        assertEquals("neither strap has banked four of its OWN rows yet", 0, sweeps.size)
+
+        repo.insert(StreamBatch(ppgWaveform = listOf(waveformRow(1_780_917_240L))),
+            "strap-a", ppgWaveformPruneEveryRows = 4)
+        assertEquals(1, sweeps.size)
+        assertEquals("strap-a must sweep on its own fourth row", "strap-a", sweeps[0].first)
+    }
+
+    /**
+     * A batch that banks no waveform row must not sweep, even with a budget of one — a WHOOP 4.0 offload
+     * (or any non-v26 second) never pays for the index scan and never evicts. Guards specifically against
+     * banking the waveform budget off a DIFFERENT stream's rows.
+     */
+    @Test
+    fun waveformRetention_otherStreamsDoNotBankTheBudget(): Unit = runBlocking {
+        val sweeps = mutableListOf<Pair<String, Int>>()
+        WhoopRepository(sweepRecordingDao(sweeps)).insert(
+            StreamBatch(v18Aux = listOf(V18AuxRow(ts = 1_780_916_150L, statusWord = 1_792L))),
+            "my-whoop",
+            ppgWaveformPruneEveryRows = 1,
+        )
+        assertEquals("a v18-aux batch must not sweep the waveform table", 0, sweeps.size)
+    }
+
+    /**
+     * The shipped cap is a real bound and matches the Swift constant. Pinned so a future "just make it
+     * 7 days" edit has to confront the NEWEST-N rationale on [WhoopRepository.PPG_WAVEFORM_RETENTION_ROWS].
+     */
+    @Test
+    fun shippedWaveformRetentionConstants() {
+        assertEquals(604_800, WhoopRepository.PPG_WAVEFORM_RETENTION_ROWS)  // 7 x 86_400 strap-seconds
+        assertEquals(10_000, WhoopRepository.PPG_WAVEFORM_PRUNE_EVERY_ROWS)
+    }
 }

--- a/android/app/src/test/java/com/noop/data/PpgWaveformMigrationTest.kt
+++ b/android/app/src/test/java/com/noop/data/PpgWaveformMigrationTest.kt
@@ -135,6 +135,15 @@ class PpgWaveformMigrationTest {
     }
 
     // MARK: - #1911 rolling retention (twin of Swift PpgWaveformSampleTests' retention block)
+    //
+    // WHAT THESE TESTS DO AND DO NOT COVER. They drive a Proxy DAO, so they pin the repository's
+    // AMORTISATION (when a sweep fires, with which deviceId and cap, and whose budget paid for it) but
+    // never execute `prunePpgWaveform`'s SQL. The statement's semantics -- newest-N kept, and the DELETE
+    // scoped so one strap's sweep cannot evict another's rows -- are proven on the Swift side against a
+    // real database by `PpgWaveformSampleTests`, and the two statements are deliberately identical text
+    // modulo the parameter syntax. A change to the SQL here MUST be mirrored there, because this file
+    // cannot fail for it. (The project pins migration SQL without Robolectric on purpose; see the class
+    // doc, so there is no real-DB seam available here.)
 
     private fun waveformRow(ts: Long) = PpgWaveformRow(ts = ts, samples = listOf(1, -2, 3), burstIndex = 0)
 


### PR DESCRIPTION
Item 3 of #1911, on both platforms. This does not complete that issue: the aggregate tables, rollup engine, tier-aware reads and settings are all still open.

## Why this table

`ppgWaveformSample` was the only **unbounded blob** table in the store, and it carries by far the largest per-row cost of any decoded stream: ~120 B/row (a 48 B packed-i16 blob for 24 samples, plus row and PK-index overhead) against ~30 B for a scalar row. `rawBatch` (50 MB) and `v18AuxSample` (604,800 rows) were already bounded; this one was not.

To be precise about scale, since it decides how much of #1911 this actually buys: **this is the worst row, not the biggest table.** v26 runs only in optical windows, roughly 28,800 rows/day on the issue's own figures, where `rrInterval` banks ~100,000/day and stays the higher-volume table by bytes. So capping this one bounds the worst-per-row offender and removes the last unbounded blob, but most of the ~93 MB/day is still unbounded elsewhere.

## What lands

A rolling cap of **604,800 newest rows per device**, swept amortised on insert once per **10,000** banked rows. It mirrors `v18AuxSample` exactly on both platforms: its own per-device counter (a shared one would let one strap spend another's budget), its own best-effort sweep (a sweep failure must not fail an insert whose rows are already committed), and on Android the same `CancellationException` rethrow.

No schema change, so **no migration and no version bump**. One write path per platform, so the cap cannot be bypassed.

## A newest-N row cap, not the age-based drop the issue asked for

#1911 item 3 proposes "dropped after the hot window", calling the waveform "diagnostic-only". **That justification does not survive the migration note on the table**, which is the authority on why these rows exist:

> this table exists so a BETTER estimator, HRV-from-PPG, or a waveform viewer can later run over the ORIGINAL samples rather than the derived bpm. Do NOT "clean up" the reader as dead code: the rows are the point.

Deleting by wall-clock age would empty the table for exactly the user such an estimator needs most: a sporadic wearer, whose v26 seconds are spread thin over months. And unlike an HR series, a waveform has no aggregate that survives the delete, so an age cutoff is unrecoverable. Newest-N bounds the bytes while always leaving a full working set to analyse. It is also the trade `v18AuxRetentionRows` already made, for the same stated reason.

604,800 = 7 x 86,400 keeps the aux table's "week of strap-seconds" semantic and matches the issue's own 7-day hot window. The bound is ~70 MB per device against aux's ~50 MB because the row is bigger. The wall-clock span is longer than that arithmetic suggests, though, because v26 only runs in optical windows: at ~28,800 rows/day the cap holds about **three weeks** of typical wear, and proportionally more for a sporadic wearer, which is exactly the population an age cutoff would have emptied. Retuning is one constant with no migration once a device `row_bytes` measurement lands.

## Stale claims corrected

Three places asserted this table was unpruned, and are updated: the GRDB migration note, the Room entity doc, and the `NoopLocalAccess` storage readout. That last one matters most, because its own comment warns that "which tables are already bounded" is the first thing a retention design reads off, and getting it wrong has such a design "solving a problem twice, or trusting a bound that was never there".

## What the cap does not guarantee

Worth stating plainly, because the first draft of this called ~70 MB a "hard ceiling" and it is not one. The amortised sweep is the **only** thing enforcing retention here: `Collector.prune` covers the raw outbox alone, and the `*ByTs` deletes belong to the timestamp heal, not to retention. Its budget counter is in-memory and per store instance, so process death resets it, and a store that never banks 10,000 waveform rows in one process lifetime never sweeps.

That is not the normal shape: the budget accumulates across every batch of a session, and one night's offload banks ~28,800 rows, crossing the threshold twice over. But a store fed only short bursts between app kills can drift above the cap indefinitely, so the constants now say so on both platforms.

`v18AuxPruneEveryRows` has the identical property. Forcing a sweep once per session would remove that gap for both tables, and belongs in a change covering both rather than being bolted onto one of them here.

## Tests

Six Swift cases and five Kotlin, twinned: newest-N is what survives; nothing is evicted under the sweep threshold; the counter resets so a long offload sweeps repeatedly rather than latching once; the budget is per device; and a batch that banks no waveform row never sweeps (so a WHOOP 4.0 offload never pays the index scan, and other streams cannot bank the waveform budget). Plus a pin on the shipped constants, so a future "just make it 7 days" edit has to confront the rationale.

One of the Swift cases came out of mutation-testing the statement: removing the outer `WHERE deviceId = ?` from the DELETE passed every other test in the suite, and that mutation is silent cross-device data loss on a multi-strap install. The existing budget test cannot see it, because it places the second strap's row at a newer timestamp than the sweeping strap's cutoff, where the rows survive the broken statement too. The new case puts them below it. The same untested mutation exists for `v18AuxSample`, whose budget test has the same shape; left alone here since it is a shipping table and not this change's subject.

The Kotlin twin drives a Proxy DAO, so it pins the amortisation (when a sweep fires, with which deviceId and cap, whose budget paid) but never executes the SQL. Its retention block now says so and points at the Swift test as the semantic oracle. The two statements were diffed and are identical text modulo parameter syntax.

Android: full suite green locally, **5411 tests, 0 failures**. Swift `WhoopStore` package tests are CI-verified (the package cannot build under WSL).


---

*Updated after three re-review passes. The first body called this "the fastest-growing table per byte in the store", which #1911's own row/day figures contradict, and called the size bound a "hard ceiling", which the in-memory sweep budget cannot hold. Both are corrected above and in the doc comments that repeated them.*
