### PR TITLE
ci: trigger the app build on the app-target tests it runs

### DIFF
--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -14,10 +14,15 @@ on:
     paths:
       - 'Strand/**'
       # The app-target TESTS, not just the sources they cover. The `Test Strand` step below runs
-      # StrandTests, but without this line a PR touching only those tests built and ran nothing: a test
-      # that failed to compile, or simply failed, merged unverified and then went red on the next
-      # unrelated PR that happened to touch `Strand/**`, which also mis-attributes the breakage to
-      # whoever that was. `project.yml` is already listed but does not cover it — the target takes
+      # StrandTests, but a PR touching only those tests matched nothing here, so it built and ran
+      # nothing: one that failed to compile, or simply failed, merged unverified and went red on the
+      # next unrelated PR that happened to touch `Strand/**`, mis-attributing the breakage to whoever
+      # that was.
+      #
+      # This is the only test directory that needs naming, and the reason is layout rather than
+      # oversight: Android's tests sit under `android/**` and the package suites under `Packages/**`,
+      # both already inside their subject's glob, while StrandTests is a SIBLING of `Strand/` instead
+      # of part of it. `project.yml` does not cover it either — the target takes
       # `sources: [StrandTests]`, a directory, so adding a test file changes no other tracked path.
       - 'StrandTests/**'
       - 'StrandiOS/**'

--- a/.github/workflows/app-build.yml
+++ b/.github/workflows/app-build.yml
@@ -13,6 +13,13 @@ on:
     branches: [main]
     paths:
       - 'Strand/**'
+      # The app-target TESTS, not just the sources they cover. The `Test Strand` step below runs
+      # StrandTests, but without this line a PR touching only those tests built and ran nothing: a test
+      # that failed to compile, or simply failed, merged unverified and then went red on the next
+      # unrelated PR that happened to touch `Strand/**`, which also mis-attributes the breakage to
+      # whoever that was. `project.yml` is already listed but does not cover it — the target takes
+      # `sources: [StrandTests]`, a directory, so adding a test file changes no other tracked path.
+      - 'StrandTests/**'
       - 'StrandiOS/**'
       - 'StrandiOSShared/**'
       - 'StrandiOSWidgets/**'


### PR DESCRIPTION
Groundwork for #1954. One line in the trigger, no new job.

## The gap

`app-build.yml` runs the app-target tests on its macOS leg:

```yaml
      - name: Test ${{ matrix.scheme }}
        if: matrix.scheme == 'Strand'
```

but its `paths:` listed the sources and not the tests. So a PR touching only
`StrandTests/**` started nothing: a test that failed to compile, or simply
failed, merged unverified and then went red on the next unrelated PR that
happened to touch `Strand/**`.

The mis-attribution is the part that costs time. The PR that turns red is not
the one that broke it, and the person reading that failure has no reason to
suspect a test file merged days earlier.

`project.yml` was already in the list but does not cover this. The target takes
`sources: [StrandTests]`, a directory, so adding a test file changes no other
tracked path.

## Why it is worth a line

`StrandTests` holds the app-target logic the Swift packages cannot reach —
backfill continuation, scheduled-report and strain-target policy — and the
source-guard tests that pin call-site invariants no unit test can drive. Adding
one of those is a routine change and exactly the shape the filter missed.

Found while confirming a new guard test in #1951 would actually run in CI. It
does, but only because that PR also edits `BLEManager.swift`.

## Scope

`StrandTests` is the only app-target test directory in the repo, and
`app-build.yml` is the only workflow listing `Strand/**`, so there is no sibling
with the same gap.

A re-review checked that claim against the other suites rather than assuming it,
and the answer explains the bug: Android CI triggers on `android/**` and its
tests live inside that; the package suites live under `Packages/**`. Both are
already covered by their subject's glob. `StrandTests` is a SIBLING of `Strand/`
rather than part of it, which is why it alone fell outside every path in the
list. That is now in the comment, so whoever adds the next test target knows
which shape needs a trigger entry and which does not.

Costs macOS minutes only on PRs that genuinely change those tests. This PR edits
the workflow, which is itself in the paths, so the change verifies itself.
