### PR TITLE
charging: stop pack presence from overriding the strap gauge

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -645,6 +645,13 @@ public final class BLEManager: NSObject, ObservableObject {
     /// Pure battery-adaptive gate (#477), the twin of Android `WhoopBleClient.idleThrottleActive`. Keyed
     /// on the STRAP's battery: armed by `thresholdPct` > 0, engages while the strap is discharging at/below
     /// `thresholdPct`. The phone's own Low Power Mode deliberately does NOT trigger it. Charging never engages.
+    ///
+    /// `charging` is not purely "is charging" (#1935): on a 5/MG it is also set on pack ATTACH, so a
+    /// depleted or badly-seated pack reads true while nothing charges, and this gate then stays off. The
+    /// window is bounded — the next BATTERY_LEVEL rewrites the flag from the strap's own gauge — and the
+    /// reasoning for accepting that rather than splitting the state is on `LiveState.charging`. Read it
+    /// before adding a trend check here: making this wait for a rising gauge would delay throttle release
+    /// on every honest attach to close an edge that already closes itself.
     static func lowPowerThrottleActive(batteryPct: Int, charging: Bool, thresholdPct: Int) -> Bool {
         thresholdPct > 0 && !charging && batteryPct <= thresholdPct
     }

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -88,20 +88,22 @@ public final class LiveState: ObservableObject {
     /// charging began. They diverge on a depleted pack or a poor contact: 21 fires, 7 never does, and
     /// this reads true while nothing charges.
     ///
-    /// THAT STATE IS BOUNDED ON THIS PLATFORM, which is why it is documented rather than split. It does
-    /// not last until 22: the next live BATTERY_LEVEL overwrites it from the gauge, so the window is about
-    /// one battery cadence. That holds here for a specific reason — the pack record is LOG-ONLY on iOS
-    /// (`FrameRouter`, Test Centre gated), so nothing but the gauge writes this flag afterwards. The
-    /// Android twin is different and worse: it writes `charging = true` from the pushed pack-info event
-    /// (109) every couple of minutes while a pack is attached, which outruns the gauge and holds the flag
-    /// true for the whole attachment. Do not port that here, and read #1935 before adding any pack-derived
-    /// write to this flag.
+    /// THAT STATE IS BOUNDED, which is why it is documented rather than split. It does not last until 22:
+    /// the next live BATTERY_LEVEL overwrites it from the strap's own GAUGE, so the window is about one
+    /// battery cadence, and the gauge always gets the last word.
+    ///
+    /// It gets the last word only because nothing else repeats, which is a real constraint rather than an
+    /// observation (#1935). The pack record reaches this platform LOG-ONLY (`FrameRouter`, Test Centre
+    /// gated) and writes nothing here. Android learned the same rule the hard way: its pushed pack-info
+    /// event (109) once wrote `charging = true` on pack PRESENCE every couple of minutes, outran the
+    /// gauge, and held a flat pack at "charging" for its whole attachment. An EDGE may set this flag
+    /// (7, 21, 22); a repeating presence signal must not, or the gauge cannot correct it.
     ///
     /// It matters beyond the pill. `BLEManager.lowPowerThrottleActive` reads it and gates THREE levers, not
     /// one: the low-battery offload cadence, the connection-priority throttle, and the continuous-capture
     /// pause behind the user's own "Pause HRV capture" percentage. So a pack attached but not charging can
-    /// keep background capture running at low battery after the user asked for it to stop, for as long as
-    /// the flag is wrong. `BLEManager.batteryPollDue` also reads it, polling every tick instead of every
+    /// keep background capture running at low battery after the user asked for it to stop, for that
+    /// window. `BLEManager.batteryPollDue` also reads it, polling every tick instead of every
     /// other, which is harmless and arguably wanted with a pack on.
     ///
     /// nil until the first event of a session; cleared on disconnect so a stale flag can't outlive the

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -76,10 +76,34 @@ public final class LiveState: ObservableObject {
     /// GET_EXTENDED_BATTERY_INFO response (#592). Shown on the Devices card as a "x.xx V" readout beside the
     /// percent; nil until the first battery event lands. Twin of the Android LiveState.batteryMv.
     @Published public var batteryMv: Int? = nil
-    /// Charging flag from the strap's BATTERY_LEVEL events — wire observation: u8 bit0 in the
-    /// event payload (4.0 @26 / 5.0 @30), pushed ~every 8 min on captured links. nil until the
-    /// first event of a session; cleared on disconnect so a stale flag can't outlive the link.
-    /// Flag ONLY — the battery % keeps its family-specific source (#77).
+    /// Charging flag. Two sources, and they mean different things (#1935).
+    ///
+    /// The authority is the strap's BATTERY_LEVEL event — wire observation: u8 bit0 in the payload
+    /// (4.0 @26 / 5.0 @30), pushed ~every 8 min on captured links. That is a LEVEL signal from the
+    /// strap's own gauge: every live battery event rewrites this flag, whatever it was.
+    ///
+    /// On a 5/MG it is ALSO set by `BATTERY_PACK_CONNECTED(21)` and cleared by
+    /// `BATTERY_PACK_REMOVED(22)`, which is a latency win — 21 leads `CHARGING_ON(7)` by up to ~17 s in
+    /// captures, so the pill responds when the pack goes on. But 21 means A PACK WAS ATTACHED, not that
+    /// charging began. They diverge on a depleted pack or a poor contact: 21 fires, 7 never does, and
+    /// this reads true while nothing charges.
+    ///
+    /// THAT STATE IS BOUNDED, which is why it is documented rather than split. It does not last until 22:
+    /// the next live BATTERY_LEVEL overwrites it from the gauge, so the window is about one battery
+    /// cadence. It matters beyond the pill because `BLEManager.lowPowerThrottleActive` reads this flag
+    /// and a true value disables the low-battery offload throttle, so a strap on a dead pack can skip
+    /// throttling for that window. Bounded and self-healing; splitting the state, or making the throttle
+    /// wait for a rising gauge, would cost every honest attach to close it.
+    ///
+    /// What reads it beyond the pill, all bounded the same way. `BLEManager.lowPowerThrottleActive` is
+    /// the one that matters, and it gates THREE levers, not one: the low-battery offload cadence, the
+    /// connection-priority throttle, and the continuous-capture pause behind the user's own "Pause HRV
+    /// capture" percentage. So a pack attached but not charging can keep background capture running at low
+    /// battery after the user asked for it to stop. `BLEManager.batteryPollDue` also reads it, polling
+    /// every tick instead of every other, which is harmless and arguably wanted with a pack on.
+    ///
+    /// nil until the first event of a session; cleared on disconnect so a stale flag can't outlive the
+    /// link. Flag ONLY — the battery % keeps its family-specific source (#77).
     @Published public var charging: Bool? = nil
 
     /// The Oura ring's current wear/charge state (nil for non-Oura straps or before any evidence this

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -88,22 +88,21 @@ public final class LiveState: ObservableObject {
     /// charging began. They diverge on a depleted pack or a poor contact: 21 fires, 7 never does, and
     /// this reads true while nothing charges.
     ///
-    /// THAT STATE IS BOUNDED, which is why it is documented rather than split. It does not last until 22:
-    /// the next live BATTERY_LEVEL overwrites it from the gauge, so the window is about one battery
-    /// cadence. One thing extends it: the live router is skipped while an offload replays (backfill never
-    /// calls `handle(frame:)`), so a long history sync holds the stale value for its duration plus a
-    /// cadence. Android has the same exclusion explicitly, in `shouldApplyChargingFromBatteryEvent`.
-    /// It matters beyond the pill because `BLEManager.lowPowerThrottleActive` reads this flag
-    /// and a true value disables the low-battery offload throttle, so a strap on a dead pack can skip
-    /// throttling for that window. Bounded and self-healing; splitting the state, or making the throttle
-    /// wait for a rising gauge, would cost every honest attach to close it.
+    /// THAT STATE IS BOUNDED ON THIS PLATFORM, which is why it is documented rather than split. It does
+    /// not last until 22: the next live BATTERY_LEVEL overwrites it from the gauge, so the window is about
+    /// one battery cadence. That holds here for a specific reason — the pack record is LOG-ONLY on iOS
+    /// (`FrameRouter`, Test Centre gated), so nothing but the gauge writes this flag afterwards. The
+    /// Android twin is different and worse: it writes `charging = true` from the pushed pack-info event
+    /// (109) every couple of minutes while a pack is attached, which outruns the gauge and holds the flag
+    /// true for the whole attachment. Do not port that here, and read #1935 before adding any pack-derived
+    /// write to this flag.
     ///
-    /// What reads it beyond the pill, all bounded the same way. `BLEManager.lowPowerThrottleActive` is
-    /// the one that matters, and it gates THREE levers, not one: the low-battery offload cadence, the
-    /// connection-priority throttle, and the continuous-capture pause behind the user's own "Pause HRV
-    /// capture" percentage. So a pack attached but not charging can keep background capture running at low
-    /// battery after the user asked for it to stop. `BLEManager.batteryPollDue` also reads it, polling
-    /// every tick instead of every other, which is harmless and arguably wanted with a pack on.
+    /// It matters beyond the pill. `BLEManager.lowPowerThrottleActive` reads it and gates THREE levers, not
+    /// one: the low-battery offload cadence, the connection-priority throttle, and the continuous-capture
+    /// pause behind the user's own "Pause HRV capture" percentage. So a pack attached but not charging can
+    /// keep background capture running at low battery after the user asked for it to stop, for as long as
+    /// the flag is wrong. `BLEManager.batteryPollDue` also reads it, polling every tick instead of every
+    /// other, which is harmless and arguably wanted with a pack on.
     ///
     /// nil until the first event of a session; cleared on disconnect so a stale flag can't outlive the
     /// link. Flag ONLY — the battery % keeps its family-specific source (#77).

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -90,7 +90,10 @@ public final class LiveState: ObservableObject {
     ///
     /// THAT STATE IS BOUNDED, which is why it is documented rather than split. It does not last until 22:
     /// the next live BATTERY_LEVEL overwrites it from the gauge, so the window is about one battery
-    /// cadence. It matters beyond the pill because `BLEManager.lowPowerThrottleActive` reads this flag
+    /// cadence. One thing extends it: the live router is skipped while an offload replays (backfill never
+    /// calls `handle(frame:)`), so a long history sync holds the stale value for its duration plus a
+    /// cadence. Android has the same exclusion explicitly, in `shouldApplyChargingFromBatteryEvent`.
+    /// It matters beyond the pill because `BLEManager.lowPowerThrottleActive` reads this flag
     /// and a true value disables the low-battery offload throttle, so a strap on a dead pack can skip
     /// throttling for that window. Bounded and self-healing; splitting the state, or making the throttle
     /// wait for a rising gauge, would cost every honest attach to close it.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -177,25 +177,24 @@ data class LiveState(
      *  a depleted pack or a poor contact: 21 fires, 7 never does, and this reads true while nothing
      *  charges.
      *
-     *  ON ANDROID THAT STATE DOES NOT HEAL ITSELF, which is the part to know before trusting the flag.
-     *  A live BATTERY_LEVEL does overwrite it from the gauge, but it is not the only writer: the pushed
-     *  pack-info event (109) sets it true AGAIN every couple of minutes for as long as a pack is
-     *  ATTACHED, keyed on presence plus a plausible SoC ([com.noop.protocol.BatteryPackInfo.Info.displayable]),
-     *  a flat pack included. That re-assertion is deliberate, the anti-staleness half for an attach edge
-     *  the app missed, but it fires several times more often than the ~8 min BATTERY_LEVEL that would
-     *  clear it, so the gauge's answer is overwritten before it can settle. A pack attached and NOT
-     *  charging therefore reads true until BATTERY_PACK_REMOVED(22), not for one battery cadence. The
-     *  gauge no longer has the last word, which is the part that is certain from the code; how often 109
-     *  repeats on a pack that is attached but FLAT is the one thing no capture has measured yet. iOS
-     *  does not do this: there the pack record is log-only, so its cadence bound is real. Tracked in
-     *  #1935; the anti-staleness job wants "a pack is attached", which [packSocPct] already answers.
+     *  THAT STATE IS BOUNDED, which is why it is documented rather than split. It does not last until 22:
+     *  the next live BATTERY_LEVEL overwrites it from the strap's own GAUGE, so the window is about one
+     *  battery cadence, and the gauge always gets the last word.
+     *
+     *  THE GAUGE ONLY GETS THE LAST WORD BECAUSE NOTHING ELSE REPEATS. That is a real constraint, not an
+     *  observation (#1935): the pushed pack-info event (109) used to write charging=true too, keyed on
+     *  pack PRESENCE plus a plausible SoC, as an anti-staleness half for a missed attach edge. It repeats
+     *  every couple of minutes, so it outran the ~8 min BATTERY_LEVEL and a flat or badly seated pack read
+     *  "charging" for its whole attachment instead of self-correcting. It now writes [packSocPct] alone,
+     *  which is what the anti-staleness job actually wanted. So: an EDGE may set this flag (7, 21, 22), a
+     *  repeating presence signal must not, or the gauge stops being able to correct it.
      *
      *  It matters beyond the pill. [WhoopBleClient.idleThrottleActive] reads this flag and gates THREE
      *  levers, not one: the low-battery offload cadence, the GATT connection-priority throttle, and the
      *  continuous-capture pause behind the user's own "Pause HRV capture" percentage. So a strap on a flat
-     *  or badly seated pack can skip low-battery throttling and keep background capture running for the
-     *  WHOLE attachment, after the user asked for it to stop. [WhoopBleClient.batteryPollDue] also reads
-     *  it, polling every tick instead of every other, which is harmless and arguably wanted with a pack on.
+     *  pack can skip low-battery throttling and keep background capture running after the user asked for
+     *  it to stop, for that window. [WhoopBleClient.batteryPollDue] also reads it, polling every tick
+     *  instead of every other, which is harmless and arguably wanted with a pack on.
      *
      *  Flag only; battery % keeps its family source (#77). Cleared on disconnect so a stale flag can't
      *  outlive the link. Twin of macOS LiveState.charging. */
@@ -8062,11 +8061,19 @@ class WhoopBleClient(
                                     // command path and the event path end up disagreeing about the same
                                     // pack, which is the drift decodeRecord() exists to prevent.
                                     if (info.displayable && soc != null) {
-                                        // charging=true here as well as on event 21 is the anti-staleness
-                                        // half: if the attach edge was missed (app started with the pack
-                                        // already on, or the link dropped over the attach), this repeating
-                                        // event re-establishes the state within a couple of minutes.
-                                        _state.update { s -> s.copy(packSocPct = soc, charging = true) }
+                                        // SoC ONLY, deliberately (#1935). This event says a pack is
+                                        // ATTACHED and how full it is, never that current is flowing.
+                                        // It used to write charging=true as well, as the anti-staleness
+                                        // half for a missed attach edge — but it repeats every couple of
+                                        // minutes, so it outran the ~8 min BATTERY_LEVEL that corrects the
+                                        // flag from the strap's own GAUGE, and a flat or badly seated pack
+                                        // then read "charging" for the whole attachment instead of
+                                        // self-correcting. BATTERY_PACK_CONNECTED(21) still lights the pill
+                                        // on the attach edge, so the latency win survives; the gauge now
+                                        // gets the last word, which is what iOS already did. A missed
+                                        // attach edge costs at most one battery cadence of lag and is then
+                                        // RIGHT, instead of being fast and possibly wrong.
+                                        _state.update { s -> s.copy(packSocPct = soc) }
                                     } else if (!info.present) {
                                         _state.update { s -> s.copy(packSocPct = null) }
                                     }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -165,10 +165,34 @@ data class LiveState(
      *  reconnects (or the settle timeout gives up). With `!connected` it drives the Devices card's
      *  transient "Reconnecting…" pill. Twin of macOS LiveState.rebootInProgress. */
     val rebootInProgress: Boolean = false,
-    /** Charging flag from BATTERY_LEVEL events — wire observation: u8 bit0 (4.0 @26 / 5.0 @30,
-     *  ~every 8 min on captured links). Flag only; battery % keeps its family source (#77).
-     *  Cleared on disconnect so a stale flag can't outlive the link. Twin of macOS
-     *  LiveState.charging. */
+    /** Charging flag. Two sources, and they mean different things (#1935).
+     *
+     *  The authority is BATTERY_LEVEL — wire observation: u8 bit0 (4.0 @26 / 5.0 @30, ~every 8 min on
+     *  captured links). That is a LEVEL signal from the strap's own gauge: every live battery event
+     *  rewrites this flag, whatever it was.
+     *
+     *  On a 5/MG it is ALSO set by BATTERY_PACK_CONNECTED(21) and cleared by BATTERY_PACK_REMOVED(22),
+     *  which is a latency win — 21 leads CHARGING_ON(7) by up to ~17 s in captures, so the pill responds
+     *  when the pack goes on. But 21 means A PACK WAS ATTACHED, not that charging began. They diverge on
+     *  a depleted pack or a poor contact: 21 fires, 7 never does, and this reads true while nothing
+     *  charges.
+     *
+     *  THAT STATE IS BOUNDED, which is why it is documented rather than split. It does not last until 22:
+     *  the next live BATTERY_LEVEL overwrites it from the gauge, so the window is about one battery
+     *  cadence. It matters beyond the pill because [lowPowerThrottleActive]'s twin reads this flag and a
+     *  true value disables the low-battery offload throttle, so a strap on a dead pack can skip
+     *  throttling for that window. Bounded and self-healing; splitting the state, or making the throttle
+     *  wait for a rising gauge, would cost every honest attach to close it.
+     *
+     *  What reads it beyond the pill, all bounded the same way. [idleThrottleActive] is the one that
+     *  matters, and it gates THREE levers, not one: the low-battery offload cadence, the GATT
+     *  connection-priority throttle, and the continuous-capture pause behind the user's own "Pause HRV
+     *  capture" percentage. So a pack attached but not charging can keep background capture running at
+     *  low battery after the user asked for it to stop. [batteryPollDue] also reads it, polling every
+     *  tick instead of every other, which is harmless and arguably wanted with a pack on.
+     *
+     *  Flag only; battery % keeps its family source (#77). Cleared on disconnect so a stale flag can't
+     *  outlive the link. Twin of macOS LiveState.charging. */
     val charging: Boolean? = null,
     /** Battery-pack charge, tenths-of-a-percent precision, from the pushed pack event (109) payload.
      *  5/MG only — a WHOOP 4.0 has no pack fuel gauge (its pack reads as a VOLTAGE via opcode 98, a
@@ -745,7 +769,14 @@ class WhoopBleClient(
          *  strap is DISCHARGING at/below [thresholdPct]. The
          *  phone's own Battery Saver deliberately does NOT trigger it — power saving is about the strap's
          *  charge, not the phone's. A charging strap never throttles. The threshold is its own hysteresis
-         *  (battery % moves slowly, so a boundary crossing flips at most once per point). */
+         *  (battery % moves slowly, so a boundary crossing flips at most once per point).
+         *
+         *  [LiveState.charging] is not purely "is charging" (#1935): on a 5/MG it is also set on pack
+         *  ATTACH, so a depleted or badly-seated pack reads true while nothing charges, and this gate then
+         *  stays off. The window is bounded — the next BATTERY_LEVEL rewrites the flag from the strap's own
+         *  gauge — and the reasoning for accepting that rather than splitting the state is on that field.
+         *  Read it before adding a trend check here: making this wait for a rising gauge would delay
+         *  throttle release on every honest attach to close an edge that already closes itself. */
         fun idleThrottleActive(batteryPct: Int, charging: Boolean, thresholdPct: Int): Boolean =
             thresholdPct > 0 && !charging && batteryPct <= thresholdPct
 

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -184,7 +184,9 @@ data class LiveState(
      *  a flat pack included. That re-assertion is deliberate, the anti-staleness half for an attach edge
      *  the app missed, but it fires several times more often than the ~8 min BATTERY_LEVEL that would
      *  clear it, so the gauge's answer is overwritten before it can settle. A pack attached and NOT
-     *  charging therefore reads true until BATTERY_PACK_REMOVED(22), not for one battery cadence. iOS
+     *  charging therefore reads true until BATTERY_PACK_REMOVED(22), not for one battery cadence. The
+     *  gauge no longer has the last word, which is the part that is certain from the code; how often 109
+     *  repeats on a pack that is attached but FLAT is the one thing no capture has measured yet. iOS
      *  does not do this: there the pack record is log-only, so its cadence bound is real. Tracked in
      *  #1935; the anti-staleness job wants "a pack is attached", which [packSocPct] already answers.
      *

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -179,7 +179,10 @@ data class LiveState(
      *
      *  THAT STATE IS BOUNDED, which is why it is documented rather than split. It does not last until 22:
      *  the next live BATTERY_LEVEL overwrites it from the gauge, so the window is about one battery
-     *  cadence. It matters beyond the pill because [lowPowerThrottleActive]'s twin reads this flag and a
+     *  cadence. One thing extends it: [shouldApplyChargingFromBatteryEvent] suppresses the rewrite while
+     *  an offload replays, so a long history sync holds the stale value for its duration plus a cadence
+     *  (iOS has the same exclusion structurally: backfill never reaches the live router). It matters
+     *  beyond the pill because [lowPowerThrottleActive]'s twin reads this flag and a
      *  true value disables the low-battery offload throttle, so a strap on a dead pack can skip
      *  throttling for that window. Bounded and self-healing; splitting the state, or making the throttle
      *  wait for a rising gauge, would cost every honest attach to close it.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -177,22 +177,23 @@ data class LiveState(
      *  a depleted pack or a poor contact: 21 fires, 7 never does, and this reads true while nothing
      *  charges.
      *
-     *  THAT STATE IS BOUNDED, which is why it is documented rather than split. It does not last until 22:
-     *  the next live BATTERY_LEVEL overwrites it from the gauge, so the window is about one battery
-     *  cadence. One thing extends it: [shouldApplyChargingFromBatteryEvent] suppresses the rewrite while
-     *  an offload replays, so a long history sync holds the stale value for its duration plus a cadence
-     *  (iOS has the same exclusion structurally: backfill never reaches the live router). It matters
-     *  beyond the pill because [lowPowerThrottleActive]'s twin reads this flag and a
-     *  true value disables the low-battery offload throttle, so a strap on a dead pack can skip
-     *  throttling for that window. Bounded and self-healing; splitting the state, or making the throttle
-     *  wait for a rising gauge, would cost every honest attach to close it.
+     *  ON ANDROID THAT STATE DOES NOT HEAL ITSELF, which is the part to know before trusting the flag.
+     *  A live BATTERY_LEVEL does overwrite it from the gauge, but it is not the only writer: the pushed
+     *  pack-info event (109) sets it true AGAIN every couple of minutes for as long as a pack is
+     *  ATTACHED, keyed on presence plus a plausible SoC ([com.noop.protocol.BatteryPackInfo.Info.displayable]),
+     *  a flat pack included. That re-assertion is deliberate, the anti-staleness half for an attach edge
+     *  the app missed, but it fires several times more often than the ~8 min BATTERY_LEVEL that would
+     *  clear it, so the gauge's answer is overwritten before it can settle. A pack attached and NOT
+     *  charging therefore reads true until BATTERY_PACK_REMOVED(22), not for one battery cadence. iOS
+     *  does not do this: there the pack record is log-only, so its cadence bound is real. Tracked in
+     *  #1935; the anti-staleness job wants "a pack is attached", which [packSocPct] already answers.
      *
-     *  What reads it beyond the pill, all bounded the same way. [idleThrottleActive] is the one that
-     *  matters, and it gates THREE levers, not one: the low-battery offload cadence, the GATT
-     *  connection-priority throttle, and the continuous-capture pause behind the user's own "Pause HRV
-     *  capture" percentage. So a pack attached but not charging can keep background capture running at
-     *  low battery after the user asked for it to stop. [batteryPollDue] also reads it, polling every
-     *  tick instead of every other, which is harmless and arguably wanted with a pack on.
+     *  It matters beyond the pill. [WhoopBleClient.idleThrottleActive] reads this flag and gates THREE
+     *  levers, not one: the low-battery offload cadence, the GATT connection-priority throttle, and the
+     *  continuous-capture pause behind the user's own "Pause HRV capture" percentage. So a strap on a flat
+     *  or badly seated pack can skip low-battery throttling and keep background capture running for the
+     *  WHOLE attachment, after the user asked for it to stop. [WhoopBleClient.batteryPollDue] also reads
+     *  it, polling every tick instead of every other, which is harmless and arguably wanted with a pack on.
      *
      *  Flag only; battery % keeps its family source (#77). Cleared on disconnect so a stale flag can't
      *  outlive the link. Twin of macOS LiveState.charging. */

--- a/android/app/src/test/java/com/noop/ble/ChargingAndReleaseTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ChargingAndReleaseTest.kt
@@ -59,4 +59,50 @@ class ChargingAndReleaseTest {
         assertNull(released.heartRate)
         assertNull(released.charging)
     }
+
+    // --- #1935: only an EDGE may set the charging flag -------------------------------------------------
+
+    /**
+     * The pushed pack-info event (109) must publish the pack's SoC and NOTHING ELSE.
+     *
+     * It used to write `charging = true` as well, keyed on pack PRESENCE, as an anti-staleness half for an
+     * attach edge the app missed. That is the one write that cannot be allowed here: 109 repeats every
+     * couple of minutes, so it outran the ~8 min BATTERY_LEVEL that corrects the flag from the strap's own
+     * gauge, and a flat or badly seated pack then read "charging" for its whole attachment instead of
+     * self-correcting. The flag reaches three throttling levers (see [LiveState.charging]), so that is not
+     * only a wrong pill.
+     *
+     * Pinned against the source the way [StalledLinkDiagnosticsTest] pins its caller-side invariants: the
+     * write lives inline in a GATT callback that no JVM test can construct, and the regression is a single
+     * word being added back.
+     */
+    @Test
+    fun `the repeating pack-info event publishes SoC without touching the charging flag`() {
+        val src = clientSource()
+        // Anchored on the handler's own guard, which is unique in the file: the decode call and the event
+        // constant both appear earlier in the address-masking helper, and anchoring there swallowed 400k
+        // characters and passed on the pre-fix source.
+        val start = src.indexOf("info.displayable && soc != null")
+        assertTrue("the pack-info event handler was not found", start > 0)
+        val end = src.indexOf("packSocPct = null", start)
+        assertTrue("the pack-info handler's absent-pack branch was not found", end > start)
+        // Comments discuss the removed write by name, so judge the CODE only.
+        val code = src.substring(start, end).lines()
+            .filterNot { it.trim().startsWith("//") }
+            .joinToString("\n")
+        assertTrue("pack info must still publish the SoC", code.contains("packSocPct = soc"))
+        assertFalse("pack PRESENCE must never write the charging flag (#1935) — an EDGE may (7, 21, 22), " +
+                    "a repeating signal may not, or the gauge can no longer correct it",
+                    code.contains("charging"))
+    }
+
+    private fun clientSource(): String {
+        var root = java.io.File(System.getProperty("user.dir") ?: ".").canonicalFile
+        repeat(4) {
+            val f = java.io.File(root, "android/app/src/main/java/com/noop/ble/WhoopBleClient.kt")
+            if (f.isFile) return f.readText()
+            root = root.parentFile ?: root
+        }
+        error("WhoopBleClient.kt not found — this test must not pass by default")
+    }
 }


### PR DESCRIPTION
Started as option A from #1935, document the conflation rather than split the
state. Re-reviewing the doc before merging showed the argument that option A
rested on was wrong, so this now carries the fix as well.

## What the re-review found

The doc claimed a spurious `charging = true` was bounded and self-healing: the
next `BATTERY_LEVEL` overwrites it from the strap's own gauge, so at worst it is
wrong for about one battery cadence. That is true on iOS. It was not true on
Android, because `BATTERY_LEVEL` was not the only writer.

The pushed pack-info event (109) also wrote `charging = true`, keyed on pack
PRESENCE plus a plausible SoC. `displayable` is `present && socPct in 0.0..100.0`,
so a flat pack qualifies, and the decoder's own hardware-confirmed note says the
strap volunteers 109 every couple of minutes while a pack is attached. That
outruns the ~8 min `BATTERY_LEVEL` that would clear the flag. So the gauge never
got the last word: a pack attached and not charging read as charging for its
whole attachment, not for one cadence.

That is not only a wrong pill. `idleThrottleActive` reads the flag and gates
three levers: the low-battery offload cadence, the GATT connection-priority
throttle, and the continuous-capture pause behind the user's own "Pause HRV
capture" percentage. A strap on a flat or badly seated pack kept background
capture running at low battery after the wearer asked for it to stop.

iOS was never affected. There the pack record is log-only and Test Centre gated,
so nothing but the gauge writes the flag.

## The fix

109 now publishes `packSocPct` alone. That is what the anti-staleness half
actually wanted, and the neighbouring doc already calls a non-null `packSocPct`
the pack-attached signal.

`BATTERY_PACK_CONNECTED(21)` still sets the flag on the attach edge, so the
latency win that #1826 added survives, and `BATTERY_LEVEL` can now correct it.
A missed attach edge costs at most one battery cadence of lag and is then right,
rather than being fast and possibly wrong. Android ends up doing what iOS
already did.

The rule both platforms now state at the field: an EDGE may set this flag
(7, 21, 22), a repeating presence signal may not, or the gauge can no longer
correct it.

## Tests

One new test, pinned against the source, because the write lives inline in a
GATT callback no JVM test can construct. It is anchored on the handler's own
`info.displayable && soc != null` guard, which is unique in the file. Anchoring
on the decode call or the event constant instead swallowed 400k characters and
passed on the pre-fix source, so the anchor is checked rather than assumed.

Verified as a negative control: re-adding `charging = true` to that one line
fails the test, restoring it passes. Full Android suite 5504 green, doc-comment
gate clean.

Swift is doc-only, so CI is the check there.

## Not included

The `charging` flag still means "attached or charging" on the 21 edge, which is
the original conflation #1935 raised. That stays documented rather than split:
21 leads `CHARGING_ON(7)` by up to ~17 s in captures, and with the gauge able to
correct the flag again, the window is genuinely one cadence.

One thing remains unmeasured, and it is noted in the code rather than glossed:
how often 109 repeats on a pack that is attached but flat. The fix does not
depend on it, since a repeating presence write is wrong regardless, but the
severity of what was there before does.
