### PR TITLE
devices: show the battery pack's charge, from an event the strap already sends

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/BatteryPackInfo.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/BatteryPackInfo.swift
@@ -50,30 +50,70 @@ public enum BatteryPackInfo {
         }
     }
 
+    /// Offset of the present flag inside the event-109 payload.
+    public static let eventRecordBase = 4
+
+    /// Where a WHOOP 5/MG EVENT frame's opaque payload begins. Mirrors `Framing.decodeEventWhoop5`.
+    public static let whoop5EventPayloadStart = 16
+
+    /// The uncatalogued 5/MG event that carries the pack record. Named here because `EventNumber` has no
+    /// entry for it — it decodes as `0x6D(109)`.
+    public static let packInfoEvent = 109
+
+    /// Decode the pack RECORD itself, given the offset of its present-flag byte.
+    ///
+    /// Split out from `decode` because the same record reaches us by two entirely different transports: as
+    /// the payload of a `GET_BATTERY_PACK_INFO` (151) COMMAND_RESPONSE, and — hardware-confirmed on WHOOP MG
+    /// fw 50.39.1.0, 2026-09-01 — as the payload of the UNCATALOGUED pushed event `0x6D` (109), which the
+    /// strap volunteers while a pack is attached. Only the framing around the record differs; the fields are
+    /// identical, so they must not be decoded twice.
+    ///
+    /// Layout from `base`: +0 present, +1 BT address (6 B), +7 serial (16 B ASCII, NUL-terminated),
+    /// +23 SoC (u16 little-endian, tenths of a percent). nil when the buffer is too short to hold it.
+    public static func decodeRecord(_ bytes: [UInt8], base: Int) -> Info? {
+        guard base >= 0, bytes.count > base else { return nil }
+        let present = bytes[base] == 1
+        guard present else { return Info(present: false, socPct: nil, serial: nil, btAddr: nil) }
+
+        let btStart = base + 1
+        let serStart = base + 7
+        let socStart = base + 23
+        guard bytes.count >= socStart + 2 else { return nil }
+
+        let btAddr = bytes[btStart..<btStart + 6].map { String(format: "%02x", $0) }.joined()
+        let serBytes = Array(bytes[serStart..<serStart + 16].prefix { $0 != 0 })
+        let serial = serBytes.isEmpty ? nil : String(bytes: serBytes, encoding: .ascii)
+        let raw = Int(bytes[socStart]) | (Int(bytes[socStart + 1]) << 8)
+        return Info(present: true, socPct: Double(raw) / 10.0, serial: serial, btAddr: btAddr)
+    }
+
+    /// Decode the pack record from the pushed event `0x6D` (109) payload — the transport that actually works
+    /// on a 5/MG. The strap sends this unprompted while a pack is attached, so it needs no command, no
+    /// send-allowlist entry and no polling, and because it repeats it is a self-refreshing LEVEL signal.
+    public static func decodeEventPayload(_ payload: [UInt8]) -> Info? {
+        decodeRecord(payload, base: eventRecordBase)
+    }
+
+    /// Decode straight from a whole 5/MG EVENT frame, so callers never need to know where the payload
+    /// starts. Callers must first check the event number is `packInfoEvent`; this does not re-check it,
+    /// because the event byte lives in the frame header rather than the record.
+    public static func decodeEventFrame(_ frame: [UInt8]) -> Info? {
+        decodeRecord(frame, base: whoop5EventPayloadStart + eventRecordBase)
+    }
+
     /// The response-command byte sits at `cmdOff` (10 on WHOOP 5/MG — the only family with a pack; a 4.0's
     /// 6 is accepted only so a caller can pass it, though 4.0 never answers 151). Returns nil when the
     /// frame is not a well-formed 151 SUCCESS response. The caller is expected to have CRC-gated the frame
     /// (the framing layer already does), as the sibling probes assume.
