### PR TITLE
connection: say why the unbonded probe was skipped, and what we hold on the link

### DIFF
--- a/android/app/src/main/java/com/noop/ble/GattCapability.kt
+++ b/android/app/src/main/java/com/noop/ble/GattCapability.kt
@@ -116,6 +116,14 @@ internal data class NotifyCharDump(
  * Same discipline as its sibling: reads already-known local state, sends nothing, and so works on exactly
  * the strap that no puffin probe can reach.
  *
+ * NO Swift twin, and this file's Swift half already says why in general: `gattTreeLines` was twinned
+ * because CoreBluetooth exposes services, characteristics and properties, "unlike the bond-state and
+ * pairing helpers, which have no Apple equivalent at all". This is one of those — it is keyed on the OS
+ * bond state, which CoreBluetooth does not publish, and on an opt-in for a probe that is Android-only.
+ * Worth recording for whoever wants the iOS equivalent: the asymmetry there runs the other way, since
+ * `CBCharacteristic.isNotifying` is authoritative, so iOS could carry the subscription column Android
+ * cannot — after the subscribe attempt, not at discovery.
+ *
  * On encryption it deliberately claims LESS than a reader might want. Android publishes no
  * link-encryption flag to a GATT client, and a remote characteristic's permissions read back as 0, so the
  * bond state is the only standing proxy and it is not the same question. The hard evidence is a CCCD

--- a/android/app/src/main/java/com/noop/ble/GattCapability.kt
+++ b/android/app/src/main/java/com/noop/ble/GattCapability.kt
@@ -85,20 +85,30 @@ internal fun gattTreeLines(services: List<Pair<String, List<Pair<String, Int>>>>
     }
 }
 
