### PR TITLE
iOS: poll 0x2A19 battery for an unbonded 5/MG on the keep-alive tick (#1953)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -4507,6 +4507,23 @@ public final class BLEManager: NSObject, ObservableObject {
         }
         // The watchdog above is the whole of the keep-alive an unbonded 5/MG can use. Everything below
         // sends puffin-framed work that needs the encrypted bond.
+        //
+        // #1953: an unbonded 5/MG (the #1635 suppressed-hello case) still gets a periodic 0x2A19 battery
+        // read on Android — `keepAliveFire` there gates on `bonded` (the live-HR shortcut), not on the
+        // encrypted bond, and polls battery on the same ~60 s cadence regardless. iOS gates the tick on
+        // `keepAliveMayRun` (which admits `bonded && .whoop5`) but the battery read lives inside
+        // `enableLiveNotifications`, which is `didBond`-gated — so the tick fires and the read does not,
+        // and an unbonded 5/MG's battery % refreshes only when the UI asks. Poll 0x2A19 here on the SAME
+        // throttle `enableLiveNotifications` uses, so the two platforms read at the same cadence without
+        // doubling the rate on a bonded strap (this path only runs when `!didBond`).
+        if !didBond, selectedModel.deviceFamily == .whoop5,
+           let p = peripheral, let b = batteryCharacteristic, b.properties.contains(.read),
+           BLEManager.shouldPollWhoop5Battery(lastReadAt: lastBatteryReadAt,
+                                              charging: state.charging == true) {
+            p.readValue(for: b)
+            lastBatteryReadAt = Date()
+            log("Reading 5/MG battery (unbonded keep-alive) (#1953)")
+        }
         guard didBond else { return }
         guard !backfilling else { return }            // never poke the strap mid-offload
         // #927: continuous capture can be overnight-only, which makes the want TIME-dependent; nothing
@@ -4554,10 +4571,11 @@ public final class BLEManager: NSObject, ObservableObject {
         // `enableLiveNotifications` is separately gated on `didBond`, so on a #1635 strap the tick fires
         // and that read does not.
         //
-        // Which leaves a real divergence, pre-existing and NOT introduced here: Android's keep-alive polls
-        // 0x2A19 for a 5/MG whenever it runs, while this one skips it unless `didBond`. An unbonded 5/MG
-        // therefore gets a periodic battery read on Android and none here. The pack's charge comes from
-        // the pushed pack-info event (109) on both, that flag's only writer since #1945.
+        // #1953 closed that divergence: the unbonded 5/MG battery read now fires from the keep-alive tick
+        // itself (above the `guard didBond` line), on the SAME throttle `enableLiveNotifications` uses, so
+        // an unbonded 5/MG gets a periodic battery read on iOS at the same ~60 s cadence Android does. The
+        // pack's charge comes from the pushed pack-info event (109) on both, that flag's only writer since
+        // #1945.
         //
         // This leaves opcode 151 with NO sender on iOS, which is the state `FrameRouter` already records
         // for its own decoder ("nothing sent the command, so the decoder had no caller"). Android keeps a

--- a/StrandTests/Whoop5BatteryBackfillThrottleTests.swift
+++ b/StrandTests/Whoop5BatteryBackfillThrottleTests.swift
@@ -119,4 +119,24 @@ final class Whoop5BatteryBackfillThrottleTests: XCTestCase {
         // The first read of a connection still always fires, charging or not.
         XCTAssertTrue(BLEManager.shouldPollWhoop5Battery(lastReadAt: nil, now: now, charging: false))
     }
+
+    // MARK: - #1953: unbonded 5/MG battery read parity
+
+    /// #1953: an unbonded 5/MG (the #1635 suppressed-hello case) gets a periodic 0x2A19 battery read on
+    /// Android's `keepAliveFire` but not on iOS — the tick runs (via `keepAliveMayRun`'s
+    /// `bonded && .whoop5` branch) but the read lives inside `enableLiveNotifications`, which is
+    /// `didBond`-gated. The fix reuses THIS throttle on the unbonded path so the two platforms read at
+    /// the same cadence without doubling the rate on a bonded strap. These pin the throttle's contract
+    /// for that new caller: the gate is the same, only the call site differs.
+    func testUnbondedBatteryReadUsesSameThrottle() {
+        // First read of a connection — always fires, bonded or not.
+        XCTAssertTrue(BLEManager.shouldPollWhoop5Battery(lastReadAt: nil))
+        // Under the floor — blocked, so an unbonded 5/MG is not re-read every 30 s tick.
+        let now = Date()
+        let last = now.addingTimeInterval(-29)
+        XCTAssertFalse(BLEManager.shouldPollWhoop5Battery(lastReadAt: last, now: now))
+        // At the floor — fires, matching Android's ~60 s cadence.
+        let last2 = now.addingTimeInterval(-BLEManager.whoop5BatteryReadMinIntervalSeconds)
+        XCTAssertTrue(BLEManager.shouldPollWhoop5Battery(lastReadAt: last2, now: now))
+    }
 }


### PR DESCRIPTION
## Summary

- The two keep-alives disagreed about whether an unbonded 5/MG gets a periodic battery read, and the strap that cannot bond is exactly the one affected.
- Android's `keepAliveFire` gates on `bonded` (the live-HR shortcut, #69) and polls 0x2A19 on the ~60 s battery cadence whenever the tick runs. iOS gates the tick on `keepAliveMayRun` (which admits `bonded && .whoop5` for the liveness watchdog), but the 0x2A19 read lives inside `enableLiveNotifications`, which is `didBond`-gated — so on a #1635 suppressed-hello strap the tick fires, the watchdog runs, but the battery read does not, and `batteryPct` refreshes only when the UI asks, `startRealtime()` fires, or a post-bond path that never runs on these straps reaches it.
- The fix issues a standalone 0x2A19 read on the unbonded 5/MG path of `keepAliveFire`, between the watchdog and the `guard didBond` line, reusing the SAME `shouldPollWhoop5Battery` throttle `enableLiveNotifications` uses:
  - the cadence matches Android's ~60 s (the throttle is already pinned to that);
  - a bonded strap is unaffected — the path only runs when `!didBond`;
  - the first read of a connection still fires promptly (`lastBatteryReadAt` is nil, reset on disconnect);
  - the liveness watchdog is unchanged — the read is additive, not a replacement.
- The `enableLiveNotifications` gate is left intact: it also performs standard HR/notify enable that needs the encrypted bond, and the issue flagged that relaxing it may be deliberate for that reason. The battery read is separated out rather than the gate relaxed.

### Files
- `Strand/BLE/BLEManager.swift` — `keepAliveFire` gains an unbonded 5/MG 0x2A19 read above the `guard didBond` line; the stale-divergence comment is updated to reflect the fix.
- `StrandTests/Whoop5BatteryBackfillThrottleTests.swift` — `testUnbondedBatteryReadUsesSameThrottle` pins the throttle's contract for the new unbonded caller.

### Test plan
- [ ] `StrandTests` including the new `testUnbondedBatteryReadUsesSameThrottle` (runs via `app-build.yml` on the `Strand` leg — on-demand)
- [ ] `swift-packages` (no changes under `Packages/`)
- [ ] `source-hygiene` doc-comment lint
- [ ] Hardware: an unbonded 5/MG (#1635 suppressed hello) should now show a battery % that refreshes about every 60 s without a manual sync, matching Android

Generated with [Devin](https://devin.ai)
