### PR TITLE
ecg: admit the four ECG probe opcodes behind a closed send gate (the three Labrador toggles become constructible)

### DIFF
--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -61,6 +61,17 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
         get() = prefs.getBoolean(KEY_ECG_RAW_DATA, false)
         set(v) = prefs.edit().putBoolean(KEY_ECG_RAW_DATA, v).apply()
 
+    /** True if the user opted in to the "MG ECG research probe" (#891/#1100) — the gated, hand-run panel
+     *  that SENDS the WHOOP MG ECG ("Labrador") toggle commands (139/125/124) to learn what a real MG does
+     *  with them. SEPARATE from [ecgRawData]: that opt-in writes ONE persistent device-config value; this
+     *  one dispatches session ECG commands. Every one is on the strict allow-list in
+     *  [com.noop.protocol.EcgResearchAllowList] and additionally gated on an attested MG at the send path
+     *  ([com.noop.ble.WhoopBleClient.ecgSendAdmitted]). Reversible, default false — a plain 5.0 or a 4.0
+     *  never sees these. Mirrors the macOS `PuffinExperiment.ecgEnabled` (`noopWhoop5Ecg`). */
+    var ecgProbe: Boolean
+        get() = prefs.getBoolean(KEY_ECG_PROBE, false)
+        set(v) = prefs.edit().putBoolean(KEY_ECG_PROBE, v).apply()
+
     /** True if the user opted in to "Experimental sleep staging (V2)": detected nights are re-staged with
      *  [com.noop.analytics.SleepStagerV2] (the transparent cardiorespiratory recipe, reimplemented from
      *  contributor PR #600) instead of the older V1 [com.noop.analytics.SleepStager]. Pure analysis switch
@@ -252,6 +263,11 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
          *  `PuffinExperiment.ecgRawDataKey`). (#891) */
         const val KEY_ECG_RAW_DATA = "noopEcgRawDataGate"
 
+        /** "MG ECG research probe" opt-in — dispatches the Labrador ECG session commands from the gated
+         *  research panel. Same UserDefaults key as macOS `PuffinExperiment.ecgEnabledKey`, so a future
+         *  cross-platform settings sync does not have to reconcile two names. (#891/#1100) */
+        const val KEY_ECG_PROBE = "noopWhoop5Ecg"
+
         /** "Ask Android to pair" opt-in — the explicit `createBond()` experiment (#1635). Android-only,
          *  so no macOS key to mirror. */
         const val KEY_EXPLICIT_BOND = "noopWhoop5ExplicitBond"
@@ -270,7 +286,7 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
          *  SettingsScreen watches exactly these for external writes. Two lists would drift. */
         internal val FIVE_MG_GATED_KEYS =
             listOf(KEY, KEY_CAPTURE, KEY_DEEP_DATA, KEY_BROADCAST_HR, KEY_ECG_RAW_DATA, KEY_EXPLICIT_BOND,
-                   KEY_UNBONDED_OFFLOAD, KEY_CLEAR_STALE_BOND)
+                   KEY_UNBONDED_OFFLOAD, KEY_CLEAR_STALE_BOND, KEY_ECG_PROBE)
 
         /** "Experimental sleep staging (V2)" opt-in (mirrors macOS `PuffinExperiment.experimentalSleepV2Key`). */
         const val KEY_EXPERIMENTAL_SLEEP_V2 = "noopExperimentalSleepV2"

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -49,6 +49,7 @@ import com.noop.protocol.DeviceConfigReadProbeReport
 import com.noop.protocol.DeviceConfigWriteGate
 import com.noop.protocol.BroadcastHrGateReport
 import com.noop.protocol.EcgRawDataGateReport
+import com.noop.protocol.EcgResearchAllowList
 import com.noop.protocol.FeatureFlagProbe
 import com.noop.protocol.FeatureFlagProbeReport
 import com.noop.protocol.Framing