-/** One puffin NOTIFY characteristic as the pairing dump sees it. */
+/**
+ * One puffin NOTIFY characteristic as the pairing dump sees it.
+ *
+ * Deliberately NO "subscribed" field. This dump is emitted at service discovery, before the CCCD queue is
+ * drained, so any subscription state read here is "not yet" by construction rather than by fact — and on
+ * API 33+ it could not be read anyway, since `writeDescriptor(descriptor, value)` never populates
+ * `descriptor.value`. Which characteristics actually subscribed is already in the log, one confirmed
+ * `Subscribed <uuid>` line each, written where the confirmation arrives.
+ */
 internal data class NotifyCharDump(
     val uuid: String,
     val hasCccd: Boolean,
-    val subscribed: Boolean,
 )
 
 /**
- * The link's PAIRING posture, next to which puffin notify chars are actually subscribed.
+ * The link's PAIRING posture, next to the puffin notify chars and whether each carries a CCCD.
  *
- * [gattTreeLines] says what the strap OFFERS; this says what we have with it. On a 5/MG the two together
+ * [gattTreeLines] says what the strap OFFERS; this says what we hold with it. On a 5/MG the two together
  * are the difference between "the chars are not there" and "the chars are there and we never subscribed
  * them", which a log otherwise cannot distinguish — the capture that prompted this showed all four puffin
  * notify chars discovered, one standard-HR subscribe, and no further word (#1949).
+ *
+ * It reports POSTURE, not outcome: this runs at service discovery, before the CCCD queue is drained, so
+ * every subscription is still ahead of it. The outcomes are the `Subscribed <uuid>` lines that follow.
  *
  * Same discipline as its sibling: reads already-known local state, sends nothing, and so works on exactly
  * the strap that no puffin probe can reach.
@@ -125,10 +135,13 @@ internal fun whoop5PairingDumpLines(
         add("  no puffin notify characteristics discovered")
     } else {
         for (c in notifyChars) {
-            add("  ${c.uuid} cccd=${if (c.hasCccd) "yes" else "no"}" +
-                " subscribed=${if (c.subscribed) "yes" else "no"}")
+            add("  ${c.uuid} cccd=${if (c.hasCccd) "yes" else "no"}")
         }
     }
+    add(
+        "  note: only the standard HR and battery chars are queued for subscription on a 5/MG, so a puffin" +
+            " char above with no later \"Subscribed\" line went unsubscribed by OUR choice, not the strap's."
+    )
     add(
         "  note: Android publishes no link-encryption flag to a GATT client and a remote characteristic's" +
             " permissions read back as 0, so bond= above is a proxy, not the answer. The hard evidence is a" +

--- a/android/app/src/main/java/com/noop/ble/GattCapability.kt
+++ b/android/app/src/main/java/com/noop/ble/GattCapability.kt
@@ -108,7 +108,10 @@ internal data class NotifyCharDump(
  * notify chars discovered, one standard-HR subscribe, and no further word (#1949).
  *
  * It reports POSTURE, not outcome: this runs at service discovery, before the CCCD queue is drained, so
- * every subscription is still ahead of it. The outcomes are the `Subscribed <uuid>` lines that follow.
+ * every subscription is still ahead of it. The outcomes are the `Subscribed <uuid>` lines that follow, and
+ * what their ABSENCE means flips with [probeOptedIn] — ours when the probe is off, the strap's when it is
+ * on and subscribing those chars itself. The note says which, because guessing wrong there inverts the
+ * single distinction this dump exists to draw.
  *
  * Same discipline as its sibling: reads already-known local state, sends nothing, and so works on exactly
  * the strap that no puffin probe can reach.
@@ -138,9 +141,19 @@ internal fun whoop5PairingDumpLines(
             add("  ${c.uuid} cccd=${if (c.hasCccd) "yes" else "no"}")
         }
     }
+    // Which way this reads FLIPS with the opt-in, and getting it wrong would invert the one distinction
+    // the dump exists to draw. With the probe off, only the standard HR and battery chars are ever queued,
+    // so an unsubscribed puffin char is ours. With it ON, the probe subscribes those same chars itself, so
+    // a missing line there is the strap's answer and not a setting.
     add(
-        "  note: only the standard HR and battery chars are queued for subscription on a 5/MG, so a puffin" +
-            " char above with no later \"Subscribed\" line went unsubscribed by OUR choice, not the strap's."
+        if (probeOptedIn) {
+            "  note: the unbonded probe is ON and subscribes the puffin chars itself, so one above with no" +
+                " later \"Subscribed\" line is the STRAP's answer, logged with the status it refused on."
+        } else {
+            "  note: only the standard HR and battery chars are queued for subscription on a 5/MG, so a" +
+                " puffin char above with no later \"Subscribed\" line went unsubscribed by OUR choice," +
+                " not the strap's."
+        }
     )
     add(
         "  note: Android publishes no link-encryption flag to a GATT client and a remote characteristic's" +

--- a/android/app/src/main/java/com/noop/ble/GattCapability.kt
+++ b/android/app/src/main/java/com/noop/ble/GattCapability.kt
@@ -84,3 +84,54 @@ internal fun gattTreeLines(services: List<Pair<String, List<Pair<String, Int>>>>
         }
     }
 }
+
+/** One puffin NOTIFY characteristic as the pairing dump sees it. */
+internal data class NotifyCharDump(
+    val uuid: String,
+    val hasCccd: Boolean,
+    val subscribed: Boolean,
+)
+
+/**
+ * The link's PAIRING posture, next to which puffin notify chars are actually subscribed.
+ *
+ * [gattTreeLines] says what the strap OFFERS; this says what we have with it. On a 5/MG the two together
+ * are the difference between "the chars are not there" and "the chars are there and we never subscribed
+ * them", which a log otherwise cannot distinguish — the capture that prompted this showed all four puffin
+ * notify chars discovered, one standard-HR subscribe, and no further word (#1949).
+ *
+ * Same discipline as its sibling: reads already-known local state, sends nothing, and so works on exactly
+ * the strap that no puffin probe can reach.
+ *
+ * On encryption it deliberately claims LESS than a reader might want. Android publishes no
+ * link-encryption flag to a GATT client, and a remote characteristic's permissions read back as 0, so the
+ * bond state is the only standing proxy and it is not the same question. The hard evidence is a CCCD
+ * write status, which is why the note names the two codes that answer it (#1635).
+ */
+internal fun whoop5PairingDumpLines(
+    bondState: Int,
+    didBond: Boolean,
+    helloWrittenThisLink: Boolean,
+    probeOptedIn: Boolean,
+    notifyChars: List<NotifyCharDump>,
+): List<String> = buildList {
+    // [bondStateName] is BondStateTrace's, deliberately: two spellings of one OS state in one log is
+    // how a reader ends up believing they are two different readings.
+    add(
+        "pairing: bond=${bondStateName(bondState)} didBond=$didBond" +
+            " helloWritten=$helloWrittenThisLink unbondedProbe=${if (probeOptedIn) "on" else "off"}"
+    )
+    if (notifyChars.isEmpty()) {
+        add("  no puffin notify characteristics discovered")
+    } else {
+        for (c in notifyChars) {
+            add("  ${c.uuid} cccd=${if (c.hasCccd) "yes" else "no"}" +
+                " subscribed=${if (c.subscribed) "yes" else "no"}")
+        }
+    }
+    add(
+        "  note: Android publishes no link-encryption flag to a GATT client and a remote characteristic's" +
+            " permissions read back as 0, so bond= above is a proxy, not the answer. The hard evidence is a" +
+            " CCCD write returning status 5 (insufficient authentication) or 15 (insufficient encryption)."
+    )
+}

