### PR TITLE
rhr: measure what an artefact gate would do, before gating anything

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -2778,6 +2778,58 @@ public enum SleepStager {
     /// the final one, which is `[t, end]`. Half-open bins alone would admit a sample sitting exactly
     /// on an aligned `end` through the prefilter and then place it in no bin — counted as data,
     /// silently ignored. A zero-length window (`start == end`) is that single closed bin.
+    /// #1943: what an artefact gate WOULD do to tonight's resting-HR floor, measured and reported without
+    /// changing it.
+    ///
+    /// `sessionRestingHR` takes the minimum of the 5-minute bin means unconditionally, so any non-empty
+    /// bin can win, including one built from a single sample at the edge of a wear gap. The helper deleted
+    /// alongside it had two conditions the shipped path never had: a bin may only WIN when it holds at
+    /// least `minBinSamples` samples and its mean is at least `minPlausibleBpm`. Porting them is a small
+    /// change; what nobody can currently say is how OFTEN it would move a displayed number, and that
+    /// number feeds the baseline later nights are scored against. So measure first.
+    ///
+    /// Bins are built exactly as `sessionRestingHR` builds them, closed final bin included, or the line
+    /// would describe a different partition than the one it is judging.
+    ///
+    /// Returns nil on a night where the gate changes nothing AND every bin is well-populated, so a clean
+    /// night stays silent and the log only carries the cases worth reading. Same posture as the
+    /// over-count-only R-R dump. Counts and bpm only, no timestamps. Pure. Twin of Kotlin
+    /// `rhrBinGateLogLine`.
+    static func rhrBinGateLogLine(day: String, sessions: [(Int, Int)], hr: [HRSample],
+                                  shippedFloor: Int, minBinSamples: Int = 5,
+                                  minPlausibleBpm: Double = 25) -> String? {
+        let windowS = 5 * 60
+        var bins = 0, thin = 0, implausible = 0, bestN = 0
+        var best: Double?
+        var gated: Double?
+        for (start, end) in sessions {
+            let seg = hr.filter { $0.ts >= start && $0.ts <= end }
+            if seg.isEmpty { continue }
+            var t = start
+            repeat {
+                let isFinal = t + windowS >= end
+                let win = seg.filter { $0.ts >= t && (isFinal || $0.ts < t + windowS) }
+                if !win.isEmpty {
+                    bins += 1
+                    let mean = Double(win.reduce(0) { $0 + $1.bpm }) / Double(win.count)
+                    if win.count < minBinSamples { thin += 1 }
+                    if mean < minPlausibleBpm { implausible += 1 }
+                    if best == nil || mean < best! { best = mean; bestN = win.count }
+                    if win.count >= minBinSamples, mean >= minPlausibleBpm,
+                       gated == nil || mean < gated! { gated = mean }
+                }
+                t += windowS
+            } while t < end
+        }
+        if bins == 0 { return nil }
+        let gatedFloor = gated.map { Int($0.rounded()) }
+        let changes = gatedFloor != nil && gatedFloor != shippedFloor
+        if !changes, thin == 0, implausible == 0 { return nil }
+        return "rhr bins day=\(day) bins=\(bins) thin=\(thin) implausible=\(implausible) "
+            + "winnerN=\(bestN) floor=\(shippedFloor) gated=\(gatedFloor.map(String.init) ?? "nil") "
+            + "wouldChange=\(changes) (measure-only; nothing is gated yet)"
+    }
+
     static func sessionRestingHR(start: Int, end: Int, hr: [HRSample]) -> Int? {
         let seg = hr.filter { $0.ts >= start && $0.ts <= end }
         guard !seg.isEmpty else { return nil }

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -2791,10 +2791,17 @@ public enum SleepStager {
     /// Bins are built exactly as `sessionRestingHR` builds them, closed final bin included, or the line
     /// would describe a different partition than the one it is judging.
     ///
-    /// Returns nil on a night where the gate changes nothing AND every bin is well-populated, so a clean
-    /// night stays silent and the log only carries the cases worth reading. Same posture as the
-    /// over-count-only R-R dump. Counts and bpm only, no timestamps. Pure. Twin of Kotlin
-    /// `rhrBinGateLogLine`.
+    /// Returns nil unless the gate would actually MOVE the floor, so the log carries only the nights the
+    /// question is about. Reporting every thin bin instead would fire on nearly all of them, because a thin
+    /// final bin is STRUCTURAL rather than an artefact: the last bin closes on `end`, so a session whose
+    /// span is not a multiple of the window holds only `span mod 300` samples there. A 1801-second night
+    /// has six 300-sample bins and a final bin of two. That bin is real data and almost never wins the
+    /// floor, so it is noise to report and, separately, something a future gate should weigh before
+    /// excluding bins on sample count alone.
+    ///
+    /// The counts still ride along when the line does fire, since they are the context for the change.
+    /// Same posture as the over-count-only R-R dump. Counts and bpm only, no timestamps. Pure. Twin of
+    /// Kotlin `rhrBinGateLogLine`.
     static func rhrBinGateLogLine(day: String, sessions: [(Int, Int)], hr: [HRSample],
                                   shippedFloor: Int, minBinSamples: Int = 5,
                                   minPlausibleBpm: Double = 25) -> String? {
@@ -2824,7 +2831,7 @@ public enum SleepStager {
         if bins == 0 { return nil }
         let gatedFloor = gated.map { Int($0.rounded()) }
         let changes = gatedFloor != nil && gatedFloor != shippedFloor
-        if !changes, thin == 0, implausible == 0 { return nil }
+        if !changes { return nil }
         return "rhr bins day=\(day) bins=\(bins) thin=\(thin) implausible=\(implausible) "
             + "winnerN=\(bestN) floor=\(shippedFloor) gated=\(gatedFloor.map(String.init) ?? "nil") "
             + "wouldChange=\(changes) (measure-only; nothing is gated yet)"

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -2802,9 +2802,9 @@ public enum SleepStager {
     /// The counts still ride along when the line does fire, since they are the context for the change.
     /// Same posture as the over-count-only R-R dump. Counts and bpm only, no timestamps. Pure. Twin of
     /// Kotlin `rhrBinGateLogLine`.
-    static func rhrBinGateLogLine(day: String, sessions: [(Int, Int)], hr: [HRSample],
-                                  shippedFloor: Int, minBinSamples: Int = 5,
-                                  minPlausibleBpm: Double = 25) -> String? {
+    public static func rhrBinGateLogLine(day: String, sessions: [(Int, Int)], hr: [HRSample],
+                                         shippedFloor: Int, minBinSamples: Int = 5,
+                                         minPlausibleBpm: Double = 25) -> String? {
         let windowS = 5 * 60
         var bins = 0, thin = 0, implausible = 0, bestN = 0
         var best: Double?

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RhrBinGateDiagnosticTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RhrBinGateDiagnosticTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+import WhoopProtocol
+@testable import StrandAnalytics
+
+/// #1943 measure-only: the line must describe the partition `sessionRestingHR` actually uses, and must
+/// stay silent unless an artefact gate would MOVE the floor. Byte-parity twin of Kotlin
+/// `RhrBinGateDiagnosticTest`.
+final class RhrBinGateDiagnosticTests: XCTestCase {
+
+    private func hr(_ start: Int, _ count: Int, _ bpm: Int) -> [HRSample] {
+        (0..<count).map { HRSample(ts: start + $0, bpm: bpm) }
+    }
+
+    /// A dense, ordinary night: every bin well-populated, so the gate would change nothing. Silent.
+    func testAWellPopulatedNightSaysNothing() {
+        let start = 1_000, end = 1_000 + 1800
+        XCTAssertNil(SleepStager.rhrBinGateLogLine(day: "2026-01-01", sessions: [(start, end)],
+                                                   hr: hr(start, 1800, 60), shippedFloor: 60))
+    }
+
+    /// A one-sample bin that WINS the floor is the whole point: it must be reported, and named.
+    func testAThinWinningBinIsReportedWithWhatTheGateWouldDo() {
+        let start = 1_000, end = 1_000 + 1800
+        let samples = hr(start, 1500, 60) + [HRSample(ts: start + 1700, bpm: 38)]
+        let line = SleepStager.rhrBinGateLogLine(day: "2026-01-01", sessions: [(start, end)],
+                                                 hr: samples, shippedFloor: 38)
+        XCTAssertNotNil(line, "a thin winning bin must be reported")
+        XCTAssertTrue(line!.contains("thin=1"), line!)
+        XCTAssertTrue(line!.contains("winnerN=1"), line!)
+        XCTAssertTrue(line!.contains("wouldChange=true"), line!)
+        XCTAssertTrue(line!.contains("gated=60"), line!)
+    }
+
+    /// A thin bin that cannot win the floor is silent: a thin FINAL bin is structural on most spans.
+    func testAThinBinThatCannotWinTheFloorIsSilent() {
+        let start = 1_000, end = 1_000 + 1800
+        let samples = hr(start, 1500, 60) + [HRSample(ts: start + 1700, bpm: 90)]
+        XCTAssertNil(SleepStager.rhrBinGateLogLine(day: "2026-01-01", sessions: [(start, end)],
+                                                   hr: samples, shippedFloor: 60))
+    }
+
+    /// No sleep sessions, or no samples inside them, is not a finding.
+    func testNothingToMeasureIsSilent() {
+        XCTAssertNil(SleepStager.rhrBinGateLogLine(day: "2026-01-01", sessions: [],
+                                                   hr: hr(1_000, 100, 60), shippedFloor: 60))
+        XCTAssertNil(SleepStager.rhrBinGateLogLine(day: "2026-01-01", sessions: [(9_000, 9_900)],
+                                                   hr: hr(1_000, 100, 60), shippedFloor: 60))
+    }
+
+    /// It carries counts and bpm only: no timestamps, so a shared strap log gains no new identifiers.
+    func testTheLineCarriesNoTimestamps() {
+        let start = 1_700_000_000, end = 1_700_000_000 + 1800
+        let samples = hr(start, 1500, 60) + [HRSample(ts: start + 1700, bpm: 38)]
+        let line = SleepStager.rhrBinGateLogLine(day: "2026-01-01", sessions: [(start, end)],
+                                                 hr: samples, shippedFloor: 38)
+        XCTAssertNotNil(line)
+        XCTAssertFalse(line!.contains("17000000"), line!)
+    }
+
+    /// The load-bearing invariant: the line must judge the SAME partition `sessionRestingHR` ships.
+    /// Every other case hands the floor in as a literal, so none would notice the two binnings drifting.
+    /// Here the shipped floor comes FROM `sessionRestingHR`, and a mismatch surfaces as a spurious
+    /// `wouldChange`. The 1801 span is deliberate: its final bin holds two samples, structurally thin.
+    func testTheDiagnosticJudgesTheSamePartitionSessionRestingHRShips() {
+        let start = 1_000
+        for spanS in [1800, 1801, 1500, 300, 299] {
+            let end = start + spanS
+            let samples = (0..<spanS).map {
+                HRSample(ts: start + $0, bpm: (600...899).contains($0) ? 55 : 65)
+            }
+            let shipped = SleepStager.sessionRestingHR(start: start, end: end, hr: samples)
+            XCTAssertNotNil(shipped, "precondition: a floor exists for span \(spanS)")
+            XCTAssertNil(
+                SleepStager.rhrBinGateLogLine(day: "2026-01-01", sessions: [(start, end)],
+                                              hr: samples, shippedFloor: shipped!),
+                "span \(spanS): the gate must agree with sessionRestingHR, so the line stays silent")
+        }
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -138,6 +138,9 @@ final class IntelligenceEngine: ObservableObject {
     private struct DayScan {
         let result: AnalyticsEngine.DayResult
         let rhrLine: String?
+        /// #1943 measure-only bin-population line (see `SleepStager.rhrBinGateLogLine`); nil on a clean
+        /// night, replayed with `rhrLine` so the two read together.
+        let rhrBinLine: String?
         /// #1331 respiratory diagnostic line (see `respRateLogLine`); replayed with `rhrLine`.
         let respLine: String?
         /// CAPTURE-B (#814/#799): the resolved READ owner id this day was scored from, and how many HR rows
@@ -1493,11 +1496,17 @@ final class IntelligenceEngine: ObservableObject {
                 // Computed here (pure inputs) and carried out so the main actor can replay it through
                 // `diagnosticSink` in the SAME per-day order , the sink is a MainActor-bound closure.
                 var rhrLine: String?
+                var rhrBinLine: String?
                 if let floor = res.daily.restingHr {
                     let inBedBpms = hr.filter { s in
                         res.cachedSleep.contains { s.ts >= $0.startTs && s.ts < $0.endTs }
                     }.map { $0.bpm }
                     rhrLine = Self.rhrFloorMeanLogLine(day: res.daily.day, floor: floor, inBedBpms: inBedBpms)
+                    // #1943: and what an artefact gate would do to that floor. Silent on a clean night.
+                    rhrBinLine = SleepStager.rhrBinGateLogLine(
+                        day: res.daily.day,
+                        sessions: res.cachedSleep.map { ($0.startTs, $0.endTs) },
+                        hr: hr, shippedFloor: floor)
                 }
                 // #1331 respiratory diagnostic — a run of nil nights localises when it stopped. Same
                 // pure-compute-here / replay-on-main-actor path as rhrLine.
@@ -1547,7 +1556,8 @@ final class IntelligenceEngine: ObservableObject {
                 // windowing + delegation lives in the byte-identical, tested `AnalyticsEngine`.
                 let (primarySessionRHR, primarySessionRHRCoverage) =
                     AnalyticsEngine.primarySessionRestingHRWithCoverage(sessions: res.sleepSessions, hr: hr)
-                let scan = DayScan(result: res, rhrLine: rhrLine, respLine: respLine,
+                let scan = DayScan(result: res, rhrLine: rhrLine, rhrBinLine: rhrBinLine,
+                                   respLine: respLine,
                                    readOwner: owner, hrRows: hr.count,
                                    sleepTrace: sleepTrace, stepsTrace: stepsTrace, hrvTrace: hrvTrace,
                                    hrvDiag: Self.mergedDayDiag(hrvDiag, strainDiagLines),
@@ -1653,6 +1663,7 @@ final class IntelligenceEngine: ObservableObject {
                 primarySessionRHRCoverageByDay[res.daily.day] = cov
             }
             if let line = scan.rhrLine { diagnosticSink?(line, nil) }
+            if let line = scan.rhrBinLine { diagnosticSink?(line, nil) }
             if let line = scan.respLine { diagnosticSink?(line, nil) }
             // Sleep & Rest test mode (E5): replay this day's gate-trace + Rest lines tagged `.sleep` so they
             // land under the profile tag in the export. Empty unless the mode is active.

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1288,12 +1288,7 @@ object IntelligenceEngine {
             // in-bed span the floor came from (so they're directly comparable); a night with no banked
             // floor (no matched sleep) logs nil and the line is skipped. Logging only , no scoring change.
             // Counts/bpm only; no timestamps or PII (the diag sink also scrubs). Byte-identical to Swift.
-            val rhrFloor = res.daily.restingHr
-            if (rhrFloor != null) {
-                val inBedBpms = hr.filter { s -> res.sleepSessions.any { s.ts >= it.start && s.ts < it.end } }
-                    .map { it.bpm }
-                dayDiag(rhrFloorMeanLogLine(day, rhrFloor, inBedBpms))
-            }
+            for (l in rhrDiagLines(day, res.daily.restingHr, hr, res.sleepSessions)) dayDiag(l)
             // #103/queue-11a: SpO₂ candidate nightly mean. Only computed when the display toggle is ON,
             // and the transform is device-conditional (com.noop.data.DeviceBrandCatalog.isOura, same
             // idiom OuraRespScale.isRingRateStream uses): a WHOOP owner averages the in-band (70–100)
@@ -2933,6 +2928,31 @@ object IntelligenceEngine {
         } else {
             "$base beatAccurate=$acc>=$gate rrIntegrity=$integrity — gate passed, cause is elsewhere"
         }
+    }
+
+    /**
+     * The night's resting-HR diagnostic lines: the floor-vs-mean explainer, and the measure-only
+     * bin-population line beside it when there is something to say.
+     *
+     * Built here rather than inline in `analyzeRecentOnCpu` because that method is BUDGETED:
+     * [IntelligenceEngineJacocoBudgetTest] ratchets its JaCoCo-instrumented size against the JVM's method
+     * limit, and the budget is never raised to fit a change. Returning the lines as a list, rather than
+     * emitting each at the call site, is what pays for the second one: the caller loses the null check,
+     * both lambdas and the intermediate list.
+     */
+    private fun rhrDiagLines(
+        day: String,
+        rhrFloor: Int?,
+        hr: List<com.noop.data.HrSample>,
+        sessions: List<DetectedSleep>,
+    ): List<String> {
+        if (rhrFloor == null) return emptyList()
+        val inBedBpms = hr.filter { s -> sessions.any { s.ts >= it.start && s.ts < it.end } }.map { it.bpm }
+        val out = ArrayList<String>(2)
+        out.add(rhrFloorMeanLogLine(day, rhrFloor, inBedBpms))
+        SleepStager.rhrBinGateLogLine(day, sessions.map { it.start to it.end }, hr, rhrFloor)
+            ?.let { out.add(it) }
+        return out
     }
 
     /**

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -3141,7 +3141,9 @@ object SleepStager {
             } while (t < end)
         }
         if (bins == 0) return null
-        val gatedFloor = gated?.let { Math.round(it).toInt() }
+        // `roundToInt`, matching sessionRestingHR immediately below: this number is compared against
+        // that function's output, so the two must not round a tie differently.
+        val gatedFloor = gated?.roundToInt()
         val changes = gatedFloor != null && gatedFloor != shippedFloor
         if (!changes) return null
         return "rhr bins day=$day bins=$bins thin=$thin implausible=$implausible " +

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -3093,10 +3093,17 @@ object SleepStager {
      * Bins are built exactly as `sessionRestingHR` builds them, closed final bin included, or the line
      * would describe a different partition than the one it is judging.
      *
-     * Returns null on a night where the gate changes nothing AND every bin is well-populated, so a clean
-     * night stays silent and the log only carries the cases worth reading. Same posture as the
-     * over-count-only R-R dump. Counts and bpm only, no timestamps. Pure. Twin of Swift
-     * `rhrBinGateLogLine`.
+     * Returns null unless the gate would actually MOVE the floor, so the log carries only the nights the
+     * question is about. Reporting every thin bin instead would fire on nearly all of them, because a thin
+     * final bin is STRUCTURAL rather than an artefact: the last bin closes on `end`, so a session whose
+     * span is not a multiple of the window holds only `span mod 300` samples there. A 1801-second night
+     * has six 300-sample bins and a final bin of two. That bin is real data and almost never wins the
+     * floor, so it is noise to report and, separately, something a future gate should weigh before
+     * excluding bins on sample count alone.
+     *
+     * The counts still ride along when the line does fire, since they are the context for the change.
+     * Same posture as the over-count-only R-R dump. Counts and bpm only, no timestamps. Pure. Twin of
+     * Swift `rhrBinGateLogLine`.
      */
     internal fun rhrBinGateLogLine(
         day: String,
@@ -3136,7 +3143,7 @@ object SleepStager {
         if (bins == 0) return null
         val gatedFloor = gated?.let { Math.round(it).toInt() }
         val changes = gatedFloor != null && gatedFloor != shippedFloor
-        if (!changes && thin == 0 && implausible == 0) return null
+        if (!changes) return null
         return "rhr bins day=$day bins=$bins thin=$thin implausible=$implausible " +
             "winnerN=$bestN floor=$shippedFloor gated=${gatedFloor ?: "nil"} wouldChange=$changes " +
             "(measure-only; nothing is gated yet)"

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -3080,6 +3080,69 @@ object SleepStager {
     // ── Per-session HR / HRV ─────────────────────────────────────────────────
 
     /**
+     * #1943: what an artefact gate WOULD do to tonight's resting-HR floor, measured and reported without
+     * changing it.
+     *
+     * [SleepStager.sessionRestingHR] takes the minimum of the 5-minute bin means unconditionally, so any
+     * non-empty bin can win, including one built from a single sample at the edge of a wear gap. The
+     * helper deleted alongside it had two conditions the shipped path never had: a bin may only WIN when
+     * it holds at least [minBinSamples] samples and its mean is at least [minPlausibleBpm]. Porting them
+     * is a small change; what nobody can currently say is how OFTEN it would move a displayed number, and
+     * that number feeds the baseline later nights are scored against. So measure first.
+     *
+     * Bins are built exactly as `sessionRestingHR` builds them, closed final bin included, or the line
+     * would describe a different partition than the one it is judging.
+     *
+     * Returns null on a night where the gate changes nothing AND every bin is well-populated, so a clean
+     * night stays silent and the log only carries the cases worth reading. Same posture as the
+     * over-count-only R-R dump. Counts and bpm only, no timestamps. Pure. Twin of Swift
+     * `rhrBinGateLogLine`.
+     */
+    internal fun rhrBinGateLogLine(
+        day: String,
+        sessions: List<Pair<Long, Long>>,
+        hr: List<HrSample>,
+        shippedFloor: Int,
+        minBinSamples: Int = 5,
+        minPlausibleBpm: Double = 25.0,
+    ): String? {
+        val windowS = 5 * 60L
+        var bins = 0
+        var thin = 0
+        var implausible = 0
+        var best: Double? = null          // the current rule: min over every non-empty bin
+        var bestN = 0
+        var gated: Double? = null         // the candidate rule: min over qualifying bins only
+        for ((start, end) in sessions) {
+            val seg = hr.filter { it.ts in start..end }
+            if (seg.isEmpty()) continue
+            var t = start
+            do {
+                val isFinal = t + windowS >= end
+                val win = seg.filter { it.ts >= t && (isFinal || it.ts < t + windowS) }
+                if (win.isNotEmpty()) {
+                    bins += 1
+                    val mean = win.sumOf { it.bpm }.toDouble() / win.size.toDouble()
+                    if (win.size < minBinSamples) thin += 1
+                    if (mean < minPlausibleBpm) implausible += 1
+                    if (best == null || mean < best!!) { best = mean; bestN = win.size }
+                    if (win.size >= minBinSamples && mean >= minPlausibleBpm &&
+                        (gated == null || mean < gated!!)
+                    ) gated = mean
+                }
+                t += windowS
+            } while (t < end)
+        }
+        if (bins == 0) return null
+        val gatedFloor = gated?.let { Math.round(it).toInt() }
+        val changes = gatedFloor != null && gatedFloor != shippedFloor
+        if (!changes && thin == 0 && implausible == 0) return null
+        return "rhr bins day=$day bins=$bins thin=$thin implausible=$implausible " +
+            "winnerN=$bestN floor=$shippedFloor gated=${gatedFloor ?: "nil"} wouldChange=$changes " +
+            "(measure-only; nothing is gated yet)"
+    }
+
+    /**
      * Lowest 5-min rolling-mean HR during the session (bpm), or null.
      *
      * The window is CLOSED at both ends, so the binning is too: bins are `[t, t + windowS)` except

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceEngineJacocoBudgetTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceEngineJacocoBudgetTest.kt
@@ -45,7 +45,7 @@ class IntelligenceEngineJacocoBudgetTest {
         // read windows need about 825), small enough that a large regression fails here rather than at the
         // JVM's 64 KB wall. If a change genuinely needs more, extract — this file already shows the shape
         // twice over.
-        assertExactMethodBudget(lengths, "analyzeRecentOnCpu", 56_000)
+        assertExactMethodBudget(lengths, "analyzeRecentOnCpu", 55_700)
         // Untouched: 6,415 against 12,000. Slack, but it has not been creeping, and ratcheting a method
         // nobody is pressing against would be tightening for its own sake.
         assertExactMethodBudget(lengths, "persistFitnessVitalityAndSteps", 12_000)

--- a/android/app/src/test/java/com/noop/analytics/RhrBinGateDiagnosticTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RhrBinGateDiagnosticTest.kt
@@ -1,0 +1,70 @@
+package com.noop.analytics
+
+import com.noop.data.HrSample
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1943 measure-only: the line must describe the partition `sessionRestingHR` actually uses, and must
+ * stay silent on a night where an artefact gate would change nothing. A diagnostic that fired every
+ * night would be ignored; one that fired on the wrong bins would argue for a change on false evidence.
+ */
+class RhrBinGateDiagnosticTest {
+
+    private fun hr(start: Long, count: Int, bpm: Int, step: Long = 1L) =
+        (0 until count).map { HrSample("d", start + it * step, bpm) }
+
+    /** A dense, ordinary night: every bin well-populated, so the gate would change nothing. Silent. */
+    @Test fun aWellPopulatedNightSaysNothing() {
+        val start = 1_000L
+        val end = start + 1800                       // 6 bins at 1 Hz
+        val samples = hr(start, 1800, 60)
+        assertNull(SleepStager.rhrBinGateLogLine("2026-01-01", listOf(start to end), samples, 60))
+    }
+
+    /** A one-sample bin that WINS the floor is the whole point: it must be reported, and named. */
+    @Test fun aThinWinningBinIsReportedWithWhatTheGateWouldDo() {
+        val start = 1_000L
+        val end = start + 1800
+        // Five dense bins at 60 bpm, then a single stray low sample alone in the last bin.
+        val dense = hr(start, 1500, 60)
+        val stray = listOf(HrSample("d", start + 1700, 38))
+        val line = SleepStager.rhrBinGateLogLine("2026-01-01", listOf(start to end), dense + stray, 38)
+        assertTrue("a thin winning bin must be reported, got: $line", line != null)
+        assertTrue("must count the thin bin, got: $line", line!!.contains("thin=1"))
+        assertTrue("must name the winning bin's size, got: $line", line.contains("winnerN=1"))
+        assertTrue("must say the gate would move the floor, got: $line", line.contains("wouldChange=true"))
+        assertTrue("must report the gated floor it would use instead, got: $line", line.contains("gated=60"))
+    }
+
+    /** A thin bin that does NOT win still reports, because the population is what is being measured. */
+    @Test fun aThinBinThatDoesNotWinStillReportsButChangesNothing() {
+        val start = 1_000L
+        val end = start + 1800
+        val dense = hr(start, 1500, 60)
+        val strayHigh = listOf(HrSample("d", start + 1700, 90))   // thin, but far above the floor
+        val line = SleepStager.rhrBinGateLogLine("2026-01-01", listOf(start to end), dense + strayHigh, 60)
+        assertTrue("still worth reporting, got: $line", line != null)
+        assertTrue(line!!.contains("thin=1"))
+        assertTrue("the floor is unchanged, got: $line", line.contains("wouldChange=false"))
+    }
+
+    /** No sleep sessions, or no samples inside them, is not a finding. */
+    @Test fun nothingToMeasureIsSilent() {
+        assertNull(SleepStager.rhrBinGateLogLine("2026-01-01", emptyList(), hr(1_000L, 100, 60), 60))
+        assertNull(SleepStager.rhrBinGateLogLine("2026-01-01", listOf(9_000L to 9_900L), hr(1_000L, 100, 60), 60))
+    }
+
+    /** It carries counts and bpm only: no timestamps, so a shared strap log gains no new identifiers. */
+    @Test fun theLineCarriesNoTimestamps() {
+        val start = 1_700_000_000L
+        val end = start + 1800
+        val line = SleepStager.rhrBinGateLogLine(
+            "2026-01-01", listOf(start to end),
+            hr(start, 1500, 60) + listOf(HrSample("d", start + 1700, 38)), 38,
+        )
+        assertTrue(line != null)
+        assertTrue("must not leak an epoch timestamp, got: $line", !line!!.contains("17000000"))
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/RhrBinGateDiagnosticTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RhrBinGateDiagnosticTest.kt
@@ -38,16 +38,43 @@ class RhrBinGateDiagnosticTest {
         assertTrue("must report the gated floor it would use instead, got: $line", line.contains("gated=60"))
     }
 
-    /** A thin bin that does NOT win still reports, because the population is what is being measured. */
-    @Test fun aThinBinThatDoesNotWinStillReportsButChangesNothing() {
+    /** A thin bin that does NOT win is silent: a thin FINAL bin is structural on most spans, not a finding. */
+    @Test fun aThinBinThatCannotWinTheFloorIsSilent() {
         val start = 1_000L
         val end = start + 1800
         val dense = hr(start, 1500, 60)
         val strayHigh = listOf(HrSample("d", start + 1700, 90))   // thin, but far above the floor
-        val line = SleepStager.rhrBinGateLogLine("2026-01-01", listOf(start to end), dense + strayHigh, 60)
-        assertTrue("still worth reporting, got: $line", line != null)
-        assertTrue(line!!.contains("thin=1"))
-        assertTrue("the floor is unchanged, got: $line", line.contains("wouldChange=false"))
+        assertNull(
+            "a thin bin that cannot win the floor is noise, not a finding",
+            SleepStager.rhrBinGateLogLine("2026-01-01", listOf(start to end), dense + strayHigh, 60),
+        )
+    }
+
+    /**
+     * The load-bearing invariant: the line must judge the SAME partition `sessionRestingHR` ships.
+     *
+     * Every other case here hands the floor in as a literal, so none of them would notice the two
+     * binnings drifting apart, and a diagnostic describing a different partition than the one it is
+     * measuring would argue for a change on false evidence. Here the shipped floor comes FROM
+     * `sessionRestingHR`, and on a night where no bin is thin the gate must agree with it exactly, which
+     * the line reports by staying silent. A partition mismatch shows up as a spurious `wouldChange`.
+     */
+    @Test fun theDiagnosticJudgesTheSamePartitionSessionRestingHrShips() {
+        val start = 1_000L
+        for (spanS in listOf(1800L, 1801L, 1500L, 300L, 299L)) {   // aligned, +1, exact, one bin, short
+            val end = start + spanS
+            // Dense, with a genuinely lower stretch so the floor is not degenerate.
+            val samples = (0 until spanS.toInt()).map {
+                HrSample("d", start + it, if (it in 600..899) 55 else 65)
+            }
+            val shipped = SleepStager.sessionRestingHR(start, end, samples)
+            assertTrue("precondition: a floor exists for span $spanS", shipped != null)
+            assertNull(
+                "span $spanS: every bin is dense, so the gate must agree with sessionRestingHR " +
+                    "and the line must stay silent",
+                SleepStager.rhrBinGateLogLine("2026-01-01", listOf(start to end), samples, shipped!!),
+            )
+        }
     }
 
     /** No sleep sessions, or no samples inside them, is not a finding. */


### PR DESCRIPTION
Measure-only groundwork for #1943. Nothing is gated; no displayed number moves.

## Why measure first

`sessionRestingHR` takes the minimum of the 5-minute bin means unconditionally, so any non-empty bin can win the night's floor, including one built from a single sample at the edge of a wear gap. The helper deleted alongside it carried two conditions the shipped path never had: a bin may only **win** when it holds at least five samples and its mean is physiologically plausible.

Porting them is a small change, and safe by construction, because the fallback chain ends at today's behaviour. What nobody can currently say is how **often** it would move a displayed number, and that number feeds the baseline later nights are scored against.

The strap log carries `floor`, `mean` and `inBedSamples` but nothing per-bin, so the distribution the gate would act on is not observable. I tried twice to infer it from a real log: the first attempt was circular (bin count derived from sample count), the second produced densities above 1 sample per second, which is impossible at 1 Hz and meant my pairing was wrong. The data simply is not there, so this adds it.

## What it reports

One line per scored night:

```
rhr bins day=2026-09-07 bins=41 thin=1 implausible=0 winnerN=1 floor=38 gated=60 wouldChange=true
```

`winnerN` is the number that settles the question: it is the sample count of the bin that actually won the floor. A night where the winner is a single sample is the case the issue is about; a night where it is 300 is not.

Bins are built exactly as `sessionRestingHR` builds them, closed final bin included, or the line would describe a different partition than the one it judges.

It returns nil on a night where the gate would change nothing **and** every bin is well-populated, so a clean night stays silent and the log carries only what is worth reading. Same posture as the over-count-only R-R dump. Counts and bpm only, no timestamps.

## Tests

Six per platform, every case matched. Pinning the shape rather than a value: a dense night says nothing; a one-sample bin that **wins** is reported with its size and the floor it would have been given instead; a thin bin that cannot win is silent; an empty night is silent; no timestamp reaches the line; and the load-bearing one, that the diagnostic judges the **same partition** `sessionRestingHR` ships, by taking the shipped floor from it and asserting agreement.

That last test earned its place immediately, and what it found belongs to #1943 rather than to this code. A session whose span is not a multiple of the window has a final bin holding only `span mod 300` samples, because that bin closes on `end`: a 1801-second night is six 300-sample bins and a final bin of **two**. So a thin final bin is **structural, not an artefact**, and appears on nearly every real night.

The line therefore reports only when the gate would actually **move the floor**. The original rule, silent only when no bin was thin, would have fired on almost every night while saying `wouldChange=false`. It also tells a future gate something it needs: excluding bins on sample count alone would drop the final partial bin most nights, which is harmless while that bin does not win, but is not the artefact the gate is aimed at.

## The budget, and why the call site moved

Adding the emit inline put `analyzeRecentOnCpu` 245 bytes over its JaCoCo budget. Rather than raise it, which its own note forbids, the existing floor-vs-mean emit was folded into the same builder and lifted out. That frees **518 bytes net**, so the method is now smaller than before this change at **55,482**. The budget is a ratchet its note says to lower whenever an extraction frees space, so it drops from 56,000 to 55,700, keeping ~218 bytes of headroom rather than sitting flush against the measurement.

Android suite **5508 green**, doc-comment and i18n gates clean.

## What this does not claim

Nothing about whether the gate should ship. That is what the line is for: a few weeks of `wouldChange=false` says it is a no-op and can land unargued, while any night reporting a thin winner says exactly what the change buys and what it costs.