+    ///
+    /// NOTE this command path is retained for completeness only. On WHOOP MG fw 50.39.1.0 opcode 151 answers
+    /// FAILURE(0) whether or not a pack is attached, so the feature is driven by `decodeEventFrame` instead.
     public static func decode(frame: [UInt8], cmdOff: Int = 10) -> Info? {
-        // Layout relative to cmdOff, pinned to the captures: +0 resp-cmd (151), +2 result (1 = SUCCESS),
-        // +4 present flag, +5 BT address (6 bytes), +11 serial (16-byte ASCII, NUL-terminated),
-        // +27 SoC (u16 little-endian, tenths of a percent).
+        // Header, pinned to the captures: +0 resp-cmd (151), +2 result (1 = SUCCESS). The record then starts
+        // at +4, which is what `decodeRecord` expects as its base.
         guard cmdOff >= 0, frame.count > cmdOff + 4 else { return nil }
         guard Int(frame[cmdOff]) == 151, Int(frame[cmdOff + 2]) == 1 else { return nil }
-        let present = frame[cmdOff + 4] == 1
-        guard present else { return Info(present: false, socPct: nil, serial: nil, btAddr: nil) }
-
-        let btStart = cmdOff + 5
-        let serStart = cmdOff + 11
-        let socStart = cmdOff + 27
-        guard frame.count >= socStart + 2 else { return nil }
-
-        let btAddr = frame[btStart..<btStart + 6].map { String(format: "%02x", $0) }.joined()
-        let serBytes = Array(frame[serStart..<serStart + 16].prefix { $0 != 0 })
-        let serial = serBytes.isEmpty ? nil : String(bytes: serBytes, encoding: .ascii)
-        let raw = Int(frame[socStart]) | (Int(frame[socStart + 1]) << 8)
-        let socPct = Double(raw) / 10.0
-        return Info(present: true, socPct: socPct, serial: serial, btAddr: btAddr)
+        return decodeRecord(frame, base: cmdOff + 4)
     }
 
     /// WHOOP 4.0 path. A 4.0 has no `GET_BATTERY_PACK_INFO` (151); its pack is read via

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BatteryPackInfoTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/BatteryPackInfoTests.swift
@@ -112,4 +112,42 @@ final class BatteryPackInfoTests: XCTestCase {
         let v = BatteryPackInfo.Info(present: true, socPct: nil, serial: nil, btAddr: nil, voltageMv: 3_900)
         XCTAssertFalse(v.displayable)
     }
