### PR TITLE
Add a zone-based local day-window helper with a Kotlin twin and a committed oracle

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalyticsEngine.swift
@@ -175,6 +175,13 @@ public enum AnalyticsEngine {
     /// from `dayString`), and the Kotlin mirror degrades the SAME way (`runCatching { … }.getOrDefault(0)`)
     /// instead of throwing, so a single bad day key can never take down a whole scoring pass on either
     /// platform (nil-tolerant over fail-fast, per the #996 review).
+    ///
+    /// This is a UTC midnight that callers pair with one captured offset and fixed 86,400-second blocks,
+    /// so every boundary beyond a clock change sits an hour from the local midnight it names.
+    /// `LocalDayWindows` is the zone-rule-correct primitive built to replace that, and is deliberately
+    /// called by nothing yet. This function remains the shipped answer until a switch-over lands; the two
+    /// disagree by an hour on the far side of a transition, and `LocalDayWindowsTests` pins both answers
+    /// so the difference is visible rather than discovered.
     static func dayStartUtcSeconds(_ day: String) -> Int {
         Int(isoDay.date(from: day)?.timeIntervalSince1970 ?? 0)
     }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/LocalDayWindows.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/LocalDayWindows.swift
@@ -142,6 +142,14 @@ public struct LocalDayStart: Hashable, Sendable {
 /// because a day on which the clocks move is 23 or 25 hours long. This type is the shared primitive
 /// that answers it correctly; it changes no caller on its own.
 ///
+/// SO TWO ANSWERS COEXIST, and this one is not yet the shipped one. `AnalyticsEngine.dayStartUtcSeconds`
+/// with `AnalyticsEngine.dayString` remains what every scored day actually uses; this file is called by
+/// nothing but its own tests until a switch-over lands. They disagree by an hour on the far side of a
+/// transition, which `LocalDayWindowsTests` pins deliberately by asserting BOTH answers for
+/// America/New_York on 2025-10-19. Reach for the core unless you are writing that switch-over.
+///
+/// Kotlin twin: `LocalDayWindows`.
+///
 /// Nothing here is inherited from a calendar: the ambiguous, skipped and non-existent cases are
 /// resolved by the rules stated on each operation, so that a future change in library behaviour is a
 /// change to this file rather than a silent change of a day boundary. The only thing asked of the

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/LocalDayWindows.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/LocalDayWindows.swift
@@ -1,0 +1,356 @@
+import Foundation
+
+/// A local calendar date as a year/month/day triple, mirroring the components of the Kotlin twin's
+/// `java.time.LocalDate`.
+///
+/// Swift has no calendar-date type that is free of a `Calendar`, and a `Calendar` is exactly what this
+/// helper must not lean on: the day-window rules in this file are stated explicitly so that a future
+/// change of library behaviour cannot move a day boundary silently. So the date is carried as its own
+/// value type and converted to and from a day number with proleptic-Gregorian arithmetic.
+public struct LocalCalendarDate: Hashable, Comparable, Sendable {
+
+    /// The proleptic Gregorian year, negative before year 1.
+    public let year: Int
+
+    /// The month, 1...12.
+    public let month: Int
+
+    /// The day of the month, 1...31. No validation happens here: an out-of-range day is normalised by
+    /// the day-number conversion, the same way `java.time` would reject it and callers here never
+    /// construct one.
+    public let day: Int
+
+    /// Build a date from its components.
+    public init(year: Int, month: Int, day: Int) {
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    /// Build the date that lies `daysSinceEpoch` days after 1970-01-01.
+    public init(daysSinceEpoch: Int) {
+        // Howard Hinnant's civil_from_days, which is exact over the whole Int range and needs no
+        // calendar object. Divisions truncate toward zero in Swift as they do in C, which is what the
+        // era shifts below are written for.
+        var z = daysSinceEpoch + 719_468
+        let era = (z >= 0 ? z : z - 146_096) / 146_097
+        z -= era * 146_097
+        let dayOfEra = z
+        let yearOfEra = (dayOfEra - dayOfEra / 1460 + dayOfEra / 36_524 - dayOfEra / 146_096) / 365
+        let dayOfYear = dayOfEra - (365 * yearOfEra + yearOfEra / 4 - yearOfEra / 100)
+        let monthPrime = (5 * dayOfYear + 2) / 153
+        let d = dayOfYear - (153 * monthPrime + 2) / 5 + 1
+        let m = monthPrime + (monthPrime < 10 ? 3 : -9)
+        let y = yearOfEra + era * 400 + (m <= 2 ? 1 : 0)
+        self.init(year: y, month: m, day: d)
+    }
+
+    /// The number of days from 1970-01-01 to this date, negative before it.
+    public var daysSinceEpoch: Int {
+        // Howard Hinnant's days_from_civil, the exact inverse of the initialiser above.
+        let y = year - (month <= 2 ? 1 : 0)
+        let era = (y >= 0 ? y : y - 399) / 400
+        let yearOfEra = y - era * 400
+        let dayOfYear = (153 * (month + (month > 2 ? -3 : 9)) + 2) / 5 + day - 1
+        let dayOfEra = yearOfEra * 365 + yearOfEra / 4 - yearOfEra / 100 + dayOfYear
+        return era * 146_097 + dayOfEra - 719_468
+    }
+
+    /// The date rendered as `YYYY-MM-DD`, which is also the day key this helper hands out.
+    public var key: String {
+        let y = year < 0 ? "-" + Self.pad(-year, 4) : Self.pad(year, 4)
+        return "\(y)-\(Self.pad(month, 2))-\(Self.pad(day, 2))"
+    }
+
+    /// The date `count` days after this one, negative counts moving backward.
+    public func adding(days count: Int) -> LocalCalendarDate {
+        LocalCalendarDate(daysSinceEpoch: daysSinceEpoch + count)
+    }
+
+    /// Order dates the way the calendar does.
+    public static func < (lhs: LocalCalendarDate, rhs: LocalCalendarDate) -> Bool {
+        if lhs.year != rhs.year { return lhs.year < rhs.year }
+        if lhs.month != rhs.month { return lhs.month < rhs.month }
+        return lhs.day < rhs.day
+    }
+
+    /// Left-pad a non-negative number with zeroes, without a formatter — the twin does the same, and a
+    /// locale-aware formatter is one more thing that could differ between the platforms.
+    private static func pad(_ value: Int, _ width: Int) -> String {
+        var s = String(value)
+        while s.count < width { s = "0" + s }
+        return s
+    }
+}
+
+/// One local day as a half-open window, with the UTC offset that was in effect when it began.
+public struct LocalDayWindow: Hashable, Sendable {
+
+    /// The date this window belongs to.
+    public let date: LocalCalendarDate
+
+    /// The first instant of the date.
+    public let start: Date
+
+    /// The start of the next date that exists in the zone, which is where this window ends. It is not
+    /// always `start` plus 24 hours, and where a calendar date is skipped entirely it is more than a
+    /// day away.
+    public let nextStart: Date
+
+    /// The UTC offset in effect at `start`, in seconds east of UTC.
+    ///
+    /// It describes the window's start only. A time of day anywhere else inside the window is derived
+    /// from the zone, never by adding this number, because a transition inside the window would make
+    /// that wrong by an hour.
+    public let utcOffsetSeconds: Int
+
+    /// Build a window from its parts.
+    public init(date: LocalCalendarDate, start: Date, nextStart: Date, utcOffsetSeconds: Int) {
+        self.date = date
+        self.start = start
+        self.nextStart = nextStart
+        self.utcOffsetSeconds = utcOffsetSeconds
+    }
+
+    /// How long the window lasts — 23, 24 or 25 hours in the fixture zones, and longer where the zone
+    /// skips a calendar date.
+    public var duration: TimeInterval {
+        nextStart.timeIntervalSince(start)
+    }
+}
+
+/// One entry of a backward run: a date that exists in the zone, with the start resolved for it.
+public struct LocalDayStart: Hashable, Sendable {
+
+    /// The date.
+    public let date: LocalCalendarDate
+
+    /// The first instant of that date in the zone.
+    public let start: Date
+
+    /// Build an entry from its parts.
+    public init(date: LocalCalendarDate, start: Date) {
+        self.date = date
+        self.start = start
+    }
+}
+
+/// When a local calendar date begins and ends in a time zone, taken from the zone's own rules.
+///
+/// The analysis core answers this question by adding fixed 86,400-second blocks to a midnight derived
+/// from a single UTC offset. That is wrong by an hour on every day boundary beyond a transition,
+/// because a day on which the clocks move is 23 or 25 hours long. This type is the shared primitive
+/// that answers it correctly; it changes no caller on its own.
+///
+/// Nothing here is inherited from a calendar: the ambiguous, skipped and non-existent cases are
+/// resolved by the rules stated on each operation, so that a future change in library behaviour is a
+/// change to this file rather than a silent change of a day boundary. The only thing asked of the
+/// platform is `TimeZone.secondsFromGMT(for:)`, the zone's raw rule lookup.
+///
+/// Both the zone and the reference instant are injectable and default to the named accessors
+/// `defaultTimeZone` and `defaultReferenceInstant`, so every rule below is provable without a device.
+public struct LocalDayWindows: Sendable {
+
+    /// The zone used when none is given: the auto-updating current zone, which follows a change of
+    /// device zone during the process's life. The Kotlin twin's default is the system default zone id,
+    /// which means the same thing.
+    ///
+    /// The zone is bound when the helper is constructed; a caller that must follow a device-zone change
+    /// during the process's life constructs a new helper.
+    public static var defaultTimeZone: TimeZone { TimeZone.autoupdatingCurrent }
+
+    /// The reference instant used when none is given: the current `Date`. The Kotlin twin's default is
+    /// the current `Instant`.
+    public static var defaultReferenceInstant: Date { Date() }
+
+    /// The zone whose rules every operation reads.
+    public let timeZone: TimeZone
+
+    /// The instant that stands for "now" — it clamps the sleep read window and nothing else. No start,
+    /// window, key or run depends on it.
+    public let referenceInstant: Date
+
+    /// Build a helper for a zone and a reference instant, both defaulting to the named accessors.
+    public init(timeZone: TimeZone = LocalDayWindows.defaultTimeZone,
+                referenceInstant: Date = LocalDayWindows.defaultReferenceInstant) {
+        self.timeZone = timeZone
+        self.referenceInstant = referenceInstant
+    }
+
+    /// The number of seconds either side of a local midnight that is probed for the offsets in effect
+    /// around it. Two days is far more than any transition needs and still far less than the gap
+    /// between two transitions anywhere in the database.
+    private static let probeWindow: Int64 = 2 * 86_400
+
+    /// The first instant that belongs to `date` in this zone, or `nil` when the zone has no instant on
+    /// that date at all.
+    ///
+    /// The rule, stated rather than inherited: where local midnight exists once, that is the start;
+    /// where it exists twice, the earlier of the two; where it does not exist, the first instant that
+    /// does exist on the date, which is the instant the clocks jumped to. Where that jump lands on a
+    /// later date the date itself never happened, and there is no start.
+    ///
+    /// The rule assumes at most one offset change within two days either side of the local midnight; no
+    /// zone in the database violates that today.
+    ///
+    /// The result does not depend on `referenceInstant`.
+    public func start(of date: LocalCalendarDate) -> Date? {
+        let localMidnight = Int64(date.daysSinceEpoch) * 86_400
+        let offsetBefore = offsetSeconds(atEpochSeconds: localMidnight - Self.probeWindow)
+        let offsetAfter = offsetSeconds(atEpochSeconds: localMidnight + Self.probeWindow)
+
+        var candidates = [localMidnight - Int64(offsetBefore), localMidnight - Int64(offsetAfter)].sorted()
+        if candidates.count == 2 && candidates[0] == candidates[1] { candidates.removeLast() }
+        // An instant maps to this local midnight exactly when reading it in the zone gives that wall
+        // time back. Ascending order means an ambiguous midnight yields the earlier instant first.
+        for candidate in candidates
+        where candidate + Int64(offsetSeconds(atEpochSeconds: candidate)) == localMidnight {
+            return Date(timeIntervalSince1970: TimeInterval(candidate))
+        }
+
+        // Local midnight fell in a gap. The first instant that exists on or after it is the instant the
+        // clocks jumped at; it belongs to this date only if it still reads as this date.
+        guard offsetBefore != offsetAfter else { return nil }
+        let jump = transitionEpochSeconds(around: localMidnight, offsetBefore: offsetBefore)
+        guard localDate(ofEpochSeconds: jump) == date else { return nil }
+        return Date(timeIntervalSince1970: TimeInterval(jump))
+    }
+
+    /// The half-open window `[start, nextStart)` of `date`, or `nil` when the date does not exist.
+    ///
+    /// `nextStart` is the start of the next date that *exists*, so a window that precedes a skipped
+    /// calendar date spans more than a day rather than ending at an instant that never happened.
+    public func window(of date: LocalCalendarDate) -> LocalDayWindow? {
+        guard let dayStart = start(of: date) else { return nil }
+        var next = date.adding(days: 1)
+        var nextStart: Date?
+        // A zone skipping more than a couple of consecutive dates has never happened; the bound keeps a
+        // corrupt zone from turning this into an unbounded walk.
+        for _ in 0..<8 {
+            if let candidate = start(of: next) {
+                nextStart = candidate
+                break
+            }
+            next = next.adding(days: 1)
+        }
+        guard let end = nextStart else { return nil }
+        return LocalDayWindow(date: date,
+                              start: dayStart,
+                              nextStart: end,
+                              utcOffsetSeconds: offsetSeconds(at: dayStart))
+    }
+
+    /// The start of the local day that contains `instant`, as an instant and without formatting a date
+    /// on the way.
+    public func startOfDay(containing instant: Date) -> Date {
+        let date = localDate(of: instant)
+        // `instant` lies on `date` by construction, so the date exists and has a start. The fallback
+        // is unreachable and exists only to keep the operation total.
+        guard let start = start(of: date) else { return instant }
+        return start
+    }
+
+    /// The `YYYY-MM-DD` key of the local day that contains `instant`.
+    ///
+    /// The key and the window agree by construction: the key names the date whose window contains the
+    /// instant, because both are derived from the same zone lookup.
+    public func dayKey(for instant: Date) -> String {
+        localDate(of: instant).key
+    }
+
+    /// The local calendar date that contains `instant` in this zone.
+    public func localDate(of instant: Date) -> LocalCalendarDate {
+        localDate(ofEpochSeconds: Int64(instant.timeIntervalSince1970.rounded(.down)))
+    }
+
+    /// Up to `count` consecutive local calendar dates ending at `date`, oldest first, each with its own
+    /// resolved start.
+    ///
+    /// A date the zone skipped is omitted rather than replaced, so the run can be shorter than
+    /// requested; if `date` itself does not exist, the newest entry is the latest existing date before
+    /// it.
+    public func backwardRun(endingAt date: LocalCalendarDate, count: Int) -> [LocalDayStart] {
+        guard count > 0 else { return [] }
+        let endDay = date.daysSinceEpoch
+        var run: [LocalDayStart] = []
+        run.reserveCapacity(count)
+        for back in stride(from: count - 1, through: 0, by: -1) {
+            let day = LocalCalendarDate(daysSinceEpoch: endDay - back)
+            if let start = start(of: day) {
+                run.append(LocalDayStart(date: day, start: start))
+            }
+        }
+        return run
+    }
+
+    /// The end of the sleep read window of `date`: the earlier of that date's next start and the
+    /// reference instant, so the current day's window never reaches into the future. `nil` when the
+    /// date does not exist.
+    ///
+    /// For a date that begins after the reference instant the end precedes the start — an empty,
+    /// inverted window — by the D7 contract; a caller wanting a non-empty window must not ask for a
+    /// future date.
+    public func sleepReadWindowEnd(of date: LocalCalendarDate) -> Date? {
+        guard let window = window(of: date) else { return nil }
+        return min(window.nextStart, referenceInstant)
+    }
+
+    /// The UTC offset in effect at `instant`, in seconds east of UTC.
+    public func offsetSeconds(at instant: Date) -> Int {
+        timeZone.secondsFromGMT(for: instant)
+    }
+
+    /// The time-zone database version this platform can observe about itself, or `nil` where it cannot.
+    ///
+    /// Only Darwin exposes one; on Linux the Foundation port has no equivalent, and saying so is the
+    /// point — a faked value would claim a fact nobody checked.
+    public static var observedTimeZoneDataVersion: String? {
+        #if canImport(Darwin)
+        return NSTimeZone.timeZoneDataVersion
+        #else
+        return nil
+        #endif
+    }
+
+    /// The note a platform attaches when a fixture value moves: it names the version recorded in the
+    /// oracle and the version this platform observes at run time.
+    ///
+    /// A version difference is not itself a failure — the fixtures are past and stable, so a routine
+    /// toolchain bump must not redden unrelated work. The note exists to make a *value* difference
+    /// explicable. It is a pure function so that its content can be asserted; where a platform cannot
+    /// observe its own version, the note says so in place of a version rather than omitting it.
+    public static func timeZoneDataVersionNote(recorded: String, observed: String?) -> String {
+        let observedText = observed.map { "observes \($0)" }
+            ?? "cannot observe its own time-zone database version"
+        return "time-zone database version: the oracle records \(recorded); this platform \(observedText)."
+    }
+
+    /// The UTC offset in effect at a whole-second instant.
+    private func offsetSeconds(atEpochSeconds seconds: Int64) -> Int {
+        timeZone.secondsFromGMT(for: Date(timeIntervalSince1970: TimeInterval(seconds)))
+    }
+
+    /// The local calendar date of a whole-second instant.
+    private func localDate(ofEpochSeconds seconds: Int64) -> LocalCalendarDate {
+        let localSeconds = seconds + Int64(offsetSeconds(atEpochSeconds: seconds))
+        var days = localSeconds / 86_400
+        if localSeconds < 0 && localSeconds % 86_400 != 0 { days -= 1 }
+        return LocalCalendarDate(daysSinceEpoch: Int(days))
+    }
+
+    /// The instant at which the zone's offset changes near `localMidnight`, found by bisecting the
+    /// probe window between the offset before and the offset after.
+    private func transitionEpochSeconds(around localMidnight: Int64, offsetBefore: Int) -> Int64 {
+        var low = localMidnight - Self.probeWindow
+        var high = localMidnight + Self.probeWindow
+        while high - low > 1 {
+            let mid = low + (high - low) / 2
+            if offsetSeconds(atEpochSeconds: mid) == offsetBefore {
+                low = mid
+            } else {
+                high = mid
+            }
+        }
+        return high
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LocalDayWindowsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LocalDayWindowsTests.swift
@@ -1,0 +1,434 @@
+import Foundation
+import XCTest
+@testable import StrandAnalytics
+
+/// The day-window primitive, one test per scenario of the `daily-windows` specification, plus the
+/// parity oracle that the Kotlin twin reads from the same committed file.
+///
+/// Every fixture passes an explicit zone and an explicit reference instant, so nothing here depends on
+/// the machine's zone or on when the suite runs. The two exceptions are the default-accessor tests,
+/// which are about the defaults themselves and deliberately do not go through the oracle.
+final class LocalDayWindowsTests: XCTestCase {
+
+    // MARK: - Fixture helpers
+
+    /// A date written the way the specification writes it.
+    private func date(_ text: String) -> LocalCalendarDate {
+        let parts = text.split(separator: "-").map { Int($0)! }
+        return LocalCalendarDate(year: parts[0], month: parts[1], day: parts[2])
+    }
+
+    /// An instant from whole seconds since the epoch.
+    private func instant(_ epochSeconds: Int) -> Date {
+        Date(timeIntervalSince1970: TimeInterval(epochSeconds))
+    }
+
+    /// A UTC instant written as `YYYY-MM-DDTHH:MM:SSZ`, parsed without a formatter so the test's own
+    /// expectations do not depend on a locale or a calendar.
+    private func utc(_ text: String) -> Date {
+        let halves = text.dropLast().split(separator: "T")
+        let day = halves[0].split(separator: "-").map { Int($0)! }
+        let time = halves[1].split(separator: ":").map { Int($0)! }
+        let days = LocalCalendarDate(year: day[0], month: day[1], day: day[2]).daysSinceEpoch
+        return instant(days * 86_400 + time[0] * 3600 + time[1] * 60 + time[2])
+    }
+
+    /// The helper for a zone, with a reference instant that no scenario in this section depends on.
+    private func windows(_ zoneName: String,
+                         reference: Date = Date(timeIntervalSince1970: 0)) -> LocalDayWindows {
+        LocalDayWindows(timeZone: TimeZone(identifier: zoneName)!, referenceInstant: reference)
+    }
+
+    // MARK: - A local date begins at its own local midnight
+
+    /// The discriminating case: the helper and the analysis core's fixed-offset arithmetic disagree by
+    /// an hour across a transition.
+    ///
+    /// The core's arithmetic is re-derived inline, verbatim per the scenario, because the incumbent
+    /// lives in the app target and a package test cannot import it: floor to a local midnight using the
+    /// zone's offset at the reference instant, then subtract whole 86,400-second days.
+    func testResolvedStartDiffersFromFixedOffsetArithmeticAcrossATransition() {
+        let zone = TimeZone(identifier: "America/New_York")!
+        let reference = utc("2025-11-10T17:00:00Z")  // 12:00 local, inside standard time
+        let helper = LocalDayWindows(timeZone: zone, referenceInstant: reference)
+
+        let resolved = helper.start(of: date("2025-10-19"))
+
+        let offset = TimeInterval(zone.secondsFromGMT(for: reference))
+        let localSeconds = reference.timeIntervalSince1970 + offset
+        let referenceMidnight = (localSeconds / 86_400).rounded(.down) * 86_400 - offset
+        let fixedOffsetStart = Date(timeIntervalSince1970: referenceMidnight - 22 * 86_400)
+
+        XCTAssertEqual(resolved, utc("2025-10-19T04:00:00Z"))
+        XCTAssertEqual(fixedOffsetStart, utc("2025-10-19T05:00:00Z"))
+        XCTAssertNotEqual(resolved, fixedOffsetStart)
+    }
+
+    /// Two reference instants on opposite sides of the zone's autumn transition give the same start.
+    func testResultDoesNotDependOnTheReferenceInstant() {
+        let before = windows("America/New_York", reference: utc("2025-10-15T12:00:00Z"))
+        let after = windows("America/New_York", reference: utc("2025-12-15T12:00:00Z"))
+
+        XCTAssertEqual(before.start(of: date("2025-10-19")), utc("2025-10-19T04:00:00Z"))
+        XCTAssertEqual(after.start(of: date("2025-10-19")), utc("2025-10-19T04:00:00Z"))
+    }
+
+    /// A zone offset of 5 hours 45 minutes puts the start on its own local midnight, off the hour.
+    func testDayWithFortyFiveMinuteOffsetStartsAtItsOwnLocalMidnight() {
+        let helper = windows("Asia/Kathmandu")
+
+        let start = helper.start(of: date("2025-06-15"))
+
+        XCTAssertEqual(start, utc("2025-06-14T18:15:00Z"))
+        XCTAssertEqual(helper.offsetSeconds(at: start!), 20_700)
+        XCTAssertNotEqual(Int(start!.timeIntervalSince1970) % 3600, 0)
+    }
+
+    // MARK: - A day window lasts as long as the zone says and carries its own offset
+
+    /// The spring-forward day is 23 hours long.
+    func testSpringForwardDayIsTwentyThreeHours() {
+        let window = windows("America/New_York").window(of: date("2025-03-09"))
+
+        XCTAssertEqual(window?.duration, 23 * 3600)
+    }
+
+    /// The fall-back day is 25 hours long.
+    func testFallBackDayIsTwentyFiveHours() {
+        let window = windows("America/New_York").window(of: date("2025-11-02"))
+
+        XCTAssertEqual(window?.duration, 25 * 3600)
+    }
+
+    /// A zone without daylight saving has 24-hour days.
+    func testDayInZoneWithoutDaylightSavingIsTwentyFourHours() {
+        let window = windows("Asia/Kolkata").window(of: date("2025-06-15"))
+
+        XCTAssertEqual(window?.duration, 24 * 3600)
+    }
+
+    /// Consecutive windows meet exactly across a transition, leaving neither a gap nor an overlap.
+    func testConsecutiveWindowsMeetExactly() throws {
+        let helper = windows("America/New_York")
+
+        let first = try XCTUnwrap(helper.window(of: date("2025-11-01")))
+        let second = try XCTUnwrap(helper.window(of: date("2025-11-02")))
+        let third = try XCTUnwrap(helper.window(of: date("2025-11-03")))
+
+        XCTAssertEqual(first.nextStart, second.start)
+        XCTAssertEqual(second.nextStart, third.start)
+    }
+
+    /// The window reports the offset in effect at its own start, not at some other moment of the day.
+    func testWindowReportsOffsetInEffectAtItsStart() {
+        let helper = windows("America/New_York")
+
+        XCTAssertEqual(helper.window(of: date("2025-11-01"))?.utcOffsetSeconds, -14_400)
+        XCTAssertEqual(helper.window(of: date("2025-11-03"))?.utcOffsetSeconds, -18_000)
+    }
+
+    // MARK: - The helper resolves the start of the local day containing an instant
+
+    /// An instant inside the repeated local hour still resolves to that day's start.
+    func testInstantInsideTwentyFiveHourDayResolvesToThatDaysStart() {
+        let helper = windows("America/New_York")
+
+        let start = helper.startOfDay(containing: utc("2025-11-02T05:30:00Z"))
+
+        XCTAssertEqual(start, utc("2025-11-02T04:00:00Z"))
+    }
+
+    /// A start instant resolves to itself, for every fixture date that exists.
+    func testContainingDayStartOfAStartInstantIsItself() {
+        for (zone, day) in [("America/New_York", "2025-03-09"),
+                            ("America/New_York", "2025-11-02"),
+                            ("America/New_York", "2025-10-19"),
+                            ("America/Santiago", "2025-09-07"),
+                            ("America/Havana", "2025-11-02"),
+                            ("Pacific/Apia", "2011-12-31"),
+                            ("Asia/Kolkata", "2025-06-15"),
+                            ("Asia/Kathmandu", "2025-06-15")] {
+            let helper = windows(zone)
+            let start = helper.start(of: date(day))
+            XCTAssertNotNil(start, "\(zone) \(day) must have a start")
+            if let start {
+                XCTAssertEqual(helper.startOfDay(containing: start), start, "\(zone) \(day)")
+            }
+        }
+    }
+
+    // MARK: - An instant's day key names the window that contains it
+
+    /// The key flips exactly at the window boundary and nowhere else.
+    func testDayKeyChangesExactlyAtTheWindowBoundary() {
+        let helper = windows("America/New_York")
+        let start = helper.start(of: date("2025-11-02"))!
+
+        XCTAssertEqual(helper.dayKey(for: start.addingTimeInterval(-1)), "2025-11-01")
+        XCTAssertEqual(helper.dayKey(for: start.addingTimeInterval(1)), "2025-11-02")
+    }
+
+    /// The key holds for all 25 hours of the fall-back day, including the repeated local hour.
+    func testDayKeyHoldsAcrossTheWholeOfATwentyFiveHourDay() {
+        let helper = windows("America/New_York")
+        let window = helper.window(of: date("2025-11-02"))!
+
+        XCTAssertEqual(helper.dayKey(for: window.start), "2025-11-02")
+        XCTAssertEqual(helper.dayKey(for: utc("2025-11-02T05:30:00Z")), "2025-11-02")
+        XCTAssertEqual(helper.dayKey(for: window.nextStart.addingTimeInterval(-1)), "2025-11-02")
+    }
+
+    // MARK: - An ambiguous or missing local midnight resolves by a stated rule
+
+    /// A date with no 00:00 starts at its first existing instant, its local 01:00.
+    func testTransitionThatSkipsLocalMidnight() {
+        let start = windows("America/Santiago").start(of: date("2025-09-07"))
+
+        XCTAssertEqual(start, utc("2025-09-07T04:00:00Z"))
+    }
+
+    /// A date with two 00:00 starts at the earlier of them.
+    func testTransitionThatRepeatsLocalMidnight() {
+        let helper = windows("America/Havana")
+
+        let start = helper.start(of: date("2025-11-02"))
+
+        XCTAssertEqual(start, utc("2025-11-02T04:00:00Z"))
+        XCTAssertEqual(helper.offsetSeconds(at: start!), -14_400)
+        // The later of the two midnights, which the rule must not pick.
+        XCTAssertEqual(helper.offsetSeconds(at: utc("2025-11-02T05:00:00Z")), -18_000)
+    }
+
+    // MARK: - A date that does not exist is skipped over
+
+    /// A calendar date the zone skipped has no start at all.
+    func testSkippedCalendarDateProducesNoStart() {
+        XCTAssertNil(windows("Pacific/Apia").start(of: date("2011-12-30")))
+    }
+
+    /// The preceding date's window reaches over the skipped date to the next existing one.
+    func testPrecedingDatesWindowReachesTheNextExistingDate() {
+        let helper = windows("Pacific/Apia")
+
+        let window = helper.window(of: date("2011-12-29"))
+
+        XCTAssertEqual(window?.nextStart, helper.start(of: date("2011-12-31")))
+        XCTAssertEqual(window?.duration, 24 * 3600)
+    }
+
+    // MARK: - A backward run yields consecutive existing dates with their own starts
+
+    /// A run spanning the autumn transition is consecutive and each entry carries its own start.
+    func testRunAcrossATransitionIsConsecutiveAndCorrectlyAnchored() {
+        let helper = windows("America/New_York")
+
+        let run = helper.backwardRun(endingAt: date("2025-11-10"), count: 21)
+
+        XCTAssertEqual(run.count, 21)
+        XCTAssertEqual(run.first?.date.key, "2025-10-21")
+        XCTAssertEqual(run.last?.date.key, "2025-11-10")
+        for (index, entry) in run.enumerated() {
+            XCTAssertEqual(entry.date.daysSinceEpoch,
+                           date("2025-10-21").daysSinceEpoch + index,
+                           "run must be consecutive at \(entry.date.key)")
+            XCTAssertEqual(entry.start, helper.start(of: entry.date), entry.date.key)
+        }
+    }
+
+    /// A run containing a skipped date is shorter than requested and omits it.
+    func testRunContainingASkippedDateIsShorterThanRequested() {
+        let run = windows("Pacific/Apia").backwardRun(endingAt: date("2012-01-02"), count: 5)
+
+        XCTAssertEqual(run.count, 4)
+        XCTAssertEqual(run.first?.date.key, "2011-12-29")
+        XCTAssertEqual(run.map(\.date.key), ["2011-12-29", "2011-12-31", "2012-01-01", "2012-01-02"])
+    }
+
+    /// A long run lands on the right calendar date, 3999 days before the anchor.
+    func testLongRunReachesTheRightCalendarDate() {
+        let run = windows("America/New_York").backwardRun(endingAt: date("2025-11-10"), count: 4000)
+
+        XCTAssertEqual(run.count, 4000)
+        XCTAssertEqual(run.first?.date.key, "2014-11-29")
+        XCTAssertEqual(run.last?.date.key, "2025-11-10")
+    }
+
+    // MARK: - The sleep read window never extends into the future
+
+    /// The current date's window stops at the reference instant instead of its next start.
+    func testCurrentDatesWindowStopsAtTheReferenceInstant() {
+        let helper = windows("America/New_York", reference: utc("2025-11-02T18:00:00Z"))
+
+        let end = helper.sleepReadWindowEnd(of: date("2025-11-02"))
+
+        XCTAssertEqual(end, utc("2025-11-02T18:00:00Z"))
+        XCTAssertNotEqual(end, helper.window(of: date("2025-11-02"))?.nextStart)
+    }
+
+    /// A past 25-hour day reaches its own next start, 25 hours after it began.
+    func testPastTwentyFiveHourDayReachesItsOwnNextStart() {
+        let helper = windows("America/New_York", reference: utc("2025-12-15T12:00:00Z"))
+
+        let end = helper.sleepReadWindowEnd(of: date("2025-11-02"))
+        let window = helper.window(of: date("2025-11-02"))!
+
+        XCTAssertEqual(end, window.nextStart)
+        XCTAssertEqual(end?.timeIntervalSince(window.start), 25 * 3600)
+    }
+
+    // MARK: - The default zone and reference instant are named, not implied
+
+    /// The default zone is the auto-updating current zone named in the design, not a snapshot of it.
+    func testDefaultZoneIsThePlatformsTrackingDeviceZone() {
+        XCTAssertEqual(LocalDayWindows.defaultTimeZone, TimeZone.autoupdatingCurrent)
+        XCTAssertEqual(LocalDayWindows().timeZone, TimeZone.autoupdatingCurrent)
+        XCTAssertEqual(LocalDayWindows(referenceInstant: Date()).timeZone, TimeZone.autoupdatingCurrent)
+    }
+
+    /// The default reference instant is the current `Date`, so it lies inside a bracket taken around
+    /// the call.
+    func testDefaultReferenceInstantIsThePlatformsCurrentInstant() {
+        let before = Date()
+        let accessor = LocalDayWindows.defaultReferenceInstant
+        let helperDefault = LocalDayWindows().referenceInstant
+        let after = Date()
+
+        XCTAssertGreaterThanOrEqual(accessor, before)
+        XCTAssertLessThanOrEqual(accessor, after)
+        XCTAssertGreaterThanOrEqual(helperDefault, before)
+        XCTAssertLessThanOrEqual(helperDefault, after)
+    }
+
+    // MARK: - Both platforms agree, proven by a committed oracle
+
+    /// The committed oracle, loaded by a path derived from this file's own location.
+    ///
+    /// It fails rather than skips when the file is absent: an oracle nobody can find would otherwise
+    /// let both platforms stay green while they disagree, which is the whole thing this file guards.
+    private func loadOracle() throws -> [String: Any] {
+        let relative = "android/app/src/test/resources/local_day_windows_oracle.json"
+        var dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        for _ in 0..<8 {
+            let candidate = dir.appendingPathComponent(relative)
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                let data = try Data(contentsOf: candidate)
+                let parsed = try JSONSerialization.jsonObject(with: data)
+                return try XCTUnwrap(parsed as? [String: Any], "the oracle must be a JSON object")
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        XCTFail("committed oracle \(relative) not found above \(#filePath) — this test must not pass by default")
+        throw CocoaError(.fileNoSuchFile)
+    }
+
+    /// Every value in the committed oracle, re-derived by the helper and compared.
+    ///
+    /// The Kotlin twin asserts the same file, so a change on either side reddens one of the two suites.
+    func testSwiftTestReadsTheSameCommittedFile() throws {
+        let oracle = try loadOracle()
+
+        let producedBy = try XCTUnwrap(oracle["producedBy"] as? [String: Any])
+        XCTAssertFalse(try XCTUnwrap(producedBy["toolchain"] as? String).isEmpty)
+        XCTAssertFalse(try XCTUnwrap(producedBy["timeZoneDataVersion"] as? String).isEmpty)
+
+        let recorded = try XCTUnwrap(producedBy["timeZoneDataVersion"] as? String)
+        let note = LocalDayWindows.timeZoneDataVersionNote(
+            recorded: recorded, observed: LocalDayWindows.observedTimeZoneDataVersion)
+
+        let starts = try XCTUnwrap(oracle["starts"] as? [[String: Any]])
+        XCTAssertEqual(starts.count, 19, "oracle section starts")
+        for record in starts {
+            let helper = windows(try XCTUnwrap(record["zone"] as? String))
+            let day = date(try XCTUnwrap(record["date"] as? String))
+            let expected = record["start"] as? Int
+            let context = "start \(helper.timeZone.identifier) \(day.key) — \(note)"
+            XCTAssertEqual(helper.start(of: day).map { Int($0.timeIntervalSince1970) }, expected, context)
+        }
+
+        let windowRecords = try XCTUnwrap(oracle["windows"] as? [[String: Any]])
+        XCTAssertEqual(windowRecords.count, 18, "oracle section windows")
+        for record in windowRecords {
+            let helper = windows(try XCTUnwrap(record["zone"] as? String))
+            let day = date(try XCTUnwrap(record["date"] as? String))
+            let window = try XCTUnwrap(helper.window(of: day))
+            let context = "window \(helper.timeZone.identifier) \(day.key) — \(note)"
+            XCTAssertEqual(Int(window.start.timeIntervalSince1970), record["start"] as? Int, context)
+            XCTAssertEqual(Int(window.nextStart.timeIntervalSince1970), record["nextStart"] as? Int, context)
+            XCTAssertEqual(window.utcOffsetSeconds, record["utcOffsetSeconds"] as? Int, context)
+        }
+
+        let containing = try XCTUnwrap(oracle["containingDayStarts"] as? [[String: Any]])
+        XCTAssertEqual(containing.count, 8, "oracle section containingDayStarts")
+        for record in containing {
+            let helper = windows(try XCTUnwrap(record["zone"] as? String))
+            let at = instant(try XCTUnwrap(record["instant"] as? Int))
+            let context = "containing \(helper.timeZone.identifier) \(record["instant"] ?? "?") — \(note)"
+            XCTAssertEqual(Int(helper.startOfDay(containing: at).timeIntervalSince1970),
+                           record["start"] as? Int, context)
+        }
+
+        let keys = try XCTUnwrap(oracle["dayKeys"] as? [[String: Any]])
+        XCTAssertEqual(keys.count, 11, "oracle section dayKeys")
+        for record in keys {
+            let helper = windows(try XCTUnwrap(record["zone"] as? String))
+            let at = instant(try XCTUnwrap(record["instant"] as? Int))
+            let context = "key \(helper.timeZone.identifier) \(record["instant"] ?? "?") — \(note)"
+            XCTAssertEqual(helper.dayKey(for: at), record["key"] as? String, context)
+        }
+
+        let runs = try XCTUnwrap(oracle["runs"] as? [[String: Any]])
+        XCTAssertEqual(runs.count, 4, "oracle section runs")
+        for record in runs {
+            let helper = windows(try XCTUnwrap(record["zone"] as? String))
+            let anchor = date(try XCTUnwrap(record["endingAt"] as? String))
+            let requested = try XCTUnwrap(record["requested"] as? Int)
+            let run = helper.backwardRun(endingAt: anchor, count: requested)
+            let context = "run \(helper.timeZone.identifier) \(anchor.key)/\(requested) — \(note)"
+            XCTAssertEqual(run.count, record["size"] as? Int, context)
+            for (edge, entry) in [("oldest", run.first), ("newest", run.last)] {
+                let expected = try XCTUnwrap(record[edge] as? [String: Any], context)
+                XCTAssertEqual(entry?.date.key, expected["date"] as? String, "\(edge) \(context)")
+                XCTAssertEqual(entry.map { Int($0.start.timeIntervalSince1970) },
+                               expected["start"] as? Int, "\(edge) \(context)")
+            }
+            // Short runs carry every entry; the 4000-day run carries its edges and its size only, so
+            // that the committed file stays reviewable, and says so in `daysTruncated`.
+            let days = try XCTUnwrap(record["days"] as? [[String: Any]], context)
+            if try XCTUnwrap(record["daysTruncated"] as? Bool, context) {
+                XCTAssertTrue(days.isEmpty, context)
+            } else {
+                XCTAssertEqual(days.count, run.count, context)
+                for (entry, expected) in zip(run, days) {
+                    XCTAssertEqual(entry.date.key, expected["date"] as? String, context)
+                    XCTAssertEqual(Int(entry.start.timeIntervalSince1970), expected["start"] as? Int, context)
+                }
+            }
+        }
+
+        let sleepEnds = try XCTUnwrap(oracle["sleepWindowEnds"] as? [[String: Any]])
+        XCTAssertEqual(sleepEnds.count, 5, "oracle section sleepWindowEnds")
+        for record in sleepEnds {
+            let reference = instant(try XCTUnwrap(record["referenceInstant"] as? Int))
+            let helper = windows(try XCTUnwrap(record["zone"] as? String), reference: reference)
+            let day = date(try XCTUnwrap(record["date"] as? String))
+            let context = "sleep end \(helper.timeZone.identifier) \(day.key) — \(note)"
+            XCTAssertEqual(helper.sleepReadWindowEnd(of: day).map { Int($0.timeIntervalSince1970) },
+                           record["end"] as? Int, context)
+        }
+    }
+
+    /// The mismatch note names the recorded version and the observed one, and says so plainly where the
+    /// platform has no version of its own to report.
+    func testMismatchNoteNamesBothDatabaseVersions() {
+        let observed = LocalDayWindows.timeZoneDataVersionNote(recorded: "2025b", observed: "2025a")
+        XCTAssertEqual(observed,
+                       "time-zone database version: the oracle records 2025b; this platform observes 2025a.")
+
+        let blind = LocalDayWindows.timeZoneDataVersionNote(recorded: "unavailable", observed: nil)
+        XCTAssertEqual(blind,
+                       "time-zone database version: the oracle records unavailable; "
+                       + "this platform cannot observe its own time-zone database version.")
+        XCTAssertTrue(blind.contains("cannot observe"))
+        XCTAssertTrue(blind.contains("unavailable"))
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalyticsEngine.kt
@@ -138,6 +138,13 @@ object AnalyticsEngine {
      * back to 0 — an empty 1970 window no real sample matches — rather than throwing, so a single bad key can
      * never take down a whole scoring pass. Byte-identical twin of the Swift `AnalyticsEngine.dayStartUtcSeconds`
      * (locked cross-platform by AnalyticsEngineDayBoundsTest / AnalyticsEngineDayBoundsTests).
+     *
+     * This is a UTC midnight that callers pair with one captured offset and fixed 86,400-second blocks, so
+     * every boundary beyond a clock change sits an hour from the local midnight it names. [LocalDayWindows]
+     * is the zone-rule-correct primitive built to replace that, and is deliberately called by nothing yet.
+     * This function remains the shipped answer until a switch-over lands; the two disagree by an hour on
+     * the far side of a transition, and `LocalDayWindowsTest` pins both answers so the difference is
+     * visible rather than discovered.
      */
     fun dayStartUtcSeconds(day: String): Long =
         runCatching { LocalDate.parse(day).atStartOfDay(ZoneOffset.UTC).toEpochSecond() }.getOrDefault(0L)

--- a/android/app/src/main/java/com/noop/analytics/LocalDayWindows.kt
+++ b/android/app/src/main/java/com/noop/analytics/LocalDayWindows.kt
@@ -190,6 +190,12 @@ internal data class LocalDayStart(
  * a day on which the clocks move is 23 or 25 hours long. This type is the shared primitive that answers
  * it correctly; it changes no caller on its own.
  *
+ * SO TWO ANSWERS COEXIST, and this one is not yet the shipped one. [AnalyticsEngine.dayStartUtcSeconds]
+ * with `AnalyticsEngine.dayString` remains what every scored day actually uses; this file is called by
+ * nothing but its own tests until a switch-over lands. They disagree by an hour on the far side of a
+ * transition, which `LocalDayWindowsTest` pins deliberately by asserting BOTH answers for
+ * America/New_York on 2025-10-19. Reach for the core unless you are writing that switch-over.
+ *
  * Nothing here is inherited from the platform's date resolution: the ambiguous, skipped and
  * non-existent cases are resolved by the rules stated on each operation, so that a future change in
  * library behaviour is a change to this file rather than a silent change of a day boundary. That is why

--- a/android/app/src/main/java/com/noop/analytics/LocalDayWindows.kt
+++ b/android/app/src/main/java/com/noop/analytics/LocalDayWindows.kt
@@ -1,0 +1,473 @@
+package com.noop.analytics
+
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * A local calendar date as a year/month/day triple, mirroring the components of `java.time.LocalDate`
+ * without depending on its resolution rules.
+ *
+ * The Swift side carries its own value type because Swift has no calendar-date type free of a
+ * `Calendar`. This twin carries the same triple rather than a `LocalDate`, so that both sides run the
+ * same proleptic-Gregorian arithmetic and neither inherits a library's choice about a day boundary.
+ *
+ * Swift twin: `LocalCalendarDate`.
+ */
+internal data class LocalCalendarDate(
+    /** The proleptic Gregorian year, negative before year 1. Swift twin: `LocalCalendarDate.year`. */
+    val year: Int,
+    /** The month, 1..12. Swift twin: `LocalCalendarDate.month`. */
+    val month: Int,
+    /**
+     * The day of the month, 1..31. No validation happens here: an out-of-range day is normalised by the
+     * day-number conversion, the same way `java.time` would reject it and callers here never construct
+     * one. Swift twin: `LocalCalendarDate.day`.
+     */
+    val day: Int,
+) : Comparable<LocalCalendarDate> {
+
+    /**
+     * The date that lies `daysSinceEpoch` days after 1970-01-01.
+     *
+     * This is the counterpart of the Swift initialiser init(daysSinceEpoch:) and carries no parity
+     * claim, because the parity guard inventories function declarations only and has no initialiser to
+     * pair a claim with.
+     *
+     * The conversion is Howard Hinnant's civil_from_days, which needs no calendar object. Kotlin's
+     * integer division truncates toward zero as Swift's does, which is what the era shifts are written
+     * for. It runs inline in the delegation below and hands its three components on as one array,
+     * because a data class constructor may only delegate to the primary one and computing the
+     * components in a named helper would leave that helper with no counterpart of its own.
+     */
+    constructor(daysSinceEpoch: Int) : this(
+        // `kotlin.run` by its full name: the bare form resolves to the receiver extension, and there is
+        // no receiver yet inside a constructor delegation.
+        kotlin.run {
+            var z = daysSinceEpoch + 719_468
+            val era = (if (z >= 0) z else z - 146_096) / 146_097
+            z -= era * 146_097
+            val dayOfEra = z
+            val yearOfEra = (dayOfEra - dayOfEra / 1460 + dayOfEra / 36_524 - dayOfEra / 146_096) / 365
+            val dayOfYear = dayOfEra - (365 * yearOfEra + yearOfEra / 4 - yearOfEra / 100)
+            val monthPrime = (5 * dayOfYear + 2) / 153
+            val d = dayOfYear - (153 * monthPrime + 2) / 5 + 1
+            val m = monthPrime + (if (monthPrime < 10) 3 else -9)
+            val y = yearOfEra + era * 400 + (if (m <= 2) 1 else 0)
+            intArrayOf(y, m, d)
+        },
+    )
+
+    /**
+     * The year, month and day of a converted day number, in that order — the one hop that lets the day-
+     * number constructor above reach the primary one.
+     */
+    private constructor(civil: IntArray) : this(year = civil[0], month = civil[1], day = civil[2])
+
+    /**
+     * The number of days from 1970-01-01 to this date, negative before it.
+     *
+     * Swift twin: `LocalCalendarDate.daysSinceEpoch`.
+     */
+    val daysSinceEpoch: Int
+        get() {
+            // Howard Hinnant's days_from_civil, the exact inverse of the day-number constructor above.
+            val y = year - (if (month <= 2) 1 else 0)
+            val era = (if (y >= 0) y else y - 399) / 400
+            val yearOfEra = y - era * 400
+            val dayOfYear = (153 * (month + (if (month > 2) -3 else 9)) + 2) / 5 + day - 1
+            val dayOfEra = yearOfEra * 365 + yearOfEra / 4 - yearOfEra / 100 + dayOfYear
+            return era * 146_097 + dayOfEra - 719_468
+        }
+
+    /**
+     * The date rendered as `YYYY-MM-DD`, which is also the day key this helper hands out.
+     *
+     * Swift twin: `LocalCalendarDate.key`.
+     */
+    val key: String
+        get() {
+            val y = if (year < 0) "-" + pad(-year, 4) else pad(year, 4)
+            return "$y-${pad(month, 2)}-${pad(day, 2)}"
+        }
+
+    /**
+     * The date `count` days after this one, negative counts moving backward.
+     *
+     * Swift twin: `LocalCalendarDate.adding(days:)`.
+     */
+    fun adding(days: Int): LocalCalendarDate = LocalCalendarDate(daysSinceEpoch = daysSinceEpoch + days)
+
+    /**
+     * Order dates the way the calendar does.
+     *
+     * Kotlin orders through `compareTo` where Swift declares the `<` operator, so the Swift `<` has no
+     * selector of its own to claim and this claim names the type that declares it.
+     *
+     * Swift twin: `LocalCalendarDate`.
+     */
+    override fun compareTo(other: LocalCalendarDate): Int {
+        if (year != other.year) return year.compareTo(other.year)
+        if (month != other.month) return month.compareTo(other.month)
+        return day.compareTo(other.day)
+    }
+
+    /**
+     * The zero-padding that belongs to the type rather than to an instance.
+     *
+     * Swift twin: `LocalCalendarDate`.
+     */
+    companion object {
+
+        /**
+         * Left-pad a non-negative number with zeroes, without a formatter — the Swift side does the same,
+         * and a locale-aware formatter is one more thing that could differ between the platforms.
+         *
+         * Swift twin: `LocalCalendarDate.pad(_:_:)`.
+         */
+        private fun pad(value: Int, width: Int): String {
+            var s = value.toString()
+            while (s.length < width) s = "0$s"
+            return s
+        }
+    }
+}
+
+/**
+ * One local day as a half-open window, with the UTC offset that was in effect when it began.
+ *
+ * Swift twin: `LocalDayWindow`.
+ */
+internal data class LocalDayWindow(
+    /** The date this window belongs to. Swift twin: `LocalDayWindow.date`. */
+    val date: LocalCalendarDate,
+    /** The first instant of the date. Swift twin: `LocalDayWindow.start`. */
+    val start: Instant,
+    /**
+     * The start of the next date that exists in the zone, which is where this window ends. It is not
+     * always `start` plus 24 hours, and where a calendar date is skipped entirely it is more than a day
+     * away. Swift twin: `LocalDayWindow.nextStart`.
+     */
+    val nextStart: Instant,
+    /**
+     * The UTC offset in effect at `start`, in seconds east of UTC.
+     *
+     * It describes the window's start only. A time of day anywhere else inside the window is derived
+     * from the zone, never by adding this number, because a transition inside the window would make that
+     * wrong by an hour. Swift twin: `LocalDayWindow.utcOffsetSeconds`.
+     */
+    val utcOffsetSeconds: Int,
+) {
+
+    /**
+     * How long the window lasts — 23, 24 or 25 hours in the fixture zones, and longer where the zone
+     * skips a calendar date. Swift returns a `TimeInterval` of seconds; the twin returns the `Duration`
+     * that carries the same seconds.
+     *
+     * Swift twin: `LocalDayWindow.duration`.
+     */
+    val duration: Duration
+        get() = Duration.between(start, nextStart)
+}
+
+/**
+ * One entry of a backward run: a date that exists in the zone, with the start resolved for it.
+ *
+ * Swift twin: `LocalDayStart`.
+ */
+internal data class LocalDayStart(
+    /** The date. Swift twin: `LocalDayStart.date`. */
+    val date: LocalCalendarDate,
+    /** The first instant of that date in the zone. Swift twin: `LocalDayStart.start`. */
+    val start: Instant,
+)
+
+/**
+ * When a local calendar date begins and ends in a time zone, taken from the zone's own rules.
+ *
+ * The analysis core answers this question by adding fixed 86,400-second blocks to a midnight derived
+ * from a single UTC offset. That is wrong by an hour on every day boundary beyond a transition, because
+ * a day on which the clocks move is 23 or 25 hours long. This type is the shared primitive that answers
+ * it correctly; it changes no caller on its own.
+ *
+ * Nothing here is inherited from the platform's date resolution: the ambiguous, skipped and
+ * non-existent cases are resolved by the rules stated on each operation, so that a future change in
+ * library behaviour is a change to this file rather than a silent change of a day boundary. That is why
+ * neither `ZonedDateTime` nor `ZoneRules.getTransition` appears below — the only thing asked of the
+ * platform is `ZoneRules.getOffset`, the zone's raw rule lookup.
+ *
+ * Both the zone and the reference instant are injectable and default to the named accessors
+ * `defaultTimeZone` and `defaultReferenceInstant`, so every rule below is provable without a device.
+ *
+ * Swift twin: `LocalDayWindows`.
+ */
+internal class LocalDayWindows(
+    /** The zone whose rules every operation reads. Swift twin: `LocalDayWindows.timeZone`. */
+    val zone: ZoneId = defaultTimeZone,
+    /**
+     * The instant that stands for "now" — it clamps the sleep read window and nothing else. No start,
+     * window, key or run depends on it. Swift twin: `LocalDayWindows.referenceInstant`.
+     */
+    val referenceInstant: Instant = defaultReferenceInstant,
+) {
+
+    /**
+     * The first instant that belongs to `date` in this zone, or `null` when the zone has no instant on
+     * that date at all.
+     *
+     * The rule, stated rather than inherited: where local midnight exists once, that is the start; where
+     * it exists twice, the earlier of the two; where it does not exist, the first instant that does
+     * exist on the date, which is the instant the clocks jumped to. Where that jump lands on a later
+     * date the date itself never happened, and there is no start.
+     *
+     * The rule assumes at most one offset change within two days either side of the local midnight; no
+     * zone in the database violates that today.
+     *
+     * The result does not depend on `referenceInstant`.
+     *
+     * Swift twin: `LocalDayWindows.start(of:)`.
+     */
+    fun start(date: LocalCalendarDate): Instant? {
+        val localMidnight = date.daysSinceEpoch.toLong() * 86_400L
+        val offsetBefore = offsetSeconds(localMidnight - probeWindow)
+        val offsetAfter = offsetSeconds(localMidnight + probeWindow)
+
+        val candidates = listOf(localMidnight - offsetBefore, localMidnight - offsetAfter)
+            .sorted()
+            .distinct()
+        // An instant maps to this local midnight exactly when reading it in the zone gives that wall time
+        // back. Ascending order means an ambiguous midnight yields the earlier instant first.
+        for (candidate in candidates) {
+            if (candidate + offsetSeconds(candidate) == localMidnight) return Instant.ofEpochSecond(candidate)
+        }
+
+        // Local midnight fell in a gap. The first instant that exists on or after it is the instant the
+        // clocks jumped at; it belongs to this date only if it still reads as this date.
+        if (offsetBefore == offsetAfter) return null
+        val jump = transitionEpochSeconds(localMidnight, offsetBefore)
+        if (localDate(jump) != date) return null
+        return Instant.ofEpochSecond(jump)
+    }
+
+    /**
+     * The half-open window `[start, nextStart)` of `date`, or `null` when the date does not exist.
+     *
+     * `nextStart` is the start of the next date that *exists*, so a window that precedes a skipped
+     * calendar date spans more than a day rather than ending at an instant that never happened.
+     *
+     * Swift twin: `LocalDayWindows.window(of:)`.
+     */
+    fun window(date: LocalCalendarDate): LocalDayWindow? {
+        val dayStart = start(date) ?: return null
+        var next = date.adding(days = 1)
+        var nextStart: Instant? = null
+        // A zone skipping more than a couple of consecutive dates has never happened; the bound keeps a
+        // corrupt zone from turning this into an unbounded walk.
+        var probes = 0
+        while (nextStart == null && probes < 8) {
+            nextStart = start(next)
+            if (nextStart == null) next = next.adding(days = 1)
+            probes += 1
+        }
+        val end = nextStart ?: return null
+        return LocalDayWindow(
+            date = date,
+            start = dayStart,
+            nextStart = end,
+            utcOffsetSeconds = offsetSeconds(dayStart),
+        )
+    }
+
+    /**
+     * The start of the local day that contains `instant`, as an instant and without formatting a date on
+     * the way.
+     *
+     * Swift twin: `LocalDayWindows.startOfDay(containing:)`.
+     */
+    fun startOfDay(instant: Instant): Instant {
+        val date = localDate(instant)
+        // `instant` lies on `date` by construction, so the date exists and has a start. The fallback is
+        // unreachable and exists only to keep the operation total.
+        return start(date) ?: instant
+    }
+
+    /**
+     * The `YYYY-MM-DD` key of the local day that contains `instant`.
+     *
+     * The key and the window agree by construction: the key names the date whose window contains the
+     * instant, because both are derived from the same zone lookup.
+     *
+     * Swift twin: `LocalDayWindows.dayKey(for:)`.
+     */
+    fun dayKey(instant: Instant): String = localDate(instant).key
+
+    /**
+     * The local calendar date that contains `instant` in this zone.
+     *
+     * Swift twin: `LocalDayWindows.localDate(of:)`.
+     */
+    fun localDate(instant: Instant): LocalCalendarDate = localDate(instant.epochSecond)
+
+    /**
+     * Up to `count` consecutive local calendar dates ending at `date`, oldest first, each with its own
+     * resolved start.
+     *
+     * A date the zone skipped is omitted rather than replaced, so the run can be shorter than requested;
+     * if `date` itself does not exist, the newest entry is the latest existing date before it.
+     *
+     * Swift twin: `LocalDayWindows.backwardRun(endingAt:count:)`.
+     */
+    fun backwardRun(endingAt: LocalCalendarDate, count: Int): List<LocalDayStart> {
+        if (count <= 0) return emptyList()
+        val endDay = endingAt.daysSinceEpoch
+        val run = ArrayList<LocalDayStart>(count)
+        for (back in count - 1 downTo 0) {
+            val day = LocalCalendarDate(daysSinceEpoch = endDay - back)
+            val start = start(day)
+            if (start != null) run.add(LocalDayStart(date = day, start = start))
+        }
+        return run
+    }
+
+    /**
+     * The end of the sleep read window of `date`: the earlier of that date's next start and the
+     * reference instant, so the current day's window never reaches into the future. `null` when the date
+     * does not exist.
+     *
+     * For a date that begins after the reference instant the end precedes the start — an empty, inverted
+     * window — by the D7 contract; a caller wanting a non-empty window must not ask for a future date.
+     *
+     * Swift twin: `LocalDayWindows.sleepReadWindowEnd(of:)`.
+     */
+    fun sleepReadWindowEnd(date: LocalCalendarDate): Instant? {
+        val window = window(date) ?: return null
+        return minOf(window.nextStart, referenceInstant)
+    }
+
+    /**
+     * The UTC offset in effect at `instant`, in seconds east of UTC.
+     *
+     * Swift twin: `LocalDayWindows.offsetSeconds(at:)`.
+     */
+    fun offsetSeconds(instant: Instant): Int = zone.rules.getOffset(instant).totalSeconds
+
+    /**
+     * The UTC offset in effect at a whole-second instant.
+     *
+     * Swift twin: `LocalDayWindows.offsetSeconds(atEpochSeconds:)`.
+     */
+    private fun offsetSeconds(epochSeconds: Long): Int =
+        zone.rules.getOffset(Instant.ofEpochSecond(epochSeconds)).totalSeconds
+
+    /**
+     * The local calendar date of a whole-second instant.
+     *
+     * Swift twin: `LocalDayWindows.localDate(ofEpochSeconds:)`.
+     */
+    private fun localDate(epochSeconds: Long): LocalCalendarDate {
+        val localSeconds = epochSeconds + offsetSeconds(epochSeconds)
+        var days = localSeconds / 86_400L
+        if (localSeconds < 0 && localSeconds % 86_400L != 0L) days -= 1
+        return LocalCalendarDate(daysSinceEpoch = days.toInt())
+    }
+
+    /**
+     * The instant at which the zone's offset changes near `localMidnight`, found by bisecting the probe
+     * window between the offset before and the offset after.
+     *
+     * Swift twin: `LocalDayWindows.transitionEpochSeconds(around:offsetBefore:)`.
+     */
+    private fun transitionEpochSeconds(localMidnight: Long, offsetBefore: Int): Long {
+        var low = localMidnight - probeWindow
+        var high = localMidnight + probeWindow
+        while (high - low > 1) {
+            val mid = low + (high - low) / 2
+            if (offsetSeconds(mid) == offsetBefore) low = mid else high = mid
+        }
+        return high
+    }
+
+    /**
+     * The named defaults and the version reporting, which belong to the type rather than to an instance.
+     *
+     * Swift twin: `LocalDayWindows`.
+     */
+    companion object {
+
+        /**
+         * The zone used when none is given: the system default zone id, which follows a change of device
+         * zone during the process's life. The Swift twin's default is the auto-updating current zone,
+         * which means the same thing.
+         *
+         * The zone is bound when the helper is constructed; a caller that must follow a device-zone
+         * change during the process's life constructs a new helper.
+         *
+         * Swift twin: `LocalDayWindows.defaultTimeZone`.
+         */
+        val defaultTimeZone: ZoneId
+            get() = ZoneId.systemDefault()
+
+        /**
+         * The reference instant used when none is given: the current `Instant`. The Swift twin's default
+         * is the current `Date`.
+         *
+         * Swift twin: `LocalDayWindows.defaultReferenceInstant`.
+         */
+        val defaultReferenceInstant: Instant
+            get() = Instant.now()
+
+        /**
+         * The time-zone database version this platform can observe about itself, or `null` where it
+         * cannot.
+         *
+         * The JVM reports the database its own `java.time` rules were built from, which is a different
+         * fact from the one the oracle records about the producing Swift toolchain. Where that fact
+         * cannot be had the answer is `null` rather than a faked value, which is the same choice the
+         * Swift side makes on Linux. `java.time.zone.ZoneRulesProvider` is not on the SDK compile
+         * classpath, so it is read reflectively rather than called directly; what a device returns is
+         * unverified here and belongs to A2's device counter-check. Where the read cannot be made the
+         * answer is the `null` branch, which the note renders as the D6 cannot-observe wording; on the
+         * JVM unit-test runner the read succeeds and the note names the version.
+         *
+         * Swift twin: `LocalDayWindows.observedTimeZoneDataVersion`.
+         */
+        val observedTimeZoneDataVersion: String?
+            get() = try {
+                val versions = Class.forName("java.time.zone.ZoneRulesProvider")
+                    .getMethod("getVersions", String::class.java)
+                    .invoke(null, ZoneId.systemDefault().id) as java.util.NavigableMap<*, *>
+                if (versions.isEmpty()) null else versions.lastKey() as? String
+            } catch (missing: ReflectiveOperationException) {
+                null
+            } catch (unsupported: RuntimeException) {
+                // `ZoneRulesException` for a zone the provider does not know, wrapped or direct.
+                null
+            }
+
+        /**
+         * The note a platform attaches when a fixture value moves: it names the version recorded in the
+         * oracle and the version this platform observes at run time.
+         *
+         * A version difference is not itself a failure — the fixtures are past and stable, so a routine
+         * toolchain bump must not redden unrelated work. The note exists to make a *value* difference
+         * explicable. It is a pure function so that its content can be asserted; where a platform cannot
+         * observe its own version, the note says so in place of a version rather than omitting it.
+         *
+         * Swift twin: `LocalDayWindows.timeZoneDataVersionNote(recorded:observed:)`.
+         */
+        fun timeZoneDataVersionNote(recorded: String, observed: String?): String {
+            val observedText = observed?.let { "observes $it" }
+                ?: "cannot observe its own time-zone database version"
+            return "time-zone database version: the oracle records $recorded; this platform $observedText."
+        }
+
+        /**
+         * The number of seconds either side of a local midnight that is probed for the offsets in effect
+         * around it. Two days is far more than any transition needs and still far less than the gap
+         * between two transitions anywhere in the database.
+         *
+         * Swift twin: `LocalDayWindows.probeWindow`.
+         */
+        private const val probeWindow: Long = 2L * 86_400L
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/LocalDayWindowsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/LocalDayWindowsTest.kt
@@ -1,0 +1,551 @@
+package com.noop.analytics
+
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * The day-window primitive, one test per scenario of the `daily-windows` specification, plus the parity
+ * oracle that the Swift twin reads from the same committed file.
+ *
+ * The test names mirror `LocalDayWindowsTests.swift` so the two suites read side by side. Every fixture
+ * passes an explicit zone and an explicit reference instant, so nothing here depends on the machine's
+ * zone or on when the suite runs. The two exceptions are the default-accessor tests, which are about the
+ * defaults themselves and deliberately do not go through the oracle.
+ */
+class LocalDayWindowsTest {
+
+    // MARK: - Fixture helpers
+
+    /** A date written the way the specification writes it. */
+    private fun date(text: String): LocalCalendarDate {
+        val parts = text.split("-").map { it.toInt() }
+        return LocalCalendarDate(year = parts[0], month = parts[1], day = parts[2])
+    }
+
+    /** An instant from whole seconds since the epoch. */
+    private fun instant(epochSeconds: Long): Instant = Instant.ofEpochSecond(epochSeconds)
+
+    /**
+     * A UTC instant written as `YYYY-MM-DDTHH:MM:SSZ`, parsed without a formatter so the test's own
+     * expectations do not depend on a locale or a calendar.
+     */
+    private fun utc(text: String): Instant {
+        val halves = text.dropLast(1).split("T")
+        val day = halves[0].split("-").map { it.toInt() }
+        val time = halves[1].split(":").map { it.toInt() }
+        val days = LocalCalendarDate(year = day[0], month = day[1], day = day[2]).daysSinceEpoch
+        return instant(days.toLong() * 86_400L + time[0] * 3600L + time[1] * 60L + time[2])
+    }
+
+    /** The helper for a zone, with a reference instant that no scenario in this section depends on. */
+    private fun windows(zoneName: String, reference: Instant = Instant.EPOCH): LocalDayWindows =
+        LocalDayWindows(zone = ZoneId.of(zoneName), referenceInstant = reference)
+
+    // MARK: - A local date begins at its own local midnight
+
+    /**
+     * The discriminating case: the helper and the analysis core's fixed-offset arithmetic disagree by an
+     * hour across a transition.
+     *
+     * The core's arithmetic is re-derived inline, verbatim per the scenario, so that both platforms
+     * compare against the same arm: floor to a local midnight using the zone's offset at the reference
+     * instant, then subtract whole 86,400-second days.
+     */
+    @Test
+    fun testResolvedStartDiffersFromFixedOffsetArithmeticAcrossATransition() {
+        val zone = ZoneId.of("America/New_York")
+        val reference = utc("2025-11-10T17:00:00Z") // 12:00 local, inside standard time
+        val helper = LocalDayWindows(zone = zone, referenceInstant = reference)
+
+        val resolved = helper.start(date("2025-10-19"))
+
+        val offset = zone.rules.getOffset(reference).totalSeconds.toLong()
+        val localSeconds = reference.epochSecond + offset
+        val referenceMidnight = Math.floorDiv(localSeconds, 86_400L) * 86_400L - offset
+        val fixedOffsetStart = instant(referenceMidnight - 22L * 86_400L)
+
+        assertEquals(utc("2025-10-19T04:00:00Z"), resolved)
+        assertEquals(utc("2025-10-19T05:00:00Z"), fixedOffsetStart)
+        assertNotEquals(fixedOffsetStart, resolved)
+    }
+
+    /** Two reference instants on opposite sides of the zone's autumn transition give the same start. */
+    @Test
+    fun testResultDoesNotDependOnTheReferenceInstant() {
+        val before = windows("America/New_York", reference = utc("2025-10-15T12:00:00Z"))
+        val after = windows("America/New_York", reference = utc("2025-12-15T12:00:00Z"))
+
+        assertEquals(utc("2025-10-19T04:00:00Z"), before.start(date("2025-10-19")))
+        assertEquals(utc("2025-10-19T04:00:00Z"), after.start(date("2025-10-19")))
+    }
+
+    /** A zone offset of 5 hours 45 minutes puts the start on its own local midnight, off the hour. */
+    @Test
+    fun testDayWithFortyFiveMinuteOffsetStartsAtItsOwnLocalMidnight() {
+        val helper = windows("Asia/Kathmandu")
+
+        val start = helper.start(date("2025-06-15"))
+
+        assertEquals(utc("2025-06-14T18:15:00Z"), start)
+        assertEquals(20_700, helper.offsetSeconds(start!!))
+        assertNotEquals(0L, start.epochSecond % 3600L)
+    }
+
+    // MARK: - A day window lasts as long as the zone says and carries its own offset
+
+    /** The spring-forward day is 23 hours long. */
+    @Test
+    fun testSpringForwardDayIsTwentyThreeHours() {
+        val window = windows("America/New_York").window(date("2025-03-09"))
+
+        assertEquals(Duration.ofHours(23), window?.duration)
+    }
+
+    /** The fall-back day is 25 hours long. */
+    @Test
+    fun testFallBackDayIsTwentyFiveHours() {
+        val window = windows("America/New_York").window(date("2025-11-02"))
+
+        assertEquals(Duration.ofHours(25), window?.duration)
+    }
+
+    /** A zone without daylight saving has 24-hour days. */
+    @Test
+    fun testDayInZoneWithoutDaylightSavingIsTwentyFourHours() {
+        val window = windows("Asia/Kolkata").window(date("2025-06-15"))
+
+        assertEquals(Duration.ofHours(24), window?.duration)
+    }
+
+    /** Consecutive windows meet exactly across a transition, leaving neither a gap nor an overlap. */
+    @Test
+    fun testConsecutiveWindowsMeetExactly() {
+        val helper = windows("America/New_York")
+
+        val first = helper.window(date("2025-11-01"))
+        val second = helper.window(date("2025-11-02"))
+        val third = helper.window(date("2025-11-03"))
+        assertNotNull("2025-11-01 must have a window", first)
+        assertNotNull("2025-11-02 must have a window", second)
+        assertNotNull("2025-11-03 must have a window", third)
+
+        assertEquals(second!!.start, first!!.nextStart)
+        assertEquals(third!!.start, second.nextStart)
+    }
+
+    /** The window reports the offset in effect at its own start, not at some other moment of the day. */
+    @Test
+    fun testWindowReportsOffsetInEffectAtItsStart() {
+        val helper = windows("America/New_York")
+
+        assertEquals(-14_400, helper.window(date("2025-11-01"))?.utcOffsetSeconds)
+        assertEquals(-18_000, helper.window(date("2025-11-03"))?.utcOffsetSeconds)
+    }
+
+    // MARK: - The helper resolves the start of the local day containing an instant
+
+    /** An instant inside the repeated local hour still resolves to that day's start. */
+    @Test
+    fun testInstantInsideTwentyFiveHourDayResolvesToThatDaysStart() {
+        val helper = windows("America/New_York")
+
+        val start = helper.startOfDay(utc("2025-11-02T05:30:00Z"))
+
+        assertEquals(utc("2025-11-02T04:00:00Z"), start)
+    }
+
+    /** A start instant resolves to itself, for every fixture date that exists. */
+    @Test
+    fun testContainingDayStartOfAStartInstantIsItself() {
+        val fixtures = listOf(
+            "America/New_York" to "2025-03-09",
+            "America/New_York" to "2025-11-02",
+            "America/New_York" to "2025-10-19",
+            "America/Santiago" to "2025-09-07",
+            "America/Havana" to "2025-11-02",
+            "Pacific/Apia" to "2011-12-31",
+            "Asia/Kolkata" to "2025-06-15",
+            "Asia/Kathmandu" to "2025-06-15",
+        )
+        for ((zone, day) in fixtures) {
+            val helper = windows(zone)
+            val start = helper.start(date(day))
+            assertNotNull("$zone $day must have a start", start)
+            assertEquals("$zone $day", start, helper.startOfDay(start!!))
+        }
+    }
+
+    // MARK: - An instant's day key names the window that contains it
+
+    /** The key flips exactly at the window boundary and nowhere else. */
+    @Test
+    fun testDayKeyChangesExactlyAtTheWindowBoundary() {
+        val helper = windows("America/New_York")
+        val start = helper.start(date("2025-11-02"))!!
+
+        assertEquals("2025-11-01", helper.dayKey(start.minusSeconds(1)))
+        assertEquals("2025-11-02", helper.dayKey(start.plusSeconds(1)))
+    }
+
+    /** The key holds for all 25 hours of the fall-back day, including the repeated local hour. */
+    @Test
+    fun testDayKeyHoldsAcrossTheWholeOfATwentyFiveHourDay() {
+        val helper = windows("America/New_York")
+        val window = helper.window(date("2025-11-02"))!!
+
+        assertEquals("2025-11-02", helper.dayKey(window.start))
+        assertEquals("2025-11-02", helper.dayKey(utc("2025-11-02T05:30:00Z")))
+        assertEquals("2025-11-02", helper.dayKey(window.nextStart.minusSeconds(1)))
+    }
+
+    // MARK: - An ambiguous or missing local midnight resolves by a stated rule
+
+    /** A date with no 00:00 starts at its first existing instant, its local 01:00. */
+    @Test
+    fun testTransitionThatSkipsLocalMidnight() {
+        val start = windows("America/Santiago").start(date("2025-09-07"))
+
+        assertEquals(utc("2025-09-07T04:00:00Z"), start)
+    }
+
+    /** A date with two 00:00 starts at the earlier of them. */
+    @Test
+    fun testTransitionThatRepeatsLocalMidnight() {
+        val helper = windows("America/Havana")
+
+        val start = helper.start(date("2025-11-02"))
+
+        assertEquals(utc("2025-11-02T04:00:00Z"), start)
+        assertEquals(-14_400, helper.offsetSeconds(start!!))
+        // The later of the two midnights, which the rule must not pick.
+        assertEquals(-18_000, helper.offsetSeconds(utc("2025-11-02T05:00:00Z")))
+    }
+
+    // MARK: - A date that does not exist is skipped over
+
+    /** A calendar date the zone skipped has no start at all. */
+    @Test
+    fun testSkippedCalendarDateProducesNoStart() {
+        assertNull(windows("Pacific/Apia").start(date("2011-12-30")))
+    }
+
+    /** The preceding date's window reaches over the skipped date to the next existing one. */
+    @Test
+    fun testPrecedingDatesWindowReachesTheNextExistingDate() {
+        val helper = windows("Pacific/Apia")
+
+        val window = helper.window(date("2011-12-29"))
+
+        assertEquals(helper.start(date("2011-12-31")), window?.nextStart)
+        assertEquals(Duration.ofHours(24), window?.duration)
+    }
+
+    // MARK: - A backward run yields consecutive existing dates with their own starts
+
+    /** A run spanning the autumn transition is consecutive and each entry carries its own start. */
+    @Test
+    fun testRunAcrossATransitionIsConsecutiveAndCorrectlyAnchored() {
+        val helper = windows("America/New_York")
+
+        val run = helper.backwardRun(endingAt = date("2025-11-10"), count = 21)
+
+        assertEquals(21, run.size)
+        assertEquals("2025-10-21", run.first().date.key)
+        assertEquals("2025-11-10", run.last().date.key)
+        run.forEachIndexed { index, entry ->
+            assertEquals(
+                "run must be consecutive at ${entry.date.key}",
+                date("2025-10-21").daysSinceEpoch + index,
+                entry.date.daysSinceEpoch,
+            )
+            assertEquals(entry.date.key, helper.start(entry.date), entry.start)
+        }
+    }
+
+    /** A run containing a skipped date is shorter than requested and omits it. */
+    @Test
+    fun testRunContainingASkippedDateIsShorterThanRequested() {
+        val run = windows("Pacific/Apia").backwardRun(endingAt = date("2012-01-02"), count = 5)
+
+        assertEquals(4, run.size)
+        assertEquals("2011-12-29", run.first().date.key)
+        assertEquals(
+            listOf("2011-12-29", "2011-12-31", "2012-01-01", "2012-01-02"),
+            run.map { it.date.key },
+        )
+    }
+
+    /** A long run lands on the right calendar date, 3999 days before the anchor. */
+    @Test
+    fun testLongRunReachesTheRightCalendarDate() {
+        val run = windows("America/New_York").backwardRun(endingAt = date("2025-11-10"), count = 4000)
+
+        assertEquals(4000, run.size)
+        assertEquals("2014-11-29", run.first().date.key)
+        assertEquals("2025-11-10", run.last().date.key)
+    }
+
+    // MARK: - The sleep read window never extends into the future
+
+    /** The current date's window stops at the reference instant instead of its next start. */
+    @Test
+    fun testCurrentDatesWindowStopsAtTheReferenceInstant() {
+        val helper = windows("America/New_York", reference = utc("2025-11-02T18:00:00Z"))
+
+        val end = helper.sleepReadWindowEnd(date("2025-11-02"))
+
+        assertEquals(utc("2025-11-02T18:00:00Z"), end)
+        assertNotEquals(helper.window(date("2025-11-02"))?.nextStart, end)
+    }
+
+    /** A past 25-hour day reaches its own next start, 25 hours after it began. */
+    @Test
+    fun testPastTwentyFiveHourDayReachesItsOwnNextStart() {
+        val helper = windows("America/New_York", reference = utc("2025-12-15T12:00:00Z"))
+
+        val end = helper.sleepReadWindowEnd(date("2025-11-02"))
+        val window = helper.window(date("2025-11-02"))!!
+
+        assertEquals(window.nextStart, end)
+        assertEquals(Duration.ofHours(25), Duration.between(window.start, end))
+    }
+
+    // MARK: - The default zone and reference instant are named, not implied
+
+    /** The default zone is the system default zone id named in the design, not a snapshot of it. */
+    @Test
+    fun testDefaultZoneIsThePlatformsTrackingDeviceZone() {
+        assertEquals(ZoneId.systemDefault(), LocalDayWindows.defaultTimeZone)
+        assertEquals(ZoneId.systemDefault(), LocalDayWindows().zone)
+        assertEquals(ZoneId.systemDefault(), LocalDayWindows(referenceInstant = Instant.now()).zone)
+    }
+
+    /**
+     * The default reference instant is the current `Instant`, so it lies inside a bracket taken around
+     * the call.
+     */
+    @Test
+    fun testDefaultReferenceInstantIsThePlatformsCurrentInstant() {
+        val before = Instant.now()
+        val accessor = LocalDayWindows.defaultReferenceInstant
+        val helperDefault = LocalDayWindows().referenceInstant
+        val after = Instant.now()
+
+        assertTrue(accessor >= before)
+        assertTrue(accessor <= after)
+        assertTrue(helperDefault >= before)
+        assertTrue(helperDefault <= after)
+    }
+
+    // MARK: - Both platforms agree, proven by a committed oracle
+
+    /**
+     * The committed oracle, loaded from the test resources on the classpath.
+     *
+     * It fails rather than skips when the file is absent: an oracle nobody can find would otherwise let
+     * both platforms stay green while they disagree, which is the whole thing this file guards.
+     */
+    private fun loadOracle(): JSONObject {
+        val stream = javaClass.classLoader!!.getResourceAsStream(ORACLE_RESOURCE)
+        if (stream == null) {
+            fail("committed oracle $ORACLE_RESOURCE not on the test classpath — this test must not pass by default")
+        }
+        return JSONObject(stream!!.bufferedReader().use { it.readText() })
+    }
+
+    /** The oracle's own `start` field, which is JSON null for a date the zone never had. */
+    private fun optionalEpochSeconds(record: JSONObject, field: String): Long? =
+        if (record.isNull(field)) null else record.getLong(field)
+
+    /**
+     * Every value in the committed oracle, re-derived by the twin and compared.
+     *
+     * The Swift side asserts the same file, so a change on either side reddens one of the two suites.
+     * The mismatch note rides along on every assertion message, so a moved value names both database
+     * versions rather than only the numbers that differ.
+     */
+    @Test
+    fun testKotlinTestAssertsTheCommittedOracle() {
+        val oracle = loadOracle()
+
+        assertFalse(oracle.getString("note").isEmpty())
+        val producedBy = oracle.getJSONObject("producedBy")
+        assertFalse(producedBy.getString("toolchain").isEmpty())
+        assertFalse(producedBy.getString("timeZoneDataVersion").isEmpty())
+
+        val recorded = producedBy.getString("timeZoneDataVersion")
+        val note = LocalDayWindows.timeZoneDataVersionNote(
+            recorded = recorded,
+            observed = LocalDayWindows.observedTimeZoneDataVersion,
+        )
+
+        val starts = oracle.getJSONArray("starts")
+        assertEquals("oracle section starts", 19, starts.length())
+        for (i in 0 until starts.length()) {
+            val record = starts.getJSONObject(i)
+            val helper = windows(record.getString("zone"))
+            val day = date(record.getString("date"))
+            val context = "start ${record.getString("zone")} ${day.key} — $note"
+            assertEquals(context, optionalEpochSeconds(record, "start"), helper.start(day)?.epochSecond)
+        }
+
+        val windowRecords = oracle.getJSONArray("windows")
+        assertEquals("oracle section windows", 18, windowRecords.length())
+        for (i in 0 until windowRecords.length()) {
+            val record = windowRecords.getJSONObject(i)
+            val helper = windows(record.getString("zone"))
+            val day = date(record.getString("date"))
+            val context = "window ${record.getString("zone")} ${day.key} — $note"
+            val window = helper.window(day)
+            assertNotNull(context, window)
+            assertEquals(context, record.getLong("start"), window!!.start.epochSecond)
+            assertEquals(context, record.getLong("nextStart"), window.nextStart.epochSecond)
+            assertEquals(context, record.getInt("utcOffsetSeconds"), window.utcOffsetSeconds)
+            assertEquals(context, record.getLong("durationSeconds"), window.duration.seconds)
+        }
+
+        val containing = oracle.getJSONArray("containingDayStarts")
+        assertEquals("oracle section containingDayStarts", 8, containing.length())
+        for (i in 0 until containing.length()) {
+            val record = containing.getJSONObject(i)
+            val helper = windows(record.getString("zone"))
+            val at = instant(record.getLong("instant"))
+            val context = "containing ${record.getString("zone")} ${record.getLong("instant")} — $note"
+            assertEquals(context, record.getLong("start"), helper.startOfDay(at).epochSecond)
+        }
+
+        val keys = oracle.getJSONArray("dayKeys")
+        assertEquals("oracle section dayKeys", 11, keys.length())
+        for (i in 0 until keys.length()) {
+            val record = keys.getJSONObject(i)
+            val helper = windows(record.getString("zone"))
+            val at = instant(record.getLong("instant"))
+            val context = "key ${record.getString("zone")} ${record.getLong("instant")} — $note"
+            assertEquals(context, record.getString("key"), helper.dayKey(at))
+        }
+
+        val runs = oracle.getJSONArray("runs")
+        assertEquals("oracle section runs", 4, runs.length())
+        for (i in 0 until runs.length()) {
+            val record = runs.getJSONObject(i)
+            val helper = windows(record.getString("zone"))
+            val anchor = date(record.getString("endingAt"))
+            val requested = record.getInt("requested")
+            val context = "run ${record.getString("zone")} ${anchor.key}/$requested — $note"
+            val run = helper.backwardRun(endingAt = anchor, count = requested)
+            assertEquals(context, record.getInt("size"), run.size)
+            for ((edge, entry) in listOf("oldest" to run.firstOrNull(), "newest" to run.lastOrNull())) {
+                val expected = record.getJSONObject(edge)
+                assertNotNull("$edge $context", entry)
+                assertEquals("$edge $context", expected.getString("date"), entry!!.date.key)
+                assertEquals("$edge $context", expected.getLong("start"), entry.start.epochSecond)
+            }
+            // Short runs carry every entry; the 4000-day run carries its edges and its size only, so that
+            // the committed file stays reviewable, and says so in `daysTruncated`.
+            val days = record.getJSONArray("days")
+            if (record.getBoolean("daysTruncated")) {
+                assertEquals(context, 0, days.length())
+            } else {
+                assertEquals(context, run.size, days.length())
+                for (d in 0 until days.length()) {
+                    val expected = days.getJSONObject(d)
+                    assertEquals(context, expected.getString("date"), run[d].date.key)
+                    assertEquals(context, expected.getLong("start"), run[d].start.epochSecond)
+                }
+            }
+        }
+
+        val sleepEnds = oracle.getJSONArray("sleepWindowEnds")
+        assertEquals("oracle section sleepWindowEnds", 5, sleepEnds.length())
+        for (i in 0 until sleepEnds.length()) {
+            val record = sleepEnds.getJSONObject(i)
+            val helper = windows(
+                record.getString("zone"),
+                reference = instant(record.getLong("referenceInstant")),
+            )
+            val day = date(record.getString("date"))
+            val context = "sleep end ${record.getString("zone")} ${day.key} — $note"
+            assertEquals(context, optionalEpochSeconds(record, "end"), helper.sleepReadWindowEnd(day)?.epochSecond)
+        }
+    }
+
+    /**
+     * The time-zone database version of the JVM this suite runs on, read from
+     * `java.time.zone.ZoneRulesProvider.getVersions` — the last key of the map for the zone in use, and
+     * `null` where the map is empty or where the read is unavailable at all, so a runner that cannot
+     * make it takes the cannot-observe branch below instead of erroring on a non-defect.
+     */
+    private fun runnerTimeZoneDataVersion(): String? =
+        try {
+            val versions = Class.forName("java.time.zone.ZoneRulesProvider")
+                .getMethod("getVersions", String::class.java)
+                .invoke(null, ZoneId.systemDefault().id) as java.util.NavigableMap<*, *>
+            if (versions.isEmpty()) null else versions.lastKey() as String?
+        } catch (missing: ReflectiveOperationException) {
+            null
+        } catch (unsupported: RuntimeException) {
+            // `ZoneRulesException` for a zone the provider does not know, wrapped or direct.
+            null
+        }
+
+    /**
+     * The mismatch note names the recorded version and the observed one, and says so plainly where the
+     * platform has no version of its own to report.
+     *
+     * The observed version is read but never gated on (D6): the fixtures are past and stable, so a
+     * routine runner-image bump must not redden unrelated work.
+     */
+    @Test
+    fun testMismatchNoteNamesBothDatabaseVersions() {
+        val observed = LocalDayWindows.timeZoneDataVersionNote(recorded = "2025b", observed = "2025a")
+        assertEquals(
+            "time-zone database version: the oracle records 2025b; this platform observes 2025a.",
+            observed,
+        )
+
+        val blind = LocalDayWindows.timeZoneDataVersionNote(recorded = "unavailable", observed = null)
+        assertEquals(
+            "time-zone database version: the oracle records unavailable; " +
+                "this platform cannot observe its own time-zone database version.",
+            blind,
+        )
+        assertTrue(blind.contains("cannot observe"))
+        assertTrue(blind.contains("unavailable"))
+
+        // What this JVM reports about itself goes into the note verbatim, whichever branch it takes. The
+        // runner's own version is read here independently, and by reflection for the same reason the
+        // implementation uses it: `java.time.zone.ZoneRulesProvider` is not on the SDK compile
+        // classpath this test source is built against, although the JVM the test runs on has it. What a
+        // device returns is unverified here and belongs to A2's device counter-check; where the read
+        // cannot be made at all, the `null` branch below asserts the D6 cannot-observe wording.
+        val version = runnerTimeZoneDataVersion()
+        assertEquals(version, LocalDayWindows.observedTimeZoneDataVersion)
+        val live = LocalDayWindows.timeZoneDataVersionNote(recorded = "unavailable", observed = version)
+        if (version == null) {
+            assertTrue(live.contains("cannot observe its own time-zone database version"))
+        } else {
+            assertFalse(version.isEmpty())
+            assertTrue(live.contains("observes $version"))
+            assertEquals(
+                "time-zone database version: the oracle records unavailable; this platform observes $version.",
+                live,
+            )
+        }
+    }
+
+    private companion object {
+
+        /** The oracle file package 1 committed under the Android test resources. */
+        const val ORACLE_RESOURCE = "local_day_windows_oracle.json"
+    }
+}

--- a/android/app/src/test/resources/local_day_windows_oracle.json
+++ b/android/app/src/test/resources/local_day_windows_oracle.json
@@ -1,0 +1,81 @@
+{
+  "note": "Produced by compiling Packages/StrandAnalytics/Sources/StrandAnalytics/LocalDayWindows.swift standalone. Dates are YYYY-MM-DD, instants are whole seconds since the epoch, offsets are seconds east of UTC.",
+  "producedBy": {"toolchain": "Swift version 6.0.3 (swift-6.0.3-RELEASE)", "timeZoneDataVersion": "unavailable"},
+  "starts": [
+    {"zone": "America/New_York", "date": "2025-02-23", "start": 1740286800},
+    {"zone": "America/New_York", "date": "2025-03-09", "start": 1741496400},
+    {"zone": "America/New_York", "date": "2025-10-19", "start": 1760846400},
+    {"zone": "America/New_York", "date": "2025-11-01", "start": 1761969600},
+    {"zone": "America/New_York", "date": "2025-11-02", "start": 1762056000},
+    {"zone": "America/New_York", "date": "2025-11-03", "start": 1762146000},
+    {"zone": "America/New_York", "date": "2025-11-10", "start": 1762750800},
+    {"zone": "America/New_York", "date": "2014-11-29", "start": 1417237200},
+    {"zone": "America/Santiago", "date": "2025-08-24", "start": 1756008000},
+    {"zone": "America/Santiago", "date": "2025-09-07", "start": 1757217600},
+    {"zone": "America/Havana", "date": "2025-10-19", "start": 1760846400},
+    {"zone": "America/Havana", "date": "2025-11-02", "start": 1762056000},
+    {"zone": "Pacific/Apia", "date": "2011-12-16", "start": 1324029600},
+    {"zone": "Pacific/Apia", "date": "2011-12-29", "start": 1325152800},
+    {"zone": "Pacific/Apia", "date": "2011-12-30", "start": null},
+    {"zone": "Pacific/Apia", "date": "2011-12-31", "start": 1325239200},
+    {"zone": "Pacific/Apia", "date": "2012-01-02", "start": 1325412000},
+    {"zone": "Asia/Kolkata", "date": "2025-06-15", "start": 1749925800},
+    {"zone": "Asia/Kathmandu", "date": "2025-06-15", "start": 1749924900}
+  ],
+  "windows": [
+    {"zone": "America/New_York", "date": "2025-02-23", "start": 1740286800, "nextStart": 1740373200, "utcOffsetSeconds": -18000, "durationSeconds": 86400},
+    {"zone": "America/New_York", "date": "2025-03-09", "start": 1741496400, "nextStart": 1741579200, "utcOffsetSeconds": -18000, "durationSeconds": 82800},
+    {"zone": "America/New_York", "date": "2025-10-19", "start": 1760846400, "nextStart": 1760932800, "utcOffsetSeconds": -14400, "durationSeconds": 86400},
+    {"zone": "America/New_York", "date": "2025-11-01", "start": 1761969600, "nextStart": 1762056000, "utcOffsetSeconds": -14400, "durationSeconds": 86400},
+    {"zone": "America/New_York", "date": "2025-11-02", "start": 1762056000, "nextStart": 1762146000, "utcOffsetSeconds": -14400, "durationSeconds": 90000},
+    {"zone": "America/New_York", "date": "2025-11-03", "start": 1762146000, "nextStart": 1762232400, "utcOffsetSeconds": -18000, "durationSeconds": 86400},
+    {"zone": "America/New_York", "date": "2025-11-10", "start": 1762750800, "nextStart": 1762837200, "utcOffsetSeconds": -18000, "durationSeconds": 86400},
+    {"zone": "America/New_York", "date": "2014-11-29", "start": 1417237200, "nextStart": 1417323600, "utcOffsetSeconds": -18000, "durationSeconds": 86400},
+    {"zone": "America/Santiago", "date": "2025-08-24", "start": 1756008000, "nextStart": 1756094400, "utcOffsetSeconds": -14400, "durationSeconds": 86400},
+    {"zone": "America/Santiago", "date": "2025-09-07", "start": 1757217600, "nextStart": 1757300400, "utcOffsetSeconds": -10800, "durationSeconds": 82800},
+    {"zone": "America/Havana", "date": "2025-10-19", "start": 1760846400, "nextStart": 1760932800, "utcOffsetSeconds": -14400, "durationSeconds": 86400},
+    {"zone": "America/Havana", "date": "2025-11-02", "start": 1762056000, "nextStart": 1762146000, "utcOffsetSeconds": -14400, "durationSeconds": 90000},
+    {"zone": "Pacific/Apia", "date": "2011-12-16", "start": 1324029600, "nextStart": 1324116000, "utcOffsetSeconds": -36000, "durationSeconds": 86400},
+    {"zone": "Pacific/Apia", "date": "2011-12-29", "start": 1325152800, "nextStart": 1325239200, "utcOffsetSeconds": -36000, "durationSeconds": 86400},
+    {"zone": "Pacific/Apia", "date": "2011-12-31", "start": 1325239200, "nextStart": 1325325600, "utcOffsetSeconds": 50400, "durationSeconds": 86400},
+    {"zone": "Pacific/Apia", "date": "2012-01-02", "start": 1325412000, "nextStart": 1325498400, "utcOffsetSeconds": 50400, "durationSeconds": 86400},
+    {"zone": "Asia/Kolkata", "date": "2025-06-15", "start": 1749925800, "nextStart": 1750012200, "utcOffsetSeconds": 19800, "durationSeconds": 86400},
+    {"zone": "Asia/Kathmandu", "date": "2025-06-15", "start": 1749924900, "nextStart": 1750011300, "utcOffsetSeconds": 20700, "durationSeconds": 86400}
+  ],
+  "containingDayStarts": [
+    {"zone": "America/New_York", "instant": 1762061400, "start": 1762056000},
+    {"zone": "America/New_York", "instant": 1762106400, "start": 1762056000},
+    {"zone": "America/New_York", "instant": 1741521600, "start": 1741496400},
+    {"zone": "America/Santiago", "instant": 1757246400, "start": 1757217600},
+    {"zone": "America/Havana", "instant": 1762057800, "start": 1762056000},
+    {"zone": "America/Havana", "instant": 1762061400, "start": 1762056000},
+    {"zone": "Pacific/Apia", "instant": 1325246400, "start": 1325239200},
+    {"zone": "Asia/Kathmandu", "instant": 1749945600, "start": 1749924900}
+  ],
+  "dayKeys": [
+    {"zone": "America/New_York", "instant": 1762055999, "key": "2025-11-01"},
+    {"zone": "America/New_York", "instant": 1762056000, "key": "2025-11-02"},
+    {"zone": "America/New_York", "instant": 1762056001, "key": "2025-11-02"},
+    {"zone": "America/New_York", "instant": 1762061400, "key": "2025-11-02"},
+    {"zone": "America/New_York", "instant": 1762145999, "key": "2025-11-02"},
+    {"zone": "America/New_York", "instant": 1762146000, "key": "2025-11-03"},
+    {"zone": "America/Santiago", "instant": 1757217600, "key": "2025-09-07"},
+    {"zone": "America/Havana", "instant": 1762056000, "key": "2025-11-02"},
+    {"zone": "Pacific/Apia", "instant": 1325239199, "key": "2011-12-29"},
+    {"zone": "Pacific/Apia", "instant": 1325239200, "key": "2011-12-31"},
+    {"zone": "Asia/Kathmandu", "instant": 1749924900, "key": "2025-06-15"}
+  ],
+  "runs": [
+    {"zone": "America/New_York", "endingAt": "2025-11-10", "requested": 21, "size": 21, "oldest": {"date": "2025-10-21", "start": 1761019200}, "newest": {"date": "2025-11-10", "start": 1762750800}, "daysTruncated": false, "days": [{"date": "2025-10-21", "start": 1761019200}, {"date": "2025-10-22", "start": 1761105600}, {"date": "2025-10-23", "start": 1761192000}, {"date": "2025-10-24", "start": 1761278400}, {"date": "2025-10-25", "start": 1761364800}, {"date": "2025-10-26", "start": 1761451200}, {"date": "2025-10-27", "start": 1761537600}, {"date": "2025-10-28", "start": 1761624000}, {"date": "2025-10-29", "start": 1761710400}, {"date": "2025-10-30", "start": 1761796800}, {"date": "2025-10-31", "start": 1761883200}, {"date": "2025-11-01", "start": 1761969600}, {"date": "2025-11-02", "start": 1762056000}, {"date": "2025-11-03", "start": 1762146000}, {"date": "2025-11-04", "start": 1762232400}, {"date": "2025-11-05", "start": 1762318800}, {"date": "2025-11-06", "start": 1762405200}, {"date": "2025-11-07", "start": 1762491600}, {"date": "2025-11-08", "start": 1762578000}, {"date": "2025-11-09", "start": 1762664400}, {"date": "2025-11-10", "start": 1762750800}]},
+    {"zone": "America/New_York", "endingAt": "2025-11-10", "requested": 4000, "size": 4000, "oldest": {"date": "2014-11-29", "start": 1417237200}, "newest": {"date": "2025-11-10", "start": 1762750800}, "daysTruncated": true, "days": []},
+    {"zone": "Pacific/Apia", "endingAt": "2012-01-02", "requested": 5, "size": 4, "oldest": {"date": "2011-12-29", "start": 1325152800}, "newest": {"date": "2012-01-02", "start": 1325412000}, "daysTruncated": false, "days": [{"date": "2011-12-29", "start": 1325152800}, {"date": "2011-12-31", "start": 1325239200}, {"date": "2012-01-01", "start": 1325325600}, {"date": "2012-01-02", "start": 1325412000}]},
+    {"zone": "Pacific/Apia", "endingAt": "2011-12-30", "requested": 3, "size": 2, "oldest": {"date": "2011-12-28", "start": 1325066400}, "newest": {"date": "2011-12-29", "start": 1325152800}, "daysTruncated": false, "days": [{"date": "2011-12-28", "start": 1325066400}, {"date": "2011-12-29", "start": 1325152800}]}
+  ],
+  "sleepWindowEnds": [
+    {"zone": "America/New_York", "date": "2025-11-02", "referenceInstant": 1762106400, "end": 1762106400},
+    {"zone": "America/New_York", "date": "2025-11-02", "referenceInstant": 1765800000, "end": 1762146000},
+    {"zone": "America/New_York", "date": "2025-11-10", "referenceInstant": 1762794000, "end": 1762794000},
+    {"zone": "America/New_York", "date": "2025-10-19", "referenceInstant": 1760529600, "end": 1760529600},
+    {"zone": "Pacific/Apia", "date": "2011-12-29", "referenceInstant": 1765800000, "end": 1325239200}
+  ]
+}


### PR DESCRIPTION
Foundation for a DST-correct day boundary, with no caller changed. The analysis core turns a timestamp into a local day by adding fixed 86 400-second blocks to a midnight derived from one UTC offset captured per scoring run; on the far side of a clock change every day boundary sits an hour away from the local midnight it claims to be. There was no shared, tested primitive that answers "when does this local date start and end in this zone". This PR adds that primitive and nothing else.

**What it adds.** `LocalDayWindows` in `StrandAnalytics` and its Kotlin twin in `com.noop.analytics`: the start instant of a local date from the zone's rules; the half-open window `[start, nextStart)` carrying the offset in effect at its start (23, 24 or 25 h, or the span to the next existing date where a zone skipped one); the start of the local day containing an instant; the day key of an instant; a backward run of up to N existing dates; and the sleep read window end with the existing clamp to "now". Skipped, repeated and non-existent local midnights follow one stated rule on both sides (first existing instant / earlier of the two / no start), implemented explicitly against the offset lookup rather than inherited from `Calendar` or `ZonedDateTime`. Zone and reference instant are injectable with named defaults. Epoch arithmetic is 64-bit on the Swift side too, so the arm64_32 watch target cannot trap past 2038.

**Parity.** One committed oracle (`android/app/src/test/resources/local_day_windows_oracle.json`), produced by compiling the Swift helper standalone, is asserted verbatim by both suites, which fail rather than skip when it is absent and pin the size of every oracle section. 25 Swift and 25 Kotlin tests, one per documented behaviour; the discriminating case pins both the helper's `2025-10-19T04:00:00Z` and the core's fixed-offset `05:00:00Z` for America/New_York. Fixtures are past and stable: New York 2025 (23 h / 25 h days), America/Santiago 2025-09-07 (no local 00:00), America/Havana 2025-11-02 (two local 00:00), Pacific/Apia 2011-12-30 (skipped date), Asia/Kolkata and Asia/Kathmandu. The oracle records the producing toolchain and time-zone database version; a version difference is named on a value mismatch but never gates. Both new tests run in default CI (`swift-packages`, `android`, `source-hygiene`).

**Documented at the declarations:** the probe assumes at most one offset change within two days of a local midnight (no zone in the database violates that); the default zone is bound when the helper is constructed; the sleep read window of a date after "now" is empty and inverted by the existing clamp rule. Not in this PR: a pre-epoch fixture (the floor-division branch is hand-checked identical on both sides).

**Limits.** Linux host, no Xcode: the oracle was produced with Swift 6.0.3 on Linux, so its recorded `timeZoneDataVersion` is the literal `unavailable`; the macOS `swift-packages` run is the first time it meets a Darwin database (past fixtures, so a disagreement would be a real finding). App targets not built here. The helper proves the two build hosts agree, not two devices; a device counter-check belongs to the switch-over that will call it.