--- a/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
+++ b/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
@@ -66,6 +66,52 @@ internal fun shouldProbeUnbondedOffload(
 }
 
 /**
+ * Why the unbonded-offload probe did NOT run on this link, or null when it will.
+ *
+ * [beginUnbondedOffloadProbe] returns SILENTLY when [shouldProbeUnbondedOffload] says no, and that
+ * silence is unreadable. A 5/MG log then shows the four puffin notify chars DISCOVERED, one standard-HR
+ * subscribe, and nothing further — which looks identical whether the app declined to ask or the strap
+ * refused. Those have opposite meanings for #1635: one is a setting, the other is the answer.
+ *
+ * Names the reason in the SAME ORDER the gate tests them, so the reason printed is the one that actually
+ * decided rather than the first one that happens to be true. Returns null exactly when the gate returns
+ * true, and the tests pin that agreement exhaustively over every input, so a new condition added to one
+ * cannot outlive the other.
+ *
+ * The consequence clause is appended only for an unbonded 5/MG, because that is the only case where the
+ * puffin chars go unsubscribed: a bonded strap reaches them through the ordinary handshake.
+ */
+internal fun unbondedProbeSkippedLine(
+    isWhoop5: Boolean,
+    optedIn: Boolean,
+    bonded: Boolean,
+    helloWrittenThisLink: Boolean,
+    alreadyProbedThisLink: Boolean,
+    previouslyRefused: Boolean,
+    silentLinksSoFar: Int,
+): String? {
+    val why = when {
+        !isWhoop5 -> "not a WHOOP 5/MG"
+        !optedIn -> "the unbonded-offload experiment is off"
+        bonded -> "this strap bonded, so the ordinary post-hello handshake reaches the offload"
+        helloWrittenThisLink ->
+            "a CLIENT_HELLO went out on this link, so a refusal here could not be attributed to the strap"
+        alreadyProbedThisLink -> "already probed on this link"
+        unbondedProbeRetired(previouslyRefused, silentLinksSoFar) ->
+            if (previouslyRefused) "retired for this strap: a refusal is latched"
+            else "retired for this strap: the silent-link budget is spent"
+        else -> return null
+    }
+    val consequence = if (isWhoop5 && !bonded) {
+        " The puffin notify chars stay unsubscribed on this link, so neither the historical offload nor a" +
+            " realtime IMU producer can reach us here."
+    } else {
+        ""
+    }
+    return "unbonded probe skipped — $why.$consequence"
+}
+
+/**
  * Has the probe stopped asking — for good, on this device?
  *
  * True on a latched refusal (the strap's verdict) or once the silent-link budget is spent. Extracted

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2598,6 +2598,11 @@ class WhoopBleClient(
     @Volatile
     private var unbondedProbeAwaitingReply = false
 
+    /** True once the probe's skip reason has been logged on this link (#1949), so a retried start does
+     *  not repeat it. Cleared with the rest of the per-link probe state. */
+    @Volatile
+    private var unbondedProbeSkipLogged = false
+
     /** #1635: the probe has run on THIS link. Separate from [unbondedProbeAwaitingReply] because the
      *  keep-alive drains the same CCCD queue every 30s and would otherwise re-enter the probe's own
      *  completion branch for the life of the connection. */
@@ -5312,7 +5317,24 @@ class WhoopBleClient(
                 previouslyRefused = refused,
                 silentLinksSoFar = unbondedProbeSilentLinks,
             )
-        ) return
+        ) {
+            // #1949: say WHY, once per link. A silent return here is what made an MG capture unreadable:
+            // the puffin chars discovered, never subscribed, and no way to tell the app declined from the
+            // strap refusing — opposite meanings for #1635. Once per link, because this path is retried.
+            if (!unbondedProbeSkipLogged) {
+                unbondedProbeSkipLogged = true
+                unbondedProbeSkippedLine(
+                    isWhoop5 = connectedFamily == DeviceFamily.WHOOP5,
+                    optedIn = PuffinExperiment.from(context).unbondedOffload,
+                    bonded = didBond,
+                    helloWrittenThisLink = helloWrittenThisLink,
+                    alreadyProbedThisLink = unbondedProbeStartedThisLink,
+                    previouslyRefused = refused,
+                    silentLinksSoFar = unbondedProbeSilentLinks,
+                )?.let { log(it, com.noop.testcentre.TestDomain.CONNECTION) }
+            }
+            return
+        }
         // Stand aside while the DIS chain still holds the one serialized GATT queue. The fixed 6s delay
         // this used to rely on was chosen by reasoning and was wrong: a capture caught the chain still
         // running at 7s, every CCCD write returning busy, all four abandoned after the shared retry
@@ -6841,6 +6863,40 @@ class WhoopBleClient(
                             properties = it.properties,
                             writingWithResponse = false,
                         ), com.noop.testcentre.TestDomain.CONNECTION)
