### PR TITLE
backfill: distinguish no-flash-cursor from writing-but-recording-nothing in the empty-offload banner (#1754)

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2800,9 +2800,17 @@ public final class BLEManager: NSObject, ObservableObject {
                 // #1683: when the strap's own newest record dates the silence, SAY it. The generic copy
                 // below omits that and promises a recovery the charge advice has already been retried for
                 // every session; the dated version is the one a stuck user can act on.
+                //
+                // #1754: the generic "clock lost sync" copy is only correct when the strap reported
+                // trim=0xFFFFFFFF (no valid flash cursor). A strap with a valid, advancing flash cursor
+                // that banks no sensor records has a different problem — the sensor front-end or power,
+                // not the clock — and telling the user to charge it sends them away from the real cause.
+                // The two states are distinguished by `backfiller.sawNoFlashCursor`.
                 state.lastSyncError = sustainedEmpty
                     ? (staleNewest.map { Backfiller.staleRecordBanner(newestUnix: $0, wallNowUnix: wallNowUnix) }
-                        ?? "Synced, but your strap had no stored history to hand over - only its diagnostic output. This usually means its clock has lost sync, so it isn't saving data to flash. Fully charge it to 100%, then reconnect, and it should start banking again.")
+                        ?? (backfiller?.sawNoFlashCursor == true
+                            ? Backfiller.noFlashCursorBanner
+                            : Backfiller.noSensorRecordsBanner))
                     : nil
             } else if let futureBanner = futureClockBanner {
                 // #324/#928: the strap banked records but its newest is dated implausibly in the FUTURE

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -147,6 +147,11 @@ final class Backfiller {
     /// Logged once per session when the strap reports trim=0xFFFFFFFF — the "no valid flash cursor"
     /// sentinel: it has no banked history to offload (a clock/charge state, not a decode bug).
     private var loggedNoCursor = false
+    /// #1754: whether THIS session saw the trim=0xFFFFFFFF "no valid flash cursor" sentinel. Exposed so
+    /// the empty-offload banner can distinguish the clock/charge state (no cursor — the existing copy is
+    /// correct) from a strap that has a valid, advancing flash cursor but banks no sensor records (NOT a
+    /// clock problem — points at the sensor front-end or power). Read-only from outside.
+    var sawNoFlashCursor: Bool { loggedNoCursor }
     /// #773: logged once per session the first time a HISTORY_END's own timestamp is dated implausibly far
     /// in the FUTURE (a corrupt strap RTC). Distinct from #547's per-record drop tally: this fires on the
     /// chunk metadata's own clock, the earliest visible tell that the strap's RTC is bogus. Reset in begin().
@@ -484,6 +489,21 @@ final class Backfiller {
         let ageDays = max(0, wallNowUnix - newestUnix) / 86_400
         return "Synced, but your strap handed over no stored history, and its newest saved record is about \(ageDays) day(s) old. If you have been wearing it since then, it has stopped saving to flash. Charge it to 100% and reconnect; NOOP already re-sets its clock every connect, so if that does not help, try Restart strap in Devices, then forget and re-pair. If the official WHOOP app is missing these days too, the strap is the cause and not NOOP."
     }
+
+    /// #1754: the banner for an empty offload whose flash cursor is VALID and ADVANCING — the strap is
+    /// writing pages but banking no sensor records, so the clock/charge advice does not apply. The
+    /// cause points at the sensor front-end or power state, not the RTC. Byte-identical to the Android
+    /// twin (`Backfiller.noSensorRecordsBanner`). Not localized, matching the sibling `lastSyncError`
+    /// copy on both platforms; localizing that surface is its own change. No em-dash (project rule).
+    nonisolated static let noSensorRecordsBanner =
+        "Synced, but your strap handed over no sensor records - only its diagnostic output. The strap's flash cursor is valid and advancing, so this is not a clock problem; it points at the sensor front-end or power state. If this persists across reconnects, please share a strap log so the cause can be identified."
+
+    /// #1754: the banner for an empty offload whose flash cursor is the 0xFFFFFFFF sentinel — the strap
+    /// has no banked history at all, the clock/charge advice IS correct. Kept as a constant so the two
+    /// banners stay side by side and the caller's branch reads as a choice between two named states.
+    /// Byte-identical to the Android twin (`Backfiller.noFlashCursorBanner`).
+    nonisolated static let noFlashCursorBanner =
+        "Synced, but your strap had no stored history to hand over - only its diagnostic output. This usually means its clock has lost sync, so it isn't saving data to flash. Fully charge it to 100%, then reconnect, and it should start banking again."
 
     /// Commit one HISTORY_END chunk: (persist decoded → enqueueRaw when present) → setCursor → ackTrim.
     /// Early-returns on any throw to preserve the safe-trim invariant.

--- a/StrandTests/BackfillerSessionTallyTests.swift
+++ b/StrandTests/BackfillerSessionTallyTests.swift
@@ -343,4 +343,41 @@ final class BackfillerSessionTallyTests: XCTestCase {
         XCTAssertFalse(line.contains("should start banking again"), line)
         XCTAssertFalse(line.contains("\u{2014}"))
     }
+
+    // ---- #1754: two distinct empty-offload banners ------------------------------------------
+
+    /// The no-flash-cursor banner (trim=0xFFFFFFFF) names the clock/charge cause — the existing copy,
+    /// now a named constant so the caller's branch reads as a choice between two states.
+    func testNoFlashCursorBannerNamesClockAndCharge() {
+        let line = Backfiller.noFlashCursorBanner
+        XCTAssertTrue(line.contains("no stored history to hand over"), line)
+        XCTAssertTrue(line.contains("clock has lost sync"), line)
+        XCTAssertTrue(line.contains("Fully charge it to 100%"), line)
+        XCTAssertFalse(line.contains("sensor front-end"), line)
+    }
+
+    /// The no-sensor-records banner (valid trim, advancing write pointer, zero rows) does NOT name
+    /// the clock — it points at the sensor front-end or power state, and asks for a strap log rather
+    /// than promising that charging will fix it.
+    func testNoSensorRecordsBannerDoesNotBlameTheClock() {
+        let line = Backfiller.noSensorRecordsBanner
+        XCTAssertTrue(line.contains("no sensor records"), line)
+        XCTAssertTrue(line.contains("flash cursor is valid and advancing"), line)
+        XCTAssertTrue(line.contains("not a clock problem"), line)
+        XCTAssertTrue(line.contains("sensor front-end or power"), line)
+        XCTAssertFalse(line.contains("clock has lost sync"), line)
+        XCTAssertFalse(line.contains("Fully charge it to 100%"), line)
+    }
+
+    /// The two banners must be distinct strings — a caller choosing between them must not get the
+    /// same copy for both states.
+    func testTheTwoBannersAreDistinct() {
+        XCTAssertNotEqual(Backfiller.noFlashCursorBanner, Backfiller.noSensorRecordsBanner)
+    }
+
+    /// No em-dash in either banner (project rule).
+    func testNoEmDashInEitherBanner() {
+        XCTAssertFalse(Backfiller.noFlashCursorBanner.contains("\u{2014}"))
+        XCTAssertFalse(Backfiller.noSensorRecordsBanner.contains("\u{2014}"))
+    }
 }

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -236,6 +236,12 @@ class Backfiller(
      */
     private var loggedNoCursor = false
 
+    /** #1754: whether THIS session saw the trim=0xFFFFFFFF "no valid flash cursor" sentinel. Exposed so
+     *  the empty-offload banner can distinguish the clock/charge state (no cursor — the existing copy is
+     *  correct) from a strap that has a valid, advancing flash cursor but banks no sensor records (NOT a
+     *  clock problem — points at the sensor front-end or power). Read-only from outside. */
+    val sawNoFlashCursor: Boolean get() = loggedNoCursor
+
     /**
      * #773: logged once per session the first time a HISTORY_END's own timestamp is dated implausibly far
      * in the FUTURE (a corrupt strap RTC). Distinct from #547's per-record drop tally: this fires on the
@@ -872,6 +878,24 @@ class Backfiller(
                 "so if that does not help, try Restart strap in Devices, then forget and re-pair. If the " +
                 "official WHOOP app is missing these days too, the strap is the cause and not NOOP."
         }
+
+        /** #1754: the banner for an empty offload whose flash cursor is VALID and ADVANCING — the strap
+         *  is writing pages but banking no sensor records, so the clock/charge advice does not apply. The
+         *  cause points at the sensor front-end or power state, not the RTC. Byte-identical to the Swift
+         *  twin (`Backfiller.noSensorRecordsBanner`). No em-dash (project rule). */
+        val noSensorRecordsBanner =
+            "Synced, but your strap handed over no sensor records - only its diagnostic output. The " +
+                "strap's flash cursor is valid and advancing, so this is not a clock problem; it points " +
+                "at the sensor front-end or power state. If this persists across reconnects, please " +
+                "share a strap log so the cause can be identified."
+
+        /** #1754: the banner for an empty offload whose flash cursor is the 0xFFFFFFFF sentinel — the
+         *  strap has no banked history at all, the clock/charge advice IS correct. Byte-identical to the
+         *  Swift twin (`Backfiller.noFlashCursorBanner`). */
+        val noFlashCursorBanner =
+            "Synced, but your strap had no stored history to hand over - only its diagnostic output. " +
+                "This usually means its clock has lost sync, so it isn't saving data to flash. Fully " +
+                "charge it to 100%, then reconnect, and it should start banking again."
     }
 }
 

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -10296,13 +10296,12 @@ class WhoopBleClient(
                         // #1754: the generic "clock lost sync" copy is only correct when the strap
                         // reported trim=0xFFFFFFFF (no valid flash cursor). A strap with a valid,
                         // advancing flash cursor that banks no sensor records has a different problem
-                        // — the sensor front-end or power, not the clock — and telling the user to
+                        // - the sensor front-end or power, not the clock - and telling the user to
                         // charge it sends them away from the real cause.
                         staleNewestSeen?.let { Backfiller.staleRecordBanner(it, nowSec) }
-                            ?: (backfiller.sawNoFlashCursor
-                                ? Backfiller.noFlashCursorBanner
-                                : Backfiller.noSensorRecordsBanner)
-                    bankedNothing -> null   // banked nothing but not yet sustained — stay silent (matches Swift)
+                            ?: if (backfiller.sawNoFlashCursor) Backfiller.noFlashCursorBanner
+                                else Backfiller.noSensorRecordsBanner
+                    bankedNothing -> null   // banked nothing but not yet sustained - stay silent (matches Swift)
                     // #324/#928: the strap banked records but its newest is dated implausibly in the future
                     // (RTC relatched ahead). #773 drops the samples so nothing is misfiled, but this path
                     // would otherwise report a clean sync and leave the user with no data + no reason.

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -10293,8 +10293,15 @@ class WhoopBleClient(
                         // #1683: when the strap's own newest record dates the silence, SAY it. The
                         // generic copy omits that and promises a recovery the charge advice has already
                         // been retried for every session.
+                        // #1754: the generic "clock lost sync" copy is only correct when the strap
+                        // reported trim=0xFFFFFFFF (no valid flash cursor). A strap with a valid,
+                        // advancing flash cursor that banks no sensor records has a different problem
+                        // — the sensor front-end or power, not the clock — and telling the user to
+                        // charge it sends them away from the real cause.
                         staleNewestSeen?.let { Backfiller.staleRecordBanner(it, nowSec) }
-                            ?: "Synced, but your strap had no stored history to hand over - only its diagnostic output. This usually means its clock has lost sync, so it isn't saving data to flash. Fully charge it to 100%, then reconnect, and it should start banking again."
+                            ?: (backfiller.sawNoFlashCursor
+                                ? Backfiller.noFlashCursorBanner
+                                : Backfiller.noSensorRecordsBanner)
                     bankedNothing -> null   // banked nothing but not yet sustained — stay silent (matches Swift)
                     // #324/#928: the strap banked records but its newest is dated implausibly in the future
                     // (RTC relatched ahead). #773 drops the samples so nothing is misfiled, but this path

--- a/android/app/src/test/java/com/noop/ble/BackfillerSessionTallyTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BackfillerSessionTallyTest.kt
@@ -3,6 +3,7 @@ package com.noop.ble
 import com.noop.data.InsertCounts
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -189,6 +190,47 @@ class BackfillerSessionTallyTest {
         assertTrue(line.contains("clock (RTC) is corrupt"))
         assertTrue(line.contains("Fully charge"))
         assertFalse(line.contains("\u2014"))
+    }
+
+    // ---- #1754: two distinct empty-offload banners ------------------------------------------
+
+    /**
+     * The no-flash-cursor banner (trim=0xFFFFFFFF) names the clock/charge cause — the existing copy,
+     * now a named constant so the caller's branch reads as a choice between two states.
+     */
+    @Test fun noFlashCursorBannerNamesClockAndCharge() {
+        val line = Backfiller.noFlashCursorBanner
+        assertTrue(line, line.contains("no stored history to hand over"))
+        assertTrue(line, line.contains("clock has lost sync"))
+        assertTrue(line, line.contains("Fully charge it to 100%"))
+        assertFalse(line, line.contains("sensor front-end"))
+    }
+
+    /**
+     * The no-sensor-records banner (valid trim, advancing write pointer, zero rows) does NOT name the
+     * clock — it points at the sensor front-end or power state, and asks for a strap log rather than
+     * promising that charging will fix it.
+     */
+    @Test fun noSensorRecordsBannerDoesNotBlameTheClock() {
+        val line = Backfiller.noSensorRecordsBanner
+        assertTrue(line, line.contains("no sensor records"))
+        assertTrue(line, line.contains("flash cursor is valid and advancing"))
+        assertTrue(line, line.contains("not a clock problem"))
+        assertTrue(line, line.contains("sensor front-end or power"))
+        assertFalse(line, line.contains("clock has lost sync"))
+        assertFalse(line, line.contains("Fully charge it to 100%"))
+    }
+
+    /** The two banners must be distinct strings — a caller choosing between them must not get the same
+     *  copy for both states. */
+    @Test fun theTwoBannersAreDistinct() {
+        assertNotEquals(Backfiller.noFlashCursorBanner, Backfiller.noSensorRecordsBanner)
+    }
+
+    /** No em-dash in either banner (project rule). */
+    @Test fun noEmDashInEitherBanner() {
+        assertFalse(Backfiller.noFlashCursorBanner.contains("\u2014"))
+        assertFalse(Backfiller.noSensorRecordsBanner.contains("\u2014"))
     }
 
     // ---- #1 records-bearing 0xFFFFFFFF END must NOT false-alarm "no banked history" ----


### PR DESCRIPTION
## Summary

- An offload that persists zero sensor records always said the same thing: "your strap had no stored history to hand over... This usually means its clock has lost sync... Fully charge it to 100%..." That copy was written for the **no-flash-cursor** state (`trim=0xFFFFFFFF`), but the banner is gated only on `sessionRowsPersisted == 0`, so it also fires for a strap whose flash cursor is perfectly healthy — and then names a cause that demonstrably does not apply.
- A WHOOP 4.0 capture showed exactly this: a valid, advancing write pointer (106970 → 106972), a healthy clock (drift -1s), and every page carrying console output only. The user is told to charge it because its clock lost sync. Charging will not change any of the above, and the message sends them away from the real cause.
- The fix exposes `Backfiller.sawNoFlashCursor` (was private `loggedNoCursor`) on both platforms and uses it at the banner decision point to choose between two named states:
  - **No flash cursor** (`trim=0xFFFFFFFF`): the existing clock/charge copy, now `Backfiller.noFlashCursorBanner`.
  - **Valid, advancing cursor, zero sensor rows**: a new `Backfiller.noSensorRecordsBanner` that says this is NOT a clock problem, points at the sensor front-end or power state, and asks for a strap log rather than promising that charging will fix it.
- Both banners are byte-identical across Swift and Kotlin, kept as named constants so the caller's branch reads as a choice between two states rather than two inline string literals. The `staleNewest` dated banner still takes precedence over both (it is the most actionable when it applies).

### Cross-platform parity
- Swift `Backfiller.sawNoFlashCursor` + `noFlashCursorBanner` + `noSensorRecordsBanner` mirror the Kotlin twins exactly.
- Tests on both platforms pin the wording and the distinction.

### Files
- `Strand/Collect/Backfiller.swift` — exposed `sawNoFlashCursor`; added `noFlashCursorBanner` + `noSensorRecordsBanner` constants.
- `Strand/BLE/BLEManager.swift` — banner decision now branches on `sawNoFlashCursor`.
- `StrandTests/BackfillerSessionTallyTests.swift` — 4 new tests.
- `android/.../ble/Backfiller.kt` — exposed `sawNoFlashCursor`; added `noFlashCursorBanner` + `noSensorRecordsBanner` constants.
- `android/.../ble/WhoopBleClient.kt` — banner decision now branches on `sawNoFlashCursor`.
- `android/.../ble/BackfillerSessionTallyTest.kt` — 4 new tests.

### Test plan
- [ ] `cd android && ./gradlew testFullDebugUnitTest --tests "com.noop.ble.BackfillerSessionTallyTest"` — all existing + 4 new tests
- [ ] `cd android && ./gradlew compileFullDebugKotlin` — no compile errors
- [ ] `xcodebuild -project Strand.xcodeproj -scheme Strand -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build` — app-target Swift compiles
- [ ] Hardware: a WHOOP 4.0 with a valid, advancing flash cursor but zero sensor rows should now see the "not a clock problem" banner instead of the "charge to 100%" banner

Generated with [Devin](https://devin.ai)
