### PR TITLE
test centre: keep the pack's BT address out of the event census

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1578,6 +1578,25 @@ class WhoopBleClient(
         }
 
         /**
+         * Mask the pack's six address bytes inside the event-census `payload=` hex, and nothing else.
+         * Event 109 (the pushed pack record, see BatteryPackInfo) carries the pack's BT address at
+         * payload offset 5..10. `redactStrapLogPii` lifts an ASCII serial out of a hex run but has no
+         * rule that reaches a colon-less address, so without this the census publishes the address in
+         * every shared strap log. Same rule as [maskPackAddrInDump]: blanked only once `decodeEventFrame`
+         * has confirmed a present pack at the expected layout — for any other event, or an undecodable
+         * 109, the payload stays whole, because there the bytes ARE the evidence the census exists for.
+         */
+        internal fun maskPackAddrInEventPayload(payloadHex: String, frame: ByteArray): String {
+            if (frame.size <= 10 || (frame[10].toInt() and 0xFF) != com.noop.protocol.BatteryPackInfo.PACK_INFO_EVENT) return payloadHex
+            val info = com.noop.protocol.BatteryPackInfo.decodeEventFrame(frame)
+            if (info == null || !info.present) return payloadHex
+            val from = 5 * 2
+            val to = from + 12
+            if (to > payloadHex.length) return payloadHex
+            return payloadHex.substring(0, from) + "••••••••••••" + payloadHex.substring(to)
+        }
+
+        /**
          * First and last octet of a pack's BT address, the rest masked — the same shape
          * `redactStrapLogPii` gives a colon-formatted MAC, applied at the SOURCE because this report
          * also reaches a copy-to-clipboard dialog that the scrubber never sees.
@@ -7867,7 +7886,8 @@ class WhoopBleClient(
                     // one), and the 5/MG opaque payload hex — which is where a pack charge would live if
                     // any event carries one. Read-only; sends nothing and decodes nothing into state.
                     if (testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
-                        val payHex = parsed.parsed["event_payload_hex"] as? String
+                        val payHex = (parsed.parsed["event_payload_hex"] as? String)
+                            ?.let { maskPackAddrInEventPayload(it, frame) }
                         log("[event] $ev${if (replayedOffload) " (replayed offload)" else ""}" +
                             (payHex?.let { " payload=$it" } ?: ""))
                     }

--- a/android/app/src/test/java/com/noop/ble/EventCensusPackAddressRedactionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/EventCensusPackAddressRedactionTest.kt
@@ -1,0 +1,69 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The Test Centre event census must not publish the pack's BT address.
+ *
+ * It logs `payload=<event_payload_hex>` for every pushed event, and event 109 — the pack record the
+ * readout reads — carries the pack's address at payload offset 5..10. [redactStrapLogPii] lifts an
+ * ASCII serial out of a hex run but has no rule that can reach a colon-less address, so the census
+ * line shipped it in every shared strap log. Masked at the source, only once the frame has decoded
+ * as a present pack; every other event, and an undecodable 109, keeps its bytes — the census exists
+ * to expose exactly those. Same shape as `BatteryPackProbeRedactionTest`.
+ */
+class EventCensusPackAddressRedactionTest {
+
+    /** A 5/MG event frame: event byte at 10, payload from 16; payload is the 32-byte pack record. */
+    private fun eventFrame(event: Int, payload: ByteArray): ByteArray {
+        val f = ByteArray(16 + payload.size)
+        f[10] = event.toByte()
+        payload.copyInto(f, 16)
+        return f
+    }
+
+    /** A pack record with a known address, an ASCII serial and an in-range SoC, present = true. */
+    private fun packRecord(present: Boolean): ByteArray {
+        val p = ByteArray(32)
+        p[4] = if (present) 1 else 0
+        byteArrayOf(0xC4.toByte(), 0x9D.toByte(), 0xED.toByte(), 0x11, 0x22, 0x33).copyInto(p, 5)
+        "WBB5AP0000001".toByteArray(Charsets.US_ASCII).copyInto(p, 11)
+        p[27] = 0x39; p[28] = 0x02   // SoC word 569 -> 56.9 %
+        return p
+    }
+
+    private fun hex(b: ByteArray) = b.joinToString("") { "%02x".format(it) }
+
+    @Test fun packEventPayloadHasItsAddressMaskedAndNothingElse() {
+        val rec = packRecord(present = true)
+        val out = WhoopBleClient.maskPackAddrInEventPayload(hex(rec), eventFrame(109, rec))
+        assertFalse("the pack address must not survive into the census", out.contains("c49ded112233"))
+        assertTrue("exactly the six address bytes are blanked", out.contains("••••••••••••"))
+        assertEquals("every byte before the address is untouched", hex(rec).substring(0, 10), out.substring(0, 10))
+        assertEquals("every byte after the address is untouched", hex(rec).substring(22), out.substring(22))
+        // The SoC word — the finding the census produced — must survive.
+        assertTrue(out.contains("3902"))
+    }
+
+    @Test fun otherEventsKeepTheirPayloadWhole() {
+        val rec = packRecord(present = true)
+        val out = WhoopBleClient.maskPackAddrInEventPayload(hex(rec), eventFrame(21, rec))
+        assertEquals("a non-109 event is never touched, whatever its bytes look like", hex(rec), out)
+    }
+
+    @Test fun anAbsentPackKeepsItsBytes() {
+        val rec = packRecord(present = false)
+        val out = WhoopBleClient.maskPackAddrInEventPayload(hex(rec), eventFrame(109, rec))
+        assertEquals("present=false is not a confirmed layout, so nothing is blanked", hex(rec), out)
+    }
+
+    @Test fun aShortOrMalformedFrameIsLeftAlone() {
+        assertEquals("abcd", WhoopBleClient.maskPackAddrInEventPayload("abcd", ByteArray(4)))
+        val rec = packRecord(present = true)
+        val short = hex(rec).substring(0, 16)   // payload hex too short to hold the address span
+        assertEquals(short, WhoopBleClient.maskPackAddrInEventPayload(short, eventFrame(109, rec)))
+    }
+}


