### PR TITLE
test centre: keep the pack probe's serial and address out of both its sinks

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1551,6 +1551,30 @@ class WhoopBleClient(
         const val BATTERY_PACK_PROBE_TIMEOUT_MS = 8_000L
 
         /**
+         * Blank the pack's six address bytes inside the raw frame dump, leaving every other byte
+         * readable. [cmdOff] + 5 is the address offset the decoder uses; [decoded] gates the edit so a
+         * frame that did NOT decode keeps all of its bytes, offsets being the open question there.
+         */
+        internal fun maskPackAddrInDump(rawHex: String, cmdOff: Int, decoded: Boolean): String {
+            if (!decoded) return rawHex
+            val from = (cmdOff + 5) * 2
+            val to = from + 12
+            if (from < 0 || to > rawHex.length) return rawHex
+            return rawHex.substring(0, from) + "••••••••••••" + rawHex.substring(to)
+        }
+
+        /**
+         * First and last octet of a pack's BT address, the rest masked — the same shape
+         * `redactStrapLogPii` gives a colon-formatted MAC, applied at the SOURCE because this report
+         * also reaches a copy-to-clipboard dialog that the scrubber never sees.
+         */
+        internal fun maskPackBtAddr(btAddr: String?): String {
+            if (btAddr.isNullOrEmpty()) return "<none>"
+            if (btAddr.length != 12) return "<malformed>"
+            return "${btAddr.take(2)}:••:••:••:••:${btAddr.takeLast(2)}"
+        }
+
+        /**
          * Format a cmd-151 COMMAND_RESPONSE into a readable report for the Devices dialog + strap log.
          * Pure, so it is unit-testable without a strap. [cmdOff] is the response-command byte offset
          * (10 on 5/MG; a WHOOP 4.0 has no pack command at all and is not expected to answer).
@@ -1564,9 +1588,16 @@ class WhoopBleClient(
          */
         internal fun formatBatteryPackProbe(frame: ByteArray, cmdOff: Int): String {
             val sb = StringBuilder()
-            sb.append("GET_BATTERY_PACK_INFO (151) response, ${frame.size} bytes, cmdOff=$cmdOff\n")
-            sb.append("raw: ${frame.joinToString("") { "%02x".format(it) }}\n\n")
             val info = com.noop.protocol.BatteryPackInfo.decode(frame, cmdOff)
+            sb.append("GET_BATTERY_PACK_INFO (151) response, ${frame.size} bytes, cmdOff=$cmdOff\n")
+            // The dump is the evidence, so it stays whole EXCEPT the six address bytes, and only once
+            // `decode` has confirmed the layout. `redactStrapLogPii` lifts the serial out of a hex run
+            // but has no rule that can reach a colon-less address, so without this the pack's MAC ships
+            // in both sinks even after scrubbing. Masked at a KNOWN offset only: when decode returned
+            // null the offsets are precisely what is in question, and blanking a guessed range there
+            // would destroy the evidence the operator opened this probe to read.
+            val rawHex = frame.joinToString("") { "%02x".format(it) }
+            sb.append("raw: ${maskPackAddrInDump(rawHex, cmdOff, info != null && info.present)}\n\n")
             if (info == null) {
                 sb.append("DID NOT DECODE as a 151 SUCCESS response at this offset.\n")
                 sb.append("Either the reply is not a 151 response, or its result byte is not SUCCESS, or\n")
@@ -1580,8 +1611,16 @@ class WhoopBleClient(
                 return sb.toString()
             }
             sb.append("present = TRUE\n")
-            sb.append("serial  = ${info.serial ?: "<undecodable>"}\n")
-            sb.append("bt addr = ${info.btAddr ?: "<none>"}\n")
+            // logSafe + a masked address, NOT the raw pair. This report goes to the SHAREABLE strap log
+            // AND to a dialog with a copy button, and neither identifier survives contact with the
+            // scrubber: `redactStrapLogPii` keys the serial rule on a literal "WHOOP " prefix (a bare
+            // `serial  = BB5AP…` matches nothing) and keys the MAC rule on COLONS, which `btAddr`'s
+            // colon-less `joinToString("")` never produces. The pack-log line in
+            // `handleCommandResponse` already learned this and says so; a probe that prints them raw
+            // would walk both straight back out. Three characters tell two packs apart, and the first
+            // and last octet tell two addresses apart, which is all a diagnostic needs.
+            sb.append("serial  = ${com.noop.data.WhoopSerialIdentity.logSafe(info.serial)}\n")
+            sb.append("bt addr = ${maskPackBtAddr(info.btAddr)}\n")
             // Read the SoC word straight from the frame rather than reconstructing it from the decoded
             // Double — decode() already bounds-checked this offset when it returned present=true, and a
             // float round-trip could land the raw value one off.
@@ -7236,7 +7275,11 @@ class WhoopBleClient(
                         _batteryPackProbe.value == WAITING_BATTERY_PACK_PROBE) {
                         val text = formatBatteryPackProbe(frame, cmdOff)
                         log("Battery-pack probe (151):\n$text")
-                        _batteryPackProbe.value = text
+                        // Scrub the DIALOG copy too. log() already redacts on the way to the strap log,
+                        // but this value is rendered behind a copy-to-clipboard button, so it is a second
+                        // sink the scrubber otherwise never sees — and the `raw:` frame dump carries the
+                        // serial as ASCII inside the hex, which is exactly what redactStrapLogPii masks.
+                        _batteryPackProbe.value = redactStrapLogPii(text)
                     }
                     // #761: a reply to the read-only feature-flag enumeration (117/118). In-flight-guarded
                     // inside handleFeatureFlagProbeResponse, so this is a byte compare on every other frame.

--- a/android/app/src/test/java/com/noop/ble/BatteryPackProbeRedactionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BatteryPackProbeRedactionTest.kt
@@ -1,0 +1,89 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The cmd-151 pack probe must not publish the pack's identity.
+ *
+ * Its report reaches TWO sinks: the shareable strap log, and a Devices dialog with a
+ * copy-to-clipboard button. [redactStrapLogPii] guards only the first, and it would not have caught
+ * either identifier anyway — the serial rule keys on a literal "WHOOP " prefix, so a bare
+ * `serial  = BB5AP…` matches nothing, and the MAC rule keys on COLONS, which `btAddr`'s colon-less
+ * `joinToString("")` never produces. So both are masked at the SOURCE instead. The pack-log line in
+ * `handleCommandResponse` already carried that lesson; these tests keep a probe from undoing it.
+ */
+class BatteryPackProbeRedactionTest {
+
+    /** A well-formed 151 SUCCESS frame at cmdOff=10 carrying a known address, serial and SoC word. */
+    private fun frameWith(mac: ByteArray, serial: String, soc: Int): ByteArray {
+        val f = ByteArray(45)
+        f[10] = 151.toByte()
+        f[12] = 1          // result = SUCCESS
+        f[14] = 1          // present = true
+        mac.copyInto(f, 15)
+        serial.toByteArray(Charsets.US_ASCII).copyInto(f, 21)
+        f[37] = (soc and 0xFF).toByte()
+        f[38] = ((soc shr 8) and 0xFF).toByte()
+        return f
+    }
+
+    private val mac = byteArrayOf(0xC4.toByte(), 0x9D.toByte(), 0xED.toByte(), 0x11, 0x22, 0x33)
+    private val serial = "WHOOP5A1B2C3D4E"
+
+    @Test fun reportNeverCarriesTheFullSerialOrAddress() {
+        val report = WhoopBleClient.formatBatteryPackProbe(frameWith(mac, serial, 812), 10)
+        assertFalse("the full pack serial must never reach the report", report.contains(serial))
+        assertFalse("the full pack address must never reach the report", report.contains("c49ded112233"))
+    }
+
+    /** Masked, not merely absent: a diagnostic still has to tell two packs and two addresses apart. */
+    @Test fun reportKeepsEnoughToDistinguishTwoPacks() {
+        val report = WhoopBleClient.formatBatteryPackProbe(frameWith(mac, serial, 812), 10)
+        assertTrue("a serial prefix is what distinguishes two packs", report.contains("serial  = WHO"))
+        assertTrue("first and last octet distinguish two addresses", report.contains("c4:••:••:••:••:33"))
+        // The finding itself must survive redaction — this is what the probe exists to collect.
+        assertTrue(report.contains("SoC raw word = 812"))
+    }
+
+    /**
+     * The dialog sink is scrubbed too. The `raw:` frame dump carries the serial as ASCII inside the
+     * hex, which the source-level masking above cannot touch and only the scrubber removes.
+     */
+    @Test fun scrubbingTheReportRemovesTheSerialFromTheRawHexDump() {
+        val report = WhoopBleClient.formatBatteryPackProbe(frameWith(mac, serial, 812), 10)
+        val hexSerial = serial.toByteArray(Charsets.US_ASCII).joinToString("") { "%02x".format(it) }
+        assertTrue("precondition: the raw dump does embed the serial", report.contains(hexSerial))
+        assertFalse("the value shown in the dialog must not", redactStrapLogPii(report).contains(hexSerial))
+    }
+
+    /** A frame that did not decode keeps every byte: there, the offsets are the open question. */
+    @Test fun anUndecodableFrameKeepsItsBytesForEvidence() {
+        val f = ByteArray(45)
+        f[10] = 151.toByte(); f[12] = 9   // result != SUCCESS -> decode() returns null
+        mac.copyInto(f, 15)
+        val report = WhoopBleClient.formatBatteryPackProbe(f, 10)
+        assertTrue(report.contains("DID NOT DECODE"))
+        assertTrue("the dump must stay whole when the layout is unconfirmed",
+            report.contains("c49ded112233"))
+    }
+
+    @Test fun maskedAddressHandlesMissingAndMalformedInput() {
+        assertEquals("<none>", WhoopBleClient.maskPackBtAddr(null))
+        assertEquals("<none>", WhoopBleClient.maskPackBtAddr(""))
+        assertEquals("<malformed>", WhoopBleClient.maskPackBtAddr("c49ded"))
+        assertEquals("c4:••:••:••:••:33", WhoopBleClient.maskPackBtAddr("c49ded112233"))
+    }
+
+    /** An absent pack reports absence and no identity at all. */
+    @Test fun absentPackReportsNoIdentifiers() {
+        val f = ByteArray(45)
+        f[10] = 151.toByte(); f[12] = 1; f[14] = 0
+        val report = WhoopBleClient.formatBatteryPackProbe(f, 10)
+        assertTrue(report.contains("present = FALSE"))
+        assertFalse(report.contains("serial  ="))
+        assertFalse(report.contains("bt addr ="))
+    }
+}


### PR DESCRIPTION
Immediate follow-up to the cmd-151 pack probe. Its report printed the pack's serial and BT address verbatim, and that report reaches **two** places a user shares: the exportable strap log, and a Devices dialog with a copy-to-clipboard button.

## Neither identifier was ever reached by the scrubber

`redactStrapLogPii` keys its serial rule on a literal `"WHOOP "` prefix, so a bare `serial  = BB5AP…` matches nothing. It keys its MAC rule on **colons**, which `btAddr`'s colon-less `joinToString("")` never produces, and `PII_HEX_DUMP_RE` needs 16+ hex characters where an address is 12. Running the real scrubber over the real report leaves both in the clear:

```
raw: ...9700010001c49ded112233••••••••••••••••••••••••002c03...
serial  = WHOOP5A1B2C3D4E      <- unredacted
bt addr = c49ded112233         <- unredacted
```

The pack-log line in `handleCommandResponse` already carried this exact lesson, about this exact decoder, and says so in a comment: `logSafe`, not the raw serial, "because the rule that protects the strap's serial would have let the pack's through to an exportable log". It also omits the address entirely. The probe undid that about a hundred lines away.

## What changes

Both are masked at the **source**, which is what covers the dialog as well: `WhoopSerialIdentity.logSafe` for the serial, first-and-last-octet for the address (the same shape the scrubber gives a colon-formatted MAC). The dialog value additionally goes through `redactStrapLogPii`, which is what lifts the serial back out of the raw hex dump that source-level masking cannot reach.

Enough survives to stay a diagnostic: three serial characters tell two packs apart, first and last octet tell two addresses apart, and `SoC raw word` is untouched.

## The raw dump keeps its evidence

Every byte stays except the six address bytes, and those are blanked **only once `decode` has confirmed the layout**. When `decode` returns null the offsets are precisely what is in question, so blanking a guessed range there would destroy the evidence the probe exists to collect. There is a test for that case specifically.

## Tests

Six, in the shape of `PiiRedactionTest`: neither identifier reaches the report; enough of each survives to distinguish two packs; scrubbing clears the serial from the hex dump; an undecodable frame keeps all its bytes; an absent pack reports no identity at all; and the mask handles null, empty and short input.

Android suite green, **5427 tests, 0 failures**.

Probe reported and implemented by @Zebsi235; this is maintainer follow-up, not a defect in the investigation, which stands.
