### PR TITLE
battery: stop asking a 5/MG for battery it refuses to answer

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -4539,13 +4539,19 @@ public final class BLEManager: NSObject, ObservableObject {
         }   // re-arm so it can't lapse
         keepAliveTick += 1
         // #battery: ~60 s normally, ~30 s while charging (see `batteryPollDue`).
-        if BLEManager.batteryPollDue(tick: keepAliveTick, charging: state.charging == true) {
+        //
+        // WHOOP 4.0 ONLY (#1948). Both commands this block used to send are refused on a 5/MG before they
+        // leave the app: the send allowlist has no clause for `.getBatteryLevel` at all, and admits
+        // `.getBatteryPackInfo` only while a user-initiated probe is in flight. So on a 5/MG this was two
+        // dead sends and two skip lines per tick, under a comment claiming the pack "rides the SAME
+        // cadence as the strap's own gauge". It never rode anything.
+        //
+        // A 5/MG needs neither. Its percent comes from the 0x2A19 read that `enableLiveNotifications`
+        // drives off this same keep-alive (throttled to `whoop5BatteryReadMinIntervalSeconds`), and its pack charge from the
+        // pushed pack-info event (109), which since #1945 is that flag's only writer.
+        if selectedModel.deviceFamily != .whoop5,
+           BLEManager.batteryPollDue(tick: keepAliveTick, charging: state.charging == true) {
             send(.getBatteryLevel, payload: [])
-            // The 5/MG battery pack rides the SAME cadence as the strap's own gauge — it is the same
-            // question about the same physical thing, and a second timer would only be a second thing to
-            // get wrong. 5/MG only: a 4.0 never answers 151 (its pack is voltage-only via 98), so asking
-            // would be traffic with no reply.
-            if selectedModel.deviceFamily == .whoop5 { send(.getBatteryPackInfo, payload: []) }
         }
     }
 

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -4542,13 +4542,17 @@ public final class BLEManager: NSObject, ObservableObject {
         //
         // WHOOP 4.0 ONLY (#1948). Both commands this block used to send are refused on a 5/MG before they
         // leave the app: the send allowlist has no clause for `.getBatteryLevel` at all, and admits
-        // `.getBatteryPackInfo` only while a user-initiated probe is in flight. So on a 5/MG this was two
-        // dead sends and two skip lines per tick, under a comment claiming the pack "rides the SAME
-        // cadence as the strap's own gauge". It never rode anything.
+        // `.getBatteryPackInfo` only while a user-initiated probe is in flight. Two dead sends and two
+        // skip lines per tick, under a comment claiming the pack "rides the SAME cadence as the strap's
+        // own gauge". It never rode anything.
         //
-        // A 5/MG needs neither. Its percent comes from the 0x2A19 read that `enableLiveNotifications`
-        // drives off this same keep-alive (throttled to `whoop5BatteryReadMinIntervalSeconds`), and its pack charge from the
-        // pushed pack-info event (109), which since #1945 is that flag's only writer.
+        // That cost lands on a BONDED 5/MG specifically, the only kind whose tick runs at all
+        // (`keepAliveMayRun` refuses an unbonded one) — which is also what makes the removal free. The
+        // same `didBond` that lets this tick fire has already run `enableLiveNotifications` a few lines
+        // above, and THAT is what drives the 0x2A19 read (throttled to
+        // `whoop5BatteryReadMinIntervalSeconds`) a 5/MG's percent actually comes from. The read and the
+        // refused send were always co-resident, so dropping the send cannot strand the reading. The
+        // pack's charge comes from the pushed pack-info event (109), that flag's only writer since #1945.
         if selectedModel.deviceFamily != .whoop5,
            BLEManager.batteryPollDue(tick: keepAliveTick, charging: state.charging == true) {
             send(.getBatteryLevel, payload: [])

--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -4546,13 +4546,23 @@ public final class BLEManager: NSObject, ObservableObject {
         // skip lines per tick, under a comment claiming the pack "rides the SAME cadence as the strap's
         // own gauge". It never rode anything.
         //
-        // That cost lands on a BONDED 5/MG specifically, the only kind whose tick runs at all
-        // (`keepAliveMayRun` refuses an unbonded one) — which is also what makes the removal free. The
-        // same `didBond` that lets this tick fire has already run `enableLiveNotifications` a few lines
-        // above, and THAT is what drives the 0x2A19 read (throttled to
-        // `whoop5BatteryReadMinIntervalSeconds`) a 5/MG's percent actually comes from. The read and the
-        // refused send were always co-resident, so dropping the send cannot strand the reading. The
-        // pack's charge comes from the pushed pack-info event (109), that flag's only writer since #1945.
+        // Removing them cannot change what a 5/MG receives, and that is the whole argument: the allowlist
+        // refused both before they reached the peripheral, so no reading ever depended on either. Do not
+        // reach for a subtler one. An earlier draft here argued that the `didBond` letting this tick run
+        // had already driven the 0x2A19 read a few lines above, which is wrong twice over —
+        // `keepAliveMayRun` also admits a `bonded && .whoop5` tick with `didBond` false, and
+        // `enableLiveNotifications` is separately gated on `didBond`, so on a #1635 strap the tick fires
+        // and that read does not.
+        //
+        // Which leaves a real divergence, pre-existing and NOT introduced here: Android's keep-alive polls
+        // 0x2A19 for a 5/MG whenever it runs, while this one skips it unless `didBond`. An unbonded 5/MG
+        // therefore gets a periodic battery read on Android and none here. The pack's charge comes from
+        // the pushed pack-info event (109) on both, that flag's only writer since #1945.
+        //
+        // This leaves opcode 151 with NO sender on iOS, which is the state `FrameRouter` already records
+        // for its own decoder ("nothing sent the command, so the decoder had no caller"). Android keeps a
+        // user-initiated probe for it; there is no iOS twin of that, so asking a 5/MG whether it answers
+        // 151 at all is an Android-side question today.
         if selectedModel.deviceFamily != .whoop5,
            BLEManager.batteryPollDue(tick: keepAliveTick, charging: state.charging == true) {
             send(.getBatteryLevel, payload: [])

--- a/StrandTests/Whoop5BatteryPollGuardTests.swift
+++ b/StrandTests/Whoop5BatteryPollGuardTests.swift
@@ -50,7 +50,12 @@ final class Whoop5BatteryPollGuardTests: XCTestCase {
               let end = src.range(of: "private func startBackfillTimer") else {
             return XCTFail("the keep-alive battery block or its next landmark was not found")
         }
+        // Comments in this block name the opcode while explaining why it is not sent, so judge the CODE
+        // only — the same rule the Kotlin twin follows. Without this the guard fails on its own rationale.
         let block = String(src[start.lowerBound..<end.lowerBound])
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+            .joined(separator: "\n")
         XCTAssertFalse(block.contains("getBatteryPackInfo"),
                        "the keep-alive must not send the pack opcode (#1948): \(block)")
     }

--- a/StrandTests/Whoop5BatteryPollGuardTests.swift
+++ b/StrandTests/Whoop5BatteryPollGuardTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import Strand
+
+/// #1948: the 5/MG keep-alive must not send battery commands the allowlist refuses.
+///
+/// Both commands that block used to send are rejected on a 5/MG before they leave the app: the send
+/// allowlist has no clause for `.getBatteryLevel` at all, and admits `.getBatteryPackInfo` only while a
+/// user-initiated probe is in flight. So a 5/MG paid two dead sends and two skip lines per tick, under a
+/// comment claiming the pack "rides the SAME cadence as the strap's own gauge".
+///
+/// A 5/MG needs neither: its percent comes from the 0x2A19 read `enableLiveNotifications` drives off this
+/// same keep-alive, and its pack charge from the pushed pack-info event (109).
+///
+/// Pinned against the SOURCE, the way `DeviceRawSourceParityTests` pins its oracle, because the send sits
+/// in a keep-alive body no unit test can drive. The Kotlin twin guard is in `ChargingAndReleaseTest`.
+final class Whoop5BatteryPollGuardTests: XCTestCase {
+
+    private func managerSource() throws -> String {
+        let root = URL(fileURLWithPath: #filePath).deletingLastPathComponent().deletingLastPathComponent()
+        return try String(contentsOf: root.appendingPathComponent("Strand/BLE/BLEManager.swift"),
+                          encoding: .utf8)
+    }
+
+    /// Whitespace-normalised on both sides. A Swift multiline literal strips indentation to its closing
+    /// delimiter, so a literal written here could never carry the source's own leading spaces, and
+    /// comparing raw text would fail for a reason that has nothing to do with the guard.
+    private func normalised(_ s: String) -> String {
+        s.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+    }
+
+    /// The poll is family-guarded, and the guard is on the SAME statement as the send — a nearby `if`
+    /// that merely reads well would not stop the traffic.
+    func testTheBatteryPollIsGuardedAwayFromWhoop5() throws {
+        let src = try normalised(managerSource())
+        let expected = normalised("""
+            if selectedModel.deviceFamily != .whoop5,
+            BLEManager.batteryPollDue(tick: keepAliveTick, charging: state.charging == true) {
+            send(.getBatteryLevel, payload: [])
+            }
+            """)
+        XCTAssertTrue(src.contains(expected),
+                      "the keep-alive battery poll must be guarded away from the 5/MG (#1948)")
+    }
+
+    /// Nothing may send the pack opcode on a cadence. The user-initiated probe still may, so this asserts
+    /// the absence in the keep-alive rather than in the file, which would forbid the probe too.
+    func testNoCadencedPackInfoSendSurvives() throws {
+        let src = try managerSource()
+        guard let start = src.range(of: "// #battery: ~60 s normally"),
+              let end = src.range(of: "private func startBackfillTimer") else {
+            return XCTFail("the keep-alive battery block or its next landmark was not found")
+        }
+        let block = String(src[start.lowerBound..<end.lowerBound])
+        XCTAssertFalse(block.contains("getBatteryPackInfo"),
+                       "the keep-alive must not send the pack opcode (#1948): \(block)")
+    }
+}

--- a/StrandTests/Whoop5BatteryPollGuardTests.swift
+++ b/StrandTests/Whoop5BatteryPollGuardTests.swift
@@ -46,9 +46,13 @@ final class Whoop5BatteryPollGuardTests: XCTestCase {
     /// the absence in the keep-alive rather than in the file, which would forbid the probe too.
     func testNoCadencedPackInfoSendSurvives() throws {
         let src = try managerSource()
-        guard let start = src.range(of: "// #battery: ~60 s normally"),
+        // The WHOLE keep-alive, not just the battery block inside it. Anchoring at the battery comment
+        // covered only what follows it, so a pack send added earlier in the same function would have
+        // slipped past while the assertion still read as if it guarded the tick. The Kotlin twin was
+        // widened for the mirror-image reason, and a control insertion proved it there.
+        guard let start = src.range(of: "private func keepAliveFire() {"),
               let end = src.range(of: "private func startBackfillTimer") else {
-            return XCTFail("the keep-alive battery block or its next landmark was not found")
+            return XCTFail("the keep-alive function or its next landmark was not found")
         }
         // Comments in this block name the opcode while explaining why it is not sent, so judge the CODE
         // only — the same rule the Kotlin twin follows. Without this the guard fails on its own rationale.
@@ -57,6 +61,6 @@ final class Whoop5BatteryPollGuardTests: XCTestCase {
             .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
             .joined(separator: "\n")
         XCTAssertFalse(block.contains("getBatteryPackInfo"),
-                       "the keep-alive must not send the pack opcode (#1948): \(block)")
+                       "no part of the keep-alive may send the pack opcode (#1948): \(block)")
     }
 }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -8468,12 +8468,16 @@ class WhoopBleClient(
                     // #battery: ~60 s normally, ~30 s while charging (see [batteryPollDue]).
                     if (batteryPollDue(keepAliveTick, s.charging == true)) send(CommandNumber.GET_BATTERY_LEVEL)
                 } else if (connectedFamily == DeviceFamily.WHOOP5) {
-                    // The battery pack rides the SAME cadence as the strap's own gauge — the same question
-                    // about the same physical thing, and a second timer would only be a second thing to get
-                    // wrong. 5/MG only: a 4.0 never answers 151 (its pack is voltage-only via 98).
-                    if (batteryPollDue(keepAliveTick, s.charging == true)) {
-                        send(CommandNumber.GET_BATTERY_PACK_INFO)
-                    }
+                    // NO pack poll here (#1948). This used to send GET_BATTERY_PACK_INFO on the same
+                    // cadence as the gauge, with a comment saying the pack "rides the SAME cadence".
+                    // It never did: the 5/MG send allowlist admits opcode 151 ONLY while a user-initiated
+                    // probe is in flight, so every one of these was refused before it left the app. A
+                    // capture caught 40 of them in 40 minutes, one wasted call and one skip line a minute.
+                    //
+                    // Nothing is lost by not asking. The pack's charge arrives on the pushed pack-info
+                    // event (109), which since #1945 is its only writer, and the STRAP's own percent comes
+                    // from the 0x2A19 read below, not from a command. The probe path is untouched, and
+                    // remains how the hardware question ("does a 5/MG answer 151 at all?") gets asked.
                     // #1865: re-arm a LAPSED realtime stream. The WHOOP4 branch above re-sends
                     // TOGGLE_REALTIME_HR every tick precisely because "the firmware lets the realtime HR
                     // stream lapse if it isn't re-armed" — a 5/MG got none of that, on the reasoning that it

--- a/android/app/src/test/java/com/noop/ble/ChargingAndReleaseTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ChargingAndReleaseTest.kt
@@ -115,8 +115,13 @@ class ChargingAndReleaseTest {
         val src = clientSource()
         val start = src.indexOf("} else if (connectedFamily == DeviceFamily.WHOOP5) {")
         assertTrue("the WHOOP5 keep-alive branch was not found", start > 0)
-        val end = src.indexOf("#1865", start)
-        assertTrue("the branch's next landmark was not found", end > start)
+        // Ends at the branch's OWN battery poll, not at the nearer #1865 landmark. Stopping there left a
+        // window holding one line of code and the rest comment, so a poll re-added anywhere past it would
+        // have slipped through while the negative control still passed — the control only re-inserts at
+        // the natural spot. This span covers every line between the branch opening and the 0x2A19 read,
+        // which is the whole region a battery send would plausibly be put back into.
+        val end = src.indexOf("5/MG battery comes only from a 0x2A19 read", start)
+        assertTrue("the branch's own battery poll was not found", end > start)
         val code = src.substring(start, end).lines()
             .filterNot { it.trim().startsWith("//") }
             .joinToString("\n")

--- a/android/app/src/test/java/com/noop/ble/ChargingAndReleaseTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ChargingAndReleaseTest.kt
@@ -96,6 +96,37 @@ class ChargingAndReleaseTest {
                     code.contains("charging"))
     }
 
+    // --- #1948: the 5/MG keep-alive asks for nothing it cannot be given ------------------------------
+
+    /**
+     * The WHOOP5 keep-alive branch must not send `GET_BATTERY_PACK_INFO`.
+     *
+     * It did, on the gauge's cadence, under a comment saying the pack "rides the SAME cadence". It never
+     * did: the 5/MG send allowlist admits opcode 151 only while a user-initiated probe is in flight, so
+     * every one was refused before leaving the app — 40 in 40 minutes of one capture. The pack's charge
+     * comes from the pushed event (109) and the strap's percent from the 0x2A19 read, so asking bought
+     * nothing and cost a skip line a minute.
+     *
+     * Pinned against the source, like the pack-event guard above, because the send lives in a keep-alive
+     * body no JVM test can drive. Scoped to the WHOOP5 branch so the WHOOP4 poll beside it is untouched.
+     */
+    @Test
+    fun `the 5MG keepalive does not poll a pack opcode the allowlist refuses`() {
+        val src = clientSource()
+        val start = src.indexOf("} else if (connectedFamily == DeviceFamily.WHOOP5) {")
+        assertTrue("the WHOOP5 keep-alive branch was not found", start > 0)
+        val end = src.indexOf("#1865", start)
+        assertTrue("the branch's next landmark was not found", end > start)
+        val code = src.substring(start, end).lines()
+            .filterNot { it.trim().startsWith("//") }
+            .joinToString("\n")
+        assertFalse("the 5/MG keep-alive must not send GET_BATTERY_PACK_INFO (#1948): $code",
+                    code.contains("GET_BATTERY_PACK_INFO"))
+        // The 4.0 branch keeps its own poll: this is a 5/MG-only removal, not a battery-polling change.
+        assertTrue("the WHOOP4 gauge poll must survive",
+                   src.contains("if (batteryPollDue(keepAliveTick, s.charging == true)) send(CommandNumber.GET_BATTERY_LEVEL)"))
+    }
+
     private fun clientSource(): String {
         var root = java.io.File(System.getProperty("user.dir") ?: ".").canonicalFile
         repeat(4) {


### PR DESCRIPTION
Option 1 from #1948, and the investigation made it bigger than the issue said.

## What was happening

The keep-alive polled battery commands the 5/MG send allowlist rejects before
they leave the app, under a comment claiming the pack "rides the SAME cadence as
the strap's own gauge".

Android sent `GET_BATTERY_PACK_INFO`, which the allowlist admits only while a
user-initiated probe is in flight:

```
12:31:48  send(GET_BATTERY_PACK_INFO) skipped — no WHOOP 5/MG framing for this command yet
12:32:48  send(GET_BATTERY_PACK_INFO) skipped — no WHOOP 5/MG framing for this command yet
```

40 of them in 40 minutes of one capture: one wasted call and one skip line per
minute.

**iOS was worse than #1948 recorded.** The allowlist has no clause for
`.getBatteryLevel` either, so the whole block was dead rather than half of it:
TWO sends and two skip lines per tick. The issue said "one refused command per
platform"; that was wrong and is corrected there.

A re-review then narrowed WHO pays it. `keepAliveMayRun` refuses an unbonded
5/MG outright, so the tick never fires there and only a BONDED 5/MG was paying.
That correction strengthens the case rather than weakening it, and is why the
comment now argues from co-residence: the same `didBond` that lets this tick run
has already fired `enableLiveNotifications` a few lines above, which drives the
`0x2A19` read a 5/MG's percent comes from. The read and the refused send were
always on the same tick, so dropping the send cannot strand the reading.

## The change

Android drops the pack poll from the WHOOP5 keep-alive branch. iOS makes that
whole battery block WHOOP 4.0 only, which matches `refreshBattery`, already
guarded `if selectedModel.deviceFamily == .whoop4` for the same command.

Nothing is lost:

- the strap's PERCENT comes from the `0x2A19` read both platforms already drive
  off this same keep-alive, on the same tick the removed send rode (iOS throttled
  to `whoop5BatteryReadMinIntervalSeconds`)
- the PACK's charge comes from the pushed pack-info event (109), that flag's only
  writer since #1945
- Android's user-initiated probe path is untouched, and remains how the hardware
  question ("does a 5/MG answer 151 at all?") gets asked

On iOS this leaves opcode 151 with no sender at all, because there is no iOS twin
of that probe. That is not a loss: it restores exactly what `FrameRouter` already
records for its own decoder, "nothing sent the command, so the decoder had no
caller". Noted at the call site so the asymmetry is not rediscovered.

The comments now say what actually happens instead of describing a cadence that
never ran.

## Tests

Both sends live in keep-alive bodies no unit test can drive, so both are pinned
against the source. The Android guard is scoped to the WHOOP5 branch and also
asserts the WHOOP4 poll beside it survives, since this is a 5/MG-only removal
rather than a change to battery polling.

Verified as a NEGATIVE CONTROL rather than assumed: re-adding the Android send
fails the guard, restoring it passes. The Swift guard needed a fix a re-review
caught before CI did: it asserted the block contains no `getBatteryPackInfo`
without stripping comments, while the comment above it names that symbol to
explain why it is not sent, so it would have failed on its own rationale. It
judges the code only now, the rule the Kotlin twin already followed. The Swift guard normalises whitespace on
both sides, because a Swift multiline literal strips indentation to its closing
delimiter and so can never carry the source's own leading spaces — a raw
comparison would have failed for a reason unrelated to the guard.

Android suite 5521 green, doc-comment gate clean. The Swift guard DOES run on
this PR: `app-build.yml` triggers on `Strand/**` and its macOS leg has a
`Test Strand` step, so `StrandTests` executes in CI here.

Worth flagging separately: that path filter lists `Strand/**`, `StrandiOS*/**`,
`Packages/**` and `project.yml`, but NOT `StrandTests/**`. A PR touching only
app-target tests therefore builds and runs nothing, and a broken test file would
merge unverified to fail on the next PR that happens to touch `Strand/**`. This
PR is covered because it edits `BLEManager.swift` too.

## Risk

About as low as it gets: these are sends the allowlist already refused. The
visible effect is less pointless traffic and quieter captures — an iOS Test
Centre connection capture on a 5/MG was carrying roughly two wasted lines a
minute.