+
+    /// REAL HARDWARE vectors: the pack record as the strap actually delivers it — the payload of the
+    /// uncatalogued pushed event 109, captured from a WHOOP MG on fw 50.39.1.0 (2026-09-01). Command 151
+    /// answers FAILURE(0) on that firmware whatever you send it, so the event is the transport the feature
+    /// runs on. The Kotlin twin asserts the same values.
+    private let packEvent569 = "f5481c000100005e005301574242354150303030303030310000003902010c00"
+    private let packEvent567 = "1e451c000100005e005301574242354150303030303030310000003702010c00"
+
+    func testPushedPackEventCarriesTheSameRecordAsTheCommandReply() {
+        let info = BatteryPackInfo.decodeEventPayload(bytes(packEvent569))
+        XCTAssertEqual(info?.present, true)
+        XCTAssertEqual(info?.serial, "WBB5AP0000001")
+        XCTAssertEqual(info?.btAddr, "00005e005301")
+        XCTAssertEqual(info?.socPct ?? -1, 56.9, accuracy: 1e-9)
+        XCTAssertNil(info?.voltageMv)               // the event never carries a voltage
+    }
+
+    /// The SoC field TRACKS A VARYING INPUT rather than merely looking plausible once: these two records are
+    /// minutes apart while the pack drains into the strap, and the value falls. A single reading cannot tell
+    /// tenths-of-a-percent from mAh; a falling pair in the physically correct direction, both inside 0...100
+    /// when read as tenths, is what settles the unit.
+    func testPackSocFallsAsThePackDrainsIntoTheStrap() {
+        let first = BatteryPackInfo.decodeEventPayload(bytes(packEvent569))?.socPct ?? -1
+        let later = BatteryPackInfo.decodeEventPayload(bytes(packEvent567))?.socPct ?? -1
+        XCTAssertEqual(first, 56.9, accuracy: 1e-9)
+        XCTAssertEqual(later, 56.7, accuracy: 1e-9)
+        XCTAssertLessThan(later, first, "pack SoC must fall while discharging into the strap")
+        XCTAssertLessThanOrEqual(first, 100.0)
+        XCTAssertGreaterThanOrEqual(later, 0.0)
+    }
+
+    /// The command path and the event path must agree field-for-field — they share `decodeRecord`, and a
+    /// refactor letting them drift would silently give the Devices card two different pack readings.
+    func testCommandAndEventPathsShareOneRecordDecoder() {
+        let viaCommand = BatteryPackInfo.decode(frame: bytes(attachedHex))
+        let viaRecord = BatteryPackInfo.decodeRecord(bytes(attachedHex), base: 14)   // cmdOff 10 + 4
+        XCTAssertEqual(viaCommand, viaRecord)
+    }
 }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -170,6 +170,14 @@ data class LiveState(
      *  Cleared on disconnect so a stale flag can't outlive the link. Twin of macOS
      *  LiveState.charging. */
     val charging: Boolean? = null,
+    /** Battery-pack charge, tenths-of-a-percent precision, from the pushed pack event (109) payload.
+     *  5/MG only — a WHOOP 4.0 has no pack fuel gauge (its pack reads as a VOLTAGE via opcode 98, a
+     *  different quantity). Null until the first pack event lands, cleared on BATTERY_PACK_REMOVED and
+     *  on disconnect, so a removed pack or a dropped link can never leave a stale charge on the card.
+     *
+     *  There is deliberately no separate "pack attached" flag: nothing needs one. Non-null here already
+     *  means a pack is attached and reporting, because the strap only sends the event while one is on. */
+    val packSocPct: Double? = null,
     /** Wrist-wear from WRIST_ON/WRIST_OFF events. Defaults TRUE to match the macOS LiveState (Swift
      *  parity) — assume worn until the strap says otherwise. (Was false, which made the UI show
      *  "Worn: Off" forever when no WRIST_ON event arrived — issue #18.) */
@@ -1344,6 +1352,12 @@ class WhoopBleClient(
                 charging = null, strapFirmware = null, historyLayoutVersion = null,
                 pairingHint = null, scanning = false,
                 statusNote = null,
+                // Pack readout dies with the link, the same rule as [charging]: a card still showing
+                // "Pack 56.9%" for a strap we are no longer talking to is a stale reading, not a stale
+                // pill. This clear is also why no expiry timer is needed — the only way to miss a pack
+                // removal is to be disconnected for it, and reconnecting starts from null either way.
+                // Event 109 re-establishes the reading within a couple of minutes if a pack is still on.
+                packSocPct = null,
             )
 
         /** #1466: did this offload hand over anything at all? Acked chunks, persisted rows, or deep packets.
@@ -7932,7 +7946,46 @@ class WhoopBleClient(
                             if (ev.startsWith("BATTERY_PACK_CONNECTED")) {
                                 _state.update { s -> s.copy(charging = true) }
                             } else if (ev.startsWith("BATTERY_PACK_REMOVED")) {
-                                _state.update { s -> s.copy(charging = false) }
+                                // Removal clears the readout too: a detached pack must not leave a stale
+                                // charge sitting on the card.
+                                _state.update { s -> s.copy(charging = false, packSocPct = null) }
+                            }
+                            // The pack's own charge. The strap volunteers the full pack record — present
+                            // flag, BT address, serial and SoC — in the UNCATALOGUED event 109 every couple
+                            // of minutes while a pack is attached, so this needs no command, no
+                            // send-allowlist entry and no polling. Because it REPEATS it is a level signal:
+                            // unlike the old edge-driven charging flag it re-establishes itself after any
+                            // reconnect and cannot go stale.
+                            //
+                            // Hardware-confirmed on WHOOP MG fw 50.39.1.0 (2026-09-01): three consecutive
+                            // records from one pack, SoC 57.1% -> 56.9% -> 56.7% as the pack drained
+                            // into the strap. That falling trend across a real physical process — not one
+                            // plausible-looking value — is what establishes the SoC word as tenths of a
+                            // percent. Gated by BatteryPackInfo.displayable below, so a wrong offset
+                            // yields nothing rather than a fabricated reading.
+                            // Matched on the event BYTE, not on the rendered label: an uncatalogued event
+                            // renders as "0x6D(109)" only because nothing names it, so a future
+                            // EventNumber entry would rename it and silently break a string match.
+                            // A 5/MG event frame carries its event number at offset 10.
+                            if (connectedFamily == DeviceFamily.WHOOP5 && frame.size > 10 &&
+                                (frame[10].toInt() and 0xFF) == com.noop.protocol.BatteryPackInfo.PACK_INFO_EVENT
+                            ) {
+                                com.noop.protocol.BatteryPackInfo.decodeEventFrame(frame)?.let { info ->
+                                    val soc = info.socPct
+                                    // [displayable] is #1303's gate, not a second copy of it: present, a
+                                    // charge, and inside 0..100. Two definitions of one rule is how the
+                                    // command path and the event path end up disagreeing about the same
+                                    // pack, which is the drift decodeRecord() exists to prevent.
+                                    if (info.displayable && soc != null) {
+                                        // charging=true here as well as on event 21 is the anti-staleness
+                                        // half: if the attach edge was missed (app started with the pack
+                                        // already on, or the link dropped over the attach), this repeating
+                                        // event re-establishes the state within a couple of minutes.
+                                        _state.update { s -> s.copy(packSocPct = soc, charging = true) }
+                                    } else if (!info.present) {
+                                        _state.update { s -> s.copy(packSocPct = null) }
+                                    }
+                                }
                             }
                         }
                         // PR #577: the strap fired its firmware smart alarm (STRAP_DRIVEN_ALARM_EXECUTED,

--- a/android/app/src/main/java/com/noop/protocol/BatteryPackInfo.kt
+++ b/android/app/src/main/java/com/noop/protocol/BatteryPackInfo.kt
@@ -38,30 +38,83 @@ object BatteryPackInfo {
             get() = present && socPct != null && socPct >= 0.0 && socPct <= 100.0
     }
 
-    /** Resp-cmd byte sits at [cmdOff] (10 on WHOOP 5/MG — the only family with a pack). Null when the
-     *  frame is not a well-formed 151 SUCCESS response; the caller CRC-gates the frame (framing layer does). */
-    fun decode(frame: ByteArray, cmdOff: Int = 10): Info? {
-        // Layout vs cmdOff, pinned to the captures: +0 resp-cmd (151), +2 result (1 = SUCCESS), +4 present
-        // flag, +5 BT address (6 bytes), +11 serial (16-byte ASCII, NUL-terminated), +27 SoC (u16 LE,
-        // tenths of a percent).
-        if (cmdOff < 0 || frame.size <= cmdOff + 4) return null
-        if ((frame[cmdOff].toInt() and 0xFF) != 151 || (frame[cmdOff + 2].toInt() and 0xFF) != 1) return null
-        val present = (frame[cmdOff + 4].toInt() and 0xFF) == 1
+    /**
+     * Decode the pack RECORD itself, given the offset of its present-flag byte.
+     *
+     * Split out from [decode] because the same record reaches us by two entirely different transports:
+     * as the payload of a `GET_BATTERY_PACK_INFO` (151) COMMAND_RESPONSE, and — hardware-confirmed on
+     * WHOOP MG fw 50.39.1.0, 2026-09-01 — as the payload of the UNCATALOGUED pushed event `0x6D` (109),
+     * which the strap volunteers every couple of minutes while a pack is attached. Only the framing
+     * around the record differs; the fields are identical, so they must not be decoded twice.
+     *
+     * Layout from [base]: +0 present, +1 BT address (6 B), +7 serial (16 B ASCII, NUL-terminated),
+     * +23 SoC (u16 LE, tenths of a percent). Null when the buffer is too short to hold it.
+     */
+    fun decodeRecord(bytes: ByteArray, base: Int): Info? {
+        if (base < 0 || bytes.size <= base) return null
+        val present = (bytes[base].toInt() and 0xFF) == 1
         if (!present) return Info(false, null, null, null)
 
-        val btStart = cmdOff + 5
-        val serStart = cmdOff + 11
-        val socStart = cmdOff + 27
-        if (frame.size < socStart + 2) return null
+        val btStart = base + 1
+        val serStart = base + 7
+        val socStart = base + 23
+        if (bytes.size < socStart + 2) return null
 
-        val btAddr = (btStart until btStart + 6).joinToString("") { "%02x".format(frame[it].toInt() and 0xFF) }
-        val serBytes = (serStart until serStart + 16).map { frame[it] }.takeWhile { it.toInt() != 0 }
+        val btAddr = (btStart until btStart + 6).joinToString("") { "%02x".format(bytes[it].toInt() and 0xFF) }
+        val serBytes = (serStart until serStart + 16).map { bytes[it] }.takeWhile { it.toInt() != 0 }
         // Null on empty OR any non-ASCII byte, matching the Swift twin's `String(bytes:encoding:.ascii)`
         // (which returns nil for any byte > 127) — keeps the two byte-identical on a malformed serial.
         val serial = if (serBytes.isEmpty() || serBytes.any { (it.toInt() and 0xFF) >= 0x80 }) null
         else String(serBytes.toByteArray(), Charsets.US_ASCII)
-        val raw = (frame[socStart].toInt() and 0xFF) or ((frame[socStart + 1].toInt() and 0xFF) shl 8)
+        val raw = (bytes[socStart].toInt() and 0xFF) or ((bytes[socStart + 1].toInt() and 0xFF) shl 8)
         return Info(true, raw / 10.0, serial, btAddr)
+    }
+
+    /**
+     * Decode the pack record from the pushed event `0x6D` (109) payload — the transport that actually
+     * works on a 5/MG. The strap sends this unprompted while a pack is attached, so it needs no command,
+     * no send-allowlist entry and no polling; the repeat cadence makes it a self-refreshing LEVEL signal
+     * that cannot go stale. The record's present flag sits at payload offset 4.
+     *
+     * Confirmed against three consecutive captures from one MG, one pack throughout (SoC 57.1 % ->
+     * 56.9 % -> 56.7 % as the pack drained into the strap) — the falling trend is what establishes the
+     * SoC word as tenths of a percent rather than a plausible-looking constant.
+     */
+    fun decodeEventPayload(payload: ByteArray): Info? = decodeRecord(payload, EVENT_RECORD_BASE)
+
+    /** Offset of the present flag inside the event-109 payload. */
+    const val EVENT_RECORD_BASE = 4
+
+    /**
+     * Decode straight from a whole 5/MG EVENT frame, so callers never have to know where the payload
+     * starts. A 5/MG event's opaque payload begins at frame offset 16 (`Framing.decodeEventWhoop5`), so
+     * the record's present flag lands at 16 + [EVENT_RECORD_BASE]. Keeping that arithmetic here means the
+     * BLE layer passes the frame it already has and no offset knowledge leaks out of the protocol package.
+     *
+     * Callers must check the event number is [PACK_INFO_EVENT] first — this does not re-check it, because
+     * the event byte lives in the frame header rather than the record.
+     */
+    fun decodeEventFrame(frame: ByteArray): Info? = decodeRecord(frame, WHOOP5_EVENT_PAYLOAD_START + EVENT_RECORD_BASE)
+
+    /** Where a WHOOP 5/MG EVENT frame's opaque payload begins. Mirrors `Framing.decodeEventWhoop5`. */
+    const val WHOOP5_EVENT_PAYLOAD_START = 16
+
+    /** Uncatalogued 5/MG event that carries the pack record. Named here because `EventNumber` has no
+     *  entry for it — it decodes as `0x6D(109)`. */
+    const val PACK_INFO_EVENT = 109
+
+    /** Resp-cmd byte sits at [cmdOff] (10 on WHOOP 5/MG — the only family with a pack). Null when the
+     *  frame is not a well-formed 151 SUCCESS response; the caller CRC-gates the frame (framing layer does).
+     *
+     *  NOTE this command path is retained for completeness only. On WHOOP MG fw 50.39.1.0 opcode 151
+     *  answers FAILURE(0) whether or not a pack is attached, so the feature is driven by
+     *  [decodeEventPayload] instead. See docs/DESIGN-battery-pack-charge.md. */
+    fun decode(frame: ByteArray, cmdOff: Int = 10): Info? {
+        // Header, pinned to the captures: +0 resp-cmd (151), +2 result (1 = SUCCESS). The record then
+        // starts at +4, which is what [decodeRecord] expects as its base.
+        if (cmdOff < 0 || frame.size <= cmdOff + 4) return null
+        if ((frame[cmdOff].toInt() and 0xFF) != 151 || (frame[cmdOff + 2].toInt() and 0xFF) != 1) return null
+        return decodeRecord(frame, cmdOff + 4)
     }
 
     /**

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -255,6 +255,8 @@ fun DevicesScreen(
                     live.batteryPct?.let { Math.round(it).toInt() } else null,
                 liveBatteryMv = if (device.status == DeviceStatus.active.name && live.connected)
                     live.batteryMv else null,
+                livePackSocPct = if (device.status == DeviceStatus.active.name && live.connected)
+                    live.packSocPct else null,
                 // Firmware version for the ACTIVE strap. It's a STABLE property (NOOP can't change a strap's
                 // firmware), so prefer the live handshake value but fall back to the last-known persisted
                 // firmware (NoopPrefs, written on connect) when the live value is momentarily null — mid-
@@ -728,6 +730,10 @@ private fun DeviceCard(
      *  generic strap, or an FTMS machine. null when not active/connected or no battery was reported. */
     liveBatteryPct: Int? = null,
     liveBatteryMv: Int? = null,
+    /** Battery-pack charge % (5/MG only), from the pushed pack event. Null when no pack is attached or
+     *  none has been reported yet — the row is simply absent then, which is the "only show it when a
+     *  pack is actually on" behaviour, for free. */
+    livePackSocPct: Double? = null,
     /** The active+connected strap's firmware version (from the connect handshake). null when not
      *  active/connected, or for a source that reports no firmware (e.g. a non-WHOOP strap). */
     liveFirmware: String? = null,
@@ -849,11 +855,18 @@ private fun DeviceCard(
             val voltsSuffix = if (liveBatteryMv != null)
                 " · " + stringResource(R.string.l10n_devices_screen_pack_voltage_9af3c3ff, liveBatteryMv / 1000.0)
             else ""
+            // Battery-pack charge (5/MG). Present only while a pack is actually attached, because the
+            // strap only sends the pack event then — so an empty suffix is the whole "hide it when not
+            // charging" rule, with no extra conditional.
+            val packSuffix = if (livePackSocPct != null)
+                " · " + stringResource(R.string.l10n_devices_screen_pack_charge_0e9589da, livePackSocPct)
+            else ""
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     lastSeenLine(device, isLiveConnected, bondRefused) +
                         (liveFirmware?.let { " · FW $it" } ?: "") +
                         voltsSuffix +
+                        packSuffix +
                         (historyLayoutLine(liveHistoryLayout)?.let { " · $it" } ?: ""),
                     style = NoopType.footnote,
                     color = Palette.textTertiary,

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -478,6 +478,7 @@
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">Keins aktiv lassen</string>
     <string name="l10n_devices_screen_name_709a2322">Name</string>
     <string name="l10n_devices_screen_pack_voltage_9af3c3ff">%1$.2f V</string>
+    <string name="l10n_devices_screen_pack_charge_0e9589da">Pack %1$.1f%%</string>
     <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Lokal gekoppelt. NOOP besitzt diesen Ring, solange es den Schlüssel hält. Wenn du ihn erneut zurücksetzt oder in der Oura-App einrichtest, besitzt NOOP ihn nicht mehr, und du müsstest ihn zum Übernehmen neu hinzufügen.</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Neuen aktiven Strap auswählen</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Gerät umbenennen</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -278,6 +278,7 @@
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">No dejar ninguna activa</string>
     <string name="l10n_devices_screen_name_709a2322">Nombre</string>
     <string name="l10n_devices_screen_pack_voltage_9af3c3ff">%1$.2f V</string>
+    <string name="l10n_devices_screen_pack_charge_0e9589da">Pack %1$.1f%%</string>
     <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Emparejado localmente. NOOP es propietario de este anillo mientras conserva la clave. Si lo restableces de nuevo o lo configuras en la app de Oura, NOOP deja de ser propietario y tendrías que volver a añadirlo para retomar el control.</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Elige una nueva pulsera activa</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Renombrar dispositivo</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -296,6 +296,7 @@
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">N\'en laisser aucune active</string>
     <string name="l10n_devices_screen_name_709a2322">Nom</string>
     <string name="l10n_devices_screen_pack_voltage_9af3c3ff">%1$.2f V</string>
+    <string name="l10n_devices_screen_pack_charge_0e9589da">Pack %1$.1f%%</string>
     <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Associée localement. NOOP possède cette bague tant qu\'il détient la clé. Si vous la réinitialisez à nouveau ou la configurez dans l\'app Oura, NOOP ne la possède plus et vous devrez la rajouter pour en reprendre le contrôle.</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Choisir un nouveau bracelet actif</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Renommer l\'appareil</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -435,6 +435,7 @@
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">Nie pozostawiaj żadnego aktywnego</string>
     <string name="l10n_devices_screen_name_709a2322">Nazwa</string>
     <string name="l10n_devices_screen_pack_voltage_9af3c3ff">%1$.2f V</string>
+    <string name="l10n_devices_screen_pack_charge_0e9589da">Pack %1$.1f%%</string>
     <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Sparowane lokalnie. NOOP jest właścicielem tego pierścienia, dopóki trzyma klucz. Jeśli zresetujesz go ponownie lub skonfigurujesz w aplikacji Oura, NOOP nie będzie już jego właścicielem i dodasz go ponownie, aby go przejąć.</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Wybierz nowy aktywny pasek</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Zmień nazwę urządzenia</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -443,6 +443,7 @@
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">Não deixe nenhum ativo</string>
     <string name="l10n_devices_screen_name_709a2322">Nome</string>
     <string name="l10n_devices_screen_pack_voltage_9af3c3ff">%1$.2f V</string>
+    <string name="l10n_devices_screen_pack_charge_0e9589da">Pack %1$.1f%%</string>
     <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Emparelhado localmente. NOOP possui este anel enquanto detém a chave. Se o repor novamente ou o configurar na aplicação Oura, o NOOP já não será o proprietário e irá adicioná-lo novamente para o assumir.</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Escolha uma nova bracelete ativa</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Renomear dispositivo</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -513,6 +513,7 @@
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">Не оставлять ни одного активным</string>
     <string name="l10n_devices_screen_name_709a2322">Имя</string>
     <string name="l10n_devices_screen_pack_voltage_9af3c3ff">%1$.2f В</string>
+    <string name="l10n_devices_screen_pack_charge_0e9589da">Блок %1$.1f%%</string>
     <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Сопряжено локально. NOOP владеет этим кольцом, пока у него есть ключ. Если вы снова сбросите кольцо или настроите его в приложении Oura, NOOP перестанет им владеть, и вам нужно будет добавить его заново, чтобы вернуть управление.</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Выберите новый активный браслет</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Переименовать устройство</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2647,4 +2647,5 @@
     <string name="l10n_devices_screen_battery_pack_probe_151_re_d722af00">电池盒探测 (151 RE)…</string>
     <string name="l10n_devices_screen_battery_pack_probe_result_151_df43dff2">电池盒探测结果 (151)</string>
     <string name="l10n_devices_screen_battery_pack_probe_explainer_40b3470d">发送只读的电池盒命令 (151) 并解码手环的回复——电池盒的电量、序列号和蓝牙地址。不会向手环写入任何内容，也不会影响您的数据。WHOOP 4.0 没有电池盒命令，预期会保持静默；这种静默本身就是有用的结果。</string>
+    <string name="l10n_devices_screen_pack_charge_0e9589da">电池盒 %1$.1f%%</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -563,6 +563,7 @@
     <string name="l10n_devices_screen_leave_none_active_b5c858cb">Leave none active</string>
     <string name="l10n_devices_screen_name_709a2322">Name</string>
     <string name="l10n_devices_screen_pack_voltage_9af3c3ff">%1$.2f V</string>
+    <string name="l10n_devices_screen_pack_charge_0e9589da">Pack %1$.1f%%</string>
     <string name="l10n_devices_screen_paired_locally_noop_owns_this_ring_30c16190">Paired locally. NOOP owns this ring while it holds the key. If you reset it again or set it up in the Oura app, NOOP no longer owns it and you would re-add it to take it over.</string>
     <string name="l10n_devices_screen_pick_a_new_active_strap_edd73542">Pick a new active strap</string>
     <string name="l10n_devices_screen_rename_device_ee233604">Rename device</string>

--- a/android/app/src/test/java/com/noop/protocol/BatteryPackInfoTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/BatteryPackInfoTest.kt
@@ -127,4 +127,48 @@ class BatteryPackInfoTest {
                                      voltageMv = 3_900)
         assertFalse(v.displayable)
     }
+
+    /**
+     * REAL HARDWARE vectors: the pack record as the strap actually delivers it — the payload of the
+     * uncatalogued pushed event 109, captured from a WHOOP MG on fw 50.39.1.0 (2026-09-01). Command 151
+     * answers FAILURE(0) on this firmware whatever you send it, so the event is the transport the
+     * feature runs on; these two frames are what proves the field offsets on MG hardware.
+     */
+    private val packEvent569 = "f5481c000100005e005301574242354150303030303030310000003902010c00"
+    private val packEvent567 = "1e451c000100005e005301574242354150303030303030310000003702010c00"
+
+    @Test fun pushedPackEventCarriesTheSameRecordAsTheCommandReply() {
+        val a = BatteryPackInfo.decodeEventPayload(bytes(packEvent569))!!
+        assertEquals(true, a.present)
+        assertEquals("WBB5AP0000001", a.serial)
+        assertEquals("00005e005301", a.btAddr)
+        assertEquals(56.9, a.socPct!!, 1e-9)
+        assertNull(a.voltageMv)                       // the event never carries a voltage
+    }
+
+    /**
+     * The SoC field TRACKS A VARYING INPUT rather than merely looking plausible once: these two records
+     * are minutes apart while the pack drains into the strap, and the value falls. A single reading
+     * cannot tell tenths-of-a-percent from mAh; a falling pair in the physically correct direction, both
+     * within 0..100 when read as tenths, is what settles the unit.
+     */
+    @Test fun packSocFallsAsThePackDrainsIntoTheStrap() {
+        val first = BatteryPackInfo.decodeEventPayload(bytes(packEvent569))!!.socPct!!
+        val later = BatteryPackInfo.decodeEventPayload(bytes(packEvent567))!!.socPct!!
+        assertEquals(56.9, first, 1e-9)
+        assertEquals(56.7, later, 1e-9)
+        assertTrue("pack SoC must fall while discharging into the strap", later < first)
+        assertTrue("read as tenths-of-a-percent both samples are a real percentage", first <= 100.0 && later >= 0.0)
+    }
+
+    /** The command path and the event path must agree field-for-field — they share [decodeRecord], and a
+     *  refactor that let them drift would silently give the Devices card two different pack readings. */
+    @Test fun commandAndEventPathsShareOneRecordDecoder() {
+        val viaCommand = BatteryPackInfo.decode(bytes(attachedHex))!!
+        val viaRecord = BatteryPackInfo.decodeRecord(bytes(attachedHex), 14)!!   // cmdOff 10 + 4
+        assertEquals(viaCommand.present, viaRecord.present)
+        assertEquals(viaCommand.serial, viaRecord.serial)
+        assertEquals(viaCommand.btAddr, viaRecord.btAddr)
+        assertEquals(viaCommand.socPct!!, viaRecord.socPct!!, 1e-9)
+    }
 }


### PR DESCRIPTION
## What this PR does

There is no way to see how full the WHOOP battery pack is, anywhere in the app.

#1303 polls command 151, decodes the reply, and **deliberately shows nothing** — because those offsets were *"an unvalidated candidate re-derived from two frames"*, and a wrong one does not fail, it renders a confident wrong number. Its comment names what is missing: *"the evidence a card needs before it can honestly show anything"*. This is that evidence, and the card.

### The finding

**No command is needed.** The strap volunteers the whole record, unprompted, every couple of minutes while a pack is attached, in an **uncatalogued event — `0x6D` (109)**. Its 32-byte payload matches `BatteryPackInfo`'s field layout offset for offset:

| offset | field |
|---|---|
| +4 | `present` |
| +5 | BT address (6 B) |
| +11 | serial (16 B ASCII, NUL-terminated) |
| +27 | SoC (u16 LE) |

So the clean-room WHOOP 5 offsets are **confirmed on MG hardware**, carried by a transport nobody had looked at.

### Why this matters more since the keep-alive poll landed

`main` now polls `GET_BATTERY_PACK_INFO(151)` on every keep-alive tick for a WHOOP 5. On a WHOOP MG (fw `50.39.1.0`) that command answers `FAILURE(0)` in every state tried, including with the pack attached and demonstrably charging — #1930 is the probe that establishes that.

So on this hardware the poll cannot yield a pack percentage, and **pushed event `0x6D` (109) is the only transport that does**.

### Why the SoC unit is tenths of a percent, not mAh

Three independent lines, because a single plausible-looking value is not evidence:

1. **A falling series tracking a real physical process** — 57.1 → 56.9 → 56.7 % while the pack drained into the strap, whose own SoC rose over the same window. Correct direction, all values ≤ 1000.
2. **Across 12 hours** — 56.4 → 42.6 %, monotonic, with the serial field constant across the series, so it is one pack across the window rather than unrelated samples.
3. **The strap says so itself.** Its own console prints `NFC COMMS: BPK SoC : 422` while our decode of event 109 read `426` six hours earlier — the firmware states the same quantity on the same scale, from a completely separate source.

### Design

- **One record decoder, two transports.** `decodeRecord(bytes, base)` is extracted so the command reply and the pushed event share it, and a test asserts both paths agree field for field. Letting them drift would put two different pack readings on one card.
- **Gated on #1303's own `Info.displayable`**, not a second copy of that rule. Two definitions of one invariant is the same drift the shared decoder exists to prevent.
- **Matched on the event BYTE at frame offset 10, not the rendered label.** An uncatalogued event reads as `0x6D(109)` only because nothing names it; adding an `EventNumber` entry later would rename it and silently break a string match.
- **The empty suffix IS the hide rule.** The strap only sends the event while a pack is attached, so "show it only when charging" needs no conditional.
- **Cleared on `BATTERY_PACK_REMOVED(22)` and on disconnect**, so a detached pack or a dropped link cannot leave a stale charge on the card.
- **Offsets stay in the protocol package** — no offset knowledge leaks into the BLE layer.
- **No new opcode, no `CommandNumber` case, no send-allowlist entry, no polling, no wire traffic.**

Because the event **repeats**, it is a level signal rather than an edge: it re-establishes itself after a reconnect and cannot go stale.

### Deliberately not included

- **No expiry timer.** The measured cadence with a pack attached varies from 24 s to over 6 minutes, so any window short enough to be useful would false-clear. Event 22 fires reliably, and a disconnect clears state already.
- **No `packPresent` flag.** A non-null `packSocPct` already means "a pack is attached and reporting".
- **Nothing that renders the serial or address.** This reads only `socPct`, `displayable` and `present` off the decoded record — the identifiers never reach a log line or the card. Checked specifically after #1931.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

**On hardware.** WHOOP MG, hw `WS50_r00`, fw `50.39.1.0`, no subscription, Pixel 9 Pro / Android 15, local `full` debug build. Two attach/detach cycles: the card showed the pack percentage in the same second as the physical attach, tracked the value down across the session, and cleared on removal.

**Android unit tests, full suite.** `./gradlew testFullDebugUnitTest` against `main` @ `744a8b9f` (after #1930 and #1931): **5,430 tests across 653 classes, 0 failures, 0 errors** (6 skipped, pre-existing). Counted from the JUnit XML with the results directory cleared beforehand, so the numbers come from a real run rather than an up-to-date task.

**Swift.** `swift build` clean and the full `WhoopProtocol` suite green on macOS, Swift 6.2.4 — **657 tests, 0 failures, 1 skipped**. `BatteryPackInfoTests` contributes 8 of those, covering both transports sharing one record decoder, the absent-pack clear, the mutated edge vectors, and the WHOOP 4.0 voltage path.

**`Tools/doc_comment_lint.py`** clean. **`Tools/i18n_audit.py --ci`** clean — no new gaps in any locale.

## Two things I would rather flag than have you find

**1. The ru and zh strings are mine, and unreviewed.** This is the first string in the app to name the battery pack, so there was no existing term in either locale to follow — the neighbouring pack string is unit-only (`%1$.2f V` → `%1$.2f В`). I wrote `Блок` and `电池盒`. Both are plausible; neither has been checked by a native speaker. I chose that over raising the `i18n_extra_locale_baseline` allowance, which only ever ratchets down, and over dropping the word, which would leave the card reading `· 41.9%` with nothing saying it is the pack. Happy to take whatever you or a translator prefer.

**2. The test fixtures carry a synthetic serial and an RFC 7042 documentation BT address**, not the ones from the capture they came from. The record is a 32-byte payload with no CRC, so substituting those two fields breaks nothing structural and every offset holds. #1833 is exactly why: an identifier inside a hex run is one a reader does not notice.

## What this does NOT claim

- **One strap, one firmware.** A non-MG WHOOP 5 may behave as the golden vectors show rather than as observed here — and on such a strap #1303's command path may work where this event may not exist. The two sources are complementary for that reason.
- The Apple **app target** (`LiveState`, `FrameRouter`, `DevicesView`) is not written; only the pure decoder is ported. That is a separate parity change.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/WhoopProtocol`)
- [x] Android unit tests pass (`./gradlew testFullDebugUnitTest`, full suite)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — the suffix reuses the existing footnote style and `Palette.textTertiary`
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in `docs/CONTRIBUTING.md`
- [x] I did not commit generated output or any secrets/keystores

## Related issues

Builds on #1303, which supplies the decoder, the `displayable` gate and the command path. Companion to #1930. Does not close anything.