### PR DESCRIPTION
Follow-up you asked for on #1929 / #1932 ("wants its own change"). Same class as your #1931.

## What this PR does

The Test Centre event census (#1825) logs `payload=<event_payload_hex>` for every pushed event. Event `0x6D` (109) — the pack record the readout in #1932 reads — carries the pack's **BT address at payload offset 5..10**. `redactStrapLogPii` lifts an ASCII serial out of a hex run, but it has no rule that can reach a colon-less address, so that census line has been publishing the pack's address in every shared strap log since #1825 merged.

Not introduced by the readout; the readout's finding is what made it knowable. It is ours, from #1825.

## What changes

One helper, `maskPackAddrInEventPayload`, applied to the census payload before it is logged. It blanks exactly the six address bytes and nothing else, and follows the rule #1931 set for the probe dump:

- **only for event 109**, checked on the frame's event byte, not the rendered label;
- **only once `BatteryPackInfo.decodeEventFrame` confirms a present pack** at the expected layout.

For any other event, an absent pack, or a frame that does not decode, the payload stays whole — because there the bytes *are* the evidence the census exists to expose, and blanking a guessed range would destroy exactly what the operator opened Test Centre to read.

Everything else on the line — event name, replayed-offload marker, SoC word — is untouched.

## Tests

Four, in the shape of `BatteryPackProbeRedactionTest`:

- a present pack's payload has its address masked, every byte before and after it byte-identical, and the SoC word survives;
- a non-109 event keeps its payload whole whatever its bytes look like;
- an absent pack (`present = false`) is not a confirmed layout, so nothing is blanked;
- a short or malformed frame is left alone.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

**Android unit tests, full suite** against `main` @ `ff103fac`: **5,434 tests across 654 classes, 0 failures, 0 errors** (6 skipped, pre-existing) — main's 5,430 plus the four new cases, all passing. Counted from the JUnit XML with the results directory cleared first. `main` has since moved by one build-number commit (`8c3ddaca`), which touches nothing this diff touches.

**`Tools/doc_comment_lint.py`** clean — after one round-trip: the first placement stacked the new helper's doc under `maskPackBtAddr`'s, the same trap #1825's review hit, and the gate caught it. **`Tools/i18n_audit.py --ci`** clean — no strings touched.

**Not run on hardware.** This is a pure function over bytes already captured; the fixtures are the same 32-byte pack record shape the readout's tests use, with an RFC 7042 documentation address and a synthetic serial.

**Not run: `swift test`.** No Swift touched — the Apple side has no event census.

## What this does NOT claim

- Nothing about the serial: the census payload still carries it as ASCII inside the hex, and `redactStrapLogPii`'s existing hex-serial rule (#1833) already lifts that on the way to the strap log. This PR only closes the gap that rule cannot reach.
- Nothing about a dialog sink: the census has none, only the strap log.

## Checklist

- [x] Swift package tests pass for any package I touched — n/a, no Swift touched
- [x] Android unit tests pass (`./gradlew testFullDebugUnitTest`, full suite)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — n/a, no UI
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders — offsets come from `BatteryPackInfo`, the mask reuses #1931's shape
- [x] Follows the conventions in `docs/CONTRIBUTING.md`
- [x] I did not commit generated output or any secrets/keystores

## Related issues

Follow-up to #1932 (the readout) and #1825 (the census). Same class as #1931. Does not close anything.