### PR TITLE
test centre: a read-only cmd-151 battery-pack probe, and what an MG answers

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1542,6 +1542,61 @@ class WhoopBleClient(
         /** #690: persisted previous body-location payload hex, so a new capture can diff against it. */
         private const val KEY_690_PREV_PAYLOAD = "noop.690.prevPayload"
 
+        /** Sentinel value of [batteryPackProbe] between sending the cmd-151 probe and its reply landing. */
+        const val WAITING_BATTERY_PACK_PROBE = "__waiting__"
+
+        /** How long to wait for a cmd-151 COMMAND_RESPONSE before treating the silence as "no reply".
+         *  Same window as the #690 probe — long enough to ride out a mid-flight sync, short enough that
+         *  the dialog does not hang. */
+        const val BATTERY_PACK_PROBE_TIMEOUT_MS = 8_000L
+
+        /**
+         * Format a cmd-151 COMMAND_RESPONSE into a readable report for the Devices dialog + strap log.
+         * Pure, so it is unit-testable without a strap. [cmdOff] is the response-command byte offset
+         * (10 on 5/MG; a WHOOP 4.0 has no pack command at all and is not expected to answer).
+         *
+         * Reports BOTH readings of the SoC word deliberately. The tenths-of-a-percent interpretation is
+         * an UNVALIDATED CANDIDATE re-derived from two captured frames, and the same raw value is
+         * equally consistent with mAh remaining; the committed "absent" vector is all zeros, so the pair
+         * confirms the present-flag discriminator and says nothing about the unit. Asserting one reading
+         * here would be a diagnostic claiming more than it can attribute, so the raw word is shown beside
+         * both and the operator settles it with a second capture at a different pack level.
+         */
+        internal fun formatBatteryPackProbe(frame: ByteArray, cmdOff: Int): String {
+            val sb = StringBuilder()
+            sb.append("GET_BATTERY_PACK_INFO (151) response, ${frame.size} bytes, cmdOff=$cmdOff\n")
+            sb.append("raw: ${frame.joinToString("") { "%02x".format(it) }}\n\n")
+            val info = com.noop.protocol.BatteryPackInfo.decode(frame, cmdOff)
+            if (info == null) {
+                sb.append("DID NOT DECODE as a 151 SUCCESS response at this offset.\n")
+                sb.append("Either the reply is not a 151 response, or its result byte is not SUCCESS, or\n")
+                sb.append("the frame is shorter than the candidate layout needs. The raw hex above is the\n")
+                sb.append("evidence — the opcode may be right and the OFFSETS wrong.")
+                return sb.toString()
+            }
+            if (!info.present) {
+                sb.append("present = FALSE — the strap reports NO pack attached.\n")
+                sb.append("If a pack IS physically attached right now, the present-flag offset is wrong.")
+                return sb.toString()
+            }
+            sb.append("present = TRUE\n")
+            sb.append("serial  = ${info.serial ?: "<undecodable>"}\n")
+            sb.append("bt addr = ${info.btAddr ?: "<none>"}\n")
+            // Read the SoC word straight from the frame rather than reconstructing it from the decoded
+            // Double — decode() already bounds-checked this offset when it returned present=true, and a
+            // float round-trip could land the raw value one off.
+            val rawWord = (frame[cmdOff + 27].toInt() and 0xFF) or ((frame[cmdOff + 28].toInt() and 0xFF) shl 8)
+            sb.append("SoC raw word = $rawWord\n")
+            sb.append("  read as tenths-of-a-percent: ${rawWord / 10.0}%\n")
+            sb.append("  read as-is (e.g. mAh):       $rawWord\n")
+            if (rawWord > 1000) {
+                sb.append("  NOTE raw > 1000, so it CANNOT be tenths of a percent — this is not SoC%.\n")
+            }
+            sb.append("\nCompare against the pack's actual level, then capture again at a clearly\n")
+            sb.append("different level: a reading that tracks the gauge and stays <= 1000 is SoC%.")
+            return sb.toString()
+        }
+
         /** #761: sentinel value of [featureFlagProbe] while the read-only enumeration walk is running. */
         const val WAITING_FEATURE_FLAG_PROBE = "__waiting__"
 
@@ -1925,6 +1980,11 @@ class WhoopBleClient(
     // #690: the body-location probe result (or the waiting sentinel), shown + copied in the Devices dialog.
     private val _bodyLocationProbe = MutableStateFlow<String?>(null)
     val bodyLocationProbe: StateFlow<String?> = _bodyLocationProbe.asStateFlow()
+
+    // The cmd-151 battery-pack probe result (or the waiting sentinel), shown + copied in the Devices
+    // dialog. Read-only diagnostic: it decodes nothing into live state and gates nothing.
+    private val _batteryPackProbe = MutableStateFlow<String?>(null)
+    val batteryPackProbe: StateFlow<String?> = _batteryPackProbe.asStateFlow()
 
     // #761: the READ-ONLY feature-flag ENUMERATION report — the flag NAMES the strap's own firmware lists
     // — or the waiting sentinel while the walk runs. Nothing is written to the strap to produce it.
@@ -4150,6 +4210,14 @@ class WhoopBleClient(
                 // probeBodyLocationAndStatus() (user-initiated, Test Centre gated); response decoded to a
                 // diagnostic report only, never gates wear/scoring. Whether 5/MG answers is a hardware check.
                 cmd != CommandNumber.GET_BODY_LOCATION_AND_STATUS &&
+                // GET_BATTERY_PACK_INFO (151) over puffin: read-only read of the pack's charge/serial.
+                // Gated HARDER than the 98/84 probes above — allowed ONLY while a probe is actually in
+                // flight, the 117/118 treatment — because unlike those two this opcode has never been
+                // sent to any strap by this app, so a default install must not be able to form these
+                // bytes at all. Driven only by probeBatteryPackInfo() (user-initiated, Test Centre
+                // gated). Whether a 5/MG answers at all is exactly the hardware question being asked.
+                !(cmd == CommandNumber.GET_BATTERY_PACK_INFO &&
+                    _batteryPackProbe.value == WAITING_BATTERY_PACK_PROBE) &&
                 // START_FF_KEY_EXCHANGE (117) / SEND_NEXT_FF (118) over puffin: the READ-ONLY feature-flag
                 // ENUMERATION probe (#761) — it reads the strap's own flag NAMES and writes no value. Gated
                 // harder than the probes above: allowed ONLY while a probe is actually in flight, so on a
@@ -4641,6 +4709,40 @@ class WhoopBleClient(
 
     /** Clear the #690 probe result (Devices dialog dismissed). */
     fun clearBodyLocationProbe() { _bodyLocationProbe.value = null }
+
+    /** Read-only cmd-151 probe: ask the strap for its battery pack's charge/serial/address and let the
+     *  COMMAND_RESPONSE hook decode + surface it. User-initiated (Test Centre gated). Decodes into the
+     *  dialog and the strap log ONLY — it feeds no live state and gates nothing.
+     *
+     *  KNOWN RESULT, so nobody re-runs this expecting data: on WHOOP MG fw 50.39.1.0 opcode 151 answers
+     *  FAILURE(0) whether or not a pack is attached and charging, across five argument forms. The pack
+     *  READOUT does not use this command at all — the strap volunteers the same record, unprompted, in
+     *  an uncatalogued pushed event, 0x6D (109). This probe is kept only as RE
+     *  instrumentation: the golden vectors behind `BatteryPackInfo` came from a WHOOP 5 rather than an
+     *  MG, so a non-MG owner running this is exactly the capture that would show whether the FAILURE is
+     *  MG-specific. Same read-only, Test-Centre-gated shape as the #592 and #690 probes. */
+    fun probeBatteryPackInfo() {
+        if (!_state.value.connected) {
+            log("Battery-pack probe (151) ignored — not connected")
+            return
+        }
+        // MUST be set before send(): the 5/MG allow-list admits opcode 151 only while this sentinel is
+        // in place, so setting it afterwards would have the strap's own gate drop our own probe.
+        _batteryPackProbe.value = WAITING_BATTERY_PACK_PROBE
+        log("Battery-pack probe: sending GET_BATTERY_PACK_INFO(151, read-only) on family=$connectedFamily; the decoded reply is dumped below when it lands")
+        send(CommandNumber.GET_BATTERY_PACK_INFO)
+        // Silence is itself a verdict. ATOMIC compare-and-set so a real reply landing microseconds
+        // before the timeout is never clobbered by this late "no reply".
+        handler.postDelayed({
+            val msg = "Battery-pack probe: no COMMAND_RESPONSE for opcode 151 within " +
+                "${BATTERY_PACK_PROBE_TIMEOUT_MS / 1000}s — the strap served no reply. On a WHOOP 4.0 that " +
+                "is EXPECTED (a 4.0 has no pack command; its pack reads as a VOLTAGE via opcode 98)."
+            if (_batteryPackProbe.compareAndSet(WAITING_BATTERY_PACK_PROBE, msg)) log(msg)
+        }, BATTERY_PACK_PROBE_TIMEOUT_MS)
+    }
+
+    /** Clear the cmd-151 probe result (Devices dialog dismissed). */
+    fun clearBatteryPackProbe() { _batteryPackProbe.value = null }
 
     /**
      * #761 read-only probe: ask the strap to ENUMERATE the feature-flag key names its firmware knows —
@@ -7125,6 +7227,16 @@ class WhoopBleClient(
                         log("Body-location probe (#690):\n$text")
                         _bodyLocationProbe.value = text
                         if (payHex != null) NoopPrefs.of(context).edit().putString(KEY_690_PREV_PAYLOAD, payHex).apply()
+                    }
+                    // cmd-151 battery-pack probe: decode the pack's charge/serial/address into the Devices
+                    // dialog and the strap log. In-flight-guarded like #690 above — 0x97 could
+                    // coincidentally be some data frame's cmd-offset byte, and this is strictly a
+                    // user-triggered diagnostic, so a stray match must never pop the result dialog.
+                    if (frame.size > cmdOff && (frame[cmdOff].toInt() and 0xFF) == CommandNumber.GET_BATTERY_PACK_INFO.rawValue &&
+                        _batteryPackProbe.value == WAITING_BATTERY_PACK_PROBE) {
+                        val text = formatBatteryPackProbe(frame, cmdOff)
+                        log("Battery-pack probe (151):\n$text")
+                        _batteryPackProbe.value = text
                     }
                     // #761: a reply to the read-only feature-flag enumeration (117/118). In-flight-guarded
                     // inside handleFeatureFlagProbeResponse, so this is a byte compare on every other frame.

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -2225,6 +2225,17 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
 
     fun clearBodyLocationProbe() = ble.clearBodyLocationProbe()
 
+    /** Read-only battery-pack probe (cmd 151) — asks the strap for its pack's charge, serial and BT
+     *  address. User-initiated, Test-Centre-gated in DevicesScreen; the decoded report goes to the
+     *  dialog + strap log only, and feeds no live state. 5/MG only in practice (a 4.0 has no pack
+     *  command), and whether a 5/MG answers at all is the hardware question being asked. */
+    fun probeBatteryPackInfo() = ble.probeBatteryPackInfo()
+
+    /** cmd-151 probe result text (null until a reply lands; waiting sentinel while in flight). */
+    val batteryPackProbe = ble.batteryPackProbe
+
+    fun clearBatteryPackProbe() = ble.clearBatteryPackProbe()
+
     /** #761: READ-ONLY feature-flag ENUMERATION probe (117 then repeated 118) — reads the flag NAMES the
      *  strap's own firmware knows and writes nothing (no SET_FF_VALUE, no value of any kind).
      *  User-initiated, Test-Centre-gated in DevicesScreen; the report goes to the dialog + strap log. */

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -125,6 +125,7 @@ fun DevicesScreen(
     val batteryProbeResult by viewModel.extendedBatteryProbe.collectAsStateWithLifecycle()
     // #690 body-location probe result — same non-null-shows-the-dialog contract.
     val bodyLocationProbeResult by viewModel.bodyLocationProbe.collectAsStateWithLifecycle()
+    val batteryPackProbeResult by viewModel.batteryPackProbe.collectAsStateWithLifecycle()
     // #761: the read-only feature-flag ENUMERATION report (or the waiting sentinel while it walks).
     val featureFlagProbeResult by viewModel.featureFlagProbe.collectAsStateWithLifecycle()
     // #103: the read-only device-config READ report (or the waiting sentinel while the plan runs).
@@ -156,6 +157,7 @@ fun DevicesScreen(
     var probeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     var batteryProbeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     var bodyLocationProbeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
+    var batteryPackProbeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     var featureFlagProbeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     var deviceConfigProbeTarget by remember { mutableStateOf<PairedDeviceRow?>(null) }
     // After removing the ACTIVE device with other devices still paired, prompt to pick a new active one.
@@ -312,6 +314,13 @@ fun DevicesScreen(
                     SourceCoordinator.isWhoop(device) &&
                     TestCentre.from(context).active(TestDomain.CONNECTION)
                 ) { { bodyLocationProbeTarget = device } } else null,
+                // cmd-151 battery-pack probe: read-only, same Test Centre gate. Offered on both families
+                // even though only a 5/MG is expected to answer — a 4.0's SILENCE is itself the evidence
+                // that the pack command is 5/MG-only, and costs nothing to collect.
+                onPackInfoProbe = if (device.status == DeviceStatus.active.name && live.connected &&
+                    SourceCoordinator.isWhoop(device) &&
+                    TestCentre.from(context).active(TestDomain.CONNECTION)
+                ) { { batteryPackProbeTarget = device } } else null,
                 // #761 feature-flag ENUMERATION probe: read-only (names only, nothing written), both
                 // families. Same Test Centre gate.
                 onFeatureFlagProbe = if (device.status == DeviceStatus.active.name && live.connected &&
@@ -474,6 +483,19 @@ fun DevicesScreen(
         BodyLocationProbeResultDialog(
             text = result,
             onDismiss = { viewModel.clearBodyLocationProbe() },
+        )
+    }
+    // cmd-151 battery-pack probe: read-only send + decoded pack charge/serial/address.
+    batteryPackProbeTarget?.let {
+        BatteryPackProbeDialog(
+            onSend = { viewModel.probeBatteryPackInfo(); batteryPackProbeTarget = null },
+            onDismiss = { batteryPackProbeTarget = null },
+        )
+    }
+    batteryPackProbeResult?.let { result ->
+        BatteryPackProbeResultDialog(
+            text = result,
+            onDismiss = { viewModel.clearBatteryPackProbe() },
         )
     }
     // #761 feature-flag ENUMERATION probe: read-only key-name listing (117 then repeated 118); no value
@@ -729,6 +751,8 @@ private fun DeviceCard(
     onBatteryProbe: (() -> Unit)? = null,
     // #690 body-location opcode probe (Test Centre → Connection, both WHOOP families). Read-only.
     onBodyLocationProbe: (() -> Unit)? = null,
+    // cmd-151 battery-pack probe (Test Centre → Connection). Read-only; 5/MG answers, a 4.0 should not.
+    onPackInfoProbe: (() -> Unit)? = null,
     /** #761 feature-flag ENUMERATION probe (Test Centre → Connection, both WHOOP families). Read-only:
      *  it reads the flag NAMES the strap's firmware knows and writes nothing. */
     onFeatureFlagProbe: (() -> Unit)? = null,
@@ -853,6 +877,7 @@ private fun DeviceCard(
                     onRebootProbe = onRebootProbe,
                     onBatteryProbe = onBatteryProbe,
                     onBodyLocationProbe = onBodyLocationProbe,
+                    onPackInfoProbe = onPackInfoProbe,
                     onFeatureFlagProbe = onFeatureFlagProbe,
                 onAbortSync = onAbortSync,
                     onDeviceConfigProbe = onDeviceConfigProbe,
@@ -977,6 +1002,7 @@ private fun DeviceActionsMenu(
     onRebootProbe: (() -> Unit)? = null,
     onBatteryProbe: (() -> Unit)? = null,
     onBodyLocationProbe: (() -> Unit)? = null,
+    onPackInfoProbe: (() -> Unit)? = null,
     /** #761 feature-flag ENUMERATION probe (Test Centre → Connection, both WHOOP families). Read-only:
      *  it reads the flag NAMES the strap's firmware knows and writes nothing. */
     onFeatureFlagProbe: (() -> Unit)? = null,
@@ -1047,6 +1073,10 @@ private fun DeviceActionsMenu(
                 // #690: read-only body-location opcode probe — decodes revision/location/confidence/status.
                 if (onBodyLocationProbe != null) {
                     MenuItem(uiString(R.string.l10n_devices_screen_body_location_probe_690_re_7def8c39), Icons.Filled.BugReport) { onOpenChange(false); onBodyLocationProbe() }
+                }
+                // Read-only battery-pack probe (cmd 151) — decodes the pack's charge/serial/address.
+                if (onPackInfoProbe != null) {
+                    MenuItem(uiString(R.string.l10n_devices_screen_battery_pack_probe_151_re_d722af00), Icons.Filled.BugReport) { onOpenChange(false); onPackInfoProbe() }
                 }
                 // #761 feature-flag ENUMERATION probe (RE): read-only key-name listing, both families.
                 if (onAbortSync != null) {
@@ -1299,6 +1329,72 @@ private fun BodyLocationProbeDialog(
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(uiString(R.string.l10n_devices_screen_cancel_77dfd213), style = NoopType.body, color = Palette.textSecondary)
+            }
+        },
+    )
+}
+
+/** Confirmation for the read-only cmd-151 battery-pack probe. Nothing is written to the strap. */
+@Composable
+private fun BatteryPackProbeDialog(
+    onSend: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Palette.surfaceOverlay,
+        title = { Text(uiString(R.string.l10n_devices_screen_battery_pack_probe_151_re_d722af00), style = NoopType.title2, color = Palette.textPrimary) },
+        text = {
+            Text(
+                uiString(R.string.l10n_devices_screen_battery_pack_probe_explainer_40b3470d),
+                style = NoopType.subhead,
+                color = Palette.textSecondary,
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onSend) {
+                Text(uiString(R.string.l10n_devices_screen_send_probe_read_only_36b318bc), style = NoopType.body, color = Palette.accent)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(uiString(R.string.l10n_devices_screen_cancel_77dfd213), style = NoopType.body, color = Palette.textSecondary)
+            }
+        },
+    )
+}
+
+/** cmd-151 probe result: raw hex plus the decoded pack record (or a "waiting…" state), with a Copy
+ *  button. Read-only; dismiss clears the result. */
+@Composable
+private fun BatteryPackProbeResultDialog(
+    text: String,
+    onDismiss: () -> Unit,
+) {
+    val clipboard = LocalClipboardManager.current
+    val waiting = text == WhoopBleClient.WAITING_BATTERY_PACK_PROBE
+    val shown = if (waiting) uiString(R.string.l10n_devices_screen_waiting_for_the_straps_reply_5a06e7ac) else text
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Palette.surfaceOverlay,
+        title = { Text(uiString(R.string.l10n_devices_screen_battery_pack_probe_result_151_df43dff2), style = NoopType.title2, color = Palette.textPrimary) },
+        text = {
+            Column(modifier = Modifier.heightIn(max = 360.dp).verticalScroll(rememberScrollState())) {
+                SelectionContainer {
+                    Text(shown, style = if (waiting) NoopType.subhead else NoopType.mono, color = Palette.textSecondary)
+                }
+            }
+        },
+        confirmButton = {
+            if (!waiting) {
+                TextButton(onClick = { clipboard.setText(AnnotatedString(text)) }) {
+                    Text(uiString(R.string.l10n_devices_screen_copy_af74f7c5), style = NoopType.body, color = Palette.accent)
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(uiString(R.string.l10n_devices_screen_close_bbfa773e), style = NoopType.body, color = Palette.textSecondary)
             }
         },
     )

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -450,6 +450,9 @@
     <string name="l10n_devices_screen_body_location_probe_690_re_7def8c39">Körperpositions-Test (#690 RE)…</string>
     <string name="l10n_devices_screen_body_location_probe_result_690_60c5ee79">Ergebnis des Körperpositions-Tests (#690)</string>
     <string name="l10n_devices_screen_body_location_probe_explainer_a9363239">Sendet den nur lesenden Körperpositions-Befehl (0x54) und schreibt die vollständige Rohantwort des Bands ins Strap-Log, wobei der Datensatz (Revision / Position / Konfidenz / Status) auf der WHOOP 4.0 dekodiert wird. Es wird nichts auf das Band geschrieben, und Trageerkennung oder Bewertung werden nie verändert.</string>
+    <string name="l10n_devices_screen_battery_pack_probe_151_re_d722af00">Akkupack-Test (151 RE)…</string>
+    <string name="l10n_devices_screen_battery_pack_probe_result_151_df43dff2">Ergebnis des Akkupack-Tests (151)</string>
+    <string name="l10n_devices_screen_battery_pack_probe_explainer_40b3470d">Sendet den nur lesenden Akkupack-Befehl (151) und dekodiert die Antwort des Bands — Ladestand, Seriennummer und Bluetooth-Adresse des Akkupacks. Es wird nichts auf das Band geschrieben und nichts fließt in deine Daten. Eine WHOOP 4.0 hat keinen Akkupack-Befehl und bleibt erwartungsgemäß stumm; dieses Schweigen ist selbst ein nützliches Ergebnis.</string>
     <string name="l10n_devices_screen_delete_this_device_s_data_3cae7a2a">Daten dieses Geräts löschen…</string>
     <string name="l10n_devices_screen_disconnect_ed28e068">Trennen</string>
     <string name="l10n_devices_screen_feature_flag_probe_761_re_21241d68">Feature-Flag-Test (#761 RE)…</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -250,6 +250,9 @@
     <string name="l10n_devices_screen_body_location_probe_690_re_7def8c39">Sonda de posición corporal (#690 RE)…</string>
     <string name="l10n_devices_screen_body_location_probe_result_690_60c5ee79">Resultado de la sonda de posición corporal (#690)</string>
     <string name="l10n_devices_screen_body_location_probe_explainer_a9363239">Envía el comando de posición corporal de solo lectura (0x54) y vuelca la respuesta cruda completa de la banda al registro, decodificando el registro (revisión / posición / confianza / estado) en la WHOOP 4.0. No se escribe nada en la banda y nunca cambia la detección de uso ni la puntuación.</string>
+    <string name="l10n_devices_screen_battery_pack_probe_151_re_d722af00">Prueba del pack de batería (151 RE)…</string>
+    <string name="l10n_devices_screen_battery_pack_probe_result_151_df43dff2">Resultado de la prueba del pack de batería (151)</string>
+    <string name="l10n_devices_screen_battery_pack_probe_explainer_40b3470d">Envía el comando de solo lectura del pack de batería (151) y descodifica la respuesta de la banda: carga, número de serie y dirección Bluetooth del pack. No se escribe nada en la banda y nada afecta a tus datos. Una WHOOP 4.0 no tiene comando de pack y se espera que no responda; ese silencio también es un resultado útil.</string>
     <string name="l10n_devices_screen_delete_this_device_s_data_3cae7a2a">Eliminar los datos de este dispositivo…</string>
     <string name="l10n_devices_screen_disconnect_ed28e068">Desconectar</string>
     <string name="l10n_devices_screen_feature_flag_probe_761_re_21241d68">Sonda de indicadores de función (#761 RE)…</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -268,6 +268,9 @@
     <string name="l10n_devices_screen_body_location_probe_690_re_7def8c39">Sonde de position corporelle (#690 RE)…</string>
     <string name="l10n_devices_screen_body_location_probe_result_690_60c5ee79">Résultat de la sonde de position corporelle (#690)</string>
     <string name="l10n_devices_screen_body_location_probe_explainer_a9363239">Envoie la commande de position corporelle en lecture seule (0x54) et consigne la réponse brute complète du bracelet dans le journal, en décodant l\'enregistrement (révision / position / confiance / état) sur la WHOOP 4.0. Rien n\'est écrit sur le bracelet, et la détection de port ou la notation ne sont jamais modifiées.</string>
+    <string name="l10n_devices_screen_battery_pack_probe_151_re_d722af00">Test du pack de batterie (151 RE)…</string>
+    <string name="l10n_devices_screen_battery_pack_probe_result_151_df43dff2">Résultat du test du pack de batterie (151)</string>
+    <string name="l10n_devices_screen_battery_pack_probe_explainer_40b3470d">Envoie la commande en lecture seule du pack de batterie (151) et décode la réponse du bracelet : charge, numéro de série et adresse Bluetooth du pack. Rien n\'est écrit sur le bracelet et rien n\'alimente tes données. Une WHOOP 4.0 n\'a pas de commande de pack et devrait rester silencieuse ; ce silence est lui-même un résultat utile.</string>
     <string name="l10n_devices_screen_delete_this_device_s_data_3cae7a2a">Supprimer les données de cet appareil…</string>
     <string name="l10n_devices_screen_disconnect_ed28e068">Déconnecter</string>
     <string name="l10n_devices_screen_feature_flag_probe_761_re_21241d68">Sonde des indicateurs de fonction (#761 RE)…</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -415,6 +415,9 @@
     <string name="l10n_devices_screen_body_location_probe_690_re_7def8c39">Sonda do lokalizacji ciała (#690 RE)…</string>
     <string name="l10n_devices_screen_body_location_probe_result_690_60c5ee79">Wynik sondy lokalizacji ciała (#690)</string>
     <string name="l10n_devices_screen_body_location_probe_explainer_a9363239">Wysyła polecenie lokalizacji ciała tylko do odczytu (0x54) i zrzuca pełną nieprzetworzoną odpowiedź paska do dziennika paska, dekodując zapis (wersja/lokalizacja/pewność/status) w WHOOP 4.0. Nic nie jest zapisane na pasku i nigdy nie zmienia sposobu wykrywania zużycia ani punktacji.</string>
+    <string name="l10n_devices_screen_battery_pack_probe_151_re_d722af00">Test pakietu baterii (151 RE)…</string>
+    <string name="l10n_devices_screen_battery_pack_probe_result_151_df43dff2">Wynik testu pakietu baterii (151)</string>
+    <string name="l10n_devices_screen_battery_pack_probe_explainer_40b3470d">Wysyła tylko do odczytu polecenie pakietu baterii (151) i dekoduje odpowiedź opaski — poziom naładowania, numer seryjny i adres Bluetooth pakietu. Nic nie jest zapisywane na opasce i nic nie trafia do Twoich danych. WHOOP 4.0 nie ma polecenia pakietu i zgodnie z oczekiwaniami milczy; samo to milczenie jest użytecznym wynikiem.</string>
     <string name="l10n_devices_screen_feature_flag_probe_761_re_21241d68">Sonda z flagą funkcji (#761 RE)…</string>
     <string name="l10n_devices_screen_stop_sync_4a1f2b6e">Zatrzymaj synchronizację</string>
     <string name="l10n_devices_screen_feature_flag_probe_result_761_c50ef4d4">Wynik sondy z flagą funkcji (nr 761)</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -415,6 +415,9 @@
     <string name="l10n_devices_screen_body_location_probe_690_re_7def8c39">Sonda de localização corporal (#690 RE)…</string>
     <string name="l10n_devices_screen_body_location_probe_result_690_60c5ee79">Resultado da sonda de localização corporal (#690)</string>
     <string name="l10n_devices_screen_body_location_probe_explainer_a9363239">Envia o comando body-location de leitura apenas (0x54) e regista a resposta bruta completa do bracelete no registo da bracelete, descodificando o registo (revisão/localização/confiança/estado) no WHOOP 4.0. Nada é escrito na bracelete e nunca altera a deteção ou pontuação de desgaste.</string>
+    <string name="l10n_devices_screen_battery_pack_probe_151_re_d722af00">Teste do pack de bateria (151 RE)…</string>
+    <string name="l10n_devices_screen_battery_pack_probe_result_151_df43dff2">Resultado do teste do pack de bateria (151)</string>
+    <string name="l10n_devices_screen_battery_pack_probe_explainer_40b3470d">Envia o comando só de leitura do pack de bateria (151) e descodifica a resposta da banda — carga, número de série e endereço Bluetooth do pack. Nada é escrito na banda e nada alimenta os teus dados. Uma WHOOP 4.0 não tem comando de pack e deverá permanecer silenciosa; esse silêncio é, em si, um resultado útil.</string>
     <string name="l10n_devices_screen_delete_this_device_s_data_3cae7a2a">Eliminar os dados deste dispositivo…</string>
     <string name="l10n_devices_screen_disconnect_ed28e068">Desconectar</string>
     <string name="l10n_devices_screen_feature_flag_probe_761_re_21241d68">Sonda de sinalizadores de funcionalidade (#761 RE)…</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -2614,4 +2614,7 @@
     <string name="units_kilometres">Километры</string>
     <string name="units_miles">Мили</string>
     <string name="units_follow_body">Как для параметров тела</string>
+    <string name="l10n_devices_screen_battery_pack_probe_151_re_d722af00">Проба батарейного блока (151 RE)…</string>
+    <string name="l10n_devices_screen_battery_pack_probe_result_151_df43dff2">Результат пробы батарейного блока (151)</string>
+    <string name="l10n_devices_screen_battery_pack_probe_explainer_40b3470d">Отправляет команду батарейного блока только для чтения (151) и декодирует ответ браслета — заряд блока, серийный номер и Bluetooth-адрес. На браслет ничего не записывается, и это не влияет на ваши данные. У WHOOP 4.0 нет команды блока, и ожидается молчание; само это молчание — полезный результат.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2644,4 +2644,7 @@
     <string name="units_kilometres">公里</string>
     <string name="units_miles">英里</string>
     <string name="units_follow_body">跟随身体测量</string>
+    <string name="l10n_devices_screen_battery_pack_probe_151_re_d722af00">电池盒探测 (151 RE)…</string>
+    <string name="l10n_devices_screen_battery_pack_probe_result_151_df43dff2">电池盒探测结果 (151)</string>
+    <string name="l10n_devices_screen_battery_pack_probe_explainer_40b3470d">发送只读的电池盒命令 (151) 并解码手环的回复——电池盒的电量、序列号和蓝牙地址。不会向手环写入任何内容，也不会影响您的数据。WHOOP 4.0 没有电池盒命令，预期会保持静默；这种静默本身就是有用的结果。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -540,6 +540,9 @@
     <string name="l10n_devices_screen_battery_clamped_2494c8c9">Battery %1$s%%</string>
     <string name="l10n_devices_screen_battery_info_probe_592_re_1dbd4c0f">Battery-info probe (#592 RE)…</string>
     <string name="l10n_devices_screen_battery_info_probe_result_592_b97c0bb8">Battery-info probe result (#592)</string>
+    <string name="l10n_devices_screen_battery_pack_probe_151_re_d722af00">Battery-pack probe (151 RE)…</string>
+    <string name="l10n_devices_screen_battery_pack_probe_result_151_df43dff2">Battery-pack probe result (151)</string>
+    <string name="l10n_devices_screen_battery_pack_probe_explainer_40b3470d">Sends the read-only battery-pack command (151) and decodes the strap\'s reply — the pack\'s charge, serial and Bluetooth address. Nothing is written to the strap and nothing feeds your data. A WHOOP 4.0 has no pack command and is expected to stay silent; that silence is itself a useful result.</string>
     <string name="l10n_devices_screen_body_location_probe_690_re_7def8c39">Body-location probe (#690 RE)…</string>
     <string name="l10n_devices_screen_body_location_probe_result_690_60c5ee79">Body-location probe result (#690)</string>
     <string name="l10n_devices_screen_body_location_probe_explainer_a9363239">Sends the read-only body-location command (0x54) and dumps the strap\'s full raw reply to the strap log, decoding the record (revision / location / confidence / status) on WHOOP 4.0. Nothing is written to the strap, and it never changes wear detection or scoring.</string>


### PR DESCRIPTION
> **Correction, shortly after opening.** The first version of this description said this PR added a five-argument *sweep*. It does not — that was argument-sweep scaffolding from a local research build, and I described it from my notes without checking it against the branch. This PR ships a **single-shot probe**: one command per press. The body below is corrected, and the section on what the sweep showed is now explicitly marked as not part of this change.

## What this PR does

`GET_BATTERY_PACK_INFO(151)` is now polled on the keep-alive cadence for a 5/MG (#1303). **On a WHOOP MG it is not answered.**

This adds a user-triggered probe in the same read-only, Test-Centre-gated shape as the #592 (opcode 98) and #690 (opcode 84) probes: a menu entry on the Devices card, a confirmation dialog, **one command per press**, and the decoded reply in a dialog and the strap log. A timeout turns silence into a stated verdict rather than an absent line. It feeds no live state and gates nothing.

**It does not add the `CommandNumber` entry** — #1303 already has it.

## The evidence

**151 is implemented, and it is refusing the request rather than the opcode.** That distinction is the finding, and it is evidence rather than inference:

| opcode | this strap's answer, same session |
|---|---|
| `GET_EXTENDED_BATTERY_INFO` (98) | **UNSUPPORTED(3)** |
| `GET_BATTERY_PACK_INFO` (151) | **FAILURE(0)** |

`commandResultLabel` separates `0=FAILURE` from `3=UNSUPPORTED`, and `UNSUPPORTED` is hardware-confirmed on this very MG by the #48 haptics rejection. **The firmware has a way to say "I do not implement that opcode", and it did not use it for 151.** It used it for 98, minutes apart.

**Tested in the state where it should have worked.** The pack was attached and *demonstrably charging*, proven independently by the strap's own gauge rising while the probe ran — live readings 30 s apart, interleaved with realtime frames, not a historical replay:

```
08:54:40  bank soc=80.0     08:55:40  bank soc=81.2
08:56:10  bank soc=81.7     08:56:40  bank soc=82.2
```

+2.2 pp in two minutes, and 151 answered `FAILURE(0)` throughout. Also tested with the pack removed.

## One observation that is NOT produced by this code

A **local research build** that varied the argument showed the firmware parses it: payload first byte `0x00` gives `FAILURE`, `0x01` gives no reply at all, across five forms and three runs. If the argument were ignored the two would be identical.

That argument-sweep scaffolding is **deliberately not shipped here** — this probe sends the default form, one command per press, matching the probes it sits beside. I record the observation because it narrows what a future capture should try, not because this PR produces it.

## A conclusion I got wrong, kept visible

My first reading was **"151 is unsupported on MG, the feature is dead"** — drawn from consistent `FAILURE`s without checking what this firmware's *other* refusals look like. That was wrong, and it is why the UNSUPPORTED-vs-FAILURE comparison above exists. One observable was standing in for a diagnosis.

## The value is in who runs it next

The golden vectors behind `BatteryPackInfo` came from a **WHOOP 5, not an MG**. A non-MG WHOOP 5 owner running this probe produces the capture that would show whether the `FAILURE` is MG-specific — and, if it is, whether the new poll is doing useful work on the hardware it was written for.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / tooling

Closest fit is tooling — a Test Centre diagnostic, not a user-facing feature.

## How it was tested

**On hardware.** WHOOP MG, hw `WS50_r00`, fw `50.39.1.0`, no subscription, Pixel 9 Pro / Android 15, local `full` debug build. The probe was run repeatedly; the `FAILURE(0)` and `UNSUPPORTED(3)` results above are from those runs, with the response frames captured.

**Android unit tests, full suite.** `./gradlew testFullDebugUnitTest` against `main`: **5,406 tests across 651 classes, 0 failures, 0 errors** (6 skipped, pre-existing). Counted from the JUnit XML with the results directory cleared beforehand.

**`Tools/doc_comment_lint.py`** clean. **`Tools/i18n_audit.py --ci`** clean — no new gaps in any locale.

**Not run: `swift test`.** This diff touches no Swift.

## What I am not claiming

- **Not that the poll should be removed.** One device, one firmware: nothing here establishes whether a non-MG WHOOP 5 answers 151.
- **Not that the poll is harmful.** A FAILURE response is cheap and the cadence is slow. What it is, on this strap, is a request that will never be answered.
- Nothing about *why* 151 refuses. Strap state and a required preceding command both remain open.
- **Not that pack charge is unavailable on an MG.** It is not — the strap volunteers the same record in pushed event `0x6D` (109), which is #1929. This is RE instrumentation, not a feature.

## One thing worth flagging

The **zh strings are mine and unreviewed** by a native speaker. The neighbouring #592/#690 probe strings are untranslated in zh, so there was no house style to follow; the ru wording does follow them closely. I chose that over raising the `i18n_extra_locale_baseline` allowance, which only ever ratchets down. Happy to take whatever a translator prefers.

## Safety

- Read-only, user-initiated, Test Centre → Connection gated, never automatic.
- Offered on both families even though only a 5/MG is expected to answer — a WHOOP 4.0's **silence** is itself evidence the pack command is 5/MG-only, and costs nothing to collect.
- **One command per press.** No sweep, no retry loop, no raw-packet entry.

## Checklist

- [x] Swift package tests pass for any package I touched — n/a, no Swift touched
- [x] Android unit tests pass (`./gradlew testFullDebugUnitTest`, full suite)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — the menu entry and dialog reuse the existing probe patterns
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in `docs/CONTRIBUTING.md`
- [x] I did not commit generated output or any secrets/keystores

## Related issues

Relates to #1303, which added the command and the keep-alive poll this reports on. Companion to #1929, the pack readout. Does not close anything.