### PR TITLE
widget: heart rate with the recent trace (Android)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -291,6 +291,20 @@
                 android:resource="@xml/noop_compact_widget_info" />
         </receiver>
 
+        <!-- Heart-rate widget (#1957): live bpm with the last three hours as a trace. Same snapshot
+             source as the score widgets; the trace is a Bitmap because Glance cannot draw one. -->
+        <receiver
+            android:name="com.noop.widget.HrWidgetReceiver"
+            android:exported="true"
+            android:label="@string/widget_hr_name">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/hr_widget_info" />
+        </receiver>
+
         <!-- K10: Coach brief home-screen widget. Shows the stored morning brief (generated on a
              schedule by CoachBriefScheduler, K5) — never live-networked. Tap → opens the app. -->
         <receiver

--- a/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.Image
+import androidx.glance.ColorFilter
 import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.LocalSize
@@ -120,10 +121,23 @@ private fun HrWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
             .padding(14.dp)
             .clickable(actionStartActivity<MainActivity>()),
     ) {
-        Text(
-            text = uiString(R.string.l10n_noop_glance_widget_heart_rate_410aa15c),
-            style = TextStyle(color = hrTextPrimary(dark), fontSize = 13.sp, fontWeight = FontWeight.Medium),
-        )
+        Row(verticalAlignment = Alignment.Vertical.CenterVertically) {
+            // The notification heart, reused. It is authored as a solid alpha mask for exactly this kind
+            // of single-colour tinting, so it takes the accent cleanly.
+            Image(
+                provider = ImageProvider(R.drawable.ic_stat_heart),
+                contentDescription = null,
+                modifier = GlanceModifier.width(14.dp).height(14.dp),
+                colorFilter = ColorFilter.tint(ColorProvider(hrAccent(dark))),
+            )
+            Spacer(GlanceModifier.width(6.dp))
+            Text(
+                text = uiString(R.string.l10n_noop_glance_widget_heart_rate_410aa15c),
+                style = TextStyle(
+                    color = hrTextPrimary(dark), fontSize = 13.sp, fontWeight = FontWeight.Medium,
+                ),
+            )
+        }
         Spacer(GlanceModifier.height(6.dp))
 
         Row(verticalAlignment = Alignment.Vertical.Bottom) {
@@ -146,9 +160,15 @@ private fun HrWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
             }
             if (stats != null) {
                 Spacer(GlanceModifier.width(10.dp))
+                // A chip, not loose text: it is a summary OF the chart, and the tinted rounded ground is
+                // what separates it from the unit label sitting next to it.
                 Text(
                     text = uiString(R.string.l10n_hr_glance_widget_min_lo_max_hi_ef900e49, stats.min, stats.max),
-                    style = TextStyle(color = hrTextSecondary(dark), fontSize = 12.sp),
+                    style = TextStyle(color = hrTextPrimary(dark), fontSize = 11.sp),
+                    modifier = GlanceModifier
+                        .background(ColorProvider(hrAccent(dark).copy(alpha = 0.18f)))
+                        .cornerRadius(10.dp)
+                        .padding(horizontal = 8.dp, vertical = 3.dp),
                 )
             }
         }
@@ -165,10 +185,15 @@ private fun HrWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
         if (snap.updatedAtMs > 0) {
             Spacer(GlanceModifier.height(6.dp))
             val time = DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(snap.updatedAtMs))
