### PR TITLE
widget: let the launcher lay out the heart-rate card

### DIFF
--- a/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
@@ -24,6 +24,7 @@ import androidx.glance.layout.Box
 import androidx.glance.layout.Column
 import androidx.glance.layout.Row
 import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxHeight
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.height
@@ -88,7 +89,10 @@ class HrGlanceWidget : GlanceAppWidget() {
 
 // Local widget colours, mirroring the siblings rather than reading Palette: Glance composes outside the
 // app theme, so every widget in this package carries its own copy on purpose.
-private fun hrSurface(dark: Boolean) = ColorProvider(if (dark) Color(0xFF0A1322) else Color(0xFFF4F1EA))
+/** The card colour as a raw Color, so the renderer can paint it as the bitmap's ground. */
+private fun hrSurfaceColor(dark: Boolean) = if (dark) Color(0xFF0A1322) else Color(0xFFF4F1EA)
+
+private fun hrSurface(dark: Boolean) = ColorProvider(hrSurfaceColor(dark))
 private fun hrTextPrimary(dark: Boolean) = ColorProvider(if (dark) Color(0xFFF4F6F8) else Color(0xFF1A2230))
 private fun hrTextSecondary(dark: Boolean) = ColorProvider(if (dark) Color(0xFF8A94A4) else Color(0xFF7C8696))
 
@@ -99,6 +103,16 @@ private const val HR_CARD_PADDING_DP = 28f
 /** The bpm scale column plus its gap. Same reasoning: one number, read by both. Two copies of a layout
  *  constant is how a chart and its axis end up a few pixels out of step. */
 private const val HR_SCALE_COLUMN_DP = 34f
+
+/**
+ * The height the trace BITMAP is drawn at.
+ *
+ * The chart box takes the card's leftover height by weight, so its real height is not knowable here —
+ * the same situation as the width. This is the figure the bitmap is drawn at and the `Image` scales
+ * from, chosen generously so the common case downscales: a 4x2 cell left roughly 36dp unspent when the
+ * chart was pinned at 56, and that slack is what the graph looked small for.
+ */
+private const val HR_CHART_TARGET_DP = 92f
 
 /** The chart width for a given widget width — the one place that arithmetic happens. */
 private fun hrChartWidthDp(widthDp: Float): Float =
@@ -194,14 +208,16 @@ private fun HrWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
         // few minutes — a void reads as broken where a shorter widget reads as new.
         if (snap.hrSeries.isNotEmpty()) {
             Spacer(GlanceModifier.height(8.dp))
-            HrTraceImage(snap, dark, widthDp = size.width.value, heightDp = 56f)
+            HrTraceImage(snap, dark, widthDp = size.width.value,
+                         modifier = GlanceModifier.defaultWeight())
             HrTimeAxis(snap, dark)
         }
 
         if (snap.updatedAtMs > 0) {
-            // Takes up the slack rather than leaving it below: a 4x2 cell is taller than this content,
-            // and the stamp reads as a footer at the bottom where it read as abandoned in the middle.
-            Spacer(GlanceModifier.defaultWeight())
+            // No slack-eating spacer here any more. The chart takes the leftover height itself, which is
+            // what the card should be spending it on — a spacer pushed the stamp to the bottom and left
+            // the graph the same 56dp it had on a card half again as tall.
+            Spacer(GlanceModifier.height(4.dp))
             val time = DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(snap.updatedAtMs))
             Row(
                 modifier = GlanceModifier.fillMaxWidth(),
@@ -224,7 +240,14 @@ private fun HrWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
  * actually gave us rather than from a guess.
  */
 @Composable
-private fun HrTraceImage(snap: WidgetSnapshot, dark: Boolean, widthDp: Float, heightDp: Float) {
+private fun HrTraceImage(
+    snap: WidgetSnapshot,
+    dark: Boolean,
+    widthDp: Float,
+    // Weighted by the CALLER: Glance scopes defaultWeight() to Row/ColumnScope, so a composable
+    // cannot claim its own share of the parent from in here.
+    modifier: GlanceModifier,
+) {
     val context = LocalContext.current
     val stats = HrTrace.stats(snap.hrSeries)
     val density = context.resources.displayMetrics.density
@@ -235,7 +258,7 @@ private fun HrTraceImage(snap: WidgetSnapshot, dark: Boolean, widthDp: Float, he
     // Height exactly as displayed, width with headroom so the Image DOWNSCALES rather than stretching
     // up: LocalSize under-reports on some launchers, and an upscale here is horizontal-only, which
     // turns the stroke elliptical (#1957).
-    val hPx = (heightDp * density).toInt().coerceAtLeast(1)
+    val hPx = (HR_CHART_TARGET_DP * density).toInt().coerceAtLeast(1)
     val wPx = HrTrace.widestAtHeight((chartWidthDp * density).toInt(), hPx)
 
     val bmp = runCatching {
@@ -245,6 +268,7 @@ private fun HrTraceImage(snap: WidgetSnapshot, dark: Boolean, widthDp: Float, he
             heightPx = hPx,
             lineColor = hrAccent(dark).toArgb(),
             fillTopColor = hrAccent(dark).copy(alpha = 0.35f).toArgb(),
+            backgroundColor = hrSurfaceColor(dark).toArgb(),
             strokePx = 2f * density,
         )
     }.getOrNull()
@@ -254,8 +278,8 @@ private fun HrTraceImage(snap: WidgetSnapshot, dark: Boolean, widthDp: Float, he
     // occupied, so the chart and its scale sat in the left half with dead space beside them. The
     // bitmap is still sized in pixels, but only to be drawn and then stretched — a smooth line
     // survives that, and the layout is now the launcher's business rather than my arithmetic.
-    Row(modifier = GlanceModifier.fillMaxWidth()) {
-        Box(modifier = GlanceModifier.height(heightDp.dp).defaultWeight()) {
+    Row(modifier = modifier.fillMaxWidth()) {
+        Box(modifier = GlanceModifier.fillMaxHeight().defaultWeight()) {
             if (bmp != null) {
                 Image(
                     provider = ImageProvider(bmp),
@@ -272,7 +296,7 @@ private fun HrTraceImage(snap: WidgetSnapshot, dark: Boolean, widthDp: Float, he
             // the bottom, which is what makes it a SCALE. Stacked from the top with fixed gaps they were
             // just three numbers near the chart, aligned to nothing.
             Column(
-                modifier = GlanceModifier.height(heightDp.dp),
+                modifier = GlanceModifier.fillMaxHeight(),
                 horizontalAlignment = Alignment.Horizontal.End,
             ) {
                 val ticks = HrTrace.bpmTicks(stats)

--- a/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
@@ -24,6 +24,7 @@ import androidx.glance.layout.Box
 import androidx.glance.layout.Column
 import androidx.glance.layout.Row
 import androidx.glance.layout.Spacer
+import androidx.glance.layout.ContentScale
 import androidx.glance.layout.fillMaxHeight
 import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
@@ -285,6 +286,12 @@ private fun HrTraceImage(
                     provider = ImageProvider(bmp),
                     contentDescription = null,
                     modifier = GlanceModifier.fillMaxSize(),
+                    // FillBounds, not the default Fit. Everything about how this bitmap is sized assumes
+                    // it STRETCHES to the box: the width is drawn with headroom so it downscales, and the
+                    // height is drawn to an estimate because a weighted box has no knowable size. Fit
+                    // preserves aspect instead, so a 1034x253 trace in an 834x253 box would have been
+                    // letterboxed to 834x204 — 49px of dead space, undoing the height it was just given.
+                    contentScale = ContentScale.FillBounds,
                 )
             }
         }

--- a/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
@@ -232,7 +232,11 @@ private fun HrTraceImage(snap: WidgetSnapshot, dark: Boolean, widthDp: Float, he
     val chartWidthDp = hrChartWidthDp(widthDp)
     // ONE box for both the geometry and the bitmap. Sizing them separately let the trace be drawn to
     // coordinates the bitmap did not have room for, clipping its right-hand end (#1957).
-    val (wPx, hPx) = HrTrace.fitBox((chartWidthDp * density).toInt(), (heightDp * density).toInt())
+    // Height exactly as displayed, width with headroom so the Image DOWNSCALES rather than stretching
+    // up: LocalSize under-reports on some launchers, and an upscale here is horizontal-only, which
+    // turns the stroke elliptical (#1957).
+    val hPx = (heightDp * density).toInt().coerceAtLeast(1)
+    val wPx = HrTrace.widestAtHeight((chartWidthDp * density).toInt(), hPx)
 
     val bmp = runCatching {
         HrTraceRenderer.render(

--- a/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
@@ -109,7 +109,6 @@ private fun hrAccent(dark: Boolean) = if (dark) Color(0xFFE0662F) else Color(0xF
 
 @Composable
 private fun HrWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
-    val context = LocalContext.current
     val size = LocalSize.current
     val stats = HrTrace.stats(snap.hrSeries)
 
@@ -196,11 +195,13 @@ private fun HrWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
         if (snap.hrSeries.isNotEmpty()) {
             Spacer(GlanceModifier.height(8.dp))
             HrTraceImage(snap, dark, widthDp = size.width.value, heightDp = 56f)
-            HrTimeAxis(snap, dark, widthDp = size.width.value)
+            HrTimeAxis(snap, dark)
         }
 
         if (snap.updatedAtMs > 0) {
-            Spacer(GlanceModifier.height(6.dp))
+            // Takes up the slack rather than leaving it below: a 4x2 cell is taller than this content,
+            // and the stamp reads as a footer at the bottom where it read as abandoned in the middle.
+            Spacer(GlanceModifier.defaultWeight())
             val time = DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(snap.updatedAtMs))
             Row(
                 modifier = GlanceModifier.fillMaxWidth(),
@@ -244,8 +245,13 @@ private fun HrTraceImage(snap: WidgetSnapshot, dark: Boolean, widthDp: Float, he
         )
     }.getOrNull()
 
+    // The chart takes the ROW's remaining width by weight rather than a width computed from
+    // LocalSize. On a One UI launcher LocalSize reported a size smaller than the card actually
+    // occupied, so the chart and its scale sat in the left half with dead space beside them. The
+    // bitmap is still sized in pixels, but only to be drawn and then stretched — a smooth line
+    // survives that, and the layout is now the launcher's business rather than my arithmetic.
     Row(modifier = GlanceModifier.fillMaxWidth()) {
-        Box(modifier = GlanceModifier.height(heightDp.dp).width(chartWidthDp.dp)) {
+        Box(modifier = GlanceModifier.height(heightDp.dp).defaultWeight()) {
             if (bmp != null) {
                 Image(
                     provider = ImageProvider(bmp),
@@ -254,7 +260,9 @@ private fun HrTraceImage(snap: WidgetSnapshot, dark: Boolean, widthDp: Float, he
                 )
             }
         }
-        if (stats != null) {
+        // A scale of one repeated number says nothing the headline has not: with no range there is
+        // nothing to scale against, and 78/78/78 beside a flat line is three labels of noise.
+        if (stats != null && stats.max > stats.min) {
             Spacer(GlanceModifier.width(6.dp))
             // Spread across the chart's height so max sits level with the top of the trace and min with
             // the bottom, which is what makes it a SCALE. Stacked from the top with fixed gaps they were
@@ -293,13 +301,15 @@ private fun HrTraceImage(snap: WidgetSnapshot, dark: Boolean, widthDp: Float, he
  * times would suggest a span that was never sampled.
  */
 @Composable
-private fun HrTimeAxis(snap: WidgetSnapshot, dark: Boolean, widthDp: Float) {
+private fun HrTimeAxis(snap: WidgetSnapshot, dark: Boolean) {
     val ticks = HrTrace.timeTicks(snap.hrSeries)
     if (ticks.isEmpty()) return
+    // Under a minute of history names one instant, and one label pinned to the left edge reads as a
+    // stray rather than an axis — so the axis only appears once there is a span to label.
+    if (ticks.size < 2) return
     val fmt = DateFormat.getTimeInstance(DateFormat.SHORT)
-    val chartWidthDp = hrChartWidthDp(widthDp)
     Spacer(GlanceModifier.height(2.dp))
-    Row(modifier = GlanceModifier.width(chartWidthDp.dp)) {
+    Row(modifier = GlanceModifier.fillMaxWidth()) {
         ticks.forEachIndexed { i, ts ->
             Text(
                 text = fmt.format(Date(ts * 1000)),

--- a/android/app/src/main/java/com/noop/widget/HrTrace.kt
+++ b/android/app/src/main/java/com/noop/widget/HrTrace.kt
@@ -119,6 +119,30 @@ object HrTrace {
      *  the transaction ceiling, and still affords a full-density chart on an ordinary phone. */
     const val MAX_BITMAP_BYTES: Int = 512 * 1024
 
+    /**
+     * The widest bitmap the budget allows at an EXACT height, with headroom over what the caller asked.
+     *
+     * Two things force this. `LocalSize` under-reports on some launchers — a One UI card reported about
+     * 60% of its true width — so a bitmap rendered at the reported width is UPSCALED to fill, and only
+     * horizontally, which turns a round stroke elliptical and soft. And [fitBox] preserves aspect, so
+     * simply asking for a wider box would shrink the height too and trade a horizontal stretch for a
+     * vertical one.
+     *
+     * So: height is taken as given and never scaled, and the width gets what is left of the budget, up
+     * to [WIDTH_HEADROOM] times the request so a small widget does not allocate a huge strip for
+     * nothing. Downscaling is the cheap direction — a smooth line loses nothing to it.
+     */
+    fun widestAtHeight(requestedPx: Int, heightPx: Int, maxBytes: Int = MAX_BITMAP_BYTES): Int {
+        val h = heightPx.coerceAtLeast(1)
+        val budgetWidth = (maxBytes / (h * 4)).coerceAtLeast(1)
+        val want = (requestedPx.coerceAtLeast(1) * WIDTH_HEADROOM).toInt()
+        return want.coerceAtMost(budgetWidth).coerceAtLeast(requestedPx.coerceAtLeast(1).coerceAtMost(budgetWidth))
+    }
+
+    /** How much wider than the reported width to draw, to cover a launcher that under-reports. Two
+     *  covers the ~1.6x seen on One UI with margin, and costs nothing a downscale does not absorb. */
+    const val WIDTH_HEADROOM: Float = 2f
+
     /** A point in the trace's pixel box, origin top-left, as the renderer wants it. */
     data class Pt(val x: Float, val y: Float)
 

--- a/android/app/src/main/java/com/noop/widget/HrTrace.kt
+++ b/android/app/src/main/java/com/noop/widget/HrTrace.kt
@@ -109,7 +109,7 @@ object HrTrace {
     fun fitBox(widthPx: Int, heightPx: Int, maxBytes: Int = MAX_BITMAP_BYTES): Pair<Int, Int> {
         val w = widthPx.coerceAtLeast(1)
         val h = heightPx.coerceAtLeast(1)
-        val bytes = w.toLong() * h.toLong() * 4L
+        val bytes = w.toLong() * h.toLong() * BYTES_PER_PIXEL
         if (bytes <= maxBytes) return w to h
         val scale = Math.sqrt(maxBytes.toDouble() / bytes.toDouble())
         return (w * scale).toInt().coerceAtLeast(1) to (h * scale).toInt().coerceAtLeast(1)
@@ -118,6 +118,11 @@ object HrTrace {
     /** The bitmap's byte budget. Half a megabyte leaves the rest of the RemoteViews comfortable inside
      *  the transaction ceiling, and still affords a full-density chart on an ordinary phone. */
     const val MAX_BITMAP_BYTES: Int = 512 * 1024
+
+    /** Bytes per pixel the renderer actually spends. The trace is one hue over an opaque card, so it is
+     *  drawn RGB_565 rather than ARGB_8888 — there is no transparency to preserve, and at four bytes a
+     *  pixel the budget could not afford both a taller chart and a width that avoids stretching it. */
+    const val BYTES_PER_PIXEL: Int = 2
 
     /**
      * The widest bitmap the budget allows at an EXACT height, with headroom over what the caller asked.
@@ -134,7 +139,7 @@ object HrTrace {
      */
     fun widestAtHeight(requestedPx: Int, heightPx: Int, maxBytes: Int = MAX_BITMAP_BYTES): Int {
         val h = heightPx.coerceAtLeast(1)
-        val budgetWidth = (maxBytes / (h * 4)).coerceAtLeast(1)
+        val budgetWidth = (maxBytes / (h * BYTES_PER_PIXEL)).coerceAtLeast(1)
         val want = (requestedPx.coerceAtLeast(1) * WIDTH_HEADROOM).toInt()
         return want.coerceAtMost(budgetWidth).coerceAtLeast(requestedPx.coerceAtLeast(1).coerceAtMost(budgetWidth))
     }

--- a/android/app/src/main/java/com/noop/widget/HrTraceRenderer.kt
+++ b/android/app/src/main/java/com/noop/widget/HrTraceRenderer.kt
@@ -32,6 +32,9 @@ internal object HrTraceRenderer {
         heightPx: Int,
         lineColor: Int,
         fillTopColor: Int,
+        /** The card underneath. Drawn as the ground and used as the gradient's far end, because an
+         *  RGB_565 bitmap has no alpha to fade into. */
+        backgroundColor: Int,
         strokePx: Float,
     ): Bitmap? {
         if (points.isEmpty()) return null
@@ -41,12 +44,16 @@ internal object HrTraceRenderer {
         val w = widthPx.coerceAtLeast(1)
         val h = heightPx.coerceAtLeast(1)
         if (w < 2 || h < 2) return null
-        if (w.toLong() * h.toLong() * 4L > HrTrace.MAX_BITMAP_BYTES) return null
+        if (w.toLong() * h.toLong() * HrTrace.BYTES_PER_PIXEL > HrTrace.MAX_BITMAP_BYTES) return null
 
+        // RGB_565, half the bytes of ARGB_8888. The trace is one hue on an opaque card, so nothing here
+        // needs transparency — and at four bytes a pixel the payload budget could not afford both a chart
+        // tall enough to read and a width that did not have to be stretched to fill.
         val bmp = runCatching {
-            Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+            Bitmap.createBitmap(w, h, Bitmap.Config.RGB_565)
         }.getOrNull() ?: return null
         val canvas = Canvas(bmp)
+        canvas.drawColor(backgroundColor)
 
         // Inset by the stroke so a point sitting exactly on the top or bottom edge is not shaved in
         // half. The geometry maps the extremes to 0 and `height`, which is correct for a line of zero
@@ -79,8 +86,9 @@ internal object HrTraceRenderer {
         fill.close()
         canvas.drawPath(fill, Paint().apply {
             isAntiAlias = true
+            isDither = true   // 565 bands a smooth ramp without it
             shader = LinearGradient(
-                0f, 0f, 0f, h.toFloat(), fillTopColor, fillTopColor and 0x00FFFFFF, Shader.TileMode.CLAMP,
+                0f, 0f, 0f, h.toFloat(), fillTopColor, backgroundColor, Shader.TileMode.CLAMP,
             )
         })
 

--- a/android/app/src/test/java/com/noop/widget/HrTraceTest.kt
+++ b/android/app/src/test/java/com/noop/widget/HrTraceTest.kt
@@ -186,4 +186,36 @@ class HrTraceTest {
         val (w, h) = HrTrace.fitBox(100_000, 100_000)
         assertTrue("$w x $h", w >= 1 && h >= 1 && w.toLong() * h * 4 <= HrTrace.MAX_BITMAP_BYTES)
     }
+
+
+    // --- bitmap width, given an exact height ------------------------------------------------------
+
+    /**
+     * Height must survive untouched. [HrTrace.fitBox] preserves aspect, so asking it for a wider box
+     * would shrink the height and trade a horizontal stretch for a vertical one — which is why the
+     * width is chosen separately once the height is fixed.
+     */
+    @Test
+    fun `width gets headroom over the request`() {
+        // 188dp of chart at 2.75x, 56dp tall: the case a One UI card actually produced.
+        val w = HrTrace.widestAtHeight(requestedPx = 517, heightPx = 154)
+        assertTrue("$w must exceed the request", w > 517)
+        assertTrue("$w must stay in budget", w.toLong() * 154 * 4 <= HrTrace.MAX_BITMAP_BYTES)
+    }
+
+    /** The budget wins over the headroom, never the other way round: a bitmap that breaks the payload
+     *  ceiling does not render at all, where a slightly stretched one merely looks soft. */
+    @Test
+    fun `the budget caps the headroom`() {
+        val h = 400
+        val w = HrTrace.widestAtHeight(requestedPx = 4000, heightPx = h)
+        assertEquals(HrTrace.MAX_BITMAP_BYTES / (h * 4), w)
+        assertTrue(w.toLong() * h * 4 <= HrTrace.MAX_BITMAP_BYTES)
+    }
+
+    @Test
+    fun `a degenerate request still yields a drawable width`() {
+        assertTrue(HrTrace.widestAtHeight(0, 0) >= 1)
+        assertTrue(HrTrace.widestAtHeight(-10, -10) >= 1)
+    }
 }

--- a/android/app/src/test/java/com/noop/widget/HrTraceTest.kt
+++ b/android/app/src/test/java/com/noop/widget/HrTraceTest.kt
@@ -161,13 +161,13 @@ class HrTraceTest {
      */
     @Test
     fun `a box within budget is left alone`() {
-        assertEquals(750 to 168, HrTrace.fitBox(750, 168))   // 250dp x 56dp at 3x: 504 KB, fits
+        assertEquals(750 to 168, HrTrace.fitBox(750, 168))   // 250dp x 56dp at 3x, well inside budget
     }
 
     @Test
     fun `an oversized box is scaled down to fit the budget`() {
         val (w, h) = HrTrace.fitBox(1200, 224)               // 300dp x 56dp at 4x: 1.03 MB
-        assertTrue("$w x $h", w.toLong() * h * 4 <= HrTrace.MAX_BITMAP_BYTES)
+        assertTrue("$w x $h", w.toLong() * h * HrTrace.BYTES_PER_PIXEL <= HrTrace.MAX_BITMAP_BYTES)
         assertTrue("must not collapse: $w x $h", w > 1 && h > 1)
     }
 
@@ -184,7 +184,7 @@ class HrTraceTest {
         assertEquals(1 to 1, HrTrace.fitBox(0, 0))
         assertEquals(1 to 1, HrTrace.fitBox(-5, -5))
         val (w, h) = HrTrace.fitBox(100_000, 100_000)
-        assertTrue("$w x $h", w >= 1 && h >= 1 && w.toLong() * h * 4 <= HrTrace.MAX_BITMAP_BYTES)
+        assertTrue("$w x $h", w >= 1 && h >= 1 && w.toLong() * h * HrTrace.BYTES_PER_PIXEL <= HrTrace.MAX_BITMAP_BYTES)
     }
 
 
@@ -200,7 +200,7 @@ class HrTraceTest {
         // 188dp of chart at 2.75x, 56dp tall: the case a One UI card actually produced.
         val w = HrTrace.widestAtHeight(requestedPx = 517, heightPx = 154)
         assertTrue("$w must exceed the request", w > 517)
-        assertTrue("$w must stay in budget", w.toLong() * 154 * 4 <= HrTrace.MAX_BITMAP_BYTES)
+        assertTrue("$w must stay in budget", w.toLong() * 154 * HrTrace.BYTES_PER_PIXEL <= HrTrace.MAX_BITMAP_BYTES)
     }
 
     /** The budget wins over the headroom, never the other way round: a bitmap that breaks the payload
@@ -209,8 +209,8 @@ class HrTraceTest {
     fun `the budget caps the headroom`() {
         val h = 400
         val w = HrTrace.widestAtHeight(requestedPx = 4000, heightPx = h)
-        assertEquals(HrTrace.MAX_BITMAP_BYTES / (h * 4), w)
-        assertTrue(w.toLong() * h * 4 <= HrTrace.MAX_BITMAP_BYTES)
+        assertEquals(HrTrace.MAX_BITMAP_BYTES / (h * HrTrace.BYTES_PER_PIXEL), w)
+        assertTrue(w.toLong() * h * HrTrace.BYTES_PER_PIXEL <= HrTrace.MAX_BITMAP_BYTES)
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #1958, from putting it on an actual home screen. Three defects, none
of which a test could have shown.

## The chart did not span the card

Everything sat in the left portion with dead space beside it. The cause: I sized
the chart from `LocalSize.current`, and a One UI launcher reported a size smaller
than the card actually occupied, so every width derived from it was short.

The chart now takes the row's remaining width by weight. The bitmap is still
measured in pixels — it has to be — but only to be drawn and then stretched,
which a smooth line survives without visible cost. Layout is the launcher's
business, not arithmetic of mine.

`LocalSize` being a hint about the cell rather than a measurement of the card is
the mistake underneath all of this, and I had treated it as the latter.

## Labels that said nothing

A single reading rendered a bpm scale of `78 / 78 / 78`. Honest — with no range
there is nothing to scale against, which is the behaviour a test pins — but three
labels repeating the headline are noise. The scale now appears only once there is
a range to describe.

The time axis went the same way. One instant pinned to the left edge read as a
stray rather than an axis, so it waits for a span to label.

## A void under the stamp

A 4x2 cell is taller than this content, so "Updated" floated with empty card
beneath it. It is pinned to the bottom now and reads as a footer.

## Then: the graph was still small

Two things, and the second was self-inflicted.

The chart was pinned at 56dp while the card had roughly 36dp going spare — and
the spacer added above to pin the stamp to the bottom was eating exactly that
slack. The fix for the void consumed the room the graph needed. The chart takes
the leftover height itself now, about 64% taller.

Taller then collided with the payload budget: at four bytes a pixel a 92dp chart
left only 518px of width for an ~834px card, a 1.6x horizontal stretch — the very
upscale removed a commit earlier. They stop competing once the bitmap stops
paying for an alpha channel it never uses. The trace is one hue over an opaque
card, so it is drawn RGB_565 over the card colour, gradient fading to that colour
rather than to transparent. Half the bytes, so the same budget affords 1034px at
that height: a 1.24x DOWNSCALE. Dither is on, since 565 bands a smooth ramp.

## And the assumption underneath all of it

Glance's `Image` defaults to `ContentScale.Fit`, which preserves aspect. Every
sizing decision above assumes the opposite — width drawn with headroom SO THAT it
downscales, height drawn to an estimate because a weighted box has no knowable
size. Under `Fit`, a 1034x253 trace in an 834x253 box would letterbox to 834x204
and sit 49px short, silently undoing the height it had just been given.

The arithmetic in both commits was right and checked. The assumption underneath
it lived in a library default I had never written down, so the two fixes were
correct and jointly inert. Now `FillBounds`, verified against the Glance API
rather than assumed.

## Verification

Full Android suite 5544 green, i18n `--ci` clean, doc-comment lint clean. The
pure-half tests are untouched and still describe the same behaviour: what changed
is which of it gets RENDERED, not what it computes.

Wants another look on a launcher, and specifically once the trace has more than
one point — the single-reading state is the only one seen so far.
