### PR TITLE
hrv: withhold RMSSD on a night whose R-R over-counts

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -424,11 +424,47 @@ public enum HRVAnalyzer {
     /// arriving in real time, carrying no timestamps to measure coverage with — and suppressing those
     /// would refuse honest readings, the opposite of the point.
     ///
-    /// Successive-difference statistics (RMSSD, pNN50) are deliberately NOT gated here. Their dominant
-    /// error on a banked stream was the lost within-second emission order (#823, root-caused in #1072),
-    /// which is fixed at the write path; whether they need a gate of their own is a question for a
-    /// post-fix capture to answer, not an assumption to bake in now.
+    /// Successive-difference statistics (RMSSD, pNN50) are not gated HERE, but they are no longer ungated:
+    /// see `successiveDiffIsTrustworthy` below. The question this comment used to leave open, whether they
+    /// need a gate of their own, was one for a post-fix capture to answer. That capture has since arrived
+    /// and answered it yes.
     public static func beatSpreadIsTrustworthy(_ verdict: RrCoverageVerdict) -> Bool {
+        switch verdict {
+        case .sameSecondOverCount, .crossSecondOverCount:
+            return false
+        case .plausible, .underCovered, .unmeasurable:
+            return true
+        }
+    }
+
+    /// Whether RMSSD / pNN50 can be trusted from a window with this coverage verdict (#1118).
+    ///
+    /// The sibling of `beatSpreadIsTrustworthy`, and the same two verdicts refuse, but for its own reason
+    /// rather than by borrowing that one's. SDNN is a spread over every interval, so a duplicated beat
+    /// widens it. Successive-difference statistics fail the other way: a beat the heart never produced
+    /// sits next to its neighbour with a near-zero difference, and RMSSD is the root mean square of
+    /// exactly those differences, so an over-counted night reads LOW. Measured on a WHOOP 4.0 night whose
+    /// banked R-R covers 2.13× the wall clock it spans, RMSSD reads 36 ms where the same night's beats
+    /// collapsed read 41 ms; the direction of the error is not obvious from the number, which is precisely
+    /// why it cannot be shown.
+    ///
+    /// The comment on `beatSpreadIsTrustworthy` used to say these were deliberately ungated because their
+    /// dominant error was the lost within-second emission order fixed at the write path (#823 / #1072),
+    /// and that whether they needed a gate of their own was for a post-fix capture to answer. The capture
+    /// arrived: a build carrying that fix, on a WHOOP 4.0, still reports `crossSecondOverCount` on every
+    /// measured night, with 91% of the inflating beat-time on seconds written by more than one delivery.
+    /// The write-path fix did not make the stream clean, so the assumption it licensed no longer holds.
+    ///
+    /// WITHHOLD, DO NOT FABRICATE. This trades a wrong number for a blank on every affected night, which
+    /// is a real cost: HRV is the dominant Charge driver, so a gated night drops that term and renormalises
+    /// the rest. That cost is accepted deliberately. A contaminated RMSSD does not merely display wrong, it
+    /// enters the personal baseline the following nights are scored against, so showing it spreads the
+    /// error into days whose own capture was clean.
+    ///
+    /// `underCovered` and `unmeasurable` stay trusted for the same reason they do above: neither duplicates
+    /// a beat, and `unmeasurable` is what an honest live spot reading looks like. Pure. Byte-parity twin of
+    /// Kotlin `successiveDiffIsTrustworthy`.
+    public static func successiveDiffIsTrustworthy(_ verdict: RrCoverageVerdict) -> Bool {
         switch verdict {
         case .sameSecondOverCount, .crossSecondOverCount:
             return false

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -462,6 +462,15 @@ public enum HRVAnalyzer {
     /// enters the personal baseline the following nights are scored against, so showing it spreads the
     /// error into days whose own capture was clean.
     ///
+    /// THE COST REACHES FURTHER THAN THE CARD, and a reader should know it before widening this rule.
+    /// `Baselines.update` holds on a nil night without advancing `nValid`, so on an install whose EVERY
+    /// night gates, the HRV baseline never reaches `Baselines.minNightsSeed` and stays calibrating
+    /// indefinitely. That is the WHOOP 4.0-only case exactly. It is still the right answer, because the
+    /// alternative is seeding a personal baseline from beats the heart did not produce and scoring every
+    /// later night against it, but it means this gate can leave a strap with no HRV baseline at all rather
+    /// than merely a gap in one. A mixed install is unaffected: its clean nights seed the baseline and the
+    /// gated ones skip-and-hold.
+    ///
     /// `underCovered` and `unmeasurable` stay trusted for the same reason they do above: neither duplicates
     /// a beat, and `unmeasurable` is what an honest live spot reading looks like. Pure. Byte-parity twin of
     /// Kotlin `successiveDiffIsTrustworthy`.

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/HRVAnalyzer.swift
@@ -424,10 +424,11 @@ public enum HRVAnalyzer {
     /// arriving in real time, carrying no timestamps to measure coverage with — and suppressing those
     /// would refuse honest readings, the opposite of the point.
     ///
-    /// Successive-difference statistics (RMSSD, pNN50) are not gated HERE, but they are no longer ungated:
-    /// see `successiveDiffIsTrustworthy` below. The question this comment used to leave open, whether they
-    /// need a gate of their own, was one for a post-fix capture to answer. That capture has since arrived
-    /// and answered it yes.
+    /// Successive-difference statistics (RMSSD, pNN50) are not gated HERE, but they are no longer ungated
+    /// by COVERAGE: see `successiveDiffIsTrustworthy` below. The question this comment left open was one for
+    /// a post-fix capture to answer; that capture arrived and answered it yes. Note it answered THIS
+    /// question only. The sibling deferral on `beatValuesAreTrustworthy`, about beat-to-beat accuracy, is
+    /// still open and still waiting on a capture of its own.
     public static func beatSpreadIsTrustworthy(_ verdict: RrCoverageVerdict) -> Bool {
         switch verdict {
         case .sameSecondOverCount, .crossSecondOverCount:
@@ -535,8 +536,12 @@ public enum HRVAnalyzer {
     /// median, so no per-beat artifact rule can see the fault — it is in the decomposition, not in
     /// outliers.
     ///
-    /// Successive-difference statistics (RMSSD, pNN50) are deliberately NOT gated here, for the same
-    /// reason they are not gated by the coverage verdict: that is a question for a capture to answer.
+    /// Successive-difference statistics (RMSSD, pNN50) are deliberately NOT gated here. They ARE now gated
+    /// on the coverage verdict (`successiveDiffIsTrustworthy`), but that is a different fault and a
+    /// different population, and the capture that justified it says nothing about this one. Gating here
+    /// would sweep in the very night described above: coverage 1.03, verdict plausible, and untrustworthy
+    /// only in its decomposition. Refusing those needs its own capture, and inventing one from a WHOOP 4.0
+    /// over-count would be exactly the assumption the paragraph above refused to bake in.
     public static func beatValuesAreTrustworthy(beatAccurateFraction: Double) -> Bool {
         // Negated `<` so a NaN input lands on `true` — NaN means "not measured", and an unmeasured
         // window must not be silently refused. Matches the NaN convention in `classifyCoverage`.

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -2816,9 +2816,16 @@ public enum SleepStager {
         let seg = rr.filter { $0.ts >= start && $0.ts <= end }
         let segTs = seg.map { $0.ts }
         let segMs = seg.map { Double($0.rrMs) }
-        let verdict = HRVAnalyzer.classifyCoverage(
-            coverage: HRVAnalyzer.rrCoverage(tsSec: segTs, rrMs: segMs),
-            collapsed: HRVAnalyzer.collapsedCoverage(tsSec: segTs, rrMs: segMs))
+        let coverage = HRVAnalyzer.rrCoverage(tsSec: segTs, rrMs: segMs)
+        // `collapsed` is deliberately the SAME figure as `coverage`, which pins every over-count here to
+        // crossSecondOverCount. That is not a claim about which kind it is. The collapsed figure exists only
+        // to choose BETWEEN the two over-count verdicts, and this gate refuses both, so the real one would
+        // change no outcome — while costing a full sort of the night's ~50-70k beats, since
+        // `collapsedCoverage` opens with a sort. This runs per session, per day, across ~21 days of every
+        // analyzeRecent, every 15 minutes; #1510 cut this exact path from six sorts a night to two, and
+        // buying a distinction the caller discards would hand that back. `rrCoverage` is a single O(n)
+        // pass. If a future gate ever needs the two over-count cases apart, compute it then.
+        let verdict = HRVAnalyzer.classifyCoverage(coverage: coverage, collapsed: coverage)
         guard HRVAnalyzer.successiveDiffIsTrustworthy(verdict) else { return nil }
         return vals.reduce(0, +) / Double(vals.count)
     }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -2802,7 +2802,25 @@ public enum SleepStager {
     /// Uses the same range-filter + ≥2-valid-interval rule as hrv.rmssd().
     static func sessionAvgHRV(start: Int, end: Int, rr: [RRInterval]) -> Double? {
         let vals = sessionHrvWindows(start: start, end: end, rr: rr, stages: []).compactMap { $0.rmssd }
-        return vals.isEmpty ? nil : vals.reduce(0, +) / Double(vals.count)
+        if vals.isEmpty { return nil }
+        // #1118: refuse the night outright when its own R-R banks more beat-time than the wall clock it
+        // spans. Gated HERE rather than at the caller because this is where RMSSD BECOMES the day's HRV:
+        // one seam covers the daily row, the sleep-session cache, the Health card and the baseline that
+        // later nights are scored against, so none of them can end up disagreeing about whether the night
+        // was trustworthy. See `HRVAnalyzer.successiveDiffIsTrustworthy` for why an over-count corrupts a
+        // successive-difference statistic and why a blank is the right answer.
+        //
+        // Classified over the SAME beats the value was built from, windowed [start, end] exactly as
+        // `sessionHrvWindows` does, so the verdict cannot describe a different set of beats than the number
+        // it is gating.
+        let seg = rr.filter { $0.ts >= start && $0.ts <= end }
+        let segTs = seg.map { $0.ts }
+        let segMs = seg.map { Double($0.rrMs) }
+        let verdict = HRVAnalyzer.classifyCoverage(
+            coverage: HRVAnalyzer.rrCoverage(tsSec: segTs, rrMs: segMs),
+            collapsed: HRVAnalyzer.collapsedCoverage(tsSec: segTs, rrMs: segMs))
+        guard HRVAnalyzer.successiveDiffIsTrustworthy(verdict) else { return nil }
+        return vals.reduce(0, +) / Double(vals.count)
     }
 
     /// Per-5-min-window RMSSD across a session, each window tagged with the sleep stage at its CENTER

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrvOverCountGateTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrvOverCountGateTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+import WhoopProtocol
+@testable import StrandAnalytics
+
+/// #1118: RMSSD is withheld on a night whose own R-R banks more beat-time than the wall clock it spans.
+///
+/// Each over-count case asserts TWICE: that the gated call returns nil, AND that the very same beats do
+/// produce an RMSSD through `sessionHrvWindows`. Without that second assertion the test would pass just as
+/// well against a window that had no usable beats at all, proving nothing about the gate.
+/// Byte-parity twin of Kotlin `HrvOverCountGateTest`.
+final class HrvOverCountGateTests: XCTestCase {
+
+    private func windowsYieldRMSSD(_ start: Int, _ end: Int, _ rr: [RRInterval]) -> Bool {
+        !SleepStager.sessionHrvWindows(start: start, end: end, rr: rr, stages: []).compactMap { $0.rmssd }.isEmpty
+    }
+
+    /// Two near-equal beats per second: ~1.8x coverage that a same-second collapse would fix.
+    func testSameSecondOverCountIsWithheld() {
+        let start = 1_000, end = 1_600
+        var rr: [RRInterval] = []
+        for i in 0..<600 {
+            rr.append(RRInterval(ts: start + i, rrMs: 900))
+            rr.append(RRInterval(ts: start + i, rrMs: 905))
+        }
+        XCTAssertTrue(windowsYieldRMSSD(start, end, rr), "precondition: these beats DO yield an RMSSD")
+        XCTAssertNil(SleepStager.sessionAvgHRV(start: start, end: end, rr: rr),
+                     "an over-counted night must report no HRV")
+    }
+
+    /// Two beats per second far enough apart that a same-second collapse cannot reach them.
+    func testCrossSecondOverCountIsWithheld() {
+        let start = 1_000, end = 1_600
+        var rr: [RRInterval] = []
+        for i in 0..<600 {
+            rr.append(RRInterval(ts: start + i, rrMs: 880))
+            rr.append(RRInterval(ts: start + i, rrMs: 960))
+        }
+        XCTAssertTrue(windowsYieldRMSSD(start, end, rr), "precondition: these beats DO yield an RMSSD")
+        XCTAssertNil(SleepStager.sessionAvgHRV(start: start, end: end, rr: rr),
+                     "an over-counted night must report no HRV")
+    }
+
+    /// The gate must not touch an ordinary night: one beat per second, coverage ~1.0.
+    func testAPlausibleNightStillReportsItsHRV() {
+        let start = 1_000, end = 1_600
+        let rr = (0..<600).map { RRInterval(ts: start + $0, rrMs: $0 % 2 == 0 ? 980 : 1_020) }
+        let hrv = SleepStager.sessionAvgHRV(start: start, end: end, rr: rr)
+        XCTAssertNotNil(hrv, "a plausible night must keep its HRV")
+        XCTAssertGreaterThan(hrv ?? 0, 0, "and it must be a real reading, not zero")
+    }
+
+    /// A sparse night is underCovered, which is honest data and stays trusted.
+    func testAnUnderCoveredNightIsNotGated() {
+        let start = 1_000, end = 1_600
+        let rr = (0..<300).map { RRInterval(ts: start + $0 * 2, rrMs: $0 % 2 == 0 ? 980 : 1_020) }
+        XCTAssertNotNil(SleepStager.sessionAvgHRV(start: start, end: end, rr: rr),
+                        "sparse is not the same as over-counted")
+    }
+
+    /// The verdict mapping itself, so the seam above and the rule stay pinned separately.
+    func testOnlyTheTwoOverCountVerdictsRefuse() {
+        XCTAssertFalse(HRVAnalyzer.successiveDiffIsTrustworthy(.sameSecondOverCount))
+        XCTAssertFalse(HRVAnalyzer.successiveDiffIsTrustworthy(.crossSecondOverCount))
+        XCTAssertTrue(HRVAnalyzer.successiveDiffIsTrustworthy(.plausible))
+        XCTAssertTrue(HRVAnalyzer.successiveDiffIsTrustworthy(.underCovered))
+        XCTAssertTrue(HRVAnalyzer.successiveDiffIsTrustworthy(.unmeasurable))
+    }
+
+    /// It refuses exactly what the SDNN gate refuses: same rule, stated twice on purpose, never drifting.
+    func testItRefusesTheSameVerdictsAsTheSdnnGate() {
+        let all: [HRVAnalyzer.RrCoverageVerdict] =
+            [.plausible, .underCovered, .sameSecondOverCount, .crossSecondOverCount, .unmeasurable]
+        for v in all {
+            XCTAssertEqual(HRVAnalyzer.beatSpreadIsTrustworthy(v),
+                           HRVAnalyzer.successiveDiffIsTrustworthy(v),
+                           "verdict \(v) must be judged alike by both gates")
+        }
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrvOverCountGateTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/HrvOverCountGateTests.swift
@@ -14,7 +14,11 @@ final class HrvOverCountGateTests: XCTestCase {
         !SleepStager.sessionHrvWindows(start: start, end: end, rr: rr, stages: []).compactMap { $0.rmssd }.isEmpty
     }
 
-    /// Two near-equal beats per second: ~1.8x coverage that a same-second collapse would fix.
+    /// Two near-equal beats per second: the shape a same-second collapse WOULD bring back under the
+    /// ceiling. It must still be withheld, and this is the case that guards the gate's cheap
+    /// classification — `sessionAvgHRV` passes coverage as its own collapsed figure to avoid a sort, so a
+    /// night of this shape reports `crossSecondOverCount` internally. The outcome is what matters and is
+    /// asserted here; restoring the real collapsed figure would relabel this night and change nothing.
     func testSameSecondOverCountIsWithheld() {
         let start = 1_000, end = 1_600
         var rr: [RRInterval] = []

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1362,9 +1362,12 @@ final class IntelligenceEngine: ObservableObject {
                     // covers 1.25x its wall-clock reads ~197 ms across a sleeping night, against a 40-100 ms
                     // physiological range. Printing that number beside the verdict that says it cannot be
                     // trusted invites it to be read as a measurement, so it is withheld instead; the
-                    // `rrIntegrity=` field on the same line says why. RMSSD/meanNN are NOT withheld — mean
-                    // rate survives an over-count, and RMSSD's dominant error was the emission order fixed
-                    // at the write path (#1072).
+                    // `rrIntegrity=` field on the same line says why. meanNN is NOT withheld: mean rate
+                    // survives an over-count. RMSSD is not withheld FROM THIS LINE either, but it no longer
+                    // reaches the card, the daily row or the baseline on an over-counted night — the gate
+                    // that stops it lives in `SleepStager.sessionAvgHRV` (#1118). Printing the computed
+                    // value here while the app refused to use it is a known wart, held back to keep this
+                    // line byte-identical to the Kotlin twin, whose method budget has no room for it.
                     // P7' follow-up: the over-count verdict is necessary but NOT sufficient. The
                     // 2026-08-06 Oura night measured coverage 1.03 / `plausible` — no duplication at
                     // all, its records tiling the timeline at a fill ratio of 0.990 — and still printed

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -442,6 +442,15 @@ object HrvAnalyzer {
      * enters the personal baseline the following nights are scored against, so showing it spreads the
      * error into days whose own capture was clean.
      *
+     * THE COST REACHES FURTHER THAN THE CARD, and a reader should know it before widening this rule.
+     * [Baselines.update] holds on a null night without advancing `nValid`, so on an install whose EVERY
+     * night gates, the HRV baseline never reaches [Baselines.minNightsSeed] and stays CALIBRATING
+     * indefinitely. That is the WHOOP 4.0-only case exactly. It is still the right answer, because the
+     * alternative is seeding a personal baseline from beats the heart did not produce and scoring every
+     * later night against it, but it means this gate can leave a strap with no HRV baseline at all rather
+     * than merely a gap in one. A mixed install is unaffected: its clean nights seed the baseline and the
+     * gated ones skip-and-hold.
+     *
      * UNDER_COVERED and UNMEASURABLE stay trusted for the same reason they do above: neither duplicates a
      * beat, and UNMEASURABLE is what an honest live spot reading looks like. Pure. Byte-parity twin of
      * Swift `successiveDiffIsTrustworthy`.

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -405,12 +405,47 @@ object HrvAnalyzer {
      * arriving in real time, carrying no timestamps to measure coverage with — and suppressing those
      * would refuse honest readings, the opposite of the point.
      *
-     * Successive-difference statistics (RMSSD, pNN50) are deliberately NOT gated here. Their dominant
-     * error on a banked stream was the lost within-second emission order (#823, root-caused in #1072),
-     * which is fixed at the write path; whether they need a gate of their own is a question for a
-     * post-fix capture to answer, not an assumption to bake in now.
+     * Successive-difference statistics (RMSSD, pNN50) are not gated HERE, but they are no longer ungated:
+     * see [successiveDiffIsTrustworthy] below. The question this comment used to leave open, whether they
+     * need a gate of their own, was one for a post-fix capture to answer. That capture has since arrived
+     * and answered it yes.
      */
     fun beatSpreadIsTrustworthy(verdict: RrCoverageVerdict): Boolean = when (verdict) {
+        RrCoverageVerdict.SAME_SECOND_OVER_COUNT, RrCoverageVerdict.CROSS_SECOND_OVER_COUNT -> false
+        RrCoverageVerdict.PLAUSIBLE, RrCoverageVerdict.UNDER_COVERED,
+        RrCoverageVerdict.UNMEASURABLE -> true
+    }
+
+    /**
+     * Whether RMSSD / pNN50 can be trusted from a window with this coverage verdict (#1118).
+     *
+     * The sibling of [beatSpreadIsTrustworthy], and the same two verdicts refuse, but for its own reason
+     * rather than by borrowing that one's. SDNN is a spread over every interval, so a duplicated beat
+     * widens it. Successive-difference statistics fail the other way: a beat the heart never produced
+     * sits next to its neighbour with a near-zero difference, and RMSSD is the root mean square of
+     * exactly those differences, so an over-counted night reads LOW. Measured on a WHOOP 4.0 night whose
+     * banked R-R covers 2.13x the wall clock it spans, RMSSD reads 36 ms where the same night's beats
+     * collapsed read 41 ms; the direction of the error is not obvious from the number, which is precisely
+     * why it cannot be shown.
+     *
+     * The comment on [beatSpreadIsTrustworthy] used to say these were deliberately ungated because their
+     * dominant error was the lost within-second emission order fixed at the write path (#823 / #1072),
+     * and that whether they needed a gate of their own was for a post-fix capture to answer. The capture
+     * arrived: a build carrying that fix, on a WHOOP 4.0, still reports `crossSecondOverCount` on every
+     * measured night, with 91% of the inflating beat-time on seconds written by more than one delivery.
+     * The write-path fix did not make the stream clean, so the assumption it licensed no longer holds.
+     *
+     * WITHHOLD, DO NOT FABRICATE. This trades a wrong number for a blank on every affected night, which
+     * is a real cost: HRV is the dominant Charge driver, so a gated night drops that term and renormalises
+     * the rest. That cost is accepted deliberately. A contaminated RMSSD does not merely display wrong, it
+     * enters the personal baseline the following nights are scored against, so showing it spreads the
+     * error into days whose own capture was clean.
+     *
+     * UNDER_COVERED and UNMEASURABLE stay trusted for the same reason they do above: neither duplicates a
+     * beat, and UNMEASURABLE is what an honest live spot reading looks like. Pure. Byte-parity twin of
+     * Swift `successiveDiffIsTrustworthy`.
+     */
+    fun successiveDiffIsTrustworthy(verdict: RrCoverageVerdict): Boolean = when (verdict) {
         RrCoverageVerdict.SAME_SECOND_OVER_COUNT, RrCoverageVerdict.CROSS_SECOND_OVER_COUNT -> false
         RrCoverageVerdict.PLAUSIBLE, RrCoverageVerdict.UNDER_COVERED,
         RrCoverageVerdict.UNMEASURABLE -> true

--- a/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
+++ b/android/app/src/main/java/com/noop/analytics/HrvAnalyzer.kt
@@ -405,10 +405,11 @@ object HrvAnalyzer {
      * arriving in real time, carrying no timestamps to measure coverage with — and suppressing those
      * would refuse honest readings, the opposite of the point.
      *
-     * Successive-difference statistics (RMSSD, pNN50) are not gated HERE, but they are no longer ungated:
-     * see [successiveDiffIsTrustworthy] below. The question this comment used to leave open, whether they
-     * need a gate of their own, was one for a post-fix capture to answer. That capture has since arrived
-     * and answered it yes.
+     * Successive-difference statistics (RMSSD, pNN50) are not gated HERE, but they are no longer ungated
+     * by COVERAGE: see [successiveDiffIsTrustworthy] below. The question this comment left open was one for
+     * a post-fix capture to answer; that capture arrived and answered it yes. Note it answered THIS
+     * question only. The sibling deferral on [beatValuesAreTrustworthy], about beat-to-beat accuracy, is
+     * still open and still waiting on a capture of its own.
      */
     fun beatSpreadIsTrustworthy(verdict: RrCoverageVerdict): Boolean = when (verdict) {
         RrCoverageVerdict.SAME_SECOND_OVER_COUNT, RrCoverageVerdict.CROSS_SECOND_OVER_COUNT -> false
@@ -522,8 +523,12 @@ object HrvAnalyzer {
      * median, so no per-beat artifact rule can see the fault — it is in the decomposition, not in
      * outliers.
      *
-     * Successive-difference statistics (RMSSD, pNN50) are deliberately NOT gated here, for the same
-     * reason they are not gated by the coverage verdict: that is a question for a capture to answer.
+     * Successive-difference statistics (RMSSD, pNN50) are deliberately NOT gated here. They ARE now gated
+     * on the coverage verdict ([successiveDiffIsTrustworthy]), but that is a different fault and a
+     * different population, and the capture that justified it says nothing about this one. Gating here
+     * would sweep in the very night described above: coverage 1.03, verdict PLAUSIBLE, and untrustworthy
+     * only in its decomposition. Refusing those needs its own capture, and inventing one from a WHOOP 4.0
+     * over-count would be exactly the assumption the paragraph above refused to bake in.
      */
     fun beatValuesAreTrustworthy(beatAccurateFraction: Double): Boolean =
         // Negated `<` so a NaN input lands on `true` — NaN means "not measured", and an unmeasured

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1140,9 +1140,13 @@ object IntelligenceEngine {
                 // 1.25x its wall-clock reads ~197 ms across a sleeping night, against a 40-100 ms
                 // physiological range. Printing that number beside the verdict that says it cannot be
                 // trusted invites it to be read as a measurement, so it is withheld instead; the
-                // `rrIntegrity=` field on the same line says why. RMSSD/meanNN are NOT withheld — mean rate
-                // survives an over-count, and RMSSD's dominant error was the emission order fixed at the
-                // write path (#1072). Twin of the Swift line.
+                // `rrIntegrity=` field on the same line says why. meanNN is NOT withheld: mean rate
+                // survives an over-count. RMSSD is not withheld FROM THIS LINE either, but it no longer
+                // reaches the card, the daily row or the baseline on an over-counted night — the gate that
+                // stops it lives in `SleepStager.sessionAvgHRV` (#1118). Printing the computed value here
+                // while the app refused to use it is a known wart: matching SDNN's `withheld` treatment
+                // needs room this method does not have, since its JaCoCo budget is already at the ratchet.
+                // Twin of the Swift line.
                 // P7' follow-up: the over-count verdict is necessary but NOT sufficient. The 2026-08-06
                 // Oura night measured coverage 1.03 / PLAUSIBLE — no duplication at all, its records
                 // tiling the timeline at a fill ratio of 0.990 — and still printed SDNN 174 ms. A BANKED

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -3108,7 +3108,26 @@ object SleepStager {
      */
     internal fun sessionAvgHRV(start: Long, end: Long, rr: List<RrInterval>): Double? {
         val vals = sessionHrvWindows(start, end, rr, emptyList()).mapNotNull { it.rmssd }
-        return if (vals.isEmpty()) null else vals.sum() / vals.size.toDouble()
+        if (vals.isEmpty()) return null
+        // #1118: refuse the night outright when its own R-R banks more beat-time than the wall clock it
+        // spans. Gated HERE rather than at the caller because this is where RMSSD BECOMES the day's HRV:
+        // one seam covers the daily row, the sleep-session cache, the Health card and the baseline that
+        // later nights are scored against, so none of them can end up disagreeing about whether the night
+        // was trustworthy. See [HrvAnalyzer.successiveDiffIsTrustworthy] for why an over-count corrupts a
+        // successive-difference statistic and why a blank is the right answer.
+        //
+        // Classified over the SAME beats the value was built from, windowed [start, end] exactly as
+        // `sessionHrvWindows` does, so the verdict cannot describe a different set of beats than the number
+        // it is gating.
+        val seg = rr.filter { it.ts in start..end }
+        val segTs = seg.map { it.ts }
+        val segMs = seg.map { it.rrMs.toDouble() }
+        val verdict = HrvAnalyzer.classifyCoverage(
+            HrvAnalyzer.rrCoverage(segTs, segMs),
+            HrvAnalyzer.collapsedCoverage(segTs, segMs),
+        )
+        if (!HrvAnalyzer.successiveDiffIsTrustworthy(verdict)) return null
+        return vals.sum() / vals.size.toDouble()
     }
 
     /**

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -3122,10 +3122,16 @@ object SleepStager {
         val seg = rr.filter { it.ts in start..end }
         val segTs = seg.map { it.ts }
         val segMs = seg.map { it.rrMs.toDouble() }
-        val verdict = HrvAnalyzer.classifyCoverage(
-            HrvAnalyzer.rrCoverage(segTs, segMs),
-            HrvAnalyzer.collapsedCoverage(segTs, segMs),
-        )
+        val coverage = HrvAnalyzer.rrCoverage(segTs, segMs)
+        // `collapsed` is deliberately the SAME figure as `coverage`, which pins every over-count here to
+        // CROSS_SECOND. That is not a claim about which kind it is. The collapsed figure exists only to
+        // choose BETWEEN the two over-count verdicts, and this gate refuses both, so the real one would
+        // change no outcome — while costing a full sort of the night's ~50-70k beats, since
+        // [HrvAnalyzer.collapsedCoverage] opens with `sortedWith`. This runs per session, per day, across
+        // ~21 days of every analyzeRecent, every 15 minutes; #1510 cut this exact path from six sorts a
+        // night to two, and buying a distinction the caller discards would hand that back. `rrCoverage` is
+        // a single O(n) pass. If a future gate ever needs the two over-count cases apart, compute it then.
+        val verdict = HrvAnalyzer.classifyCoverage(coverage, coverage)
         if (!HrvAnalyzer.successiveDiffIsTrustworthy(verdict)) return null
         return vals.sum() / vals.size.toDouble()
     }

--- a/android/app/src/test/java/com/noop/analytics/HrvOverCountGateTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvOverCountGateTest.kt
@@ -1,0 +1,81 @@
+package com.noop.analytics
+
+import com.noop.data.RrInterval
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1118: RMSSD is withheld on a night whose own R-R banks more beat-time than the wall clock it spans.
+ *
+ * Each over-count case asserts TWICE: that the gated call returns null, AND that the very same beats do
+ * produce an RMSSD through [SleepStager.sessionHrvWindows]. Without that second assertion the test would
+ * pass just as well against a window that had no usable beats at all, proving nothing about the gate.
+ */
+class HrvOverCountGateTest {
+
+    private fun rr(ts: Long, ms: Int) = RrInterval(deviceId = "d", ts = ts, rrMs = ms)
+
+    private fun windowsYieldRmssd(start: Long, end: Long, rr: List<RrInterval>): Boolean =
+        SleepStager.sessionHrvWindows(start, end, rr, emptyList()).mapNotNull { it.rmssd }.isNotEmpty()
+
+    /** Two near-equal beats per second: ~1.8x coverage that a same-second collapse would fix. */
+    @Test fun sameSecondOverCountIsWithheld() {
+        val start = 1000L
+        val end = start + 600
+        val rr = (0 until 600).flatMap { i -> listOf(rr(start + i, 900), rr(start + i, 905)) }
+        assertTrue("precondition: these beats DO yield an RMSSD", windowsYieldRmssd(start, end, rr))
+        assertNull("an over-counted night must report no HRV", SleepStager.sessionAvgHRV(start, end, rr))
+    }
+
+    /** Two beats per second far enough apart that a same-second collapse cannot reach them. */
+    @Test fun crossSecondOverCountIsWithheld() {
+        val start = 1000L
+        val end = start + 600
+        val rr = (0 until 600).flatMap { i -> listOf(rr(start + i, 880), rr(start + i, 960)) }
+        assertTrue("precondition: these beats DO yield an RMSSD", windowsYieldRmssd(start, end, rr))
+        assertNull("an over-counted night must report no HRV", SleepStager.sessionAvgHRV(start, end, rr))
+    }
+
+    /** The gate must not touch an ordinary night: one beat per second, coverage ~1.0. */
+    @Test fun aPlausibleNightStillReportsItsHrv() {
+        val start = 1000L
+        val end = start + 600
+        val rr = (0 until 600).map { i -> rr(start + i, if (i % 2 == 0) 980 else 1020) }
+        val hrv = SleepStager.sessionAvgHRV(start, end, rr)
+        assertNotNull("a plausible night must keep its HRV", hrv)
+        assertTrue("and it must be a real reading, not zero", hrv!! > 0.0)
+    }
+
+    /** A sparse night is UNDER_COVERED, which is honest data and stays trusted. */
+    @Test fun anUnderCoveredNightIsNotGated() {
+        val start = 1000L
+        val end = start + 600
+        // A beat every other second: ~0.5 coverage, nothing duplicated.
+        val rr = (0 until 300).map { i -> rr(start + i * 2, if (i % 2 == 0) 980 else 1020) }
+        assertNotNull("sparse is not the same as over-counted",
+            SleepStager.sessionAvgHRV(start, end, rr))
+    }
+
+    /** The verdict mapping itself, so the seam above and the rule stay pinned separately. */
+    @Test fun onlyTheTwoOverCountVerdictsRefuse() {
+        assertFalse(HrvAnalyzer.successiveDiffIsTrustworthy(
+            HrvAnalyzer.RrCoverageVerdict.SAME_SECOND_OVER_COUNT))
+        assertFalse(HrvAnalyzer.successiveDiffIsTrustworthy(
+            HrvAnalyzer.RrCoverageVerdict.CROSS_SECOND_OVER_COUNT))
+        assertTrue(HrvAnalyzer.successiveDiffIsTrustworthy(HrvAnalyzer.RrCoverageVerdict.PLAUSIBLE))
+        assertTrue(HrvAnalyzer.successiveDiffIsTrustworthy(HrvAnalyzer.RrCoverageVerdict.UNDER_COVERED))
+        assertTrue(HrvAnalyzer.successiveDiffIsTrustworthy(HrvAnalyzer.RrCoverageVerdict.UNMEASURABLE))
+    }
+
+    /** It refuses exactly what the SDNN gate refuses: same rule, stated twice on purpose, never drifting. */
+    @Test fun itRefusesTheSameVerdictsAsTheSdnnGate() {
+        for (v in HrvAnalyzer.RrCoverageVerdict.entries) {
+            assertEquals("verdict $v must be judged alike by both gates",
+                HrvAnalyzer.beatSpreadIsTrustworthy(v), HrvAnalyzer.successiveDiffIsTrustworthy(v))
+        }
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/HrvOverCountGateTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/HrvOverCountGateTest.kt
@@ -22,7 +22,13 @@ class HrvOverCountGateTest {
     private fun windowsYieldRmssd(start: Long, end: Long, rr: List<RrInterval>): Boolean =
         SleepStager.sessionHrvWindows(start, end, rr, emptyList()).mapNotNull { it.rmssd }.isNotEmpty()
 
-    /** Two near-equal beats per second: ~1.8x coverage that a same-second collapse would fix. */
+    /**
+     * Two near-equal beats per second: the shape a same-second collapse WOULD bring back under the
+     * ceiling. It must still be withheld, and this is the case that guards the gate's cheap
+     * classification — [SleepStager.sessionAvgHRV] passes coverage as its own collapsed figure to avoid
+     * a sort, so a night of this shape reports CROSS_SECOND internally. The outcome is what matters and
+     * is asserted here; restoring the real collapsed figure would relabel this night and change nothing.
+     */
     @Test fun sameSecondOverCountIsWithheld() {
         val start = 1000L
         val end = start + 600


### PR DESCRIPTION
The backstop #1118 describes, now that the measurement it was waiting on exists.

## Why now

`beatSpreadIsTrustworthy` left this open in as many words: successive-difference statistics were ungated because their dominant error was the lost within-second emission order corrected at the write path (#823 / #1072), and whether they needed a gate of their own was *"a question for a post-fix capture to answer, not an assumption to bake in now."*

That capture has arrived. A build carrying the write-path fix, on a WHOOP 4.0, still reports `crossSecondOverCount` on **every** measured night, `coverage=2.13`, with **91%** of the inflating beat-time on seconds written by more than one delivery (`multiMs=91%`, `ordUnknown=0`, `secsNoStart=0`). The write-path fix did not make the stream clean, so the assumption no longer holds. Both platforms' comments are corrected to say so rather than left asserting something the data contradicts.

The same log settles the scope: every WHOOP 4.0 night is affected and no WHOOP 5 night is, so the gate's blast radius is measured rather than guessed, which is what #1118 asked for before gating.

## What it does

`successiveDiffIsTrustworthy` refuses the same two verdicts as the SDNN gate, but carries its own reasoning instead of borrowing that one's, because the two statistics fail in opposite directions. SDNN widens under a duplicated beat. A successive-difference statistic reads **low**, because a beat the heart never produced sits beside its neighbour with a near-zero difference and RMSSD is the root mean square of exactly those differences. On the captured night RMSSD reads 36 ms where the same beats collapsed read 41 ms. The direction of that error is invisible in the number, which is why it cannot be shown.

Applied in `sessionAvgHRV`, where RMSSD *becomes* the day's HRV, so one seam covers the daily row, the sleep-session cache, the Health card and the baseline later nights are scored against. Classified over the same beats the value was built from, windowed `[start, end]` identically on both platforms, so the verdict cannot describe a different set of beats than the number it gates.

## The cost, accepted deliberately

This trades a wrong number for a blank on every affected night. HRV is the dominant Charge driver, so a gated night drops that term and renormalises the rest. That is the intended trade: a contaminated RMSSD does not merely display wrong, it enters the personal baseline the following nights are scored against, spreading the error into days whose own capture was clean.

**The cost reaches further than the card, and this is the part worth arguing about.** `Baselines.update` holds on a null night *without advancing* `nValid`, so on an install whose every night gates, the baseline never reaches `minNightsSeed` and stays CALIBRATING indefinitely. On a WHOOP 4.0 the over-count is every measured night, so a **4.0-only install gets no HRV baseline at all**, not merely a degraded one, and anything waiting on a seeded baseline never starts.

A mixed install is unaffected, which is exactly why this was easy to miss: the capture that prompted the gate has WHOOP 5 nights on either side, so its baseline is already seeded and the gated nights just skip-and-hold. Read only that log and the gate looks like it costs a few blanks.

I still think it is right, because the alternative is seeding a personal baseline from beats the heart did not produce and scoring every later night against it. But it is the difference between "some nights are blank" and "this hardware has no HRV until the two-train fix lands", so it is stated here and at the rule's definition rather than left to be re-derived from `Baselines`.

## Verified it does not fire on honest nights

The obvious failure mode is gating a genuinely fast heart, since a 75 bpm night legitimately puts two beats inside some seconds. It does not: coverage measures beat-time against wall span rather than beats per second, so 45, 50, 60 and 75 bpm nights all classify `plausible` and keep their HRV. Checked directly rather than reasoned about.

## The threshold it hangs on, and why that is safe here

Worth raising before a reviewer does. The gate triggers on `COVERAGE_PLAUSIBLE_CEILING`, whose own doc calls it "a ROUNDING allowance, deliberately not a tuned threshold — where the real boundary sits needs coverage figures from several wearers". Using it to withhold user-visible data gives it weight it was not designed to carry, so I checked what real nights actually measure.

The population is bimodal, with a wide empty band across the ceiling. From one wearer's 25 scored nights across both straps:

| band | nights | values |
|---|---|---|
| kept | 17 | 0.47 to 0.94 |
| *the 1.10 ceiling* | 0 | nothing within 0.16 either side |
| withheld | 8 | 1.34 to 2.13 |

The nearest night below is 0.94 and the nearest above is 1.34, so the exact trigger point does not decide any night here: moving it anywhere between 0.95 and 1.33 changes nothing. Every WHOOP 5 night sits at 0.63 to 0.94, far from gating. That is one wearer and does not tune the threshold, which stays what its doc says it is; it does establish that this gate is not balancing on it.

## Tests

Six per platform, twinned. Each over-count case asserts **twice**: that the gated call returns nothing, and that the same beats *do* yield an RMSSD through `sessionHrvWindows`. Without that second assertion the test would pass equally against a window that simply had no usable beats, proving nothing about the gate. Plus a case pinning that both gates judge every verdict alike, so the two rules cannot drift apart.

Android full suite green, **5436 tests, 0 failures**. Swift is CI-verified (the package cannot build under WSL).

## Follow-up this creates, not addressed here

With the value withheld, the HRV card falls back to `missingCaption = "No HRV value"`, which explains nothing, and on an affected strap that becomes the nightly state. The `Vital.missingCaption` doc is explicit that an empty tile must say WHY ("Required (no default) so a new vital must state its own reason"), so that caption should name the over-count. It is left out of this PR because it is new user-facing copy needing real translations in seven locales, and this repo has a standing warning about rushing those. The existing `unverified · over-reports R-R` caveat also wants rewording once there is no value for "unverified" to describe.
