### PR TITLE
explorer: stop the readings table printing the unit twice

### DIFF
--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -1343,7 +1343,14 @@ struct MetricDetailView: View {
         let readings = windowed.map {
             VitalReading(day: $0.day, value: $0.value, source: sourceByDay[$0.day] ?? metric.source)
         }
-        let rows = vitalReadingRows(readings: readings, unit: metric.unit,
+        // The unit is passed EMPTY on purpose (#1942). `vitalReadingRows` appends its `unit` to whatever
+        // the formatter returns, and every `MetricDescriptor.format` overload already ends in the unit —
+        // the CONVERTED one, at that. Passing `metric.unit` here rendered "33 % %", and worse than a
+        // repeat for the three convertible families, whose stored label contradicts the displayed one:
+        // "182.0 lb kg", "Δ0.5 °F °C", "12.5 /21 /100". The Android twin appends the same way and is
+        // correct because every one of its call sites passes a UNIT-LESS closure; iOS has no unit-less
+        // formatter that also converts, so the unit comes from `fmt` and the parameter stays empty.
+        let rows = vitalReadingRows(readings: readings, unit: "",
                                     strapDeviceId: repo.deviceId, format: fmt)
         if !rows.isEmpty {
             NoopCard {

--- a/StrandTests/VitalReadingsTableTests.swift
+++ b/StrandTests/VitalReadingsTableTests.swift
@@ -87,4 +87,39 @@ final class VitalReadingsTableTests: XCTestCase {
         )
         XCTAssertEqual(rows.first?.value, "72")
     }
+
+    // MARK: - #1942: the Explorer pairs a unit-BEARING formatter with an EMPTY unit
+
+    /// Every test above passes `spo2Format`, a unit-LESS closure, which is the contract this function was
+    /// written to and the one all of Android's call sites follow. The Explorer cannot follow it: its
+    /// formatter is `MetricDescriptor.format`, which already ends in the unit, and the CONVERTED one —
+    /// there is no unit-less iOS formatter that also converts kg→lb / °C→°F / 0–100→0–21. So it pairs that
+    /// formatter with an empty unit, and this pins both halves of that pairing.
+    ///
+    /// Passing the descriptor's stored `unit` alongside it is what rendered "33 % %" in the readings table
+    /// while the hero and the stat tiles, which render the formatter directly, stayed correct (#1942).
+    func testExplorerFormatterAlreadyCarriesTheUnitSoTheUnitParameterIsEmpty() throws {
+        let spo2 = try XCTUnwrap(MetricCatalog.metric(key: "spo2", source: strap))
+        let explorerFormat: (Double) -> String = { spo2.format($0, system: .metric, temperature: .celsius) }
+
+        // Half one: the Explorer's own formatter is unit-BEARING, unlike `spo2Format` above.
+        XCTAssertEqual(explorerFormat(97), "97 %")
+
+        // Half two: paired with an empty unit, the row carries exactly one.
+        let rows = vitalReadingRows(readings: spo2Readings(), unit: "", strapDeviceId: strap,
+                                    now: now, format: explorerFormat)
+        XCTAssertEqual(rows.first?.value, "97 %")
+    }
+
+    /// The function itself is not at fault, and this says so: given the pairing the Explorer used to pass,
+    /// doubling is the CORRECT output. That is why the fix is at the call site and why Android, whose
+    /// twin appends identically, was never affected. Kept as the counter-case to the test above so a
+    /// future reader restoring `unit: metric.unit` sees what it does.
+    func testAUnitBearingFormatterPlusAUnitDoublesItWhichIsWhyTheCallSitePassesEmpty() throws {
+        let spo2 = try XCTUnwrap(MetricCatalog.metric(key: "spo2", source: strap))
+        let rows = vitalReadingRows(readings: spo2Readings(), unit: spo2.unit, strapDeviceId: strap,
+                                    now: now,
+                                    format: { spo2.format($0, system: .metric, temperature: .celsius) })
+        XCTAssertEqual(rows.first?.value, "97 % %")
+    }
 }


### PR DESCRIPTION
Reported by @Geg0r in #1942, with two screenshots that made it quick to place.

## What happened

`vitalReadingRows` appends its `unit` parameter to whatever the formatter
returns:

```swift
value: unit.isEmpty ? value : "\(value) \(unit)",
```

The Explorer passed `metric.unit` alongside `format: fmt`, and every
`MetricDescriptor.format` overload already ends in the unit. Hence `33 % %` in
the readings table, while the hero and the stat tiles stayed correct because
they render the formatter directly.

For the three convertible families it was worse than a repeat, because `format`
converts and relabels while the stored `unit` does not:

| metric | preference | rendered |
|---|---|---|
| Weight | Imperial | `182.0 lb kg` |
| Skin Temp | Fahrenheit | `Δ0.5 °F °C` |
| Effort | /21 scale | `12.5 /21 /100` |

@Geg0r happened to hit `%` and `rpm`, where the stored and displayed labels
agree, so it looked like a harmless duplicate.

## The change

One line: the unit parameter goes empty and the formatter supplies it, with a
comment at the call site saying why so it does not get restored.

Android was never affected and needs no change. Its twin appends the unit the
same way, but every one of its call sites passes a UNIT-LESS closure
(`{ it.roundToInt().toString() }`, `{ String.format("%.1f", it) }`,
`{ UnitFormatter.effortDisplay(it, effortScale) }`), which is the contract the
function was written to. iOS has no unit-less formatter that also converts
kg→lb / °C→°F / 0–100→0–21, so it cannot follow that contract and pairs the
unit-bearing formatter with an empty unit instead.

## Why the tests did not catch it

`VitalReadingsTableTests` passes `spo2Format`, a unit-less closure, and asserts
`"97 %"`. The function was tested and correct; nothing pinned the call site's
pairing. Two tests now do: one that the Explorer's own formatter is unit-bearing
and pairs with an empty unit, and its counter-case, that the same formatter plus
a unit doubles it. The second is deliberately a test of correct behaviour under
the pairing that caused this, so a future reader restoring `unit: metric.unit`
sees what it does and where the fault is not.

These are app-target tests, so they run in the on-demand app-build gate rather
than default CI.