@@ -4397,7 +4398,12 @@ class WhoopBleClient(
                 // verified — same discipline as the R22 read-back above. The write ack is never the proof.
                 // Both the ECG gate (#891) and the Broadcast-HR gate (#1061) read themselves back over this.
                 !(DeviceConfigWriteGate.isReadBackOpcode(cmd.rawValue) &&
-                    (ecgGateReport != null || broadcastHrGateReport != null))) {
+                    (ecgGateReport != null || broadcastHrGateReport != null)) &&
+                // MG ECG ("Labrador") research probe (#891/#1100): the ECG opcodes 123/124/125/139, admitted
+                // ONLY by ecgSendAdmitted — the probe opt-in on, on a connected, positively-attested MG. The
+                // opcode gate is the positive allow-list EcgResearchAllowList, a closed set of four, so the
+                // firmware-load family three codes above 139 is not expressible through it.
+                !ecgSendAdmitted(cmd)) {
                 log("send(${cmd.name}) skipped — no WHOOP 5/MG framing for this command yet")
                 return
             }
@@ -8820,6 +8826,29 @@ class WhoopBleClient(
         ecgGateReport = null
         _ecgRawDataGate.value = report
         log("ECG gate (#891):\n${report.render()}")
+    }
+
+    /**
+     * THE send allow-list for the WHOOP MG ECG ("Labrador") opcodes (#891/#1100).
+     *
+     * True only for an opcode in the positive allow-list [EcgResearchAllowList.PROBE_OPCODES], with the ECG
+     * probe opt-in on, on a connected, positively-attested MG. Every other opcode, family or state is false
+     * — the firmware-load family and the rest of [EcgResearchAllowList.FORBIDDEN] are refused because they
+     * are simply not in that set, not because a deny-list caught them.
+     *
+     * Nothing in this change can make it return true in practice: there is no ECG caller on Android yet and
+     * no Settings row that sets [PuffinExperiment.ecgProbe], so the opcodes this change makes constructible
+     * are not reachable from any code path. That is the point — the enum widening and the gate that bounds
+     * it land together, and the probe that needs it lands afterwards against a gate already in `main`.
+     *
+     * The run-arming and stop-override conditions belong with that probe, and tighten this further.
+     */
+    private fun ecgSendAdmitted(cmd: CommandNumber): Boolean {
+        if (!EcgResearchAllowList.isProbeOpcode(cmd.rawValue)) return false
+        if (connectedFamily != DeviceFamily.WHOOP5) return false
+        if (!whoop5Variant().isMG) return false
+        if (!_state.value.connected) return false
+        return puffinExperiment.ecgProbe
     }
 
     /** Clear the #891 result (Settings row dismissed / disconnect). Twin of Swift clearEcgRawDataGate(). */

