### PR TITLE
strength: exercise to muscle attribution (stage 1)

### DIFF
--- a/Packages/StrandImport/Sources/StrandImport/MuscleGroups.swift
+++ b/Packages/StrandImport/Sources/StrandImport/MuscleGroups.swift
@@ -66,9 +66,21 @@ public enum MuscleAttribution {
     /// Order matters: the first rule that matches wins, so the more specific phrase has to be tested
     /// before the word it contains. "leg curl" is hamstrings and must be decided before "curl" sends
     /// it to biceps; "front raise" is shoulders and must beat "raise"; "calf raise" likewise.
+    /// Real exercises this vocabulary has no group for, which must attribute NOTHING rather than
+    /// fall through to a generic rule that would be wrong.
+    ///
+    /// "Neck Curl" contains "curl" and came out as BICEPS. These thirteen groups have no neck, so a
+    /// blank is the only honest answer, and a blank is what the whole table is supposed to prefer: it
+    /// invites a look, where a wrong muscle does not.
+    ///
+    /// Kept separate from `rules` because a rule must name at least one group. An entry here is the
+    /// deliberate absence of one, which is a different statement from "not recognised".
+    static let unattributable: [String] = ["neck"]
+
     public static func muscles(for exercise: String) -> [MuscleGroup] {
         let n = normalise(exercise)
         guard !n.isEmpty else { return [] }
+        guard !unattributable.contains(where: { n.contains($0) }) else { return [] }
         for (needle, groups) in rules where n.contains(needle) {
             return groups
         }
@@ -145,8 +157,10 @@ public enum MuscleAttribution {
         // spinal one. Both contain "curl", so the generic rule would call them biceps.
         ("nordic curl", [.hamstrings]),
         ("jefferson curl", [.lowerBack, .hamstrings]),
-        ("curl", [.biceps]),
+        // Before the generic curl: a wrist curl is forearms, and "Wrist Curl" is how the exercise is
+        // normally written, so the rule below was unreachable for the title it exists to catch.
         ("wrist", [.forearms]),
+        ("curl", [.biceps]),
         ("farmer", [.forearms]),
         // trunk
         ("plank", [.abs]),

--- a/Packages/StrandImport/Sources/StrandImport/MuscleGroups.swift
+++ b/Packages/StrandImport/Sources/StrandImport/MuscleGroups.swift
@@ -116,6 +116,11 @@ public enum MuscleAttribution {
         ("chest press", [.chest, .triceps]),
         ("chest fly", [.chest]),
         ("pec deck", [.chest]),
+        // Before the generic fly: a reverse fly and a rear-delt fly are REAR movements, and both
+        // contain "fly", so the generic rule would file the opposite side of the body. Order is the
+        // whole contract here, not a stylistic choice.
+        ("rear delt", [.shoulders, .upperBack]),
+        ("reverse fly", [.shoulders, .upperBack]),
         ("fly", [.chest]),
         ("push up", [.chest, .triceps]),
         ("pushup", [.chest, .triceps]),
@@ -126,8 +131,9 @@ public enum MuscleAttribution {
         ("arnold press", [.shoulders]),
         ("lateral raise", [.shoulders]),
         ("front raise", [.shoulders]),
-        ("rear delt", [.shoulders, .upperBack]),
         // arms
+        // Hevy writes it as one word; the two-word rule missed the spelling the catalogue uses.
+        ("skullcrusher", [.triceps]),
         ("skull crusher", [.triceps]),
         ("tricep", [.triceps]),
         ("pushdown", [.triceps]),
@@ -135,6 +141,10 @@ public enum MuscleAttribution {
         ("hammer curl", [.biceps, .forearms]),
         ("preacher curl", [.biceps]),
         ("bicep", [.biceps]),
+        // Before the generic curl: a nordic curl is a hamstring movement and a jefferson curl is a
+        // spinal one. Both contain "curl", so the generic rule would call them biceps.
+        ("nordic curl", [.hamstrings]),
+        ("jefferson curl", [.lowerBack, .hamstrings]),
         ("curl", [.biceps]),
         ("wrist", [.forearms]),
         ("farmer", [.forearms]),

--- a/Packages/StrandImport/Sources/StrandImport/MuscleGroups.swift
+++ b/Packages/StrandImport/Sources/StrandImport/MuscleGroups.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+// MARK: - Exercise → muscle attribution
+//
+// Groundwork for a per-muscle strength view. NOOP already imports lifting sessions (Hevy CSV,
+// Liftosaur JSON) but aggregates them to a set count and a volume figure, so nothing downstream can
+// say WHICH muscles did the work. This maps an exercise name to the muscles that move it.
+//
+// Keyword matching on a normalised name, NOT an exhaustive catalogue. Lifting trackers let people
+// type anything, so a closed list would silently mis-attribute everything it did not recognise. The
+// rule here is the project's usual one: an exercise this cannot place returns NOTHING, and the
+// caller shows no attribution rather than a guess. A wrong muscle is worse than a blank one, because
+// a blank invites the user to look while a wrong one does not.
+//
+// PRIMARY movers only. A barbell squat loads glutes and hamstrings too, and a bench press loads
+// triceps and shoulders — but attributing every synergist would make every session light up the
+// whole body and stop distinguishing a push day from a leg day. The screen this feeds is about where
+// the work went, not about what was innervated.
+
+/// The muscle groups a strength view can attribute work to.
+///
+/// Deliberately coarse. These are the granularity a lifting log can actually support: an exercise
+/// name can tell you "lats", it cannot honestly tell you which head of which muscle.
+public enum MuscleGroup: String, CaseIterable, Sendable, Equatable {
+    case chest
+    case upperBack
+    case lats
+    case shoulders
+    case biceps
+    case triceps
+    case forearms
+    case abs
+    case lowerBack
+    case glutes
+    case quadriceps
+    case hamstrings
+    case calves
+}
+
+public enum MuscleAttribution {
+
+    /// Normalise a logged exercise name for matching.
+    ///
+    /// Trackers append equipment in parentheses ("Squat (Barbell)"), use hyphens and en-dashes
+    /// inconsistently ("Seated Cable Row - V Grip"), and vary in case. The parenthetical is KEPT
+    /// rather than stripped, because it can carry the distinguishing word: a "Row (Machine)" and a
+    /// "Row (Dumbbell)" are the same muscles, but "Curl (Barbell)" and "Leg Curl" are not.
+    public static func normalise(_ raw: String) -> String {
+        let lowered = raw.lowercased()
+        var out = ""
+        var lastWasSpace = false
+        for ch in lowered {
+            if ch.isLetter || ch.isNumber {
+                out.append(ch)
+                lastWasSpace = false
+            } else if !lastWasSpace {
+                out.append(" ")
+                lastWasSpace = true
+            }
+        }
+        return out.trimmingCharacters(in: .whitespaces)
+    }
+
+    /// The primary movers for a logged exercise name, or an empty array when it cannot be placed.
+    ///
+    /// Order matters: the first rule that matches wins, so the more specific phrase has to be tested
+    /// before the word it contains. "leg curl" is hamstrings and must be decided before "curl" sends
+    /// it to biceps; "front raise" is shoulders and must beat "raise"; "calf raise" likewise.
+    public static func muscles(for exercise: String) -> [MuscleGroup] {
+        let n = normalise(exercise)
+        guard !n.isEmpty else { return [] }
+        for (needle, groups) in rules where n.contains(needle) {
+            return groups
+        }
+        return []
+    }
+
+    /// Longest-phrase-first, so a specific lift is decided before the generic word inside it. Held as
+    /// an ordered array rather than a dictionary precisely because that order is the logic.
+    static let rules: [(String, [MuscleGroup])] = [
+        // legs — the specific curls and raises must precede the generic ones
+        ("leg curl", [.hamstrings]),
+        ("romanian deadlift", [.hamstrings, .glutes]),
+        ("stiff leg deadlift", [.hamstrings, .glutes]),
+        ("good morning", [.hamstrings, .lowerBack]),
+        ("leg extension", [.quadriceps]),
+        ("hack squat", [.quadriceps]),
+        ("front squat", [.quadriceps]),
+        ("bulgarian", [.quadriceps, .glutes]),
+        ("lunge", [.quadriceps, .glutes]),
+        ("leg press", [.quadriceps, .glutes]),
+        ("squat", [.quadriceps, .glutes]),
+        ("hip thrust", [.glutes]),
+        ("glute bridge", [.glutes]),
+        ("calf raise", [.calves]),
+        ("calf press", [.calves]),
+        // hinge / back
+        ("deadlift", [.lowerBack, .glutes, .hamstrings]),
+        ("back extension", [.lowerBack]),
+        ("hyperextension", [.lowerBack]),
+        ("pull up", [.lats, .biceps]),
+        ("pullup", [.lats, .biceps]),
+        ("chin up", [.lats, .biceps]),
+        ("chinup", [.lats, .biceps]),
+        ("lat pulldown", [.lats]),
+        ("pulldown", [.lats]),
+        ("pullover", [.lats]),
+        ("face pull", [.upperBack, .shoulders]),
+        ("shrug", [.upperBack]),
+        // Before the generic row: an upright row is a shoulder movement, and every
+        // upright row contains "row", so the generic rule would swallow it.
+        ("upright row", [.shoulders, .upperBack]),
+        ("row", [.upperBack, .lats]),
+        // push
+        ("bench press", [.chest, .triceps]),
+        ("chest press", [.chest, .triceps]),
+        ("chest fly", [.chest]),
+        ("pec deck", [.chest]),
+        ("fly", [.chest]),
+        ("push up", [.chest, .triceps]),
+        ("pushup", [.chest, .triceps]),
+        ("dip", [.chest, .triceps]),
+        ("overhead press", [.shoulders, .triceps]),
+        ("shoulder press", [.shoulders, .triceps]),
+        ("military press", [.shoulders, .triceps]),
+        ("arnold press", [.shoulders]),
+        ("lateral raise", [.shoulders]),
+        ("front raise", [.shoulders]),
+        ("rear delt", [.shoulders, .upperBack]),
+        // arms
+        ("skull crusher", [.triceps]),
+        ("tricep", [.triceps]),
+        ("pushdown", [.triceps]),
+        ("kickback", [.triceps]),
+        ("hammer curl", [.biceps, .forearms]),
+        ("preacher curl", [.biceps]),
+        ("bicep", [.biceps]),
+        ("curl", [.biceps]),
+        ("wrist", [.forearms]),
+        ("farmer", [.forearms]),
+        // trunk
+        ("plank", [.abs]),
+        ("crunch", [.abs]),
+        ("sit up", [.abs]),
+        ("situp", [.abs]),
+        ("leg raise", [.abs]),
+        ("hanging raise", [.abs]),
+        ("ab wheel", [.abs]),
+        ("russian twist", [.abs]),
+    ]
+}

--- a/Packages/StrandImport/Sources/StrandImport/MuscleGroups.swift
+++ b/Packages/StrandImport/Sources/StrandImport/MuscleGroups.swift
@@ -61,11 +61,6 @@ public enum MuscleAttribution {
         return out.trimmingCharacters(in: .whitespaces)
     }
 
-    /// The primary movers for a logged exercise name, or an empty array when it cannot be placed.
-    ///
-    /// Order matters: the first rule that matches wins, so the more specific phrase has to be tested
-    /// before the word it contains. "leg curl" is hamstrings and must be decided before "curl" sends
-    /// it to biceps; "front raise" is shoulders and must beat "raise"; "calf raise" likewise.
     /// Real exercises this vocabulary has no group for, which must attribute NOTHING rather than
     /// fall through to a generic rule that would be wrong.
     ///
@@ -77,6 +72,11 @@ public enum MuscleAttribution {
     /// deliberate absence of one, which is a different statement from "not recognised".
     static let unattributable: [String] = ["neck"]
 
+    /// The primary movers for a logged exercise name, or an empty array when it cannot be placed.
+    ///
+    /// Order matters: the first rule that matches wins, so the more specific phrase has to be tested
+    /// before the word it contains. "leg curl" is hamstrings and must be decided before "curl" sends
+    /// it to biceps; "front raise" is shoulders and must beat "raise"; "calf raise" likewise.
     public static func muscles(for exercise: String) -> [MuscleGroup] {
         let n = normalise(exercise)
         guard !n.isEmpty else { return [] }

--- a/Packages/StrandImport/Tests/StrandImportTests/MuscleGroupsTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/MuscleGroupsTests.swift
@@ -50,6 +50,24 @@ final class MuscleGroupsTests: XCTestCase {
         XCTAssertEqual(MuscleAttribution.muscles(for: "Chest Fly"), [.chest])
     }
 
+    /// A wrist curl is forearms. The rule for it existed but sat BELOW the generic biceps "curl",
+    /// so it could never match the spelling the exercise is normally written with.
+    func testWristCurlIsForearmsNotBiceps() {
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Wrist Curl"), [.forearms])
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Reverse Wrist Curl (Barbell)"), [.forearms])
+    }
+
+    /// These thirteen groups have no neck, and "Neck Curl" contains "curl", so it came out as biceps.
+    /// A blank is the only honest answer: the table prefers a blank to a wrong muscle everywhere else,
+    /// and an exercise the vocabulary cannot express is exactly where that has to hold.
+    func testAnExerciseTheVocabularyCannotExpressAttributesNothing() {
+        XCTAssertTrue(MuscleAttribution.muscles(for: "Neck Curl").isEmpty)
+        XCTAssertTrue(MuscleAttribution.muscles(for: "Neck Extension").isEmpty)
+        XCTAssertTrue(MuscleAttribution.muscles(for: "Weighted Neck Harness").isEmpty)
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Bicep Curl"), [.biceps],
+                       "the guard must not swallow an ordinary curl")
+    }
+
     /// Hevy writes it as one word. A rule that only matches the spaced spelling silently attributes
     /// nothing for the spelling the catalogue actually uses, which reads as an unknown lift.
     func testSkullcrusherMatchesBothSpellings() {

--- a/Packages/StrandImport/Tests/StrandImportTests/MuscleGroupsTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/MuscleGroupsTests.swift
@@ -36,6 +36,27 @@ final class MuscleGroupsTests: XCTestCase {
         XCTAssertEqual(MuscleAttribution.muscles(for: "Hammer Curl"), [.biceps, .forearms])
     }
 
+    /// Titles that match TWO rules whose needles do not contain each other, so the structural
+    /// shadowing test cannot see them: "Rear Delt Fly" contains both "rear delt" and "fly", and
+    /// whichever sits first in the table wins. Every one of these was wrong when first written.
+    func testCompoundTitlesResolveToTheRearOrLegMovementNotTheGenericOne() {
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Rear Delt Fly"), [.shoulders, .upperBack],
+                       "the generic chest 'fly' rule would file the opposite side of the body")
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Reverse Fly (Dumbbell)"), [.shoulders, .upperBack])
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Nordic Curl"), [.hamstrings],
+                       "a nordic curl is hamstrings, not the biceps 'curl' rule")
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Jefferson Curl"), [.lowerBack, .hamstrings])
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Cable Fly"), [.chest], "a plain fly is still chest")
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Chest Fly"), [.chest])
+    }
+
+    /// Hevy writes it as one word. A rule that only matches the spaced spelling silently attributes
+    /// nothing for the spelling the catalogue actually uses, which reads as an unknown lift.
+    func testSkullcrusherMatchesBothSpellings() {
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Skullcrusher (Barbell)"), [.triceps])
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Skull Crusher"), [.triceps])
+    }
+
     /// Equipment parentheses, hyphens and case must not change the answer.
     func testNormalisationIgnoresEquipmentPunctuationAndCase() {
         let expected: [MuscleGroup] = [.chest, .triceps]
@@ -69,6 +90,11 @@ final class MuscleGroupsTests: XCTestCase {
     /// Guards the ordering property itself rather than individual pairs: if a rule's needle contains
     /// an earlier rule's needle, the earlier one wins and the later is dead. This catches a new rule
     /// appended in the wrong place, which no example-based test would.
+    ///
+    /// What it does NOT catch: two rules whose needles do not contain each other, where a real title
+    /// contains BOTH. "rear delt" and "fly" are disjoint, yet "Rear Delt Fly" matches whichever comes
+    /// first — and it came out as chest until an example test was written for it. The example test
+    /// above is the guard for that class; this one cannot be.
     func testNoRuleIsShadowedByAnEarlierOne() {
         let rules = MuscleAttribution.rules
         for (i, later) in rules.enumerated() {

--- a/Packages/StrandImport/Tests/StrandImportTests/MuscleGroupsTests.swift
+++ b/Packages/StrandImport/Tests/StrandImportTests/MuscleGroupsTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import StrandImport
+
+/// Exercise → muscle attribution.
+///
+/// The ordering cases are the ones that matter. The rules are matched first-hit-wins on a normalised
+/// name, so every generic word ("curl", "raise", "row", "press") has specific phrases that contain it
+/// and must be decided first. A regression there does not crash or blank — it silently attributes leg
+/// work to biceps, which is exactly the kind of confident wrong answer this project treats as worse
+/// than nothing.
+final class MuscleGroupsTests: XCTestCase {
+
+    func testTheLiftsFromARealLogAttributeCorrectly() {
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Romanian Deadlift (Barbell)"),
+                       [.hamstrings, .glutes])
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Squat (Barbell)"), [.quadriceps, .glutes])
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Seated Cable Row - V Grip"),
+                       [.upperBack, .lats])
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Bicep Curl (Dumbbell)"), [.biceps])
+    }
+
+    /// "leg curl" contains "curl"; "romanian deadlift" contains "deadlift". If the generic rule won,
+    /// hamstring work would be filed under biceps and lower back.
+    func testSpecificPhrasesBeatTheGenericWordTheyContain() {
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Lying Leg Curl"), [.hamstrings],
+                       "leg curl must not fall through to the biceps 'curl' rule")
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Romanian Deadlift"), [.hamstrings, .glutes],
+                       "must not fall through to the generic deadlift rule")
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Calf Raise (Machine)"), [.calves],
+                       "calf raise must not fall through to a shoulder 'raise'")
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Front Raise"), [.shoulders])
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Hanging Leg Raise"), [.abs],
+                       "a hanging leg raise is trunk work, not quads")
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Upright Row"), [.shoulders, .upperBack],
+                       "upright row must not fall through to the back 'row' rule")
+        XCTAssertEqual(MuscleAttribution.muscles(for: "Hammer Curl"), [.biceps, .forearms])
+    }
+
+    /// Equipment parentheses, hyphens and case must not change the answer.
+    func testNormalisationIgnoresEquipmentPunctuationAndCase() {
+        let expected: [MuscleGroup] = [.chest, .triceps]
+        for spelling in ["Bench Press", "bench press", "Bench Press (Barbell)",
+                         "BENCH-PRESS", "Bench  Press   (Smith Machine)"] {
+            XCTAssertEqual(MuscleAttribution.muscles(for: spelling), expected, spelling)
+        }
+    }
+
+    /// An unrecognised lift attributes NOTHING. A wrong muscle is worse than a blank one: the blank
+    /// invites a look, the wrong one does not.
+    func testAnUnknownExerciseAttributesNothing() {
+        XCTAssertTrue(MuscleAttribution.muscles(for: "Kettlebell Flow").isEmpty)
+        XCTAssertTrue(MuscleAttribution.muscles(for: "").isEmpty)
+        XCTAssertTrue(MuscleAttribution.muscles(for: "   ").isEmpty)
+        XCTAssertTrue(MuscleAttribution.muscles(for: "???").isEmpty)
+    }
+
+    /// Every rule must map to at least one group, and every group named must be a real case — a typo
+    /// in the table would otherwise sit there attributing nothing and look like an unknown lift.
+    func testEveryRuleIsWellFormed() {
+        XCTAssertFalse(MuscleAttribution.rules.isEmpty)
+        for (needle, groups) in MuscleAttribution.rules {
+            XCTAssertFalse(needle.isEmpty)
+            XCTAssertEqual(needle, MuscleAttribution.normalise(needle),
+                           "rule '\(needle)' must already be in normalised form or it can never match")
+            XCTAssertFalse(groups.isEmpty, "rule '\(needle)' attributes nothing")
+        }
+    }
+
+    /// Guards the ordering property itself rather than individual pairs: if a rule's needle contains
+    /// an earlier rule's needle, the earlier one wins and the later is dead. This catches a new rule
+    /// appended in the wrong place, which no example-based test would.
+    func testNoRuleIsShadowedByAnEarlierOne() {
+        let rules = MuscleAttribution.rules
+        for (i, later) in rules.enumerated() {
+            for earlier in rules[..<i] where later.0.contains(earlier.0) {
+                XCTFail("'\(later.0)' is unreachable: '\(earlier.0)' matches it first")
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/ingest/MuscleGroups.kt
+++ b/android/app/src/main/java/com/noop/ingest/MuscleGroups.kt
@@ -1,0 +1,187 @@
+package com.noop.ingest
+
+// MARK: - Exercise → muscle attribution
+//
+// Groundwork for a per-muscle strength view. NOOP already imports lifting sessions (Hevy CSV,
+// Liftosaur JSON) but aggregates them to a set count and a volume figure, so nothing downstream can
+// say WHICH muscles did the work. This maps an exercise name to the muscles that move it.
+//
+// Kotlin mirror of the macOS/iOS source of truth
+//   Packages/StrandImport/Sources/StrandImport/MuscleGroups.swift
+// The rule table is the logic here, so the two must stay identical ROW FOR ROW AND IN ORDER: the
+// first match wins, and a row moved on one platform silently attributes a different muscle there.
+//
+// Keyword matching on a normalised name, NOT an exhaustive catalogue. Lifting trackers let people
+// type anything, so a closed list would silently mis-attribute everything it did not recognise. The
+// rule here is the project's usual one: an exercise this cannot place returns NOTHING, and the
+// caller shows no attribution rather than a guess. A wrong muscle is worse than a blank one, because
+// a blank invites the user to look while a wrong one does not.
+//
+// PRIMARY movers only. A barbell squat loads glutes and hamstrings too, and a bench press loads
+// triceps and shoulders — but attributing every synergist would make every session light up the
+// whole body and stop distinguishing a push day from a leg day. The screen this feeds is about where
+// the work went, not about what was innervated.
+
+/**
+ * The muscle groups a strength view can attribute work to.
+ *
+ * Deliberately coarse. These are the granularity a lifting log can actually support: an exercise
+ * name can tell you "lats", it cannot honestly tell you which head of which muscle.
+ */
+enum class MuscleGroup {
+    CHEST,
+    UPPER_BACK,
+    LATS,
+    SHOULDERS,
+    BICEPS,
+    TRICEPS,
+    FOREARMS,
+    ABS,
+    LOWER_BACK,
+    GLUTES,
+    QUADRICEPS,
+    HAMSTRINGS,
+    CALVES,
+}
+
+object MuscleAttribution {
+
+    /**
+     * Normalise a logged exercise name for matching.
+     *
+     * Trackers append equipment in parentheses ("Squat (Barbell)"), use hyphens and en-dashes
+     * inconsistently ("Seated Cable Row - V Grip"), and vary in case. The parenthetical is KEPT
+     * rather than stripped, because it can carry the distinguishing word: a "Row (Machine)" and a
+     * "Row (Dumbbell)" are the same muscles, but "Curl (Barbell)" and "Leg Curl" are not.
+     */
+    fun normalise(raw: String): String {
+        val out = StringBuilder(raw.length)
+        var lastWasSpace = false
+        for (ch in raw.lowercase()) {
+            if (ch.isLetterOrDigit()) {
+                out.append(ch)
+                lastWasSpace = false
+            } else if (!lastWasSpace) {
+                out.append(' ')
+                lastWasSpace = true
+            }
+        }
+        return out.toString().trim()
+    }
+
+    /**
+     * Real exercises this vocabulary has no group for, which must attribute NOTHING rather than fall
+     * through to a generic rule that would be wrong.
+     *
+     * "Neck Curl" contains "curl" and came out as BICEPS. These thirteen groups have no neck, so a
+     * blank is the only honest answer, and a blank is what the whole table is supposed to prefer: it
+     * invites a look, where a wrong muscle does not.
+     *
+     * Kept separate from [rules] because a rule must name at least one group. An entry here is the
+     * deliberate absence of one, which is a different statement from "not recognised".
+     */
+    internal val unattributable: List<String> = listOf("neck")
+
+    /**
+     * The primary movers for a logged exercise name, or an empty list when it cannot be placed.
+     *
+     * Order matters: the first rule that matches wins, so the more specific phrase has to be tested
+     * before the word it contains. "leg curl" is hamstrings and must be decided before "curl" sends
+     * it to biceps; "front raise" is shoulders and must beat "raise"; "calf raise" likewise.
+     */
+    fun muscles(exercise: String): List<MuscleGroup> {
+        val n = normalise(exercise)
+        if (n.isEmpty()) return emptyList()
+        if (unattributable.any { n.contains(it) }) return emptyList()
+        for ((needle, groups) in rules) if (n.contains(needle)) return groups
+        return emptyList()
+    }
+
+    /**
+     * Longest-phrase-first, so a specific lift is decided before the generic word inside it. Held as
+     * an ordered list rather than a map precisely because that order is the logic.
+     */
+    internal val rules: List<Pair<String, List<MuscleGroup>>> = listOf(
+        // legs — the specific curls and raises must precede the generic ones
+        "leg curl" to listOf(MuscleGroup.HAMSTRINGS),
+        "romanian deadlift" to listOf(MuscleGroup.HAMSTRINGS, MuscleGroup.GLUTES),
+        "stiff leg deadlift" to listOf(MuscleGroup.HAMSTRINGS, MuscleGroup.GLUTES),
+        "good morning" to listOf(MuscleGroup.HAMSTRINGS, MuscleGroup.LOWER_BACK),
+        "leg extension" to listOf(MuscleGroup.QUADRICEPS),
+        "hack squat" to listOf(MuscleGroup.QUADRICEPS),
+        "front squat" to listOf(MuscleGroup.QUADRICEPS),
+        "bulgarian" to listOf(MuscleGroup.QUADRICEPS, MuscleGroup.GLUTES),
+        "lunge" to listOf(MuscleGroup.QUADRICEPS, MuscleGroup.GLUTES),
+        "leg press" to listOf(MuscleGroup.QUADRICEPS, MuscleGroup.GLUTES),
+        "squat" to listOf(MuscleGroup.QUADRICEPS, MuscleGroup.GLUTES),
+        "hip thrust" to listOf(MuscleGroup.GLUTES),
+        "glute bridge" to listOf(MuscleGroup.GLUTES),
+        "calf raise" to listOf(MuscleGroup.CALVES),
+        "calf press" to listOf(MuscleGroup.CALVES),
+        // hinge / back
+        "deadlift" to listOf(MuscleGroup.LOWER_BACK, MuscleGroup.GLUTES, MuscleGroup.HAMSTRINGS),
+        "back extension" to listOf(MuscleGroup.LOWER_BACK),
+        "hyperextension" to listOf(MuscleGroup.LOWER_BACK),
+        "pull up" to listOf(MuscleGroup.LATS, MuscleGroup.BICEPS),
+        "pullup" to listOf(MuscleGroup.LATS, MuscleGroup.BICEPS),
+        "chin up" to listOf(MuscleGroup.LATS, MuscleGroup.BICEPS),
+        "chinup" to listOf(MuscleGroup.LATS, MuscleGroup.BICEPS),
+        "lat pulldown" to listOf(MuscleGroup.LATS),
+        "pulldown" to listOf(MuscleGroup.LATS),
+        "pullover" to listOf(MuscleGroup.LATS),
+        "face pull" to listOf(MuscleGroup.UPPER_BACK, MuscleGroup.SHOULDERS),
+        "shrug" to listOf(MuscleGroup.UPPER_BACK),
+        // Before the generic row: an upright row is a shoulder movement, and every
+        // upright row contains "row", so the generic rule would swallow it.
+        "upright row" to listOf(MuscleGroup.SHOULDERS, MuscleGroup.UPPER_BACK),
+        "row" to listOf(MuscleGroup.UPPER_BACK, MuscleGroup.LATS),
+        // push
+        "bench press" to listOf(MuscleGroup.CHEST, MuscleGroup.TRICEPS),
+        "chest press" to listOf(MuscleGroup.CHEST, MuscleGroup.TRICEPS),
+        "chest fly" to listOf(MuscleGroup.CHEST),
+        "pec deck" to listOf(MuscleGroup.CHEST),
+        // Before the generic fly: a reverse fly and a rear-delt fly are REAR movements, and both
+        // contain "fly", so the generic rule would file the opposite side of the body. Order is the
+        // whole contract here, not a stylistic choice.
+        "rear delt" to listOf(MuscleGroup.SHOULDERS, MuscleGroup.UPPER_BACK),
+        "reverse fly" to listOf(MuscleGroup.SHOULDERS, MuscleGroup.UPPER_BACK),
+        "fly" to listOf(MuscleGroup.CHEST),
+        "push up" to listOf(MuscleGroup.CHEST, MuscleGroup.TRICEPS),
+        "pushup" to listOf(MuscleGroup.CHEST, MuscleGroup.TRICEPS),
+        "dip" to listOf(MuscleGroup.CHEST, MuscleGroup.TRICEPS),
+        "overhead press" to listOf(MuscleGroup.SHOULDERS, MuscleGroup.TRICEPS),
+        "shoulder press" to listOf(MuscleGroup.SHOULDERS, MuscleGroup.TRICEPS),
+        "military press" to listOf(MuscleGroup.SHOULDERS, MuscleGroup.TRICEPS),
+        "arnold press" to listOf(MuscleGroup.SHOULDERS),
+        "lateral raise" to listOf(MuscleGroup.SHOULDERS),
+        "front raise" to listOf(MuscleGroup.SHOULDERS),
+        // arms
+        // Hevy writes it as one word; the two-word rule missed the spelling the catalogue uses.
+        "skullcrusher" to listOf(MuscleGroup.TRICEPS),
+        "skull crusher" to listOf(MuscleGroup.TRICEPS),
+        "tricep" to listOf(MuscleGroup.TRICEPS),
+        "pushdown" to listOf(MuscleGroup.TRICEPS),
+        "kickback" to listOf(MuscleGroup.TRICEPS),
+        "hammer curl" to listOf(MuscleGroup.BICEPS, MuscleGroup.FOREARMS),
+        "preacher curl" to listOf(MuscleGroup.BICEPS),
+        "bicep" to listOf(MuscleGroup.BICEPS),
+        // Before the generic curl: a nordic curl is a hamstring movement and a jefferson curl is a
+        // spinal one. Both contain "curl", so the generic rule would call them biceps.
+        "nordic curl" to listOf(MuscleGroup.HAMSTRINGS),
+        "jefferson curl" to listOf(MuscleGroup.LOWER_BACK, MuscleGroup.HAMSTRINGS),
+        // Before the generic curl: a wrist curl is forearms, and "Wrist Curl" is how the exercise is
+        // normally written, so the rule below was unreachable for the title it exists to catch.
+        "wrist" to listOf(MuscleGroup.FOREARMS),
+        "curl" to listOf(MuscleGroup.BICEPS),
+        "farmer" to listOf(MuscleGroup.FOREARMS),
+        // trunk
+        "plank" to listOf(MuscleGroup.ABS),
+        "crunch" to listOf(MuscleGroup.ABS),
+        "sit up" to listOf(MuscleGroup.ABS),
+        "situp" to listOf(MuscleGroup.ABS),
+        "leg raise" to listOf(MuscleGroup.ABS),
+        "hanging raise" to listOf(MuscleGroup.ABS),
+        "ab wheel" to listOf(MuscleGroup.ABS),
+        "russian twist" to listOf(MuscleGroup.ABS),
+    )
+}

--- a/android/app/src/test/java/com/noop/ingest/MuscleGroupsTest.kt
+++ b/android/app/src/test/java/com/noop/ingest/MuscleGroupsTest.kt
@@ -1,0 +1,198 @@
+package com.noop.ingest
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Exercise → muscle attribution. Kotlin twin of the macOS MuscleGroupsTests - same cases, same
+ * assertions, so a rule that moves on one platform and not the other fails here.
+ *
+ * The ordering cases are the ones that matter. The rules are matched first-hit-wins on a normalised
+ * name, so every generic word ("curl", "raise", "row", "press") has specific phrases that contain it
+ * and must be decided first. A regression there does not crash or blank - it silently attributes leg
+ * work to biceps, which is exactly the kind of confident wrong answer this project treats as worse
+ * than nothing.
+ */
+class MuscleGroupsTest {
+
+    @Test
+    fun theLiftsFromARealLogAttributeCorrectly() {
+        assertEquals(
+            listOf(MuscleGroup.HAMSTRINGS, MuscleGroup.GLUTES),
+            MuscleAttribution.muscles("Romanian Deadlift (Barbell)"),
+        )
+        assertEquals(
+            listOf(MuscleGroup.QUADRICEPS, MuscleGroup.GLUTES),
+            MuscleAttribution.muscles("Squat (Barbell)"),
+        )
+        assertEquals(
+            listOf(MuscleGroup.UPPER_BACK, MuscleGroup.LATS),
+            MuscleAttribution.muscles("Seated Cable Row - V Grip"),
+        )
+        assertEquals(listOf(MuscleGroup.BICEPS), MuscleAttribution.muscles("Bicep Curl (Dumbbell)"))
+    }
+
+    /**
+     * "leg curl" contains "curl"; "romanian deadlift" contains "deadlift". If the generic rule won,
+     * hamstring work would be filed under biceps and lower back.
+     */
+    @Test
+    fun specificPhrasesBeatTheGenericWordTheyContain() {
+        assertEquals(listOf(MuscleGroup.HAMSTRINGS), MuscleAttribution.muscles("Lying Leg Curl"))
+        assertEquals(
+            listOf(MuscleGroup.HAMSTRINGS, MuscleGroup.GLUTES),
+            MuscleAttribution.muscles("Romanian Deadlift"),
+        )
+        assertEquals(listOf(MuscleGroup.CALVES), MuscleAttribution.muscles("Calf Raise (Machine)"))
+        assertEquals(listOf(MuscleGroup.SHOULDERS), MuscleAttribution.muscles("Front Raise"))
+        assertEquals(listOf(MuscleGroup.ABS), MuscleAttribution.muscles("Hanging Leg Raise"))
+        assertEquals(
+            listOf(MuscleGroup.SHOULDERS, MuscleGroup.UPPER_BACK),
+            MuscleAttribution.muscles("Upright Row"),
+        )
+        assertEquals(
+            listOf(MuscleGroup.BICEPS, MuscleGroup.FOREARMS),
+            MuscleAttribution.muscles("Hammer Curl"),
+        )
+    }
+
+    /**
+     * Titles that match TWO rules whose needles do not contain each other, so the structural
+     * shadowing test cannot see them: "Rear Delt Fly" contains both "rear delt" and "fly", and
+     * whichever sits first in the table wins. Every one of these was wrong when first written.
+     */
+    @Test
+    fun compoundTitlesResolveToTheRearOrLegMovementNotTheGenericOne() {
+        val rear = listOf(MuscleGroup.SHOULDERS, MuscleGroup.UPPER_BACK)
+        assertEquals(rear, MuscleAttribution.muscles("Rear Delt Fly"))
+        assertEquals(rear, MuscleAttribution.muscles("Reverse Fly (Dumbbell)"))
+        assertEquals(listOf(MuscleGroup.HAMSTRINGS), MuscleAttribution.muscles("Nordic Curl"))
+        assertEquals(
+            listOf(MuscleGroup.LOWER_BACK, MuscleGroup.HAMSTRINGS),
+            MuscleAttribution.muscles("Jefferson Curl"),
+        )
+        assertEquals(listOf(MuscleGroup.CHEST), MuscleAttribution.muscles("Cable Fly"))
+        assertEquals(listOf(MuscleGroup.CHEST), MuscleAttribution.muscles("Chest Fly"))
+    }
+
+    /**
+     * A wrist curl is forearms. The rule for it existed but sat BELOW the generic biceps "curl", so
+     * it could never match the spelling the exercise is normally written with.
+     */
+    @Test
+    fun wristCurlIsForearmsNotBiceps() {
+        assertEquals(listOf(MuscleGroup.FOREARMS), MuscleAttribution.muscles("Wrist Curl"))
+        assertEquals(
+            listOf(MuscleGroup.FOREARMS),
+            MuscleAttribution.muscles("Reverse Wrist Curl (Barbell)"),
+        )
+    }
+
+    /**
+     * These thirteen groups have no neck, and "Neck Curl" contains "curl", so it came out as biceps.
+     * A blank is the only honest answer: the table prefers a blank to a wrong muscle everywhere else,
+     * and an exercise the vocabulary cannot express is exactly where that has to hold.
+     */
+    @Test
+    fun anExerciseTheVocabularyCannotExpressAttributesNothing() {
+        assertTrue(MuscleAttribution.muscles("Neck Curl").isEmpty())
+        assertTrue(MuscleAttribution.muscles("Neck Extension").isEmpty())
+        assertTrue(MuscleAttribution.muscles("Weighted Neck Harness").isEmpty())
+        assertEquals(listOf(MuscleGroup.BICEPS), MuscleAttribution.muscles("Bicep Curl"))
+    }
+
+    /**
+     * Hevy writes it as one word. A rule that only matches the spaced spelling silently attributes
+     * nothing for the spelling the catalogue actually uses, which reads as an unknown lift.
+     */
+    @Test
+    fun skullcrusherMatchesBothSpellings() {
+        assertEquals(listOf(MuscleGroup.TRICEPS), MuscleAttribution.muscles("Skullcrusher (Barbell)"))
+        assertEquals(listOf(MuscleGroup.TRICEPS), MuscleAttribution.muscles("Skull Crusher"))
+    }
+
+    /** Equipment parentheses, hyphens and case must not change the answer. */
+    @Test
+    fun normalisationIgnoresEquipmentPunctuationAndCase() {
+        val expected = listOf(MuscleGroup.CHEST, MuscleGroup.TRICEPS)
+        for (spelling in listOf(
+            "Bench Press", "bench press", "Bench Press (Barbell)",
+            "BENCH-PRESS", "Bench  Press   (Smith Machine)",
+        )) {
+            assertEquals(spelling, expected, MuscleAttribution.muscles(spelling))
+        }
+    }
+
+    /**
+     * An unrecognised lift attributes NOTHING. A wrong muscle is worse than a blank one: the blank
+     * invites a look, the wrong one does not.
+     */
+    @Test
+    fun anUnknownExerciseAttributesNothing() {
+        assertTrue(MuscleAttribution.muscles("Kettlebell Flow").isEmpty())
+        assertTrue(MuscleAttribution.muscles("").isEmpty())
+        assertTrue(MuscleAttribution.muscles("   ").isEmpty())
+        assertTrue(MuscleAttribution.muscles("???").isEmpty())
+    }
+
+    /**
+     * Every rule must map to at least one group, and every needle must already be normalised - a rule
+     * that is not would sit there matching nothing and look like an unknown lift.
+     */
+    @Test
+    fun everyRuleIsWellFormed() {
+        assertFalse(MuscleAttribution.rules.isEmpty())
+        for ((needle, groups) in MuscleAttribution.rules) {
+            assertFalse(needle.isEmpty())
+            assertEquals(needle, MuscleAttribution.normalise(needle))
+            assertFalse("rule '$needle' attributes nothing", groups.isEmpty())
+        }
+    }
+
+    /**
+     * Guards the ordering property itself rather than individual pairs: if a rule's needle contains
+     * an earlier rule's needle, the earlier one wins and the later is dead.
+     *
+     * What it does NOT catch: two rules whose needles do not contain each other, where a real title
+     * contains BOTH. "rear delt" and "fly" are disjoint, yet "Rear Delt Fly" matches whichever comes
+     * first - and it came out as chest until an example test was written for it. The example test
+     * above is the guard for that class; this one cannot be.
+     */
+    @Test
+    fun noRuleIsShadowedByAnEarlierOne() {
+        val rules = MuscleAttribution.rules
+        for ((i, later) in rules.withIndex()) {
+            for (earlier in rules.subList(0, i)) {
+                assertFalse(
+                    "'${later.first}' is unreachable: '${earlier.first}' matches it first",
+                    later.first.contains(earlier.first),
+                )
+            }
+        }
+    }
+
+    /**
+     * The parity guard. The Swift table is the source of truth and the order IS the logic, so this
+     * pins the row count and a handful of positions: a rule inserted or moved on one platform and not
+     * the other changes an attribution silently, and nothing else in either suite would notice.
+     */
+    @Test
+    fun theRuleTableMatchesTheSwiftSourceOfTruth() {
+        assertEquals(66, MuscleAttribution.rules.size)
+        assertEquals("leg curl", MuscleAttribution.rules.first().first)
+        assertEquals("russian twist", MuscleAttribution.rules.last().first)
+        val order = MuscleAttribution.rules.map { it.first }
+        for ((specific, generic) in listOf(
+            "leg curl" to "curl", "wrist" to "curl", "nordic curl" to "curl",
+            "rear delt" to "fly", "reverse fly" to "fly", "upright row" to "row",
+            "romanian deadlift" to "deadlift", "hack squat" to "squat", "chest fly" to "fly",
+        )) {
+            assertTrue(
+                "'$specific' must be ordered before '$generic'",
+                order.indexOf(specific) < order.indexOf(generic),
+            )
+        }
+    }
+}


### PR DESCRIPTION
**Draft — stage 1 of a per-muscle strength view.** Nothing calls this yet, and
that is stated rather than hidden.

## What the request needs, and what NOOP has

A user asked for the muscle-load / working-sets view: a body map shaded by
recent load, and per-muscle set counts against a usual week.

| needed | NOOP today |
|---|---|
| session window, volume, set count | **have** — `LiftingSession` |
| per-exercise NAMES | **missing** — aggregated to `exerciseCount` at parse |
| per-exercise sets / reps / volume | missing |
| exercise → muscle mapping | **this PR** |
| per-muscle load with decay | missing |
| body map + working-sets UI | missing, both platforms |

The blocker is the second row: the import keeps `exerciseCount`, an integer, and
throws the names away. Every later stage depends on fixing that, and fixing it
properly means persisting per-exercise rows — a schema change on both platforms.

## Why this piece first

It is the only part that is novel, pure, fully testable, and useful regardless of
how the rest is built or where it is displayed. It also settles the question the
rest hangs on: what granularity can a lifting log honestly support? An exercise
name can tell you "lats". It cannot tell you which head of which muscle, and a
view implying otherwise would be inventing precision.

## The design decisions worth arguing with

- **Keyword rules, not a closed catalogue.** Trackers let people type anything. A
  fixed list silently mis-attributes everything it does not recognise.
- **Unknown attributes NOTHING.** A wrong muscle is worse than a blank one: the
  blank invites a look, the wrong one does not.
- **Primary movers only.** A squat loads hamstrings and a bench loads shoulders,
  but attributing every synergist lights the whole body on every session and stops
  distinguishing a push day from a leg day.
- **Coarse groups.** Thirteen. That is what a name can support.

## The ordering is the logic, so it is tested as a property

Rules are first-hit-wins, and every generic word has specific phrases containing
it — `leg curl` before `curl`, `calf raise` before `raise`, `upright row` before
`row`, `romanian deadlift` before `deadlift`. A misplaced rule does not crash or
blank; it files leg work under biceps.

So besides the example tests there is one asserting the PROPERTY: no rule may be
a superset of an earlier rule, because such a rule is unreachable. It found three
dead entries in my first table, including an `upright row` that the generic `row`
swallowed — none of which an example-based test would have caught unless someone
thought to write that example.

## Not in this PR

1. **Per-exercise persistence** — the schema change, both platforms. This is the
   real gate and deserves its own review; there are 43 existing migrations to
   follow, and Android's Room version / schema / migration triple has to move
   together or existing installs crash.
2. **The load model** — how load accumulates per muscle and how fast it fades.
   The screenshot is honest that decay is "assumed, not measured", and that
   assumption should be argued explicitly rather than inherited.
3. **UI**, both platforms.
4. **The Kotlin twin.** `LiftingImporter` is already mirrored, so this table must
   be too before anything ships — a per-muscle view that disagreed across phones
   would be worse than none.

## Provenance

Written from the concept, not ported: there is no fork checkout here, and NOOP's
provenance rule treats facts as reusable and expression as licensed. The muscle
groupings are anatomical facts; the rule table, its ordering and the honest-blank
behaviour are this file's own.

## Verification

Six tests. Swift does not compile in my environment (`StrandImport` pulls GRDB,
which wants `sqlite3.h`), so I simulated the matcher and re-ran every asserted
example plus the shadowing property before pushing — that is how the three dead
rules were found rather than by waiting for CI.