-            Text(
-                text = uiString(R.string.l10n_hr_glance_widget_updated_time_1b5feedb, time),
-                style = TextStyle(color = hrTextSecondary(dark), fontSize = 10.sp),
-            )
+            Row(
+                modifier = GlanceModifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.Horizontal.CenterHorizontally,
+            ) {
+                Text(
+                    text = uiString(R.string.l10n_hr_glance_widget_updated_time_1b5feedb, time),
+                    style = TextStyle(color = hrTextSecondary(dark), fontSize = 10.sp),
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
@@ -140,6 +140,22 @@ private fun HrWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
         }
         Spacer(GlanceModifier.height(6.dp))
 
+        // Built OUT here, not inside the semantics lambda: #571 recorded that the i18n audit cannot see
+        // copy assigned inside one, so a literal written there ships English to every locale. The bare
+        // number alone left TalkBack reading "69" with no unit and no idea what it measured.
+        val hrLabel = uiString(R.string.l10n_noop_glance_widget_heart_rate_410aa15c)
+        // Staleness is drawn ONLY by dimming the number, which is a colour-only channel — so TalkBack,
+        // and anyone who cannot perceive the dim, was told a carried-over reading was current. Marked on
+        // the LIVE side, exactly as the sibling widget settled it (#1799): a stale value then carries no
+        // claim rather than a contradicted one.
+        val liveSuffix =
+            if (snap.heartRateStale) "" else " " + uiString(R.string.l10n_today_screen_sync_chip_live_98aadb37)
+        val hrSpoken = snap.heartRate
+            ?.let {
+                "$hrLabel " + uiString(R.string.l10n_today_screen_value_bpm_8f3a90c3, it.toString()) + liveSuffix
+            }
+            ?: hrLabel
+
         Row(verticalAlignment = Alignment.Vertical.Bottom) {
             Text(
                 text = snap.heartRate?.toString() ?: "—",
@@ -148,6 +164,7 @@ private fun HrWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
                     fontSize = 30.sp,
                     fontWeight = FontWeight.Bold,
                 ),
+                modifier = GlanceModifier.semantics { contentDescription = hrSpoken },
             )
             if (snap.heartRate != null) {
                 Spacer(GlanceModifier.width(4.dp))
@@ -247,11 +264,16 @@ private fun HrTraceImage(snap: WidgetSnapshot, dark: Boolean, widthDp: Float, he
                 horizontalAlignment = Alignment.Horizontal.End,
             ) {
                 val ticks = HrTrace.bpmTicks(stats)
+                // Spoken WITH the unit. The previous description was the bare number the label already
+                // shows, which is exactly as useful as none: TalkBack announced "84, 72, 59" against a
+                // chart it cannot see. Glance has no way to mark a Text decorative, so the next best
+                // thing is to make each one say what it measures.
+                val spoken = ticks.map { uiString(R.string.l10n_today_screen_value_bpm_8f3a90c3, it.toString()) }
                 ticks.forEachIndexed { i, tick ->
                     Text(
                         text = tick.toString(),
                         style = TextStyle(color = hrTextSecondary(dark), fontSize = 10.sp),
-                        modifier = GlanceModifier.semantics { contentDescription = tick.toString() },
+                        modifier = GlanceModifier.semantics { contentDescription = spoken[i] },
                     )
                     if (i < ticks.size - 1) Spacer(GlanceModifier.defaultWeight())
                 }

--- a/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
@@ -1,0 +1,213 @@
+package com.noop.widget
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.LocalContext
+import androidx.glance.LocalSize
+import androidx.glance.action.actionStartActivity
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.width
+import androidx.glance.semantics.contentDescription
+import androidx.glance.semantics.semantics
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.noop.R
+import com.noop.ui.MainActivity
+import com.noop.ui.uiString
+import java.text.DateFormat
+import java.util.Date
+
+/**
+ * Home-screen widget: the live heart rate with the last [HrTrace.WINDOW_SEC] drawn as a trace (#1957).
+ *
+ * Renders purely from the [WidgetSnapshotStore] snapshot, like its siblings — no BLE, no DB — so it
+ * costs nothing and survives process death. Tapping opens the app.
+ *
+ * The trace is an IMAGE because Glance compiles to RemoteViews, which cannot draw. [HrTrace] decides
+ * where the ink goes and [HrTraceRenderer] puts it on a Bitmap; the labels around it stay Glance `Text`
+ * so they remain crisp, themed and readable to TalkBack.
+ *
+ * Honest-blank throughout: no reading means "—" and no chart, never a flat line at zero. A trace with a
+ * single point draws a dot rather than nothing, because a widget placed this minute has exactly one.
+ */
+class HrGlanceWidget : GlanceAppWidget() {
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val snap = runCatching { WidgetSnapshotStore.load(context) }.getOrDefault(WidgetSnapshot())
+        val dark = runCatching {
+            when (context.getSharedPreferences("noop_prefs", Context.MODE_PRIVATE)
+                .getString("theme.appearance", "system")) {
+                "light" -> false
+                "dark" -> true
+                else -> (context.resources.configuration.uiMode and
+                    android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
+                    android.content.res.Configuration.UI_MODE_NIGHT_YES
+            }
+        }.getOrDefault(true)
+        provideContent { HrWidgetContent(snap, dark) }
+    }
+
+    /** Same defence as [NoopGlanceWidget.onCompositionError]: swap Glance's built-in error layout for
+     *  ours. The widget heals on the next successful push. */
+    override fun onCompositionError(
+        context: Context,
+        glanceId: GlanceId,
+        appWidgetId: Int,
+        throwable: Throwable,
+    ) {
+        runCatching {
+            val rv = android.widget.RemoteViews(context.packageName, R.layout.noop_widget_error)
+            android.appwidget.AppWidgetManager.getInstance(context).updateAppWidget(appWidgetId, rv)
+        }
+    }
+}
+
+// Local widget colours, mirroring the siblings rather than reading Palette: Glance composes outside the
+// app theme, so every widget in this package carries its own copy on purpose.
+private fun hrSurface(dark: Boolean) = ColorProvider(if (dark) Color(0xFF0A1322) else Color(0xFFF4F1EA))
+private fun hrTextPrimary(dark: Boolean) = ColorProvider(if (dark) Color(0xFFF4F6F8) else Color(0xFF1A2230))
+private fun hrTextSecondary(dark: Boolean) = ColorProvider(if (dark) Color(0xFF8A94A4) else Color(0xFF7C8696))
+
+/** The trace tint. A heart reads red in this app's language, not the screenshot's blue. */
+private fun hrAccent(dark: Boolean) = if (dark) Color(0xFFE0662F) else Color(0xFFC84E1E)
+
+@Composable
+private fun HrWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
+    val context = LocalContext.current
+    val size = LocalSize.current
+    val stats = HrTrace.stats(snap.hrSeries)
+
+    Column(
+        modifier = GlanceModifier
+            .fillMaxSize()
+            .background(hrSurface(dark))
+            .cornerRadius(16.dp)
+            .padding(14.dp)
+            .clickable(actionStartActivity<MainActivity>()),
+    ) {
+        Text(
+            text = uiString(R.string.l10n_noop_glance_widget_heart_rate_410aa15c),
+            style = TextStyle(color = hrTextPrimary(dark), fontSize = 13.sp, fontWeight = FontWeight.Medium),
+        )
+        Spacer(GlanceModifier.height(6.dp))
+
+        Row(verticalAlignment = Alignment.Vertical.Bottom) {
+            Text(
+                text = snap.heartRate?.toString() ?: "—",
+                style = TextStyle(
+                    color = if (snap.heartRateStale) hrTextSecondary(dark) else hrTextPrimary(dark),
+                    fontSize = 30.sp,
+                    fontWeight = FontWeight.Bold,
+                ),
+            )
+            if (snap.heartRate != null) {
+                Spacer(GlanceModifier.width(4.dp))
+                Text(
+                    // The existing unit resource, not a literal. The audit did not flag one here, but it
+                    // has known blind spots and the string already exists translated.
+                    text = uiString(R.string.today_unit_bpm),
+                    style = TextStyle(color = hrTextSecondary(dark), fontSize = 12.sp),
+                )
+            }
+            if (stats != null) {
+                Spacer(GlanceModifier.width(10.dp))
+                Text(
+                    text = uiString(R.string.l10n_hr_glance_widget_min_lo_max_hi_ef900e49, stats.min, stats.max),
+                    style = TextStyle(color = hrTextSecondary(dark), fontSize = 12.sp),
+                )
+            }
+        }
+
+        Spacer(GlanceModifier.height(8.dp))
+        HrTraceImage(snap, dark, widthDp = size.width.value, heightDp = 56f)
+
+        if (snap.updatedAtMs > 0) {
+            Spacer(GlanceModifier.height(6.dp))
+            val time = DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(snap.updatedAtMs))
+            Text(
+                text = uiString(R.string.l10n_hr_glance_widget_updated_time_1b5feedb, time),
+                style = TextStyle(color = hrTextSecondary(dark), fontSize = 10.sp),
+            )
+        }
+    }
+}
+
+/**
+ * The trace, plus the bpm scale down its right edge.
+ *
+ * Bitmap construction is wrapped: an OOM or a hostile size must leave the widget without a chart, not
+ * without a widget. `size.width` is the WIDGET's width, so the chart is sized from what the launcher
+ * actually gave us rather than from a guess.
+ */
+@Composable
+private fun HrTraceImage(snap: WidgetSnapshot, dark: Boolean, widthDp: Float, heightDp: Float) {
+    val context = LocalContext.current
+    val stats = HrTrace.stats(snap.hrSeries)
+    val density = context.resources.displayMetrics.density
+    // Leave room for the scale column so the trace is not drawn under its own labels.
+    val chartWidthDp = (widthDp - 28f - 34f).coerceAtLeast(24f)
+    val wPx = (chartWidthDp * density).toInt()
+    val hPx = (heightDp * density).toInt()
+
+    val bmp = runCatching {
+        HrTraceRenderer.render(
+            points = HrTrace.points(snap.hrSeries, wPx.toFloat(), hPx.toFloat()),
+            widthPx = wPx,
+            heightPx = hPx,
+            lineColor = hrAccent(dark).toArgb(),
+            fillTopColor = hrAccent(dark).copy(alpha = 0.35f).toArgb(),
+            strokePx = 2f * density,
+        )
+    }.getOrNull()
+
+    Row(modifier = GlanceModifier.fillMaxWidth()) {
+        Box(modifier = GlanceModifier.height(heightDp.dp).width(chartWidthDp.dp)) {
+            if (bmp != null) {
+                Image(
+                    provider = ImageProvider(bmp),
+                    contentDescription = null,
+                    modifier = GlanceModifier.fillMaxSize(),
+                )
+            }
+        }
+        if (stats != null) {
+            Spacer(GlanceModifier.width(6.dp))
+            Column(
+                modifier = GlanceModifier.height(heightDp.dp),
+                horizontalAlignment = Alignment.Horizontal.End,
+            ) {
+                for (tick in HrTrace.bpmTicks(stats)) {
+                    Text(
+                        text = tick.toString(),
+                        style = TextStyle(color = hrTextSecondary(dark), fontSize = 10.sp),
+                        modifier = GlanceModifier.semantics { contentDescription = tick.toString() },
+                    )
+                    Spacer(GlanceModifier.height(6.dp))
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
@@ -91,6 +91,18 @@ private fun hrSurface(dark: Boolean) = ColorProvider(if (dark) Color(0xFF0A1322)
 private fun hrTextPrimary(dark: Boolean) = ColorProvider(if (dark) Color(0xFFF4F6F8) else Color(0xFF1A2230))
 private fun hrTextSecondary(dark: Boolean) = ColorProvider(if (dark) Color(0xFF8A94A4) else Color(0xFF7C8696))
 
+/** Card padding, both sides. The chart and the axis under it must subtract the SAME figure or the
+ *  labels drift out of line with the trace they annotate. */
+private const val HR_CARD_PADDING_DP = 28f
+
+/** The bpm scale column plus its gap. Same reasoning: one number, read by both. Two copies of a layout
+ *  constant is how a chart and its axis end up a few pixels out of step. */
+private const val HR_SCALE_COLUMN_DP = 34f
+
+/** The chart width for a given widget width — the one place that arithmetic happens. */
+private fun hrChartWidthDp(widthDp: Float): Float =
+    (widthDp - HR_CARD_PADDING_DP - HR_SCALE_COLUMN_DP).coerceAtLeast(24f)
+
 /** The trace tint. A heart reads red in this app's language, not the screenshot's blue. */
 private fun hrAccent(dark: Boolean) = if (dark) Color(0xFFE0662F) else Color(0xFFC84E1E)
 
@@ -141,8 +153,14 @@ private fun HrWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
             }
         }
 
-        Spacer(GlanceModifier.height(8.dp))
-        HrTraceImage(snap, dark, widthDp = size.width.value, heightDp = 56f)
+        // No series, no chart row at all. On upgrade every existing install has a heart rate in prefs
+        // but no trace yet, and reserving the height for it would show a blank rectangle for the first
+        // few minutes — a void reads as broken where a shorter widget reads as new.
+        if (snap.hrSeries.isNotEmpty()) {
+            Spacer(GlanceModifier.height(8.dp))
+            HrTraceImage(snap, dark, widthDp = size.width.value, heightDp = 56f)
+            HrTimeAxis(snap, dark, widthDp = size.width.value)
+        }
 
         if (snap.updatedAtMs > 0) {
             Spacer(GlanceModifier.height(6.dp))
@@ -168,7 +186,7 @@ private fun HrTraceImage(snap: WidgetSnapshot, dark: Boolean, widthDp: Float, he
     val stats = HrTrace.stats(snap.hrSeries)
     val density = context.resources.displayMetrics.density
     // Leave room for the scale column so the trace is not drawn under its own labels.
-    val chartWidthDp = (widthDp - 28f - 34f).coerceAtLeast(24f)
+    val chartWidthDp = hrChartWidthDp(widthDp)
     // ONE box for both the geometry and the bitmap. Sizing them separately let the trace be drawn to
     // coordinates the bitmap did not have room for, clipping its right-hand end (#1957).
     val (wPx, hPx) = HrTrace.fitBox((chartWidthDp * density).toInt(), (heightDp * density).toInt())
@@ -196,19 +214,51 @@ private fun HrTraceImage(snap: WidgetSnapshot, dark: Boolean, widthDp: Float, he
         }
         if (stats != null) {
             Spacer(GlanceModifier.width(6.dp))
+            // Spread across the chart's height so max sits level with the top of the trace and min with
+            // the bottom, which is what makes it a SCALE. Stacked from the top with fixed gaps they were
+            // just three numbers near the chart, aligned to nothing.
             Column(
                 modifier = GlanceModifier.height(heightDp.dp),
                 horizontalAlignment = Alignment.Horizontal.End,
             ) {
-                for (tick in HrTrace.bpmTicks(stats)) {
+                val ticks = HrTrace.bpmTicks(stats)
+                ticks.forEachIndexed { i, tick ->
                     Text(
                         text = tick.toString(),
                         style = TextStyle(color = hrTextSecondary(dark), fontSize = 10.sp),
                         modifier = GlanceModifier.semantics { contentDescription = tick.toString() },
                     )
-                    Spacer(GlanceModifier.height(6.dp))
+                    if (i < ticks.size - 1) Spacer(GlanceModifier.defaultWeight())
                 }
             }
+        }
+    }
+}
+
+/**
+ * The time labels under the trace: first, middle and last of the DATA (see [HrTrace.timeTicks]).
+ *
+ * Spread with weighted spacers rather than fixed gaps, so the middle label sits over the middle of the
+ * chart whatever width the launcher gave the widget. Formatted through the locale's short time format,
+ * so a 12-hour device reads as one — a widget is not the place to impose a clock convention.
+ *
+ * Degrades with the ticks: under a minute of history there is one instant to name, and naming it three
+ * times would suggest a span that was never sampled.
+ */
+@Composable
+private fun HrTimeAxis(snap: WidgetSnapshot, dark: Boolean, widthDp: Float) {
+    val ticks = HrTrace.timeTicks(snap.hrSeries)
+    if (ticks.isEmpty()) return
+    val fmt = DateFormat.getTimeInstance(DateFormat.SHORT)
+    val chartWidthDp = hrChartWidthDp(widthDp)
+    Spacer(GlanceModifier.height(2.dp))
+    Row(modifier = GlanceModifier.width(chartWidthDp.dp)) {
+        ticks.forEachIndexed { i, ts ->
+            Text(
+                text = fmt.format(Date(ts * 1000)),
+                style = TextStyle(color = hrTextSecondary(dark), fontSize = 9.sp),
+            )
+            if (i < ticks.size - 1) Spacer(GlanceModifier.defaultWeight())
         }
     }
 }

--- a/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
@@ -169,8 +169,9 @@ private fun HrTraceImage(snap: WidgetSnapshot, dark: Boolean, widthDp: Float, he
     val density = context.resources.displayMetrics.density
     // Leave room for the scale column so the trace is not drawn under its own labels.
     val chartWidthDp = (widthDp - 28f - 34f).coerceAtLeast(24f)
-    val wPx = (chartWidthDp * density).toInt()
-    val hPx = (heightDp * density).toInt()
+    // ONE box for both the geometry and the bitmap. Sizing them separately let the trace be drawn to
+    // coordinates the bitmap did not have room for, clipping its right-hand end (#1957).
+    val (wPx, hPx) = HrTrace.fitBox((chartWidthDp * density).toInt(), (heightDp * density).toInt())
 
     val bmp = runCatching {
         HrTraceRenderer.render(

--- a/android/app/src/main/java/com/noop/widget/HrTrace.kt
+++ b/android/app/src/main/java/com/noop/widget/HrTrace.kt
@@ -88,6 +88,37 @@ object HrTrace {
     }
 
 
+    /**
+     * The largest drawing box that fits the widget payload budget, keeping the requested aspect.
+     *
+     * RemoteViews travels to the launcher over a BINDER TRANSACTION with a hard size ceiling, and a
+     * widget that exceeds it does not degrade — it fails to render at all. An ARGB_8888 bitmap costs
+     * four bytes a pixel, so a 300dp-wide chart on a 4x screen is already about a megabyte on its own,
+     * before the rest of the RemoteViews. Dimension caps alone do not express that: the constraint is
+     * AREA, and a wide-and-short box and a tall-and-narrow one can both be legal while their product
+     * is not.
+     *
+     * Downscaling is nearly free here in a way it would not be for text or an icon: a sparkline is a
+     * smooth line, and the `Image` stretches the result back to the same slot, so the only cost is a
+     * fractionally softer stroke.
+     *
+     * Returned as the box BOTH [points] and the renderer must use. They used to disagree — geometry ran
+     * at the requested width while the renderer clamped its own — which silently clipped the right-hand
+     * end of the trace on any screen large enough to hit the cap.
+     */
+    fun fitBox(widthPx: Int, heightPx: Int, maxBytes: Int = MAX_BITMAP_BYTES): Pair<Int, Int> {
+        val w = widthPx.coerceAtLeast(1)
+        val h = heightPx.coerceAtLeast(1)
+        val bytes = w.toLong() * h.toLong() * 4L
+        if (bytes <= maxBytes) return w to h
+        val scale = Math.sqrt(maxBytes.toDouble() / bytes.toDouble())
+        return (w * scale).toInt().coerceAtLeast(1) to (h * scale).toInt().coerceAtLeast(1)
+    }
+
+    /** The bitmap's byte budget. Half a megabyte leaves the rest of the RemoteViews comfortable inside
+     *  the transaction ceiling, and still affords a full-density chart on an ordinary phone. */
+    const val MAX_BITMAP_BYTES: Int = 512 * 1024
+
     /** A point in the trace's pixel box, origin top-left, as the renderer wants it. */
     data class Pt(val x: Float, val y: Float)
 

--- a/android/app/src/main/java/com/noop/widget/HrTrace.kt
+++ b/android/app/src/main/java/com/noop/widget/HrTrace.kt
@@ -1,0 +1,153 @@
+package com.noop.widget
+
+/** One point on the widget's heart-rate trace: when it was taken, and the bpm. */
+data class HrPoint(val ts: Long, val bpm: Int)
+
+/**
+ * The pure half of the heart-rate widget: what the trace CONTAINS and where its ink goes.
+ *
+ * Split from the drawing because Glance cannot draw. A sparkline has to be rendered to a Bitmap and
+ * handed over as an Image, and a Bitmap is not something a JVM test can meaningfully assert about — so
+ * everything decidable without a Canvas lives here, unit-tested, and the renderer is left with nothing
+ * but `moveTo`/`lineTo` over coordinates this file produced.
+ *
+ * Also the shape an iOS twin would share. SwiftUI can draw the trace directly, so the renderer will not
+ * port, but the retention rule, the tick choices and the normalisation are the same decisions on both
+ * platforms and should not be made twice.
+ */
+object HrTrace {
+
+    /** How much history the trace shows. Three hours matches what fits legibly at widget width. */
+    const val WINDOW_SEC: Long = 3 * 60 * 60
+
+    /** One point per minute. The strap streams ~1/s; keeping every sample would put 10 800 points behind
+     *  a trace 300 pixels wide, which costs prefs space and buys nothing the eye can resolve. */
+    const val BUCKET_SEC: Long = 60
+
+    /** Hard cap, so a clock jump backwards cannot grow the series without bound. WINDOW_SEC/BUCKET_SEC
+     *  is 180; the slack absorbs a boundary point without letting the list run away. */
+    const val MAX_POINTS: Int = 200
+
+    /**
+     * Fold a fresh reading into the series: one point per minute bucket, newest wins within a bucket.
+     *
+     * Newest-wins rather than an average because the widget's headline number is the LATEST bpm, and a
+     * trace whose last point disagreed with the number printed above it would read as a bug. Within a
+     * minute the difference is a beat or two.
+     */
+    fun append(series: List<HrPoint>, ts: Long, bpm: Int, nowSec: Long = ts): List<HrPoint> {
+        if (bpm <= 0) return prune(series, nowSec)
+        val bucket = ts / BUCKET_SEC * BUCKET_SEC
+        val out = ArrayList<HrPoint>(series.size + 1)
+        for (p in series) if (p.ts != bucket) out.add(p)
+        out.add(HrPoint(bucket, bpm))
+        out.sortBy { it.ts }
+        return prune(out, nowSec)
+    }
+
+    /** Drop anything older than the window, then anything beyond the cap (oldest first). */
+    fun prune(series: List<HrPoint>, nowSec: Long): List<HrPoint> {
+        val floor = nowSec - WINDOW_SEC
+        val kept = series.filter { it.ts >= floor }.sortedBy { it.ts }
+        return if (kept.size <= MAX_POINTS) kept else kept.subList(kept.size - MAX_POINTS, kept.size)
+    }
+
+    /** `ts:bpm` pairs, comma separated. Compact enough that 200 points sit well inside a prefs string,
+     *  and readable in a bug report, which a binary blob would not be. */
+    fun encode(series: List<HrPoint>): String =
+        series.joinToString(",") { "${it.ts}:${it.bpm}" }
+
+    /** Tolerant by design: a malformed pair is skipped rather than throwing. This runs on the widget's
+     *  render path, where the alternative to a partial trace is a crashed home screen. */
+    fun decode(s: String?): List<HrPoint> {
+        if (s.isNullOrBlank()) return emptyList()
+        val out = ArrayList<HrPoint>()
+        for (part in s.split(',')) {
+            val i = part.indexOf(':')
+            if (i <= 0 || i == part.length - 1) continue
+            val ts = part.substring(0, i).toLongOrNull() ?: continue
+            val bpm = part.substring(i + 1).toIntOrNull() ?: continue
+            if (bpm > 0) out.add(HrPoint(ts, bpm))
+        }
+        out.sortBy { it.ts }
+        return out
+    }
+
+    /** The three numbers the header shows. Null when there is nothing to describe. */
+    data class Stats(val min: Int, val max: Int, val latest: Int)
+
+    fun stats(series: List<HrPoint>): Stats? {
+        if (series.isEmpty()) return null
+        var lo = series[0].bpm
+        var hi = series[0].bpm
+        for (p in series) {
+            if (p.bpm < lo) lo = p.bpm
+            if (p.bpm > hi) hi = p.bpm
+        }
+        return Stats(min = lo, max = hi, latest = series.last().bpm)
+    }
+
+
+    /** A point in the trace's pixel box, origin top-left, as the renderer wants it. */
+    data class Pt(val x: Float, val y: Float)
+
+    /**
+     * The trace as pixels inside a `width` x `height` box.
+     *
+     * Two degenerate shapes decide most of this, and both are ordinary rather than exotic — a widget
+     * placed mid-afternoon has one point, and a resting arm holds one bpm for minutes at a time:
+     *
+     *  - ONE point, or every point at the same instant: there is no time axis to spread across, so it
+     *    sits at the left edge rather than at x=NaN.
+     *  - every bpm equal: there is no range to scale into, so the line runs along the VERTICAL MIDDLE.
+     *    Pinning it to the top or bottom would read as a maxed-out or flatlined heart.
+     *
+     * Y is flipped on the way out: bpm rises upward, pixels rise downward.
+     */
+    fun points(series: List<HrPoint>, width: Float, height: Float): List<Pt> {
+        if (series.isEmpty() || width <= 0f || height <= 0f) return emptyList()
+        val t0 = series.first().ts
+        val t1 = series.last().ts
+        val span = (t1 - t0).toFloat()
+        var lo = series[0].bpm
+        var hi = series[0].bpm
+        for (p in series) {
+            if (p.bpm < lo) lo = p.bpm
+            if (p.bpm > hi) hi = p.bpm
+        }
+        val range = (hi - lo).toFloat()
+        return series.map { p ->
+            val x = if (span <= 0f) 0f else (p.ts - t0) / span * width
+            val y = if (range <= 0f) height / 2f else height - (p.bpm - lo) / range * height
+            Pt(x, y)
+        }
+    }
+
+    /**
+     * The three bpm labels down the right edge: max, midpoint, min, exactly as they are stacked in the
+     * chart. Returned high-to-low so the caller can lay them out top-down without re-sorting.
+     *
+     * A flat series returns the same number three times rather than an invented spread — the honest
+     * reading of a steady heart is one number, and manufacturing 58/59/60 around it would put ticks on
+     * the chart that no sample supports.
+     */
+    fun bpmTicks(stats: Stats): List<Int> =
+        listOf(stats.max, (stats.min + stats.max + 1) / 2, stats.min)
+
+    /**
+     * The three timestamps along the bottom: first, middle, last of the DATA, not of the window.
+     *
+     * Anchored to the data because a widget holding forty minutes of history would otherwise label its
+     * axis with two hours that were never sampled, and the trace would appear crushed into the right
+     * third of a mostly empty chart. Fewer than three distinct instants returns what there is, so the
+     * renderer draws one label rather than three copies of it.
+     */
+    fun timeTicks(series: List<HrPoint>): List<Long> {
+        if (series.isEmpty()) return emptyList()
+        val first = series.first().ts
+        val last = series.last().ts
+        if (first == last) return listOf(first)
+        val mid = first + (last - first) / 2
+        return if (mid == first || mid == last) listOf(first, last) else listOf(first, mid, last)
+    }
+}

--- a/android/app/src/main/java/com/noop/widget/HrTraceRenderer.kt
+++ b/android/app/src/main/java/com/noop/widget/HrTraceRenderer.kt
@@ -21,14 +21,6 @@ import android.graphics.Shader
  */
 internal object HrTraceRenderer {
 
-    /** Widest bitmap we will build. RemoteViews carries its payload over a Binder transaction with a
-     *  hard size limit, and a widget that exceeds it does not degrade, it fails to render at all. A
-     *  trace is a thin line: past this width the extra pixels buy nothing the eye resolves. */
-    const val MAX_WIDTH_PX = 1080
-
-    /** Same reasoning vertically. */
-    const val MAX_HEIGHT_PX = 480
-
     /**
      * @param points from [HrTrace.points], already normalised into the box
      * @return the trace, or null when there is nothing to draw or the box is degenerate — the caller
@@ -43,9 +35,13 @@ internal object HrTraceRenderer {
         strokePx: Float,
     ): Bitmap? {
         if (points.isEmpty()) return null
-        val w = widthPx.coerceIn(1, MAX_WIDTH_PX)
-        val h = heightPx.coerceIn(1, MAX_HEIGHT_PX)
+        // The caller sized this with [HrTrace.fitBox], which owns the payload budget. Clamping to a
+        // DIFFERENT ceiling here is what previously let the geometry and the bitmap disagree, so this
+        // only guards against a nonsense box, and re-checks the budget rather than re-deciding it.
+        val w = widthPx.coerceAtLeast(1)
+        val h = heightPx.coerceAtLeast(1)
         if (w < 2 || h < 2) return null
+        if (w.toLong() * h.toLong() * 4L > HrTrace.MAX_BITMAP_BYTES) return null
 
         val bmp = runCatching {
             Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)

--- a/android/app/src/main/java/com/noop/widget/HrTraceRenderer.kt
+++ b/android/app/src/main/java/com/noop/widget/HrTraceRenderer.kt
@@ -1,0 +1,101 @@
+package com.noop.widget
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.LinearGradient
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.Shader
+
+/**
+ * Draws the heart-rate trace to a Bitmap, because Glance cannot draw one.
+ *
+ * Glance compiles to RemoteViews, which has no Canvas and no arbitrary shapes — a sparkline can only
+ * reach a widget as an Image. So this exists, and it is kept deliberately STUPID: every decision worth
+ * testing was already made in [HrTrace], and what remains is `moveTo`/`lineTo` over coordinates handed
+ * in. Nothing here chooses a tick, a range, or a point.
+ *
+ * The LABELS are not drawn here either, though the design has them. They are Glance `Text` in the
+ * composable instead, which keeps them crisp at any density, themeable with the rest of the widget, and
+ * legible to TalkBack — none of which a label baked into a bitmap would be.
+ */
+internal object HrTraceRenderer {
+
+    /** Widest bitmap we will build. RemoteViews carries its payload over a Binder transaction with a
+     *  hard size limit, and a widget that exceeds it does not degrade, it fails to render at all. A
+     *  trace is a thin line: past this width the extra pixels buy nothing the eye resolves. */
+    const val MAX_WIDTH_PX = 1080
+
+    /** Same reasoning vertically. */
+    const val MAX_HEIGHT_PX = 480
+
+    /**
+     * @param points from [HrTrace.points], already normalised into the box
+     * @return the trace, or null when there is nothing to draw or the box is degenerate — the caller
+     *         shows the empty state rather than an empty image.
+     */
+    fun render(
+        points: List<HrTrace.Pt>,
+        widthPx: Int,
+        heightPx: Int,
+        lineColor: Int,
+        fillTopColor: Int,
+        strokePx: Float,
+    ): Bitmap? {
+        if (points.isEmpty()) return null
+        val w = widthPx.coerceIn(1, MAX_WIDTH_PX)
+        val h = heightPx.coerceIn(1, MAX_HEIGHT_PX)
+        if (w < 2 || h < 2) return null
+
+        val bmp = runCatching {
+            Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        }.getOrNull() ?: return null
+        val canvas = Canvas(bmp)
+
+        // Inset by the stroke so a point sitting exactly on the top or bottom edge is not shaved in
+        // half. The geometry maps the extremes to 0 and `height`, which is correct for a line of zero
+        // width and half a stroke short of it for a real one.
+        val inset = strokePx / 2f
+        val usableH = (h - strokePx).coerceAtLeast(1f)
+        fun px(p: HrTrace.Pt) = p.x to (inset + p.y / h * usableH)
+
+        val line = Path()
+        points.forEachIndexed { i, p ->
+            val (x, y) = px(p)
+            if (i == 0) line.moveTo(x, y) else line.lineTo(x, y)
+        }
+
+        // A single point has no line to stroke, so give it a dot — otherwise a widget placed this
+        // minute renders as an empty chart, which reads as "no data" rather than "one reading".
+        if (points.size == 1) {
+            val (x, y) = px(points[0])
+            canvas.drawCircle(x.coerceAtLeast(strokePx), y, strokePx, Paint().apply {
+                isAntiAlias = true
+                color = lineColor
+            })
+            return bmp
+        }
+
+        // Fill first, so the stroke sits on top of its own gradient rather than under it.
+        val fill = Path(line)
+        fill.lineTo(points.last().x, h.toFloat())
+        fill.lineTo(points.first().x, h.toFloat())
+        fill.close()
+        canvas.drawPath(fill, Paint().apply {
+            isAntiAlias = true
+            shader = LinearGradient(
+                0f, 0f, 0f, h.toFloat(), fillTopColor, fillTopColor and 0x00FFFFFF, Shader.TileMode.CLAMP,
+            )
+        })
+
+        canvas.drawPath(line, Paint().apply {
+            isAntiAlias = true
+            style = Paint.Style.STROKE
+            strokeWidth = strokePx
+            strokeCap = Paint.Cap.ROUND
+            strokeJoin = Paint.Join.ROUND
+            color = lineColor
+        })
+        return bmp
+    }
+}

--- a/android/app/src/main/java/com/noop/widget/HrWidgetReceiver.kt
+++ b/android/app/src/main/java/com/noop/widget/HrWidgetReceiver.kt
@@ -1,0 +1,9 @@
+package com.noop.widget
+
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+/** Manifest entry point for the heart-rate widget — all rendering lives in [HrGlanceWidget]. */
+class HrWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = HrGlanceWidget()
+}

--- a/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
@@ -24,6 +24,11 @@ data class WidgetSnapshot(
     /** Strap battery 0–100, null until the strap reports it. */
     val batteryPct: Int? = null,
     val connected: Boolean = false,
+    /** The last [HrTrace.WINDOW_SEC] of heart rate, one point per minute, for the trace widget (#1957).
+     *  Maintained by the STORE rather than by producers: `save` folds each live sample in and `load`
+     *  hands back the pruned series, so nothing that pushes a snapshot had to learn about it. Empty
+     *  until a live sample lands, which is also what a fresh install and a quiet strap look like. */
+    val hrSeries: List<HrPoint> = emptyList(),
     /** Wall-clock millis of the last push, so the widget can show honest staleness. */
     val updatedAtMs: Long = 0L,
 )
@@ -40,6 +45,10 @@ data class WidgetSnapshot(
  */
 object WidgetSnapshotStore {
     private const val FILE = "noop_widget"
+
+    /** Prefs key for the encoded heart-rate trace (#1957). Its own key so an older build, or a wipe of
+     *  the trace, leaves every scalar the other widgets read untouched. */
+    private const val KEY_SERIES = "hrSeries"
 
     suspend fun push(context: Context, snap: WidgetSnapshot) {
         val app = context.applicationContext
@@ -58,13 +67,18 @@ object WidgetSnapshotStore {
         val compactIds = runCatching {
             GlanceAppWidgetManager(app).getGlanceIds(NoopCompactGlanceWidget::class.java)
         }.getOrDefault(emptyList())
-        if (standardIds.isEmpty() && compactIds.isEmpty()) return
+        val hrIds = runCatching {
+            GlanceAppWidgetManager(app).getGlanceIds(HrGlanceWidget::class.java)
+        }.getOrDefault(emptyList())
+        if (standardIds.isEmpty() && compactIds.isEmpty() && hrIds.isEmpty()) return
         runCatching { NoopGlanceWidget().updateAll(app) }
         runCatching { NoopCompactGlanceWidget().updateAll(app) }
+        runCatching { HrGlanceWidget().updateAll(app) }
     }
 
     fun save(context: Context, snap: WidgetSnapshot) {
-        val e = context.getSharedPreferences(FILE, Context.MODE_PRIVATE).edit()
+        val prefs = context.getSharedPreferences(FILE, Context.MODE_PRIVATE)
+        val e = prefs.edit()
             .putInt("recovery", snap.recoveryPct ?: -1)
             .putInt("rest", snap.restPct ?: -1)
             .putInt("effort", snap.effortPct ?: -1)
@@ -76,7 +90,18 @@ object WidgetSnapshotStore {
         // `hrLive` records that the retained value is now a carry-over so the widget dims it (see HrDisplay).
         val live = (snap.heartRate ?: 0) > 0
         e.putBoolean("hrLive", live)
-        if (live) e.putInt("hr", snap.heartRate!!).putLong("hrAt", snap.updatedAtMs)
+        if (live) {
+            e.putInt("hr", snap.heartRate!!).putLong("hrAt", snap.updatedAtMs)
+            // #1957: fold the sample into the trace. Read-modify-write is affordable here precisely
+            // because PushGate already throttles an unchanged key to once a minute, which is the same
+            // cadence HrTrace buckets at — so this runs about once per point, not once per sample.
+            val nowSec = snap.updatedAtMs / 1000
+            val folded = HrTrace.append(
+                HrTrace.decode(prefs.getString(KEY_SERIES, null)),
+                ts = nowSec, bpm = snap.heartRate!!, nowSec = nowSec,
+            )
+            e.putString(KEY_SERIES, HrTrace.encode(folded))
+        }
         e.apply()
     }
 
@@ -96,6 +121,13 @@ object WidgetSnapshotStore {
             heartRateStale = hrStale,
             batteryPct = p.getInt("battery", -1).takeIf { it >= 0 },
             connected = p.getBoolean("connected", false),
+            // Pruned on the way OUT as well as on the way in: a widget read hours after the last push
+            // would otherwise draw a trace whose newest point is stale, under a header that already
+            // dropped the number for being too old (see [HrDisplay.STALE_CAP_MS]).
+            hrSeries = HrTrace.prune(
+                HrTrace.decode(p.getString(KEY_SERIES, null)),
+                nowSec = System.currentTimeMillis() / 1000,
+            ),
             updatedAtMs = p.getLong("updatedAt", 0L),
         )
     }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2750,4 +2750,8 @@
     <string name="units_follow_body">Wie Körpermaße</string>
     <string name="l10n_today_screen_pending_sync_cbe01f9e">Sync ausstehend</string>
     <string name="l10n_today_screen_strap_history_still_offloading_80140264">Strap-Verlauf wird noch übertragen</string>
+    <string name="l10n_hr_glance_widget_min_lo_max_hi_ef900e49">Min %1$d • Max %2$d</string>
+    <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Aktualisiert %1$s</string>
+    <string name="widget_hr_name">NOOP Herzfrequenz</string>
+    <string name="widget_hr_description">Live-Herzfrequenz mit den letzten drei Stunden als Verlauf.</string>
 </resources>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2750,7 +2750,7 @@
     <string name="units_follow_body">Wie Körpermaße</string>
     <string name="l10n_today_screen_pending_sync_cbe01f9e">Sync ausstehend</string>
     <string name="l10n_today_screen_strap_history_still_offloading_80140264">Strap-Verlauf wird noch übertragen</string>
-    <string name="l10n_hr_glance_widget_min_lo_max_hi_ef900e49">Min %1$d • Max %2$d</string>
+    <string name="l10n_hr_glance_widget_min_lo_max_hi_ef900e49">Min. %1$d • Max. %2$d</string>
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Aktualisiert %1$s</string>
     <string name="widget_hr_name">NOOP Herzfrequenz</string>
     <string name="widget_hr_description">Live-Herzfrequenz mit den letzten drei Stunden als Verlauf.</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2737,4 +2737,8 @@
     <string name="units_follow_body">Según medidas corporales</string>
     <string name="l10n_today_screen_pending_sync_cbe01f9e">Sincronización pendiente</string>
     <string name="l10n_today_screen_strap_history_still_offloading_80140264">el historial de la pulsera aún se está transfiriendo</string>
+    <string name="l10n_hr_glance_widget_min_lo_max_hi_ef900e49">Mín %1$d • Máx %2$d</string>
+    <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Actualizado %1$s</string>
+    <string name="widget_hr_name">NOOP Frecuencia cardíaca</string>
+    <string name="widget_hr_description">Frecuencia cardíaca en directo con las últimas tres horas como gráfico.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2736,4 +2736,8 @@
     <string name="units_follow_body">Selon les mensurations</string>
     <string name="l10n_today_screen_pending_sync_cbe01f9e">Synchronisation en attente</string>
     <string name="l10n_today_screen_strap_history_still_offloading_80140264">l\'historique du bracelet est encore en cours de transfert</string>
+    <string name="l10n_hr_glance_widget_min_lo_max_hi_ef900e49">Min %1$d • Max %2$d</string>
+    <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Mis à jour %1$s</string>
+    <string name="widget_hr_name">NOOP Fréquence cardiaque</string>
+    <string name="widget_hr_description">Fréquence cardiaque en direct avec les trois dernières heures en courbe.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2736,7 +2736,7 @@
     <string name="units_follow_body">Selon les mensurations</string>
     <string name="l10n_today_screen_pending_sync_cbe01f9e">Synchronisation en attente</string>
     <string name="l10n_today_screen_strap_history_still_offloading_80140264">l\'historique du bracelet est encore en cours de transfert</string>
-    <string name="l10n_hr_glance_widget_min_lo_max_hi_ef900e49">Min %1$d • Max %2$d</string>
+    <string name="l10n_hr_glance_widget_min_lo_max_hi_ef900e49">Min. %1$d • Max. %2$d</string>
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Mis à jour %1$s</string>
     <string name="widget_hr_name">NOOP Fréquence cardiaque</string>
     <string name="widget_hr_description">Fréquence cardiaque en direct avec les trois dernières heures en courbe.</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2741,4 +2741,8 @@
     <string name="units_follow_body">Jak pomiary ciała</string>
     <string name="l10n_today_screen_pending_sync_cbe01f9e">Oczekuje na synchronizację</string>
     <string name="l10n_today_screen_strap_history_still_offloading_80140264">historia paska wciąż jest przesyłana</string>
+    <string name="l10n_hr_glance_widget_min_lo_max_hi_ef900e49">Min %1$d • Maks %2$d</string>
+    <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Zaktualizowano %1$s</string>
+    <string name="widget_hr_name">NOOP Tętno</string>
+    <string name="widget_hr_description">Tętno na żywo z ostatnimi trzema godzinami jako wykres.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2729,4 +2729,8 @@
     <string name="units_follow_body">Como medidas corporais</string>
     <string name="l10n_today_screen_pending_sync_cbe01f9e">Sincronização pendente</string>
     <string name="l10n_today_screen_strap_history_still_offloading_80140264">o histórico da bracelete ainda está a ser transferido</string>
+    <string name="l10n_hr_glance_widget_min_lo_max_hi_ef900e49">Mín %1$d • Máx %2$d</string>
+    <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Atualizado %1$s</string>
+    <string name="widget_hr_name">NOOP Frequência cardíaca</string>
+    <string name="widget_hr_description">Frequência cardíaca em direto com as últimas três horas em gráfico.</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -2620,4 +2620,8 @@
     <string name="l10n_devices_screen_battery_pack_probe_explainer_40b3470d">Отправляет команду батарейного блока только для чтения (151) и декодирует ответ браслета — заряд блока, серийный номер и Bluetooth-адрес. На браслет ничего не записывается, и это не влияет на ваши данные. У WHOOP 4.0 нет команды блока, и ожидается молчание; само это молчание — полезный результат.</string>
     <string name="l10n_today_screen_pending_sync_cbe01f9e">Ожидает синхронизации</string>
     <string name="l10n_today_screen_strap_history_still_offloading_80140264">история браслета ещё передаётся</string>
+    <string name="l10n_hr_glance_widget_min_lo_max_hi_ef900e49">Мин %1$d • Макс %2$d</string>
+    <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Обновлено %1$s</string>
+    <string name="widget_hr_name">NOOP Пульс</string>
+    <string name="widget_hr_description">Пульс в реальном времени и график за последние три часа.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2650,4 +2650,8 @@
     <string name="l10n_devices_screen_pack_charge_0e9589da">电池盒 %1$.1f%%</string>
     <string name="l10n_today_screen_pending_sync_cbe01f9e">等待同步</string>
     <string name="l10n_today_screen_strap_history_still_offloading_80140264">手环历史记录仍在传输</string>
+    <string name="l10n_hr_glance_widget_min_lo_max_hi_ef900e49">最低 %1$d • 最高 %2$d</string>
+    <string name="l10n_hr_glance_widget_updated_time_1b5feedb">更新于 %1$s</string>
+    <string name="widget_hr_name">NOOP 心率</string>
+    <string name="widget_hr_description">实时心率，并显示最近三小时的曲线。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,8 @@
 <resources>
     <string name="app_name">NOOP</string>
     <string name="widget_description">Today\'s Rest, Charge and Effort, with live heart rate and strap battery at a glance.</string>
+    <string name="widget_hr_name">NOOP Heart Rate</string>
+    <string name="widget_hr_description">Live heart rate with the last three hours as a trace.</string>
     <string name="widget_compact_name">NOOP Compact</string>
     <string name="widget_compact_description">Compact Rest, Charge and Effort widget, with live heart rate and strap battery.</string>
     <string name="widget_error">NOOP widget couldn\'t draw — it will recover on the next update.</string>
@@ -629,6 +631,8 @@
     <string name="l10n_hrv_snapshot_screen_not_enough_clean_beats_sit_still_0893e6c2">Not enough clean beats - sit still and try again. %1$s of </string>
     <string name="l10n_hrv_snapshot_screen_rmssd_e240fd3c">RMSSD</string>
     <string name="l10n_hrv_snapshot_screen_sdnn_9ab9ee2a">SDNN</string>
+    <string name="l10n_hr_glance_widget_min_lo_max_hi_ef900e49">Min %1$d • Max %2$d</string>
+    <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Updated %1$s</string>
     <string name="l10n_hydration_screen_a_simple_goal_that_adjusts_to_723dc08a">A simple goal that adjusts to your effort. General wellness guidance, not medical advice.</string>
     <string name="l10n_hydration_screen_bottle_3b8ac6c7">Bottle</string>
     <string name="l10n_hydration_screen_cancel_77dfd213">Cancel</string>

--- a/android/app/src/main/res/xml/hr_widget_info.xml
+++ b/android/app/src/main/res/xml/hr_widget_info.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Wider and shorter than the score widget: the trace needs horizontal room to be readable, and
+     nothing here is stacked. 4x2 cells at the default launcher grid. updatePeriodMillis is 0 because
+     WidgetSnapshotStore pushes on the app's own cadence; letting the system poll as well would wake
+     the widget on a schedule that has nothing to do with when a heart rate arrived. -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/widget_hr_description"
+    android:minWidth="250dp"
+    android:minHeight="110dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="2"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/glance_default_loading_layout" />

--- a/android/app/src/test/java/com/noop/widget/HrTraceTest.kt
+++ b/android/app/src/test/java/com/noop/widget/HrTraceTest.kt
@@ -150,4 +150,40 @@ class HrTraceTest {
     fun `stats over an empty series is null, not zero`() {
         assertNull(HrTrace.stats(emptyList()))
     }
+
+
+    // --- the drawing box -------------------------------------------------------------------------
+
+    /**
+     * RemoteViews fails to render rather than degrading when its transaction is too big, so the box has
+     * to be decided on AREA. The first version of this capped width and height independently, which let
+     * 1080x480 through at 1.98 MB — nearly double the ceiling it was written to respect.
+     */
+    @Test
+    fun `a box within budget is left alone`() {
+        assertEquals(750 to 168, HrTrace.fitBox(750, 168))   // 250dp x 56dp at 3x: 504 KB, fits
+    }
+
+    @Test
+    fun `an oversized box is scaled down to fit the budget`() {
+        val (w, h) = HrTrace.fitBox(1200, 224)               // 300dp x 56dp at 4x: 1.03 MB
+        assertTrue("$w x $h", w.toLong() * h * 4 <= HrTrace.MAX_BITMAP_BYTES)
+        assertTrue("must not collapse: $w x $h", w > 1 && h > 1)
+    }
+
+    /** Aspect must survive, or the trace is drawn into a box shaped unlike the slot it is stretched
+     *  back into, and the stroke thickens on one axis only. */
+    @Test
+    fun `scaling preserves the aspect ratio`() {
+        val (w, h) = HrTrace.fitBox(2000, 500)
+        assertEquals(4.0, w.toDouble() / h.toDouble(), 0.05)
+    }
+
+    @Test
+    fun `a degenerate box never returns zero`() {
+        assertEquals(1 to 1, HrTrace.fitBox(0, 0))
+        assertEquals(1 to 1, HrTrace.fitBox(-5, -5))
+        val (w, h) = HrTrace.fitBox(100_000, 100_000)
+        assertTrue("$w x $h", w >= 1 && h >= 1 && w.toLong() * h * 4 <= HrTrace.MAX_BITMAP_BYTES)
+    }
 }

--- a/android/app/src/test/java/com/noop/widget/HrTraceTest.kt
+++ b/android/app/src/test/java/com/noop/widget/HrTraceTest.kt
@@ -1,0 +1,153 @@
+package com.noop.widget
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The heart-rate widget's pure half (#1957). Everything decidable without a Canvas is decided here,
+ * because the Bitmap the renderer produces is not something a JVM test can assert about.
+ *
+ * The cases that carry weight are the DEGENERATE ones — a single point, a flat bpm, a clock that went
+ * backwards — since those are ordinary on a home screen (a widget placed mid-afternoon, a resting arm)
+ * and are exactly where a normalisation divides by zero.
+ */
+class HrTraceTest {
+
+    private fun series(vararg pairs: Pair<Long, Int>) = pairs.map { HrPoint(it.first, it.second) }
+
+    // --- retention -------------------------------------------------------------------------------
+
+    @Test
+    fun `one point per minute bucket, newest wins`() {
+        var s = HrTrace.append(emptyList(), ts = 600, bpm = 60)
+        s = HrTrace.append(s, ts = 620, bpm = 64)   // same minute bucket
+        s = HrTrace.append(s, ts = 660, bpm = 70)   // next bucket
+        assertEquals(2, s.size)
+        assertEquals(64, s[0].bpm)   // newest within the bucket won
+        assertEquals(600, s[0].ts)   // and the point is stamped at the bucket, not the sample
+        assertEquals(70, s[1].bpm)
+    }
+
+    /** The headline number is the latest bpm; a trace ending on an average would disagree with it. */
+    @Test
+    fun `the last point equals the latest reading`() {
+        var s = emptyList<HrPoint>()
+        for (i in 0..5) s = HrTrace.append(s, ts = 600 + i * 60L, bpm = 60 + i)
+        assertEquals(65, HrTrace.stats(s)!!.latest)
+        assertEquals(65, s.last().bpm)
+    }
+
+    @Test
+    fun `readings older than the window fall off`() {
+        val now = 100_000L
+        val s = series((now - HrTrace.WINDOW_SEC - 60) to 50, (now - 60) to 70)
+        val kept = HrTrace.prune(s, now)
+        assertEquals(1, kept.size)
+        assertEquals(70, kept[0].bpm)
+    }
+
+    /** A clock that jumps backwards must not be able to grow the series without bound. */
+    @Test
+    fun `the point cap holds under a backwards clock`() {
+        var s = emptyList<HrPoint>()
+        for (i in 0 until HrTrace.MAX_POINTS + 50) s = HrTrace.append(s, ts = i * 60L, bpm = 60, nowSec = 0)
+        assertTrue("size=${s.size}", s.size <= HrTrace.MAX_POINTS)
+    }
+
+    @Test
+    fun `a non-positive bpm is not recorded`() {
+        val s = HrTrace.append(emptyList(), ts = 600, bpm = 0)
+        assertTrue(s.isEmpty())
+    }
+
+    // --- round trip ------------------------------------------------------------------------------
+
+    @Test
+    fun `encode and decode round trip`() {
+        val s = series(600L to 60, 660L to 62, 720L to 58)
+        assertEquals(s, HrTrace.decode(HrTrace.encode(s)))
+    }
+
+    /**
+     * Decoding runs on the widget's render path, where the alternative to a partial trace is a crashed
+     * home screen. Every malformed shape must be skipped rather than thrown.
+     */
+    @Test
+    fun `a malformed series degrades instead of throwing`() {
+        assertEquals(emptyList<HrPoint>(), HrTrace.decode(null))
+        assertEquals(emptyList<HrPoint>(), HrTrace.decode(""))
+        assertEquals(emptyList<HrPoint>(), HrTrace.decode("garbage"))
+        val partial = HrTrace.decode("600:60,nope,700:,:70,800:x,900:64")
+        assertEquals(series(600L to 60, 900L to 64), partial)
+    }
+
+    // --- geometry --------------------------------------------------------------------------------
+
+    @Test
+    fun `points span the box and flip bpm upward`() {
+        val pts = HrTrace.points(series(0L to 60, 60L to 80), width = 100f, height = 50f)
+        assertEquals(0f, pts[0].x, 0.001f)
+        assertEquals(100f, pts[1].x, 0.001f)
+        assertEquals(50f, pts[0].y, 0.001f)   // the LOW bpm sits at the BOTTOM
+        assertEquals(0f, pts[1].y, 0.001f)    // the high bpm at the top
+    }
+
+    /** A resting arm holds one bpm for minutes. Range zero must not divide, and must not read as a
+     *  flatlined or maxed-out heart, so the line runs along the middle. */
+    @Test
+    fun `a flat series draws down the middle`() {
+        val pts = HrTrace.points(series(0L to 60, 60L to 60, 120L to 60), width = 90f, height = 40f)
+        assertEquals(3, pts.size)
+        for (p in pts) assertEquals(20f, p.y, 0.001f)
+    }
+
+    /** A widget placed mid-afternoon has exactly one point until the next minute ticks. */
+    @Test
+    fun `a single point sits at the left edge rather than at NaN`() {
+        val pts = HrTrace.points(series(600L to 61), width = 100f, height = 50f)
+        assertEquals(1, pts.size)
+        assertEquals(0f, pts[0].x, 0.001f)
+        assertTrue("y=${pts[0].y}", !pts[0].y.isNaN())
+    }
+
+    @Test
+    fun `an empty series or a zero-size box draws nothing`() {
+        assertTrue(HrTrace.points(emptyList(), 100f, 50f).isEmpty())
+        assertTrue(HrTrace.points(series(0L to 60), 0f, 50f).isEmpty())
+        assertTrue(HrTrace.points(series(0L to 60), 100f, 0f).isEmpty())
+    }
+
+    // --- ticks -----------------------------------------------------------------------------------
+
+    @Test
+    fun `bpm ticks run max, middle, min`() {
+        assertEquals(listOf(84, 72, 59), HrTrace.bpmTicks(HrTrace.Stats(min = 59, max = 84, latest = 69)))
+    }
+
+    /** Three copies of one number is the honest reading of a steady heart; inventing a spread would put
+     *  ticks on the chart that no sample supports. */
+    @Test
+    fun `a flat series labels one number three times`() {
+        assertEquals(listOf(60, 60, 60), HrTrace.bpmTicks(HrTrace.Stats(min = 60, max = 60, latest = 60)))
+    }
+
+    @Test
+    fun `time ticks anchor to the data, not the window`() {
+        val ticks = HrTrace.timeTicks(series(1_000L to 60, 1_600L to 62, 2_200L to 64))
+        assertEquals(listOf(1_000L, 1_600L, 2_200L), ticks)
+    }
+
+    @Test
+    fun `time ticks degrade when there is not enough span to place three`() {
+        assertEquals(emptyList<Long>(), HrTrace.timeTicks(emptyList()))
+        assertEquals(listOf(600L), HrTrace.timeTicks(series(600L to 60)))
+        assertEquals(listOf(600L, 601L), HrTrace.timeTicks(series(600L to 60, 601L to 61)))
+    }
+
+    @Test
+    fun `stats over an empty series is null, not zero`() {
+        assertNull(HrTrace.stats(emptyList()))
+    }
+}


### PR DESCRIPTION
Groundwork for #1957, Android only. iOS is deliberately left out — WidgetKit can
draw the trace directly, so the renderer will not port, and the shared half is
worth agreeing on here first.

## Why it is shaped this way

Glance compiles to RemoteViews, which has no Canvas. A sparkline cannot be drawn
by a composable at all: it has to be rendered to a Bitmap and handed over as an
`Image`. So the work splits, and the split is the design:

- **`HrTrace`** — everything decidable WITHOUT a Canvas. Retention (one point per
  minute over three hours, capped), encode/decode, stats, normalisation into the
  pixel box, and the tick choices. Pure, 16 tests.
- **`HrTraceRenderer`** — deliberately stupid. `moveTo`/`lineTo` over coordinates
  handed to it. It chooses no tick, no range and no point, because a Bitmap is
  not something a JVM test can assert about and as little as possible should
  depend on one.

The LABELS are not in the bitmap either, though the design has them. They are
Glance `Text`, so they stay crisp at any density, themed light and dark with the
rest of the widget, and legible to TalkBack — none of which a baked-in label
would be.

RemoteViews carries its payload over a Binder transaction with a hard size limit,
and a widget that exceeds it does not degrade, it fails to render. Hence the
bitmap cap.

## No producer changed

`WidgetSnapshotStore` folds each live sample into the trace in `save` and returns
it pruned from `load`, so `WhoopConnectionService` and `AppViewModel` did not have
to learn about it. That is affordable because `PushGate` already throttles an
unchanged key to about once a minute, which is exactly the bucket size the trace
keeps — the read-modify-write runs about once per point, not once per sample.

`PushGate`'s key is explicit field concatenation, so adding a field to the
snapshot does not perturb throttling.

## The tested cases are the ordinary ones

Not exotic — these are what a home screen actually does:

- a widget placed mid-afternoon has exactly ONE point: it draws a dot, rather
  than an empty chart that reads as "no data"
- a resting arm holds one bpm for minutes: a zero range runs down the vertical
  MIDDLE, not pinned to an edge where it would read as a flatlined or maxed-out
  heart
- a backwards clock cannot grow the series past its cap
- a malformed stored series degrades to a partial trace instead of throwing on
  the render path, where the alternative is a crashed home screen
- time ticks anchor to the DATA, not the window, so forty minutes of history does
  not get labelled with two hours that were never sampled

## Two choices worth vetoing

- The trace is **red**, the app's heart colour, rather than the blue of the
  design that prompted this.
- **4x2 cells**, wider than the 2x2 score widget, because a trace needs
  horizontal room to be readable.

## Verification

Full Android suite 5537 green, i18n audit clean, doc-comment lint clean. Four new
strings across all seven Android locales — a `GermanLocalizationTest` failure is
what caught that the set is seven, not the four I had assumed.

**Not verified on a device.** The bitmap path is exactly the kind of thing that
looks right in code and wrong on a launcher, so this wants a testing build and a
home screen before it is trusted.

## What review passes changed after the first push

Five, and none of them were reachable from the tests, which is the useful part:

- the bitmap caps were per-DIMENSION, so 1080x480 was legal at 1.98 MB against a
  Binder ceiling near one; and the geometry ran at the requested width while the
  renderer clamped its own, silently clipping the right of the trace. One box,
  decided on bytes, now serves both.
- `timeTicks` was written, documented and TESTED, then never called. The design
  has time labels and the widget did not draw them.
- the bpm scale was stacked from the top with fixed gaps, so it was three numbers
  near a chart rather than a scale aligned to it.
- the empty state reserved chart height to draw nothing, which on upgrade is a
  blank rectangle for the first few minutes.
- TalkBack read the widget as noise, and staleness was carried ONLY by a dimmed
  colour, so a carried-over reading was announced as current. Fixed the way the
  sibling widget settled the same thing in #1799.

The i18n echo gate then caught Min/Max being identical to English in de and fr.
Running `Tools/i18n_audit.py` bare exits 0; the workflow runs it with `--ci` and a
base ref, and only that applies the echo and coverage gates.