--- a/android/app/src/main/java/com/noop/protocol/Enums.kt
+++ b/android/app/src/main/java/com/noop/protocol/Enums.kt
@@ -262,16 +262,29 @@ enum class CommandNumber(val rawValue: Int) {
     // not add it and deliberately does not remove it either: dropping a pre-existing entry would change
     // the curated send surface for a reason that has nothing to do with decoding ECG packets, and that is
     // a separate decision from the one below.
-    SELECT_WRIST(123);
+    SELECT_WRIST(123),
+    // The three WHOOP MG ECG ("Labrador") TOGGLES (124 / 125 / 139).
     //
-    // The three WHOOP MG ECG ("Labrador") TOGGLES (124 / 125 / 139) are deliberately ABSENT from this
-    // enum. This branch originally listed them here so a COMMAND_RESPONSE for one would be labelled
-    // rather than shown as a bare hex opcode — a reason #893 has since made obsolete, by giving Android
-    // a read-only `CommandNames` label table that names every opcode the schema names without making any
-    // of them constructible. Android has no ECG app layer and sends none of them, so growing the
-    // SENDER enum to buy a label would widen what the command sender can express for nothing. Apple's
-    // `WhoopCommand` carries them because Apple actually drives the gated probe. See
-    // `com.noop.protocol.Whoop5Ecg` for the decoder and `Whoop5EcgProbe` for the verdict rules.
+    // These were ABSENT, and the reason given was: "Android has no ECG app layer and sends none of them,
+    // so growing the SENDER enum to buy a label would widen what the command sender can express for
+    // nothing." The label half of that is still right — #893's read-only `CommandNames` table names every
+    // opcode the schema names without making any constructible, and nothing here is added for a label.
+    //
+    // What changed is the premise: the gated MG ECG research probe (#891/#1100) is an Android ECG app
+    // layer, and it does send them, exactly as Apple's `WhoopCommand` already does for the same probe.
+    //
+    // Adding them does not widen the REACHABLE surface, which is the property that matters. Every send
+    // passes the single `send()` chokepoint, where [WhoopBleClient.ecgSendAdmitted] admits an opcode only
+    // if it is in the positive allow-list [com.noop.protocol.EcgResearchAllowList.PROBE_OPCODES], the ECG
+    // probe opt-in is on, and the strap is a POSITIVELY-attested MG. The allow-list is a closed set of
+    // four, so the firmware-load family three codes above 139 (142/143/144) is not expressible through it
+    // — asserted in EcgResearchAllowListTest, not merely asserted here.
+    //
+    // See `com.noop.protocol.Whoop5Ecg` for the command builders and decoder, and `Whoop5EcgProbe` for
+    // the verdict rules. Values are the schema numbers.
+    TOGGLE_LABRADOR_DATA_GENERATION(124),
+    TOGGLE_LABRADOR_RAW_SAVE(125),
+    TOGGLE_LABRADOR_FILTERED(139);
 
     companion object {
         private val byRaw = entries.associateBy { it.rawValue }

--- a/android/app/src/test/java/com/noop/protocol/CommandCatalogueTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/CommandCatalogueTest.kt
@@ -111,15 +111,32 @@ class CommandCatalogueTest {
         }
     }
 
-    /** The ECG family #891 turns on. None is sendable; all three are now legible. */
+    /**
+     * The ECG family #891 turns on: all three legible, and — since the gated MG ECG research probe
+     * (#891/#1100) gave Android an ECG app layer that drives them — all three now constructible too.
+     *
+     * This assertion used to be `assertNull`, on the grounds that "Android has no ECG app layer and sends
+     * none of them". That premise is what changed; the safety property did not. Being in the sender enum
+     * makes an opcode EXPRESSIBLE, not REACHABLE: every send crosses the one `send()` chokepoint, where
+     * `WhoopBleClient.ecgSendAdmitted` requires the opcode to be in the closed four-element allow-list
+     * [EcgResearchAllowList.PROBE_OPCODES], the ECG probe opt-in to be on, and the strap to be a
+     * positively-attested MG.
+     *
+     * `senderEnumStaysCuratedAfterTheLabelFix` above is the other half of this and is deliberately
+     * unchanged: the destructive families — firmware load, DFU, fuel-gauge reset, and the *_NEW trio at
+     * 142/143/144 that sits three codes above 139 — are still `assertNull`. Widening the enum's top from
+     * 123 to 139 did not drag its neighbours in.
+     */
     @Test
-    fun theMgEcgTogglesAreNamedButNotSendable() {
+    fun theMgEcgTogglesAreNamedAndNowConstructibleBehindTheSendGate() {
         assertEquals("TOGGLE_LABRADOR_DATA_GENERATION", CommandNames.byRaw[124])
         assertEquals("TOGGLE_LABRADOR_RAW_SAVE", CommandNames.byRaw[125])
         assertEquals("TOGGLE_LABRADOR_FILTERED", CommandNames.byRaw[139])
-        assertNull(CommandNumber.fromRaw(124))
-        assertNull(CommandNumber.fromRaw(125))
-        assertNull(CommandNumber.fromRaw(139))
+        assertEquals(124, CommandNumber.fromRaw(124)?.rawValue)
+        assertEquals(125, CommandNumber.fromRaw(125)?.rawValue)
+        assertEquals(139, CommandNumber.fromRaw(139)?.rawValue)
+        // SELECT_WRIST(123) was already here and is untouched by this change.
+        assertEquals(123, CommandNumber.fromRaw(123)?.rawValue)
     }
 
     /**

--- a/android/app/src/test/java/com/noop/protocol/CommandCatalogueTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/CommandCatalogueTest.kt
@@ -135,7 +135,9 @@ class CommandCatalogueTest {
         assertEquals(124, CommandNumber.fromRaw(124)?.rawValue)
         assertEquals(125, CommandNumber.fromRaw(125)?.rawValue)
         assertEquals(139, CommandNumber.fromRaw(139)?.rawValue)
-        // SELECT_WRIST(123) was already here and is untouched by this change.
+        // SELECT_WRIST(123) was already constructible; what changes for it is the SEND surface: the gate now
+        // admits it to an attested MG with the probe opt-in on, and unlike the three toggles it is PERSISTENT
+        // wrist config (see EcgResearchAllowList) — a toggle stops when the session does, this does not.
         assertEquals(123, CommandNumber.fromRaw(123)?.rawValue)
     }
 

--- a/android/app/src/test/java/com/noop/protocol/EcgResearchAllowListTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/EcgResearchAllowListTest.kt
@@ -89,6 +89,7 @@ class EcgResearchAllowListTest {
         }
     }
 
+    /** The forbidden set and the probe set are disjoint: no never-send opcode is reachable through a probe case. */
     @Test
     fun noForbiddenOpcodeIsReachableThroughTheProbeCases() {
         for (op in EcgResearchAllowList.FORBIDDEN.keys) {

--- a/android/app/src/test/java/com/noop/protocol/EcgResearchAllowListTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/EcgResearchAllowListTest.kt
@@ -2,6 +2,7 @@ package com.noop.protocol
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -73,15 +74,21 @@ class EcgResearchAllowListTest {
     }
 
     /**
-     * The companion guard — that every DISPATCHABLE opcode is a constructible [CommandNumber] — is
-     * deliberately NOT here. It is an invariant of the SEND PATH: `send()` forms a frame from a
-     * `CommandNumber`, so an allow-listed opcode the enum cannot express could not be dispatched at all.
+     * The send-path invariant this allow-list depends on: `send()` forms a frame from a [CommandNumber],
+     * so an allow-listed opcode the enum cannot express could not be dispatched at all. Guards against an
+     * enum entry being removed and the allow-list silently admitting an opcode the sender cannot form.
      *
-     * Nothing in this change dispatches anything, and opcodes 124/125/139 are absent from that enum on
-     * purpose — upstream excluded them with a comment saying Android has no ECG app layer and sends
-     * none of them. Asserting their presence here would fail for the correct reason, so the guard lands
-     * with the send-path wiring that makes it true and gives it something worth protecting.
+     * This is the assertion the pure-modules split deliberately deferred: 124/125/139 were absent from
+     * `CommandNumber` on purpose, so it would have failed there for the correct reason. The change that
+     * widens the enum is the change that gets to make it true.
      */
+    @Test
+    fun everyDispatchableOpcodeIsAConstructibleCommandNumber() {
+        for (op in EcgResearchAllowList.DISPATCHABLE_OPCODES) {
+            assertNotNull("CommandNumber must carry opcode $op", CommandNumber.fromRaw(op))
+        }
+    }
+
     @Test
     fun noForbiddenOpcodeIsReachableThroughTheProbeCases() {
         for (op in EcgResearchAllowList.FORBIDDEN.keys) {


### PR DESCRIPTION
Split 4 of the MG ECG research series; split 3 is merged (#1941 → `7ec7e778`). This is the review-sensitive one.

## What this PR does

Adds `TOGGLE_LABRADOR_DATA_GENERATION(124)`, `TOGGLE_LABRADOR_RAW_SAVE(125)` and
`TOGGLE_LABRADOR_FILTERED(139)` to `CommandNumber`, adds the ECG probe opt-in key
(`PuffinExperiment.ecgProbe`, `noopWhoop5Ecg` — the same key string macOS already uses), and wires a send
gate into the single `send()` chokepoint:

```kotlin
private fun ecgSendAdmitted(cmd: CommandNumber): Boolean {
    if (!EcgResearchAllowList.isProbeOpcode(cmd.rawValue)) return false
    if (connectedFamily != DeviceFamily.WHOOP5) return false
    if (!whoop5Variant().isMG) return false
    if (!_state.value.connected) return false
    return puffinExperiment.ecgProbe
}
```

**The gate admits four opcodes, not three.** `PROBE_OPCODES` is `{123, 124, 125, 139}` and `ecgSendAdmitted`
keys off that set, so `SELECT_WRIST(123)` — already constructible on `main`, but absent from the 5/MG send guard and
therefore skipped today — becomes sendable to an attested MG whenever the probe opt-in is on. It is the one opcode of
the four the allow-list flags as **persistent wrist config** rather than a session toggle: a toggle stops when the
session does, a wrist-config write does not. That is a different risk class, and it is why the probe PR offers no
control for it (its right/left mapping is unverified on hardware and one value the measured firmware refuses).

**This answers the comment it removes.** `Enums.kt` excluded these three on purpose: *"Android has no ECG
app layer and sends none of them, so growing the SENDER enum to buy a label would widen what the command
sender can express for nothing."* The label half is still right — #893's read-only `CommandNames` table
names every opcode without making any constructible, and nothing here is added for a label. What changed
is the premise: the gated MG ECG research probe (#891/#1100) is an Android ECG app layer, and it does send
them, exactly as Apple's `WhoopCommand` already does for the same probe.

**Adding them does not widen the *reachable* surface, which is the property that matters.** Every send
passes the one `send()` chokepoint; there the opcode must be in the positive allow-list
`EcgResearchAllowList.PROBE_OPCODES` (a closed set of four — #1941), the probe opt-in must be on, and the
strap must be a connected, positively-attested MG. The firmware-load family three codes above 139
(142/143/144) is not expressible through it — asserted by `senderEnumStaysCuratedAfterTheLabelFix`, which
is untouched and still green.

**The enum is also a lookup table, and that side does not leak either** (checked in review): `CommandNumber.fromRaw`
has one caller in the tree, `advanceDeviceConfigProbe`, independently gated on `DeviceConfigReadProbe.isReadOnlyOpcode`,
so 124/125/139 becoming non-null there changes nothing.

**With this PR merged and nothing else, no code path sends any of the four.** There is no ECG caller on
Android yet and no Settings row sets the opt-in. The enum widening and the gate that bounds it land
together, so the probe that needs them (next PR) lands against a gate already in `main`, and tightens it
(arming state, stop-override) rather than introducing it. A reviewer can check "nothing sends" by looking
for a caller: there is none.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

**Android unit tests, full suite** on `3ec6f49f` (the code head), base `main` @ `0e6845cd`: **5,554 tests, 0 failures,
0 errors**, 662 classes — main's 5,553 plus the restored guard. Counted from the JUnit XML with the results
directory cleared first, oracle synced in its own invocation. `986b9153` on top is comment-only (the review's two
notes); `CommandCatalogueTest` + `EcgResearchAllowListTest` and `doc_comment_lint` re-run on it.

The tests that change, deliberately:

- `EcgResearchAllowListTest.everyDispatchableOpcodeIsAConstructibleCommandNumber` — **restored**. It asserts
  every allow-listed opcode is a constructible `CommandNumber`, so an allow-listed opcode the sender cannot
  form is caught. It was held out of #1941 because it would have failed there for the correct reason
  (`CommandNumber must carry opcode 139`); this PR is what makes it true.
- `CommandCatalogueTest.theMgEcgTogglesAreNamedButNotSendable` → **`…AndNowConstructibleBehindTheSendGate`**.
  The `assertNull` on 124/125/139 flips to asserting their raw values, with the reasoning in its KDoc.
  Its neighbour `senderEnumStaysCuratedAfterTheLabelFix` (25/36/37/38/45/99/142/143/144 stay
  unconstructible) is untouched — the evidence that moving the enum's top from 123 to 139 dragged nothing
  in.

**Gates:** `Tools/doc_comment_lint.py` clean · `Tools/i18n_audit.py --ci upstream/main` clean (no strings —
there is deliberately no Settings row in this PR).

**Not run on hardware** — by construction nothing here can send. **Swift:** n/a, no Swift touched;
`swift test` unchanged.

## What this does NOT claim

- That anything sends. Nothing can, and the body says how to check.
- Anything about what the strap does with 123/124/125/139 — the hardware evidence belongs to the probe PR.
- That the 4.0/5.0 negative case is exercised on hardware here; the gate refuses on family and `isMG`
  by construction, and the probe PR carries the hardware run.

## Checklist

- [x] Swift package tests pass for any package I touched — n/a, no Swift touched
- [x] Android unit tests pass (`./gradlew testFullDebugUnitTest`, full suite)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — n/a, no UI
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders — the three enum values
      are the schema numbers, already in `CommandNames`
- [x] Follows the conventions in `docs/CONTRIBUTING.md`
- [x] I did not commit generated output or any secrets/keystores

## Related issues

#891, #1100 · builds on #1941 (the allow-list, merged as `7ec7e778`), #1765, #1727 · #893 (the label table this
deliberately does not duplicate). Does not close anything.