+                    }
+                }
+                // #1949: and what we HAVE with the strap, next to what it offers. The sibling dump above
+                // covers fd4b0002, the write char; this covers the four NOTIFY chars the offload and the
+                // realtime IMU producer both arrive on. A capture showed all four discovered, one
+                // standard-HR subscribe, and nothing more — which reads identically to the strap refusing
+                // them. Only HEART_RATE_CHAR and BATTERY_CHAR reach `cccdQueue` below on a 5/MG, so
+                // "subscribed=no" here is the app's own doing and the log should say so rather than
+                // leave it to be inferred. Local reads only, like its sibling: no GATT operation.
+                if (testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
+                    val notifyDump = runCatching {
+                        WHOOP5_NOTIFY_CHARS.mapNotNull { u ->
+                            whoop5.getCharacteristic(u)?.let { ch ->
+                                val cccd = ch.getDescriptor(CCCD)
+                                NotifyCharDump(
+                                    uuid = u.toString().take(8),
+                                    hasCccd = cccd != null,
+                                    subscribed = cccd?.value?.contentEquals(
+                                        BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE,
+                                    ) == true,
+                                )
+                            }
+                        }
+                    }.getOrDefault(emptyList())
+                    for (line in whoop5PairingDumpLines(
+                        bondState = runCatching { g.device.bondState }.getOrDefault(-1),
+                        didBond = didBond,
+                        helloWrittenThisLink = helloWrittenThisLink,
+                        probeOptedIn = runCatching {
+                            PuffinExperiment.from(context).unbondedOffload
+                        }.getOrDefault(false),
+                        notifyChars = notifyDump,
+                    )) {
+                        log(line, com.noop.testcentre.TestDomain.CONNECTION)
                     }
                 }
             } else {
@@ -10982,6 +11038,7 @@ class WhoopBleClient(
             chargeUnbondedProbeSilence()
         }
         unbondedProbeStartedThisLink = false
+        unbondedProbeSkipLogged = false
         unbondedProbeDeferrals = 0
         disChainInFlight = false
         unbondedProbeSubscribed = 0

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5326,7 +5326,13 @@ class WhoopBleClient(
                 silentLinksSoFar = silentLinksNow,
             )
         ) {
-            // #1949: say WHY, once per link. A silent return here is what made an MG capture unreadable:
+            // #1949: say WHY, once per link. UNGATED, unlike the pairing dump, and deliberately so: the
+            // domain argument to log() is a TAG rather than a gate, so this lands in an ordinary strap
+            // log. That is the point — it explains a silence to whoever reads the log they already have,
+            // and it costs one line, only on a no-hello 5/MG link, which is the only place the probe is
+            // scheduled. The dump is eight lines of readout and stays behind the Test Centre domain.
+            //
+            // A silent return here is what made an MG capture unreadable:
             // the puffin chars discovered, never subscribed, and no way to tell the app declined from the
             // strap refusing — opposite meanings for #1635. Once per link, because this path is retried.
             if (!unbondedProbeSkipLogged) {

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -6883,6 +6883,12 @@ class WhoopBleClient(
                 // them. Only HEART_RATE_CHAR and BATTERY_CHAR reach `cccdQueue` below on a 5/MG, so
                 // "subscribed=no" here is the app's own doing and the log should say so rather than
                 // leave it to be inferred. Local reads only, like its sibling: no GATT operation.
+                //
+                // Per CONNECT, unlike the tree above which is once per strap, and the difference is the
+                // point: the tree is static for a device while this is exactly the state that changes
+                // between links — a bond acquired, a hello written, the opt-in flipped. Seven lines
+                // against that sibling's thirty, so a reconnect loop costs a quarter as much as the
+                // enumeration that deliberately declined to repeat.
                 if (testCentre.active(com.noop.testcentre.TestDomain.CONNECTION)) {
                     val notifyDump = runCatching {
                         WHOOP5_NOTIFY_CHARS.mapNotNull { u ->

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5308,14 +5308,22 @@ class WhoopBleClient(
 
     private fun beginUnbondedOffloadProbe(g: BluetoothGatt) {
         val refused = unbondedOffloadPreviouslyRefused(g.device.address)
+        // Read each input ONCE: the gate's verdict and the line that explains it must be about the same
+        // state, or the log will name a reason that was not the one that decided.
+        val isWhoop5Now = connectedFamily == DeviceFamily.WHOOP5
+        val optedInNow = PuffinExperiment.from(context).unbondedOffload
+        val bondedNow = didBond
+        val helloWrittenNow = helloWrittenThisLink
+        val alreadyProbedNow = unbondedProbeStartedThisLink
+        val silentLinksNow = unbondedProbeSilentLinks
         if (!shouldProbeUnbondedOffload(
-                isWhoop5 = connectedFamily == DeviceFamily.WHOOP5,
-                optedIn = PuffinExperiment.from(context).unbondedOffload,
-                bonded = didBond,
-                helloWrittenThisLink = helloWrittenThisLink,
-                alreadyProbedThisLink = unbondedProbeStartedThisLink,
+                isWhoop5 = isWhoop5Now,
+                optedIn = optedInNow,
+                bonded = bondedNow,
+                helloWrittenThisLink = helloWrittenNow,
+                alreadyProbedThisLink = alreadyProbedNow,
                 previouslyRefused = refused,
-                silentLinksSoFar = unbondedProbeSilentLinks,
+                silentLinksSoFar = silentLinksNow,
             )
         ) {
             // #1949: say WHY, once per link. A silent return here is what made an MG capture unreadable:
@@ -5323,14 +5331,17 @@ class WhoopBleClient(
             // strap refusing — opposite meanings for #1635. Once per link, because this path is retried.
             if (!unbondedProbeSkipLogged) {
                 unbondedProbeSkipLogged = true
+                // The SAME values the gate just refused on, not a second read of each. `didBond` and the
+                // rest are @Volatile and the pref is a live file read, so re-reading them here could
+                // explain the skip with a state that is no longer the one that caused it.
                 unbondedProbeSkippedLine(
-                    isWhoop5 = connectedFamily == DeviceFamily.WHOOP5,
-                    optedIn = PuffinExperiment.from(context).unbondedOffload,
-                    bonded = didBond,
-                    helloWrittenThisLink = helloWrittenThisLink,
-                    alreadyProbedThisLink = unbondedProbeStartedThisLink,
+                    isWhoop5 = isWhoop5Now,
+                    optedIn = optedInNow,
+                    bonded = bondedNow,
+                    helloWrittenThisLink = helloWrittenNow,
+                    alreadyProbedThisLink = alreadyProbedNow,
                     previouslyRefused = refused,
-                    silentLinksSoFar = unbondedProbeSilentLinks,
+                    silentLinksSoFar = silentLinksNow,
                 )?.let { log(it, com.noop.testcentre.TestDomain.CONNECTION) }
             }
             return
@@ -6876,13 +6887,9 @@ class WhoopBleClient(
                     val notifyDump = runCatching {
                         WHOOP5_NOTIFY_CHARS.mapNotNull { u ->
                             whoop5.getCharacteristic(u)?.let { ch ->
-                                val cccd = ch.getDescriptor(CCCD)
                                 NotifyCharDump(
                                     uuid = u.toString().take(8),
-                                    hasCccd = cccd != null,
-                                    subscribed = cccd?.value?.contentEquals(
-                                        BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE,
-                                    ) == true,
+                                    hasCccd = ch.getDescriptor(CCCD) != null,
                                 )
                             }
                         }

--- a/android/app/src/test/java/com/noop/ble/GattTreeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/GattTreeTest.kt
@@ -92,6 +92,30 @@ class GattTreeTest {
                    lines.any { it.contains("no later \"Subscribed\" line went unsubscribed by OUR choice") })
     }
 
+    /**
+     * What an ABSENT `Subscribed` line means inverts with the opt-in, and this is the one distinction the
+     * dump exists to draw. Probe off: only HR and battery are ever queued, so an unsubscribed puffin char
+     * is ours. Probe ON: the probe subscribes those same chars, so a missing line is the strap refusing.
+     * A single unconditional sentence here would be confidently wrong in exactly the configuration the
+     * probe is run for.
+     */
+    @Test
+    fun `the note flips with the opt-in, because the meaning of a missing subscribe does`() {
+        val off = whoop5PairingDumpLines(
+            bondState = 10, didBond = false, helloWrittenThisLink = false,
+            probeOptedIn = false, notifyChars = chars(),
+        )
+        assertTrue(off.toString(), off.any { it.contains("went unsubscribed by OUR choice") })
+        assertTrue(off.toString(), off.none { it.contains("is the STRAP's answer") })
+
+        val on = whoop5PairingDumpLines(
+            bondState = 10, didBond = false, helloWrittenThisLink = false,
+            probeOptedIn = true, notifyChars = chars(),
+        )
+        assertTrue(on.toString(), on.any { it.contains("is the STRAP's answer") })
+        assertTrue(on.toString(), on.none { it.contains("by OUR choice") })
+    }
+
     /** Discovering none is itself a reading, and must not render as an empty section. */
     @Test
     fun `no discovered notify chars says so rather than printing nothing`() {

--- a/android/app/src/test/java/com/noop/ble/GattTreeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/GattTreeTest.kt
@@ -42,4 +42,62 @@ class GattTreeTest {
         assertTrue(single.contains(names))
         assertTrue(tree.contains(names))
     }
+
+    // --- #1949: the pairing dump ----------------------------------------------------------------------
+
+    private fun chars() = listOf(
+        NotifyCharDump("fd4b0003", hasCccd = true, subscribed = false),
+        NotifyCharDump("fd4b0007", hasCccd = true, subscribed = true),
+    )
+
+    @Test
+    fun `the header carries the pairing posture the log otherwise lacks`() {
+        val head = whoop5PairingDumpLines(
+            bondState = 10, didBond = false, helloWrittenThisLink = false,
+            probeOptedIn = false, notifyChars = chars(),
+        ).first()
+        assertEquals(
+            "pairing: bond=BOND_NONE didBond=false helloWritten=false unbondedProbe=off",
+            head,
+        )
+    }
+
+    @Test
+    fun `each notify char reports its CCCD and whether we subscribed it`() {
+        val lines = whoop5PairingDumpLines(
+            bondState = 12, didBond = true, helloWrittenThisLink = true,
+            probeOptedIn = true, notifyChars = chars(),
+        )
+        assertEquals("  fd4b0003 cccd=yes subscribed=no", lines[1])
+        assertEquals("  fd4b0007 cccd=yes subscribed=yes", lines[2])
+        assertTrue(lines.first(), lines.first().contains("bond=BOND_BONDED"))
+        assertTrue(lines.first(), lines.first().contains("unbondedProbe=on"))
+    }
+
+    /** Discovering none is itself a reading, and must not render as an empty section. */
+    @Test
+    fun `no discovered notify chars says so rather than printing nothing`() {
+        val lines = whoop5PairingDumpLines(
+            bondState = 10, didBond = false, helloWrittenThisLink = false,
+            probeOptedIn = false, notifyChars = emptyList(),
+        )
+        assertEquals("  no puffin notify characteristics discovered", lines[1])
+    }
+
+    /**
+     * The note is the honest part: bond state is a proxy, not an encryption reading, and the codes it
+     * names are what actually answer the question. Pinned so a later edit cannot quietly upgrade the
+     * claim to "the link is encrypted", which nothing here knows.
+     */
+    @Test
+    fun `the note refuses to claim an encryption state it cannot read`() {
+        val note = whoop5PairingDumpLines(
+            bondState = 10, didBond = false, helloWrittenThisLink = false,
+            probeOptedIn = false, notifyChars = chars(),
+        ).last()
+        assertTrue(note, note.contains("no link-encryption flag"))
+        assertTrue(note, note.contains("status 5 (insufficient authentication)"))
+        assertTrue(note, note.contains("15 (insufficient encryption)"))
+    }
+
 }

--- a/android/app/src/test/java/com/noop/ble/GattTreeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/GattTreeTest.kt
@@ -46,8 +46,8 @@ class GattTreeTest {
     // --- #1949: the pairing dump ----------------------------------------------------------------------
 
     private fun chars() = listOf(
-        NotifyCharDump("fd4b0003", hasCccd = true, subscribed = false),
-        NotifyCharDump("fd4b0007", hasCccd = true, subscribed = true),
+        NotifyCharDump("fd4b0003", hasCccd = true),
+        NotifyCharDump("fd4b0007", hasCccd = false),
     )
 
     @Test
@@ -63,15 +63,33 @@ class GattTreeTest {
     }
 
     @Test
-    fun `each notify char reports its CCCD and whether we subscribed it`() {
+    fun `each notify char reports whether it carries a CCCD`() {
         val lines = whoop5PairingDumpLines(
             bondState = 12, didBond = true, helloWrittenThisLink = true,
             probeOptedIn = true, notifyChars = chars(),
         )
-        assertEquals("  fd4b0003 cccd=yes subscribed=no", lines[1])
-        assertEquals("  fd4b0007 cccd=yes subscribed=yes", lines[2])
+        assertEquals("  fd4b0003 cccd=yes", lines[1])
+        assertEquals("  fd4b0007 cccd=no", lines[2])
         assertTrue(lines.first(), lines.first().contains("bond=BOND_BONDED"))
         assertTrue(lines.first(), lines.first().contains("unbondedProbe=on"))
+    }
+
+    /**
+     * There must be NO subscription column. This runs at service discovery, before the CCCD queue is
+     * drained, so any such field would read "not yet" as a matter of ordering rather than fact — and on
+     * API 33+ it could not be read at all, since `writeDescriptor(descriptor, value)` leaves
+     * `descriptor.value` null. The outcomes are the `Subscribed <uuid>` lines that follow, and the note
+     * points a reader at them instead of restating them wrongly here.
+     */
+    @Test
+    fun `no line claims a subscription state this dump cannot know yet`() {
+        val lines = whoop5PairingDumpLines(
+            bondState = 10, didBond = false, helloWrittenThisLink = false,
+            probeOptedIn = false, notifyChars = chars(),
+        )
+        assertTrue(lines.toString(), lines.none { it.contains("subscribed=") })
+        assertTrue("a reader must be told where the answer is: $lines",
+                   lines.any { it.contains("no later \"Subscribed\" line went unsubscribed by OUR choice") })
     }
 
     /** Discovering none is itself a reading, and must not render as an empty section. */

--- a/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
@@ -526,4 +526,86 @@ class UnbondedOffloadProbeTest {
         }
     }
 
+    // --- #1949: the probe's skip reason ---------------------------------------------------------------
+
+    /**
+     * The explanation and the gate must agree on EVERY input, or a log line will claim a probe ran that
+     * did not, or stay silent about one that was skipped. Exhaustive rather than sampled because the two
+     * are separate `when` chains over the same seven inputs, and the failure mode is a condition added to
+     * one and forgotten in the other, which no hand-picked case is likely to sit on.
+     */
+    @Test
+    fun `a skip reason is produced exactly when the gate refuses`() {
+        val bools = listOf(false, true)
+        var refusals = 0
+        for (isWhoop5 in bools) for (optedIn in bools) for (bonded in bools)
+            for (hello in bools) for (already in bools) for (refused in bools)
+                for (silent in listOf(0, UNBONDED_PROBE_MAX_SILENT_LINKS)) {
+                    val runs = shouldProbeUnbondedOffload(
+                        isWhoop5 = isWhoop5, optedIn = optedIn, bonded = bonded,
+                        helloWrittenThisLink = hello, alreadyProbedThisLink = already,
+                        previouslyRefused = refused, silentLinksSoFar = silent,
+                    )
+                    val line = unbondedProbeSkippedLine(
+                        isWhoop5 = isWhoop5, optedIn = optedIn, bonded = bonded,
+                        helloWrittenThisLink = hello, alreadyProbedThisLink = already,
+                        previouslyRefused = refused, silentLinksSoFar = silent,
+                    )
+                    assertEquals(
+                        "gate=$runs but line=${line ?: "null"} for isWhoop5=$isWhoop5 optedIn=$optedIn " +
+                            "bonded=$bonded hello=$hello already=$already refused=$refused silent=$silent",
+                        runs, line == null,
+                    )
+                    if (!runs) refusals++
+                }
+        assertTrue("the sweep must actually exercise refusals", refusals > 0)
+    }
+
+    /** The reason printed is the one that DECIDED, so it must follow the gate's own order, not the first
+     *  condition that happens to be true. Every input below is refusing at once. */
+    @Test
+    fun `the reason follows the gate's order when several conditions refuse`() {
+        val line = unbondedProbeSkippedLine(
+            isWhoop5 = false, optedIn = false, bonded = true, helloWrittenThisLink = true,
+            alreadyProbedThisLink = true, previouslyRefused = true, silentLinksSoFar = 99,
+        )
+        assertTrue("family is tested first: $line", line!!.contains("not a WHOOP 5/MG"))
+    }
+
+    @Test
+    fun `the common case names the experiment, and says what it costs`() {
+        val line = unbondedProbeSkippedLine(
+            isWhoop5 = true, optedIn = false, bonded = false, helloWrittenThisLink = false,
+            alreadyProbedThisLink = false, previouslyRefused = false, silentLinksSoFar = 0,
+        )!!
+        assertTrue(line, line.contains("the unbonded-offload experiment is off"))
+        assertTrue("an unbonded 5/MG must be told what stays unsubscribed: $line",
+                   line.contains("puffin notify chars stay unsubscribed"))
+        assertTrue("and that it reaches the IMU producer too: $line", line.contains("realtime IMU"))
+    }
+
+    /** A bonded strap reaches those chars through the ordinary handshake, so the consequence clause would
+     *  be false there. The retirement reasons must also distinguish a latched refusal from a spent budget:
+     *  one is the strap's verdict, the other is ours. */
+    @Test
+    fun `the consequence is omitted when it would not be true, and retirement says which kind`() {
+        val bonded = unbondedProbeSkippedLine(
+            isWhoop5 = true, optedIn = true, bonded = true, helloWrittenThisLink = false,
+            alreadyProbedThisLink = false, previouslyRefused = false, silentLinksSoFar = 0,
+        )!!
+        assertTrue(bonded, !bonded.contains("stay unsubscribed"))
+
+        val refused = unbondedProbeSkippedLine(
+            isWhoop5 = true, optedIn = true, bonded = false, helloWrittenThisLink = false,
+            alreadyProbedThisLink = false, previouslyRefused = true, silentLinksSoFar = 0,
+        )!!
+        assertTrue(refused, refused.contains("a refusal is latched"))
+
+        val spent = unbondedProbeSkippedLine(
+            isWhoop5 = true, optedIn = true, bonded = false, helloWrittenThisLink = false,
+            alreadyProbedThisLink = false, previouslyRefused = false,
+            silentLinksSoFar = UNBONDED_PROBE_MAX_SILENT_LINKS,
+        )!!
+        assertTrue(spent, spent.contains("silent-link budget is spent"))
+    }
 }


### PR DESCRIPTION
Groundwork for #1949. Nothing is gated and no behaviour changes; this makes a
5/MG log answerable.

## What a capture could not tell you

An MG log showed the four puffin notify chars discovered, one standard-HR
subscribe, and nothing further:

```
[connection]   service fd4b0001-cce1-4033-93ce-002d5875f58a (5 char)
[connection]     fd4b0003-... props=0x10 (Notify)
[connection]     fd4b0004-... props=0x10 (Notify)
[connection]     fd4b0005-... props=0x10 (Notify)
[connection]     fd4b0007-... props=0x10 (Notify)
Subscribed 00002a37-0000-1000-8000-00805f9b34fb
```

Reading that, there is no way to tell the app declined to subscribe them from
the strap refusing. Those are opposite answers for #1635: one is a setting, the
other is the verdict the probe exists to obtain. Both silences are now spoken.

## The probe's skip reason

`beginUnbondedOffloadProbe` returned silently whenever `shouldProbeUnbondedOffload`
said no. It now names which of the seven conditions decided, in the gate's own
order so the reason printed is the one that actually decided rather than the
first that happens to be true. Once per link, because the path is retried.

The common case is the actionable one:

```
unbonded probe skipped — the unbonded-offload experiment is off. The puffin notify
chars stay unsubscribed on this link, so neither the historical offload nor a
realtime IMU producer can reach us here.
```

The consequence clause is appended only for an unbonded 5/MG, since a bonded
strap reaches those chars through the ordinary handshake and the sentence would
be false there.

## The pairing dump

`gattTreeLines` says what the strap OFFERS. This says what we HOLD with it: bond
state, `didBond`, whether a hello went out, whether the probe is opted in, and
per notify characteristic whether it carries a CCCD.

It reports POSTURE, not outcome. A first draft of this carried a `subscribed`
column and a re-review removed it, because it could not have been honest: the
dump runs at service discovery, before the CCCD queue is drained, so every
subscription is still ahead of it, and on API 33+ it could not have been read
anyway since `writeDescriptor(descriptor, value)` never populates
`descriptor.value`. It would have printed `subscribed=no` universally, including
for a probe that HAD subscribed the puffin chars, which is the one case this
exists to observe. Those outcomes are already in the log as one confirmed
`Subscribed <uuid>` line each, so the note points a reader at them and says what
their absence means. A test pins the column's absence with that reasoning
attached.

What that absence MEANS flips with the opt-in, and a later pass caught the note
asserting one half of it unconditionally. With the probe off, only
`HEART_RATE_CHAR` and `BATTERY_CHAR` reach `cccdQueue`, so an unsubscribed puffin
char is ours. With the probe ON it subscribes those same chars itself, so a
missing line there is the STRAP refusing, which is the opposite conclusion and
the whole reason the probe is run. The note branches, and both branches are
pinned with each asserting the other's wording is absent.

On encryption it deliberately claims less than a reader might want. Android
publishes no link-encryption flag to a GATT client, and a remote
characteristic's permissions read back as 0, so bond state is a proxy and not
the same question. The note names the two CCCD write statuses that do answer it,
5 and 15, which is what the probe already listens for. A test pins that wording
so a later edit cannot quietly upgrade it to a claim the code cannot make.

`bondStateName` is `BondStateTrace`'s, not a second spelling: two renderings of
one OS state in one log is how a reader ends up believing they are two readings.

## Tests

The explanation and the gate are pinned against each other EXHAUSTIVELY, over
every combination of the seven inputs. They are separate `when` chains over the
same conditions, and the failure mode is a condition added to one and forgotten
in the other, which no hand-picked case is likely to sit on. Plus order,
consequence-clause suppression, the two retirement kinds, and the dump's shape.

The gate's inputs are read ONCE and the same values handed to the explanation.
They are `@Volatile` fields and a live pref read, so re-reading them could name a
reason that was not the one that decided.

Android suite 5520 green, doc-comment gate clean.

## Scope

Android only, and the twinned file already stated the rule. `GattCapability` has
a Swift half, so an untwinned function in it deserves an answer, and its header
gives one: `gattTreeLines` was twinned because CoreBluetooth exposes services,
characteristics and properties, "unlike the bond-state and pairing helpers, which
have no Apple equivalent at all". The pairing dump is one of those, keyed on an
OS bond state CoreBluetooth does not publish and on an Android-only probe's
opt-in. The skip reason has nothing to twin either: there is no iOS probe whose
silence needs explaining. That rationale is now recorded at the function rather
than left to be re-derived.

Worth recording, because it runs opposite to the guess: iOS is the platform that
COULD carry the subscription column removed above. `CBCharacteristic.isNotifying`
is authoritative where Android's `descriptor.value` is null on API 33+, and iOS
already re-subscribes the puffin chars post-bond precisely because the strap
refuses them until the link is encrypted (issue #17). An iOS equivalent would be
a different and slightly better instrument, emitted after the subscribe attempt.

The two lines have deliberately different visibility. The domain argument to
`log()` is a TAG, not a gate, so the skip reason lands in an ordinary strap log:
one line, only on a no-hello 5/MG link, explaining a silence to whoever reads the
log they already have. The dump is eight lines of readout and stays behind the
Test Centre connection domain.

Local reads on already-discovered state, gated to the Test Centre connection
domain. No GATT operation and no traffic, which is the same discipline
`gattTreeLines` was written to, and the reason both work on exactly the strap
that no puffin probe can reach.
