### PR TITLE
widget: measure what the home-screen widgets cost, and stop sending updates that change nothing

### DIFF
--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -150,6 +150,10 @@ object AndroidDiagnostics {
                     "(if you restored a backup, fully restart the app — #57)")
             }
             if (restoreAt > 0L) add("Last restore: ${relTime(now - restoreAt * 1000L)}")
+            // What the home-screen widgets actually cost. Reported unconditionally, including the "no
+            // pushes" case, because the absence of widget activity is itself the answer to a drain
+            // report — and until this line existed an export could not distinguish the two.
+            add(com.noop.widget.WidgetTelemetry.snapshot(now).render())
             // #1770 follow-up: which streams the ACTIVE strap actually delivered over the last 48 h. Four
             // EXISTS seeks, not counts — see WhoopDao.streamPresence for why that distinction matters on a
             // table holding ~190k motion rows a night.

--- a/android/app/src/main/java/com/noop/widget/CoachBriefGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/CoachBriefGlanceWidget.kt
@@ -46,16 +46,7 @@ class CoachBriefGlanceWidget : GlanceAppWidget() {
         val prefs = context.getSharedPreferences("noop_widget", Context.MODE_PRIVATE)
         val briefText = prefs.getString("coachBriefText", null)
         val briefDateMs = prefs.getLong("coachBriefDateMs", 0L)
-        val dark = runCatching {
-            when (context.getSharedPreferences("noop_prefs", Context.MODE_PRIVATE)
-                .getString("theme.appearance", "system")) {
-                "light" -> false
-                "dark" -> true
-                else -> (context.resources.configuration.uiMode and
-                    android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
-                    android.content.res.Configuration.UI_MODE_NIGHT_YES
-            }
-        }.getOrDefault(true)
+        val dark = WidgetTheme.isDark(context)
         provideContent { CoachBriefWidgetContent(briefText, briefDateMs, dark) }
     }
 }

--- a/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
@@ -61,16 +61,7 @@ class HrGlanceWidget : GlanceAppWidget() {
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val snap = runCatching { WidgetSnapshotStore.load(context) }.getOrDefault(WidgetSnapshot())
-        val dark = runCatching {
-            when (context.getSharedPreferences("noop_prefs", Context.MODE_PRIVATE)
-                .getString("theme.appearance", "system")) {
-                "light" -> false
-                "dark" -> true
-                else -> (context.resources.configuration.uiMode and
-                    android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
-                    android.content.res.Configuration.UI_MODE_NIGHT_YES
-            }
-        }.getOrDefault(true)
+        val dark = WidgetTheme.isDark(context)
         provideContent { HrWidgetContent(snap, dark) }
     }
 

--- a/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
@@ -12,6 +12,7 @@ import androidx.glance.Image
 import androidx.glance.ColorFilter
 import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
+import androidx.glance.LocalGlanceId
 import androidx.glance.LocalSize
 import androidx.glance.action.actionStartActivity
 import androidx.glance.action.clickable
@@ -258,6 +259,8 @@ private fun HrTraceImage(
 ) {
     val context = LocalContext.current
     val density = context.resources.displayMetrics.density
+    // Identifies THIS placed widget, so the redundant-draw memo below cannot confuse two of them.
+    val glanceInstance = LocalGlanceId.current.toString()
     // Leave room for the scale column so the trace is not drawn under its own labels.
     val chartWidthDp = hrChartWidthDp(widthDp)
     // ONE box for both the geometry and the bitmap. Sizing them separately let the trace be drawn to
@@ -289,7 +292,11 @@ private fun HrTraceImage(
         )
         // A push carrying no live sample appends no point, so this draw reproduced the previous bitmap
         // exactly. Counting them sizes the saving a future cache would take; nothing is skipped here.
-        if (HrTraceSeen.repeat(snap.hrSeries, wPx, hPx, dark)) WidgetTelemetry.noteRedundantRender()
+        // Keyed by the PLACED WIDGET, not globally: two HR widgets would otherwise answer for each
+        // other, and two of the same size would make each one's necessary draw look like a repeat.
+        if (HrTraceSeen.repeat(glanceInstance, snap.hrSeries, wPx, hPx, dark)) {
+            WidgetTelemetry.noteRedundantRender()
+        }
     }
 
     // The chart takes the ROW's remaining width by weight rather than a width computed from

--- a/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/HrGlanceWidget.kt
@@ -268,6 +268,9 @@ private fun HrTraceImage(
     val hPx = (HR_CHART_TARGET_DP * density).toInt().coerceAtLeast(1)
     val wPx = HrTrace.widestAtHeight((chartWidthDp * density).toInt(), hPx)
 
+    // Measured, because "the widget drains the battery" was not decidable from an export: this is the
+    // only widget that ships a BITMAP rather than a few KB of text, and nothing counted what that cost.
+    val startedNs = System.nanoTime()
     val bmp = runCatching {
         HrTraceRenderer.render(
             points = HrTrace.points(snap.hrSeries, wPx.toFloat(), hPx.toFloat()),
@@ -279,6 +282,15 @@ private fun HrTraceImage(
             strokePx = 2f * density,
         )
     }.getOrNull()
+    if (bmp != null) {
+        WidgetTelemetry.noteRender(
+            bytes = wPx * hPx * HrTrace.BYTES_PER_PIXEL,
+            elapsedMs = (System.nanoTime() - startedNs) / 1_000_000,
+        )
+        // A push carrying no live sample appends no point, so this draw reproduced the previous bitmap
+        // exactly. Counting them sizes the saving a future cache would take; nothing is skipped here.
+        if (HrTraceSeen.repeat(snap.hrSeries, wPx, hPx, dark)) WidgetTelemetry.noteRedundantRender()
+    }
 
     // The chart takes the ROW's remaining width by weight rather than a width computed from
     // LocalSize. On a One UI launcher LocalSize reported a size smaller than the card actually

--- a/android/app/src/main/java/com/noop/widget/HrTrace.kt
+++ b/android/app/src/main/java/com/noop/widget/HrTrace.kt
@@ -146,8 +146,19 @@ object HrTrace {
         return want.coerceAtMost(budgetWidth).coerceAtLeast(requestedPx.coerceAtLeast(1).coerceAtMost(budgetWidth))
     }
 
-    /** How much wider than the reported width to draw, to cover a launcher that under-reports. Two
-     *  covers the ~1.6x seen on One UI with margin, and costs nothing a downscale does not absorb. */
+    /**
+     * How much wider than the reported width to draw, to cover a launcher that under-reports.
+     *
+     * NOTE THAT THIS CEILING IS RARELY THE ONE THAT BINDS. [MAX_BITMAP_BYTES] runs out first at any
+     * realistic widget size: at 420dpi a 300dp-wide card gets 1.66x, a 380dp one 1.26x, and at 480dpi
+     * a 380dp card gets 0.96x — narrower than the reported width, so the bitmap is UPSCALED, which is
+     * the artefact this constant exists to prevent. Raising this number changes nothing on a real
+     * phone; the byte budget is the lever, and it trades directly against horizontal resolution.
+     *
+     * Kept at two because it is the correct intent and it still binds on a small widget. The gap
+     * between the intent and what the budget allows is measured rather than papered over — see the
+     * widget cost counters.
+     */
     const val WIDTH_HEADROOM: Float = 2f
 
     /** A point in the trace's pixel box, origin top-left, as the renderer wants it. */

--- a/android/app/src/main/java/com/noop/widget/NoopCompactGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/NoopCompactGlanceWidget.kt
@@ -45,16 +45,7 @@ class NoopCompactGlanceWidget : GlanceAppWidget() {
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val snap = runCatching { WidgetSnapshotStore.load(context) }.getOrDefault(WidgetSnapshot())
-        val dark = runCatching {
-            when (context.getSharedPreferences("noop_prefs", Context.MODE_PRIVATE)
-                .getString("theme.appearance", "system")) {
-                "light" -> false
-                "dark" -> true
-                else -> (context.resources.configuration.uiMode and
-                    android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
-                    android.content.res.Configuration.UI_MODE_NIGHT_YES
-            }
-        }.getOrDefault(true)
+        val dark = WidgetTheme.isDark(context)
         provideContent { CompactWidgetContent(snap, dark) }
     }
 

--- a/android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/NoopGlanceWidget.kt
@@ -55,16 +55,7 @@ class NoopGlanceWidget : GlanceAppWidget() {
         // Follow the app's Light/Dark/System theme (read straight from noop_prefs; the widget runs in a
         // separate process so it can't see the in-app snapshot state). System resolves off the device's
         // night-mode config. Any failure degrades to dark (the historical default).
-        val dark = runCatching {
-            when (context.getSharedPreferences("noop_prefs", Context.MODE_PRIVATE)
-                .getString("theme.appearance", "system")) {
-                "light" -> false
-                "dark" -> true
-                else -> (context.resources.configuration.uiMode and
-                    android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
-                    android.content.res.Configuration.UI_MODE_NIGHT_YES
-            }
-        }.getOrDefault(true)
+        val dark = WidgetTheme.isDark(context)
         provideContent { WidgetContent(snap, dark) }
     }
 

--- a/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
@@ -86,7 +86,7 @@ object WidgetSnapshotStore {
         // actually render rather than re-deriving it: `load` resolves staleness and prunes the trace,
         // and a guess at either would be the thing that drifts.
         val visible = runCatching { load(app) }.getOrNull()
-        if (visible != null && !RenderedGate.changed(visible)) {
+        if (visible != null && !RenderedGate.changed(visible, WidgetTheme.isDark(app))) {
             // The stamp reads "Updated <time>", so it names when the data is FROM. A push that carried
             // nothing new must not advance it: doing so would tell the reader 14:47 while showing them
             // 14:32's reading. Putting it back also keeps what the prefs hold and what the widget shows
@@ -214,6 +214,13 @@ internal object HrDisplay {
  * The key spans every field any of the three widgets renders, so "nothing changed" means none of them
  * had anything to show — a narrower per-widget gate would be a different, visible trade.
  *
+ * The APPEARANCE is in the key even though it is not in the snapshot. The widgets read
+ * `theme.appearance` themselves at composition, and nothing refreshes them when it changes — today a
+ * theme flip reaches the screen only because every push updated unconditionally. Leaving it out would
+ * have meant a widget sat in the wrong colours until something unrelated moved, which is a regression
+ * this gate would have introduced rather than a cost it inherited. Resolved through [WidgetTheme] so it
+ * cannot disagree with what the widgets themselves decide.
+ *
  * `updatedAtMs` is the one field held OUT, and it is the reason this gate needed thought rather than a
  * port. All three widgets display it, so including it would mean the key changed on every push and the
  * gate could never fire; excluding it naively would freeze a visible clock. The resolution is that the
@@ -227,11 +234,12 @@ internal object RenderedGate {
     /** True when [visible] differs from what was last sent. The first call after a process start always
      *  admits: the widgets may be showing something an earlier process left them. */
     @Synchronized
-    fun changed(visible: WidgetSnapshot): Boolean {
+    fun changed(visible: WidgetSnapshot, dark: Boolean): Boolean {
         val newest = visible.hrSeries.lastOrNull()
         val key = "${visible.recoveryPct}|${visible.restPct}|${visible.effortPct}|" +
             "${visible.batteryPct}|${visible.connected}|${visible.heartRate}|" +
-            "${visible.heartRateStale}|${visible.hrSeries.size}|${newest?.ts}|${newest?.bpm}"
+            "${visible.heartRateStale}|${visible.hrSeries.size}|${newest?.ts}|${newest?.bpm}|" +
+            "$dark"
         val differs = key != last
         last = key
         return differs

--- a/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
@@ -75,6 +75,16 @@ object WidgetSnapshotStore {
             GlanceAppWidgetManager(app).getGlanceIds(HrGlanceWidget::class.java)
         }.getOrDefault(emptyList())
         if (standardIds.isEmpty() && compactIds.isEmpty() && hrIds.isEmpty()) return
+
+        // Nothing the widgets DISPLAY changed, so there is nothing to send. Read back what they will
+        // actually render rather than re-deriving it: `load` resolves staleness and prunes the trace,
+        // and a guess at either would be the thing that drifts.
+        val visible = runCatching { load(app) }.getOrNull()
+        if (visible != null && !RenderedGate.changed(visible)) {
+            WidgetTelemetry.notePushUnchanged()
+            return
+        }
+
         // Update only the providers that actually have a widget placed. The ids are already in hand, and
         // `updateAll` on a provider with none still crosses into GlanceAppWidgetManager to discover that
         // for itself. Someone running just the HR widget was paying for two of those on every push.
@@ -162,6 +172,49 @@ internal object HrDisplay {
         val fresh = live && age <= LIVE_MS                    // a live push AND recent — not a stale carry-over
         return lastHr to !fresh
     }
+}
+
+/**
+ * The second gate, after [PushGate]: does anything the widgets DISPLAY differ from what they were last
+ * sent?
+ *
+ * [PushGate] deliberately does not know the heart-rate VALUE (only whether there is one), because
+ * keying on it would admit a push per sample. That leaves a gap it cannot close: its 60-second timer
+ * clause fires whether or not anything moved, so a strap that has gone quiet used to cost a full widget
+ * update every minute — on the HR widget, a half-megabyte bitmap across a Binder transaction to draw
+ * exactly what was already on screen.
+ *
+ * The Apple side has had this since #1957 (`WidgetPublish.saveAndReloadIfChanged` +
+ * `WidgetSnapshot.renderedContentChanged`); Android did not, and was doing strictly more work per push
+ * for identical data.
+ *
+ * Deliberately NOT the Apple rule, which also declines a reload when only the TRACE advanced. WidgetKit
+ * rebuilds a timeline on its own schedule, so a point persisted without a reload still reaches the
+ * screen; Glance has no such rebuild (`updatePeriodMillis="0"`), so declining there would freeze the
+ * chart at rest until the number itself moved. This skips only when NOTHING changed, which is free.
+ * Whether the trace-only case is worth its cost is a question for the widget cost counters.
+ *
+ * The key spans every field any of the three widgets renders, so "nothing changed" means none of them
+ * had anything to show — a narrower per-widget gate would be a different, visible trade.
+ */
+internal object RenderedGate {
+    private var last: String? = null
+
+    /** True when [visible] differs from what was last sent. The first call after a process start always
+     *  admits: the widgets may be showing something an earlier process left them. */
+    @Synchronized
+    fun changed(visible: WidgetSnapshot): Boolean {
+        val newest = visible.hrSeries.lastOrNull()
+        val key = "${visible.recoveryPct}|${visible.restPct}|${visible.effortPct}|" +
+            "${visible.batteryPct}|${visible.connected}|${visible.heartRate}|" +
+            "${visible.heartRateStale}|${visible.hrSeries.size}|${newest?.ts}|${newest?.bpm}"
+        val differs = key != last
+        last = key
+        return differs
+    }
+
+    @Synchronized
+    fun resetForTest() { last = null }
 }
 
 /**

--- a/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
@@ -75,9 +75,12 @@ object WidgetSnapshotStore {
             GlanceAppWidgetManager(app).getGlanceIds(HrGlanceWidget::class.java)
         }.getOrDefault(emptyList())
         if (standardIds.isEmpty() && compactIds.isEmpty() && hrIds.isEmpty()) return
-        runCatching { NoopGlanceWidget().updateAll(app) }
-        runCatching { NoopCompactGlanceWidget().updateAll(app) }
-        runCatching { HrGlanceWidget().updateAll(app) }
+        // Update only the providers that actually have a widget placed. The ids are already in hand, and
+        // `updateAll` on a provider with none still crosses into GlanceAppWidgetManager to discover that
+        // for itself. Someone running just the HR widget was paying for two of those on every push.
+        if (standardIds.isNotEmpty()) runCatching { NoopGlanceWidget().updateAll(app) }
+        if (compactIds.isNotEmpty()) runCatching { NoopCompactGlanceWidget().updateAll(app) }
+        if (hrIds.isNotEmpty()) runCatching { HrGlanceWidget().updateAll(app) }
     }
 
     fun save(context: Context, snap: WidgetSnapshot) {

--- a/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
@@ -59,6 +59,12 @@ object WidgetSnapshotStore {
         }
         WidgetTelemetry.notePushAdmitted(snap.updatedAtMs)
 
+        // Kept so a push that turns out to carry nothing new can put it back. All three widgets RENDER
+        // this stamp — the HR card as a permanent "Updated <time>" line, the 2x2 and compact as their
+        // disconnected "last seen" — so it is not the metadata the Apple twin can treat it as.
+        val previousUpdatedAt = app.getSharedPreferences(FILE, Context.MODE_PRIVATE)
+            .getLong("updatedAt", 0L)
+
         // Persist before anything suspending, and only THEN mark the gate (#82: marking before the
         // write let a cancelled push burn the refresh window — the widget starved on stale prefs).
         // Saving even with no widget placed means a widget added later renders fresh data instantly.
@@ -81,6 +87,17 @@ object WidgetSnapshotStore {
         // and a guess at either would be the thing that drifts.
         val visible = runCatching { load(app) }.getOrNull()
         if (visible != null && !RenderedGate.changed(visible)) {
+            // The stamp reads "Updated <time>", so it names when the data is FROM. A push that carried
+            // nothing new must not advance it: doing so would tell the reader 14:47 while showing them
+            // 14:32's reading. Putting it back also keeps what the prefs hold and what the widget shows
+            // in agreement, so a recomposition for some unrelated reason — a launcher restart, a resize
+            // — cannot surface a time this push declined to display.
+            if (previousUpdatedAt > 0L) {
+                runCatching {
+                    app.getSharedPreferences(FILE, Context.MODE_PRIVATE).edit()
+                        .putLong("updatedAt", previousUpdatedAt).apply()
+                }
+            }
             WidgetTelemetry.notePushUnchanged()
             return
         }
@@ -196,6 +213,13 @@ internal object HrDisplay {
  *
  * The key spans every field any of the three widgets renders, so "nothing changed" means none of them
  * had anything to show — a narrower per-widget gate would be a different, visible trade.
+ *
+ * `updatedAtMs` is the one field held OUT, and it is the reason this gate needed thought rather than a
+ * port. All three widgets display it, so including it would mean the key changed on every push and the
+ * gate could never fire; excluding it naively would freeze a visible clock. The resolution is that the
+ * stamp names when the DATA is from, not when the app last woke: [WidgetSnapshotStore.push] restores
+ * the previous value when it declines, so a frozen stamp is the truthful one. The Apple twin sidesteps
+ * this entirely because no widget family there renders the timestamp.
  */
 internal object RenderedGate {
     private var last: String? = null

--- a/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
@@ -53,7 +53,11 @@ object WidgetSnapshotStore {
     suspend fun push(context: Context, snap: WidgetSnapshot) {
         val app = context.applicationContext
         // Cheap, non-suspending gate FIRST — at live-HR cadence (~1/s) almost every call ends here.
-        if (!PushGate.admit(snap)) return
+        if (!PushGate.admit(snap)) {
+            WidgetTelemetry.notePushGated(snap.updatedAtMs)
+            return
+        }
+        WidgetTelemetry.notePushAdmitted(snap.updatedAtMs)
 
         // Persist before anything suspending, and only THEN mark the gate (#82: marking before the
         // write let a cancelled push burn the refresh window — the widget starved on stale prefs).

--- a/android/app/src/main/java/com/noop/widget/WidgetTelemetry.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetTelemetry.kt
@@ -1,5 +1,7 @@
 package com.noop.widget
 
+import java.util.Locale
+
 /**
  * Counters for what the home-screen widgets actually cost, so "the widget drains my battery" is
  * decidable from an export instead of being argued from the code.
@@ -128,15 +130,24 @@ object WidgetTelemetry {
          * sessions is the whole point of collecting this.
          */
         fun render(): String {
-            if (pushesAdmitted == 0L && pushesGated == 0L) return "Widgets:     no pushes this app session"
+            // Renders are checked too: a widget composes from saved prefs when it is placed or after a
+            // process start, with no push involved. Reporting "no pushes" there would be true and would
+            // silently drop the draw counts, which are the expensive half.
+            if (pushesAdmitted == 0L && pushesGated == 0L && renders == 0L) {
+                return "Widgets:     no pushes this app session"
+            }
             val mins = uptimeMs / 60_000
-            val parts = ArrayList<String>(5)
-            parts.add("$pushesAdmitted pushed / ${pushesAdmitted + pushesGated} offered")
-            pushesPerHour?.let { parts.add("${"%.1f".format(it)}/h") }
+            val parts = ArrayList<String>(6)
+            if (pushesAdmitted > 0L || pushesGated > 0L) {
+                parts.add("$pushesAdmitted pushed / ${pushesAdmitted + pushesGated} offered")
+            } else {
+                parts.add("no pushes")
+            }
+            pushesPerHour?.let { parts.add("${String.format(Locale.US, "%.1f", it)}/h") }
             if (renders > 0) {
                 parts.add("$renders trace draw${if (renders == 1L) "" else "s"}")
                 meanRenderBytes?.let { parts.add("mean ${it / 1024}KB") }
-                renderBytesPerHour?.let { parts.add("${"%.1f".format(it / 1_048_576.0)}MB/h") }
+                renderBytesPerHour?.let { parts.add("${String.format(Locale.US, "%.1f", it / 1_048_576.0)}MB/h") }
                 parts.add("draw ${renderMs / renders}ms avg / ${renderMsMax}ms max")
             }
             if (rendersRedundant > 0) parts.add("$rendersRedundant redundant")
@@ -155,20 +166,35 @@ object WidgetTelemetry {
  * The signature covers everything the drawing depends on, not just the series: a size change or a
  * theme flip produces a genuinely different bitmap from the same points, and counting that as
  * redundant would overstate the saving on offer.
+ *
+ * Kept PER WIDGET INSTANCE. A single shared slot was wrong in the way that matters most here: with
+ * two HR widgets placed, each draw would clobber the other's signature, and two same-sized widgets
+ * would make each one's necessary first draw look like a repeat of the other's — inflating the
+ * redundancy count, which is exactly the direction that would argue for an optimisation that is not
+ * actually available. The map is bounded by the number of placed widgets.
  */
 internal object HrTraceSeen {
-    private var last: String? = null
+    private val last = HashMap<String, String>()
 
-    /** True when this draw reproduces the previous one exactly. Records the signature either way. */
+    /**
+     * True when this draw reproduces this WIDGET's previous one exactly. Records the signature either
+     * way. [instance] identifies the placed widget, so two of them cannot answer for each other.
+     */
     @Synchronized
-    fun repeat(series: List<HrPoint>, widthPx: Int, heightPx: Int, dark: Boolean): Boolean {
+    fun repeat(
+        instance: String,
+        series: List<HrPoint>,
+        widthPx: Int,
+        heightPx: Int,
+        dark: Boolean,
+    ): Boolean {
         val newest = series.lastOrNull()
         val sig = "${series.size}|${newest?.ts}|${newest?.bpm}|$widthPx|$heightPx|$dark"
-        val same = sig == last
-        last = sig
+        val same = sig == last[instance]
+        last[instance] = sig
         return same
     }
 
     @Synchronized
-    fun resetForTest() { last = null }
+    fun resetForTest() { last.clear() }
 }

--- a/android/app/src/main/java/com/noop/widget/WidgetTelemetry.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetTelemetry.kt
@@ -40,6 +40,7 @@ object WidgetTelemetry {
     private var renderBytes = 0L
     private var renderMs = 0L
     private var renderMsMax = 0L
+    private var pushesUnchanged = 0L
     private var lastPushAtMs = 0L
 
     /** A push [PushGate] let through: prefs written and every placed widget recomposed. */
@@ -55,6 +56,16 @@ object WidgetTelemetry {
     fun notePushGated(nowMs: Long) {
         if (startedAtMs == 0L) startedAtMs = nowMs
         pushesGated += 1
+    }
+
+    /**
+     * A push [PushGate] admitted but [RenderedGate] then dropped, because nothing the widgets display
+     * had changed. Counted separately from a gated push: this is the saving the rendered gate takes,
+     * and it needs to be visible to justify keeping it.
+     */
+    @Synchronized
+    fun notePushUnchanged() {
+        pushesUnchanged += 1
     }
 
     /** One trace bitmap built: [bytes] is what crosses the Binder, [elapsedMs] is the draw alone. */
@@ -81,6 +92,7 @@ object WidgetTelemetry {
         uptimeMs = if (startedAtMs == 0L) 0L else nowMs - startedAtMs,
         pushesAdmitted = pushesAdmitted,
         pushesGated = pushesGated,
+        pushesUnchanged = pushesUnchanged,
         renders = renders,
         rendersRedundant = rendersRedundant,
         renderBytes = renderBytes,
@@ -91,7 +103,7 @@ object WidgetTelemetry {
 
     @Synchronized
     fun resetForTest() {
-        startedAtMs = 0L; pushesAdmitted = 0L; pushesGated = 0L
+        startedAtMs = 0L; pushesAdmitted = 0L; pushesGated = 0L; pushesUnchanged = 0L
         renders = 0L; rendersRedundant = 0L; renderBytes = 0L; renderMs = 0L; renderMsMax = 0L
         lastPushAtMs = 0L
     }
@@ -100,6 +112,7 @@ object WidgetTelemetry {
         val uptimeMs: Long,
         val pushesAdmitted: Long,
         val pushesGated: Long,
+        val pushesUnchanged: Long,
         val renders: Long,
         val rendersRedundant: Long,
         val renderBytes: Long,
@@ -150,6 +163,7 @@ object WidgetTelemetry {
                 renderBytesPerHour?.let { parts.add("${String.format(Locale.US, "%.1f", it / 1_048_576.0)}MB/h") }
                 parts.add("draw ${renderMs / renders}ms avg / ${renderMsMax}ms max")
             }
+            if (pushesUnchanged > 0) parts.add("$pushesUnchanged unchanged")
             if (rendersRedundant > 0) parts.add("$rendersRedundant redundant")
             return "Widgets:     ${parts.joinToString(" · ")} (over ${mins}m)"
         }

--- a/android/app/src/main/java/com/noop/widget/WidgetTelemetry.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetTelemetry.kt
@@ -1,0 +1,174 @@
+package com.noop.widget
+
+/**
+ * Counters for what the home-screen widgets actually cost, so "the widget drains my battery" is
+ * decidable from an export instead of being argued from the code.
+ *
+ * The question that prompted this: the HR widget is the only one that ships a BITMAP. The other two
+ * send a few KB of text as RemoteViews; the trace image is sized up to [HrTrace.MAX_BITMAP_BYTES] and
+ * crosses a Binder transaction to the launcher on every push. Same cadence, a very different payload,
+ * and until now nothing measured either.
+ *
+ * What is deliberately counted, and why each one is needed to answer it:
+ *
+ *  - **admitted vs gated pushes** — [PushGate] is supposed to collapse a ~1/s live-HR stream to about
+ *    one push a minute. If the gated count is not vastly larger than the admitted one, the throttle is
+ *    not doing its job and nothing downstream matters.
+ *  - **renders and bytes** — the actual Binder payload. `bytes / renders` is the mean bitmap, and the
+ *    total is what a day of streaming costs.
+ *  - **skipped renders** — a null-HR push appends no point, so the trace is unchanged and the redraw
+ *    produces an identical bitmap. Counting these sizes the cheapest available saving before anyone
+ *    writes the code to take it.
+ *  - **render time** — separates "the drawing is expensive" from "the transfer is expensive". They
+ *    have different fixes and the numbers cannot be guessed apart.
+ *
+ * Process-lifetime counters, reset when the process dies, reported as a rate over [uptimeMs] so a
+ * short session and a long one are comparable. Not persisted: a per-push disk write to measure the
+ * cost of pushes would be its own answer to the question.
+ *
+ * Cheap enough to leave always on. Every field is an increment on a path that already does IPC.
+ */
+object WidgetTelemetry {
+
+    private var startedAtMs = 0L
+    private var pushesAdmitted = 0L
+    private var pushesGated = 0L
+    private var renders = 0L
+    private var rendersRedundant = 0L
+    private var renderBytes = 0L
+    private var renderMs = 0L
+    private var renderMsMax = 0L
+    private var lastPushAtMs = 0L
+
+    /** A push [PushGate] let through: prefs written and every placed widget recomposed. */
+    @Synchronized
+    fun notePushAdmitted(nowMs: Long) {
+        if (startedAtMs == 0L) startedAtMs = nowMs
+        pushesAdmitted += 1
+        lastPushAtMs = nowMs
+    }
+
+    /** A push the gate dropped. At live-HR cadence this should dwarf the admitted count. */
+    @Synchronized
+    fun notePushGated(nowMs: Long) {
+        if (startedAtMs == 0L) startedAtMs = nowMs
+        pushesGated += 1
+    }
+
+    /** One trace bitmap built: [bytes] is what crosses the Binder, [elapsedMs] is the draw alone. */
+    @Synchronized
+    fun noteRender(bytes: Int, elapsedMs: Long) {
+        renders += 1
+        renderBytes += bytes.toLong()
+        renderMs += elapsedMs
+        if (elapsedMs > renderMsMax) renderMsMax = elapsedMs
+    }
+
+    /**
+     * A redraw whose trace had not advanced since the previous one, so it produced an identical
+     * bitmap. Counted, not avoided — see the class doc.
+     */
+    @Synchronized
+    fun noteRedundantRender() {
+        rendersRedundant += 1
+    }
+
+    /** Immutable read for the report. */
+    @Synchronized
+    fun snapshot(nowMs: Long): Snapshot = Snapshot(
+        uptimeMs = if (startedAtMs == 0L) 0L else nowMs - startedAtMs,
+        pushesAdmitted = pushesAdmitted,
+        pushesGated = pushesGated,
+        renders = renders,
+        rendersRedundant = rendersRedundant,
+        renderBytes = renderBytes,
+        renderMs = renderMs,
+        renderMsMax = renderMsMax,
+        lastPushAgoMs = if (lastPushAtMs == 0L) null else nowMs - lastPushAtMs,
+    )
+
+    @Synchronized
+    fun resetForTest() {
+        startedAtMs = 0L; pushesAdmitted = 0L; pushesGated = 0L
+        renders = 0L; rendersRedundant = 0L; renderBytes = 0L; renderMs = 0L; renderMsMax = 0L
+        lastPushAtMs = 0L
+    }
+
+    data class Snapshot(
+        val uptimeMs: Long,
+        val pushesAdmitted: Long,
+        val pushesGated: Long,
+        val renders: Long,
+        val rendersRedundant: Long,
+        val renderBytes: Long,
+        val renderMs: Long,
+        val renderMsMax: Long,
+        val lastPushAgoMs: Long?,
+    ) {
+        /** Mean bitmap in bytes, or null before the first render. */
+        val meanRenderBytes: Long? get() = if (renders > 0) renderBytes / renders else null
+
+        /**
+         * Pushes per hour, extrapolated from this process's uptime. Null under a minute of uptime:
+         * a rate from a few seconds of samples is noise wearing a number's clothes.
+         */
+        val pushesPerHour: Double?
+            get() = if (uptimeMs >= 60_000L) pushesAdmitted * 3_600_000.0 / uptimeMs else null
+
+        /**
+         * Bitmap bytes per hour at the observed rate — the figure the drain question turns on, since
+         * this is what crosses a Binder transaction to the launcher.
+         */
+        val renderBytesPerHour: Double?
+            get() = if (uptimeMs >= 60_000L) renderBytes * 3_600_000.0 / uptimeMs else null
+
+        /**
+         * One line for the diagnostics header. Deliberately reports the RATE alongside the raw counts:
+         * a total is not comparable between a five-minute session and an all-day one, and comparing
+         * sessions is the whole point of collecting this.
+         */
+        fun render(): String {
+            if (pushesAdmitted == 0L && pushesGated == 0L) return "Widgets:     no pushes this app session"
+            val mins = uptimeMs / 60_000
+            val parts = ArrayList<String>(5)
+            parts.add("$pushesAdmitted pushed / ${pushesAdmitted + pushesGated} offered")
+            pushesPerHour?.let { parts.add("${"%.1f".format(it)}/h") }
+            if (renders > 0) {
+                parts.add("$renders trace draw${if (renders == 1L) "" else "s"}")
+                meanRenderBytes?.let { parts.add("mean ${it / 1024}KB") }
+                renderBytesPerHour?.let { parts.add("${"%.1f".format(it / 1_048_576.0)}MB/h") }
+                parts.add("draw ${renderMs / renders}ms avg / ${renderMsMax}ms max")
+            }
+            if (rendersRedundant > 0) parts.add("$rendersRedundant redundant")
+            return "Widgets:     ${parts.joinToString(" · ")} (over ${mins}m)"
+        }
+    }
+}
+
+/**
+ * Remembers just enough about the last trace drawn to recognise the next one as identical.
+ *
+ * A signature, never the bitmap: the point is to MEASURE how often a redraw is redundant without
+ * retaining half a megabyte to prove it. Holding the image is the optimisation, and it carries a
+ * memory trade this change deliberately does not take.
+ *
+ * The signature covers everything the drawing depends on, not just the series: a size change or a
+ * theme flip produces a genuinely different bitmap from the same points, and counting that as
+ * redundant would overstate the saving on offer.
+ */
+internal object HrTraceSeen {
+    private var last: String? = null
+
+    /** True when this draw reproduces the previous one exactly. Records the signature either way. */
+    @Synchronized
+    fun repeat(series: List<HrPoint>, widthPx: Int, heightPx: Int, dark: Boolean): Boolean {
+        val newest = series.lastOrNull()
+        val sig = "${series.size}|${newest?.ts}|${newest?.bpm}|$widthPx|$heightPx|$dark"
+        val same = sig == last
+        last = sig
+        return same
+    }
+
+    @Synchronized
+    fun resetForTest() { last = null }
+}

--- a/android/app/src/main/java/com/noop/widget/WidgetTheme.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetTheme.kt
@@ -1,0 +1,29 @@
+package com.noop.widget
+
+import android.content.Context
+import android.content.res.Configuration
+
+/**
+ * Whether a widget should draw dark, resolved the way every widget in this package resolves it.
+ *
+ * This lived as four byte-identical copies, one per widget. It is extracted because a FIFTH reader
+ * arrived that must not disagree with them: [RenderedGate] decides whether a push is worth sending, and
+ * the appearance is an input the widgets read at composition rather than one the snapshot carries. A
+ * gate that resolved the theme even slightly differently would decline a push the widgets needed, and
+ * the widget would sit in the wrong colours until something unrelated moved.
+ *
+ * The in-app override wins; "system" falls back to the configuration's night mode. Defaults to dark on
+ * any failure, matching what the four copies did.
+ */
+internal object WidgetTheme {
+
+    fun isDark(context: Context): Boolean = runCatching {
+        when (context.getSharedPreferences("noop_prefs", Context.MODE_PRIVATE)
+            .getString("theme.appearance", "system")) {
+            "light" -> false
+            "dark" -> true
+            else -> (context.resources.configuration.uiMode and
+                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+        }
+    }.getOrDefault(true)
+}

--- a/android/app/src/test/java/com/noop/widget/RenderedGateTest.kt
+++ b/android/app/src/test/java/com/noop/widget/RenderedGateTest.kt
@@ -108,4 +108,30 @@ class RenderedGateTest {
         assertTrue(RenderedGate.changed(snap(hr = null, series = emptyList())))
         repeat(10) { assertFalse(RenderedGate.changed(snap(hr = null, series = emptyList()))) }
     }
+
+    /**
+     * The timestamp is the field this gate could most easily have got wrong, so it is asserted from
+     * both sides.
+     *
+     * All three widgets RENDER it — the HR card as a permanent "Updated <time>" line, the 2x2 and
+     * compact as their disconnected "last seen". Including it in the key would change the key on every
+     * push and the gate could never fire. Excluding it and letting the stamp advance anyway would tell
+     * the reader 14:47 while showing them 14:32's reading, and freeze a visible clock at whatever a
+     * later unrelated recomposition happened to read.
+     *
+     * So the key excludes it deliberately, and [WidgetSnapshotStore.push] puts the previous value back
+     * when it declines. This pins the first half; the second is push()'s.
+     */
+    @Test
+    fun theStampAloneDoesNotSend() {
+        RenderedGate.changed(snap())
+        val later = WidgetSnapshot(
+            recoveryPct = 70, restPct = 80, effortPct = 40,
+            heartRate = 62, heartRateStale = false, batteryPct = 80, connected = true,
+            hrSeries = listOf(HrPoint(ts = 1000, bpm = 62)),
+            updatedAtMs = 1_700_000_900_000L,          // fifteen minutes later, same everything else
+        )
+        assertFalse("a newer stamp with identical content is not worth an update",
+            RenderedGate.changed(later))
+    }
 }

--- a/android/app/src/test/java/com/noop/widget/RenderedGateTest.kt
+++ b/android/app/src/test/java/com/noop/widget/RenderedGateTest.kt
@@ -1,0 +1,111 @@
+package com.noop.widget
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pins the second gate: a push [PushGate] admitted still costs nothing when none of the widgets have
+ * anything different to show.
+ *
+ * This is the Android half of what `WidgetPublish.saveAndReloadIfChanged` has done on the Apple side
+ * since #1957, minus the trace-only case that Glance cannot take (no OS-scheduled rebuild to carry a
+ * withheld point to the screen). Everything asserted below is a case where a full widget update —
+ * including a half-megabyte bitmap over a Binder transaction — would have drawn what was already
+ * there.
+ */
+class RenderedGateTest {
+
+    @Before
+    fun setUp() = RenderedGate.resetForTest()
+
+    private fun snap(
+        hr: Int? = 62,
+        stale: Boolean = false,
+        recovery: Int? = 70,
+        battery: Int? = 80,
+        connected: Boolean = true,
+        series: List<HrPoint> = listOf(HrPoint(ts = 1000, bpm = 62)),
+    ) = WidgetSnapshot(
+        recoveryPct = recovery,
+        restPct = 80,
+        effortPct = 40,
+        heartRate = hr,
+        heartRateStale = stale,
+        batteryPct = battery,
+        connected = connected,
+        hrSeries = series,
+        updatedAtMs = 1_700_000_000_000L,
+    )
+
+    /** The widgets may be showing what an earlier process left them, so the first push always sends. */
+    @Test
+    fun theFirstPushAfterAProcessStartAlwaysSends() {
+        assertTrue(RenderedGate.changed(snap()))
+    }
+
+    /**
+     * The case this exists for: PushGate's 60-second timer fires whether or not anything moved, so a
+     * quiet strap used to cost a full widget update a minute to redraw an identical screen.
+     */
+    @Test
+    fun anIdenticalSnapshotIsNotSentTwice() {
+        assertTrue(RenderedGate.changed(snap()))
+        assertFalse(RenderedGate.changed(snap()))
+        assertFalse(RenderedGate.changed(snap()))
+    }
+
+    /**
+     * The heart-rate VALUE has to count, because PushGate deliberately does not know it — it keys on
+     * whether a reading exists, so that a stream of samples cannot admit a push each. If this gate
+     * ignored the value too, a changing heart rate would never reach the screen.
+     */
+    @Test
+    fun aChangedHeartRateSends() {
+        RenderedGate.changed(snap(hr = 62))
+        assertTrue(RenderedGate.changed(snap(hr = 63)))
+    }
+
+    /** Crossing LIVE_MS dims the reading, which is a visible change with no value change behind it. */
+    @Test
+    fun aStalenessFlipSends() {
+        RenderedGate.changed(snap(stale = false))
+        assertTrue(RenderedGate.changed(snap(stale = true)))
+    }
+
+    /** A new trace point IS sent on Android, unlike the Apple rule: nothing else would carry it. */
+    @Test
+    fun anAdvancedTraceSends() {
+        val series = listOf(HrPoint(ts = 1000, bpm = 62))
+        RenderedGate.changed(snap(series = series))
+        assertTrue(RenderedGate.changed(snap(series = series + HrPoint(ts = 1060, bpm = 63))))
+    }
+
+    /** A point ageing out of the window redraws the chart just as surely as one arriving. */
+    @Test
+    fun aPrunedTraceSends() {
+        RenderedGate.changed(snap(series = listOf(HrPoint(1000, 62), HrPoint(1060, 63))))
+        assertTrue(RenderedGate.changed(snap(series = listOf(HrPoint(1060, 63)))))
+    }
+
+    /** Every scalar the 2x2 and compact widgets render has to count, not just the HR ones. */
+    @Test
+    fun theOtherWidgetsFieldsSendToo() {
+        RenderedGate.changed(snap())
+        assertTrue("recovery", RenderedGate.changed(snap(recovery = 71)))
+        assertTrue("battery", RenderedGate.changed(snap(recovery = 71, battery = 79)))
+        assertTrue("connected", RenderedGate.changed(snap(recovery = 71, battery = 79, connected = false)))
+    }
+
+    /**
+     * The end state after a disconnect: the trace prunes empty and the reading is dropped, and from
+     * then on every push is identical. That is where this gate pays for itself, so it must not keep
+     * sending once there is nothing left to say.
+     */
+    @Test
+    fun aDrainedSnapshotSettlesAndStopsSending() {
+        assertTrue(RenderedGate.changed(snap(hr = null, series = emptyList())))
+        repeat(10) { assertFalse(RenderedGate.changed(snap(hr = null, series = emptyList()))) }
+    }
+}

--- a/android/app/src/test/java/com/noop/widget/RenderedGateTest.kt
+++ b/android/app/src/test/java/com/noop/widget/RenderedGateTest.kt
@@ -42,7 +42,7 @@ class RenderedGateTest {
     /** The widgets may be showing what an earlier process left them, so the first push always sends. */
     @Test
     fun theFirstPushAfterAProcessStartAlwaysSends() {
-        assertTrue(RenderedGate.changed(snap()))
+        assertTrue(RenderedGate.changed(snap(), dark = false))
     }
 
     /**
@@ -51,9 +51,9 @@ class RenderedGateTest {
      */
     @Test
     fun anIdenticalSnapshotIsNotSentTwice() {
-        assertTrue(RenderedGate.changed(snap()))
-        assertFalse(RenderedGate.changed(snap()))
-        assertFalse(RenderedGate.changed(snap()))
+        assertTrue(RenderedGate.changed(snap(), dark = false))
+        assertFalse(RenderedGate.changed(snap(), dark = false))
+        assertFalse(RenderedGate.changed(snap(), dark = false))
     }
 
     /**
@@ -63,39 +63,39 @@ class RenderedGateTest {
      */
     @Test
     fun aChangedHeartRateSends() {
-        RenderedGate.changed(snap(hr = 62))
-        assertTrue(RenderedGate.changed(snap(hr = 63)))
+        RenderedGate.changed(snap(hr = 62), dark = false)
+        assertTrue(RenderedGate.changed(snap(hr = 63), dark = false))
     }
 
     /** Crossing LIVE_MS dims the reading, which is a visible change with no value change behind it. */
     @Test
     fun aStalenessFlipSends() {
-        RenderedGate.changed(snap(stale = false))
-        assertTrue(RenderedGate.changed(snap(stale = true)))
+        RenderedGate.changed(snap(stale = false), dark = false)
+        assertTrue(RenderedGate.changed(snap(stale = true), dark = false))
     }
 
     /** A new trace point IS sent on Android, unlike the Apple rule: nothing else would carry it. */
     @Test
     fun anAdvancedTraceSends() {
         val series = listOf(HrPoint(ts = 1000, bpm = 62))
-        RenderedGate.changed(snap(series = series))
-        assertTrue(RenderedGate.changed(snap(series = series + HrPoint(ts = 1060, bpm = 63))))
+        RenderedGate.changed(snap(series = series), dark = false)
+        assertTrue(RenderedGate.changed(snap(series = series + HrPoint(ts = 1060, bpm = 63)), dark = false))
     }
 
     /** A point ageing out of the window redraws the chart just as surely as one arriving. */
     @Test
     fun aPrunedTraceSends() {
-        RenderedGate.changed(snap(series = listOf(HrPoint(1000, 62), HrPoint(1060, 63))))
-        assertTrue(RenderedGate.changed(snap(series = listOf(HrPoint(1060, 63)))))
+        RenderedGate.changed(snap(series = listOf(HrPoint(1000, 62), HrPoint(1060, 63))), dark = false)
+        assertTrue(RenderedGate.changed(snap(series = listOf(HrPoint(1060, 63))), dark = false))
     }
 
     /** Every scalar the 2x2 and compact widgets render has to count, not just the HR ones. */
     @Test
     fun theOtherWidgetsFieldsSendToo() {
-        RenderedGate.changed(snap())
-        assertTrue("recovery", RenderedGate.changed(snap(recovery = 71)))
-        assertTrue("battery", RenderedGate.changed(snap(recovery = 71, battery = 79)))
-        assertTrue("connected", RenderedGate.changed(snap(recovery = 71, battery = 79, connected = false)))
+        RenderedGate.changed(snap(), dark = false)
+        assertTrue("recovery", RenderedGate.changed(snap(recovery = 71), dark = false))
+        assertTrue("battery", RenderedGate.changed(snap(recovery = 71, battery = 79), dark = false))
+        assertTrue("connected", RenderedGate.changed(snap(recovery = 71, battery = 79, connected = false), dark = false))
     }
 
     /**
@@ -105,8 +105,8 @@ class RenderedGateTest {
      */
     @Test
     fun aDrainedSnapshotSettlesAndStopsSending() {
-        assertTrue(RenderedGate.changed(snap(hr = null, series = emptyList())))
-        repeat(10) { assertFalse(RenderedGate.changed(snap(hr = null, series = emptyList()))) }
+        assertTrue(RenderedGate.changed(snap(hr = null, series = emptyList()), dark = false))
+        repeat(10) { assertFalse(RenderedGate.changed(snap(hr = null, series = emptyList()), dark = false)) }
     }
 
     /**
@@ -124,7 +124,7 @@ class RenderedGateTest {
      */
     @Test
     fun theStampAloneDoesNotSend() {
-        RenderedGate.changed(snap())
+        RenderedGate.changed(snap(), dark = false)
         val later = WidgetSnapshot(
             recoveryPct = 70, restPct = 80, effortPct = 40,
             heartRate = 62, heartRateStale = false, batteryPct = 80, connected = true,
@@ -132,6 +132,19 @@ class RenderedGateTest {
             updatedAtMs = 1_700_000_900_000L,          // fifteen minutes later, same everything else
         )
         assertFalse("a newer stamp with identical content is not worth an update",
-            RenderedGate.changed(later))
+            RenderedGate.changed(later, dark = false))
+    }
+
+    /**
+     * The appearance is an input the widgets read at composition, not one the snapshot carries, and
+     * nothing refreshes them when it changes — a theme flip reaches the screen only because a push
+     * updated them. Leaving it out of the key would have left a widget in the wrong colours until
+     * something unrelated moved, which is a regression this gate would have INTRODUCED.
+     */
+    @Test
+    fun aThemeFlipSends() {
+        RenderedGate.changed(snap(), dark = false)
+        assertTrue(RenderedGate.changed(snap(), dark = true))
+        assertFalse("and settles again once sent", RenderedGate.changed(snap(), dark = true))
     }
 }

--- a/android/app/src/test/java/com/noop/widget/WidgetTelemetryTest.kt
+++ b/android/app/src/test/java/com/noop/widget/WidgetTelemetryTest.kt
@@ -179,4 +179,38 @@ class WidgetTelemetryTest {
             Locale.setDefault(original)
         }
     }
+
+    /**
+     * The effective width headroom, which is NOT [HrTrace.WIDTH_HEADROOM]: the byte budget runs out
+     * first at any realistic widget size. Pinned because the constant reads like the guarantee and is
+     * not, and because the value below 1.0 is the case where the bitmap is UPSCALED — the artefact the
+     * headroom exists to prevent. If a change to the budget or the chart height moves these, that is
+     * worth seeing rather than discovering from a soft stroke on someone's home screen.
+     */
+    @Test
+    fun theByteBudgetBindsBeforeTheWidthHeadroomDoes() {
+        fun effective(densityDpi: Float, widthDp: Float): Double {
+            val density = densityDpi / 160f
+            val chartDp = (widthDp - 28f - 34f).coerceAtLeast(24f)
+            val req = (chartDp * density).toInt()
+            val h = (92f * density).toInt()
+            return HrTrace.widestAtHeight(req, h).toDouble() / req
+        }
+        // The property, not a pinned number: at every realistic size the BUDGET is what caps the width,
+        // so the nominal headroom is never reached and raising it would change nothing.
+        for (dpi in listOf(420f, 480f)) {
+            for (dp in listOf(300f, 340f, 380f)) {
+                val eff = effective(dpi, dp)
+                assertTrue(
+                    "$dpi/$dp reached $eff, so the byte budget was not the binding constraint",
+                    eff < HrTrace.WIDTH_HEADROOM,
+                )
+            }
+        }
+        // The case that matters: a wide card at high density is drawn NARROWER than it is displayed,
+        // so the bitmap is UPSCALED — precisely the artefact the headroom exists to prevent.
+        assertTrue("480dpi/380dp should be upscaled", effective(480f, 380f) < 1.0)
+        // And a small card is where the intent survives best, though still short of the nominal 2x.
+        assertTrue("420dpi/300dp should have the most headroom", effective(420f, 300f) > 1.5)
+    }
 }

--- a/android/app/src/test/java/com/noop/widget/WidgetTelemetryTest.kt
+++ b/android/app/src/test/java/com/noop/widget/WidgetTelemetryTest.kt
@@ -6,6 +6,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.util.Locale
 
 /**
  * Pins the widget cost counters. These exist to answer a field report ("battery drain feels worse
@@ -87,17 +88,17 @@ class WidgetTelemetryTest {
     @Test
     fun anUnchangedSeriesIsRecognisedAsARepeat() {
         val series = listOf(HrPoint(ts = 100, bpm = 60), HrPoint(ts = 160, bpm = 62))
-        assertFalse("the first draw is never a repeat", HrTraceSeen.repeat(series, 800, 250, false))
-        assertTrue(HrTraceSeen.repeat(series, 800, 250, false))
-        assertTrue(HrTraceSeen.repeat(series, 800, 250, false))
+        assertFalse("the first draw is never a repeat", HrTraceSeen.repeat("w1", series, 800, 250, false))
+        assertTrue(HrTraceSeen.repeat("w1", series, 800, 250, false))
+        assertTrue(HrTraceSeen.repeat("w1", series, 800, 250, false))
     }
 
     /** A new bucket is a different picture. */
     @Test
     fun anAdvancedSeriesIsNotARepeat() {
         val series = listOf(HrPoint(ts = 100, bpm = 60))
-        HrTraceSeen.repeat(series, 800, 250, false)
-        assertFalse(HrTraceSeen.repeat(series + HrPoint(ts = 160, bpm = 62), 800, 250, false))
+        HrTraceSeen.repeat("w1", series, 800, 250, false)
+        assertFalse(HrTraceSeen.repeat("w1", series + HrPoint(ts = 160, bpm = 62), 800, 250, false))
     }
 
     /**
@@ -108,16 +109,74 @@ class WidgetTelemetryTest {
     @Test
     fun aResizeOrThemeFlipIsNotARepeat() {
         val series = listOf(HrPoint(ts = 100, bpm = 60))
-        HrTraceSeen.repeat(series, 800, 250, false)
-        assertFalse("a resize redraws", HrTraceSeen.repeat(series, 900, 250, false))
-        assertFalse("a theme flip redraws", HrTraceSeen.repeat(series, 900, 250, true))
-        assertTrue(HrTraceSeen.repeat(series, 900, 250, true))
+        HrTraceSeen.repeat("w1", series, 800, 250, false)
+        assertFalse("a resize redraws", HrTraceSeen.repeat("w1", series, 900, 250, false))
+        assertFalse("a theme flip redraws", HrTraceSeen.repeat("w1", series, 900, 250, true))
+        assertTrue(HrTraceSeen.repeat("w1", series, 900, 250, true))
     }
 
     /** The newest sample's VALUE changing at the same timestamp still redraws. */
     @Test
     fun aChangedBpmAtTheSameTimestampIsNotARepeat() {
-        HrTraceSeen.repeat(listOf(HrPoint(ts = 100, bpm = 60)), 800, 250, false)
-        assertFalse(HrTraceSeen.repeat(listOf(HrPoint(ts = 100, bpm = 61)), 800, 250, false))
+        HrTraceSeen.repeat("w1", listOf(HrPoint(ts = 100, bpm = 60)), 800, 250, false)
+        assertFalse(HrTraceSeen.repeat("w1", listOf(HrPoint(ts = 100, bpm = 61)), 800, 250, false))
+    }
+
+    /**
+     * Two placed HR widgets must not answer for each other. A single shared slot made each widget's
+     * necessary FIRST draw look like a repeat of the other's, inflating the redundancy count - and an
+     * inflated count argues for an optimisation that is not actually on offer, which is the one
+     * direction this measurement must not be wrong in.
+     */
+    @Test
+    fun twoPlacedWidgetsDoNotAnswerForEachOther() {
+        val series = listOf(HrPoint(ts = 100, bpm = 60))
+        assertFalse("w1's first draw", HrTraceSeen.repeat("w1", series, 800, 250, false))
+        assertFalse("w2's first draw is its own, not a repeat of w1's",
+            HrTraceSeen.repeat("w2", series, 800, 250, false))
+        // Each still recognises its OWN repeat.
+        assertTrue(HrTraceSeen.repeat("w1", series, 800, 250, false))
+        assertTrue(HrTraceSeen.repeat("w2", series, 800, 250, false))
+        // And an advance on one does not clear the other.
+        val grown = series + HrPoint(ts = 160, bpm = 62)
+        assertFalse(HrTraceSeen.repeat("w1", grown, 800, 250, false))
+        assertTrue(HrTraceSeen.repeat("w2", series, 800, 250, false))
+    }
+
+    /**
+     * A widget composes from saved prefs when it is placed, or after a process start, with no push
+     * involved. Reporting "no pushes" there is true and drops the draw counts, which are the
+     * expensive half and the whole reason this exists.
+     */
+    @Test
+    fun drawsWithNoPushesAreStillReported() {
+        WidgetTelemetry.noteRender(bytes = 512 * 1024, elapsedMs = 5)
+        WidgetTelemetry.noteRender(bytes = 512 * 1024, elapsedMs = 5)
+        val line = WidgetTelemetry.snapshot(t0 + 120_000L).render()
+        assertTrue("must not claim an empty session: $line", "no pushes this app session" !in line)
+        assertTrue(line, "no pushes" in line)
+        assertTrue(line, "2 trace draws" in line)
+        assertTrue(line, "mean 512KB" in line)
+    }
+
+    /**
+     * The rate is a diagnostics field read by eye and by grep. Under a locale whose decimal separator
+     * is a comma, an unqualified format would print "30,0MB/h" and put a field separator inside a
+     * number.
+     */
+    @Test
+    fun ratesFormatWithADotWhateverTheDefaultLocale() {
+        val original = Locale.getDefault()
+        try {
+            Locale.setDefault(Locale.GERMANY)
+            repeat(10) { WidgetTelemetry.notePushAdmitted(t0 + it * 60_000L) }
+            repeat(10) { WidgetTelemetry.noteRender(bytes = 512 * 1024, elapsedMs = 4) }
+            val line = WidgetTelemetry.snapshot(t0 + 600_000L).render()
+            assertTrue(line, "60.0/h" in line)
+            assertTrue(line, "30.0MB/h" in line)
+            assertFalse(line, "," in line.substringAfter("Widgets:"))
+        } finally {
+            Locale.setDefault(original)
+        }
     }
 }

--- a/android/app/src/test/java/com/noop/widget/WidgetTelemetryTest.kt
+++ b/android/app/src/test/java/com/noop/widget/WidgetTelemetryTest.kt
@@ -1,0 +1,123 @@
+package com.noop.widget
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pins the widget cost counters. These exist to answer a field report ("battery drain feels worse
+ * with the widget enabled") from an export rather than from an argument about the code, so the thing
+ * worth testing is that the numbers mean what the line claims they mean.
+ */
+class WidgetTelemetryTest {
+
+    @Before
+    fun setUp() {
+        WidgetTelemetry.resetForTest()
+        HrTraceSeen.resetForTest()
+    }
+
+    private val t0 = 1_700_000_000_000L
+
+    /**
+     * The gate is the whole reason a ~1/s live-HR stream does not become a push per second, so the
+     * offered count has to include what was dropped. Reporting only what got through would make a
+     * broken throttle look like a quiet one.
+     */
+    @Test
+    fun offeredCountIncludesWhatTheGateDropped() {
+        WidgetTelemetry.notePushAdmitted(t0)
+        repeat(59) { WidgetTelemetry.notePushGated(t0 + it * 1000L) }
+        val s = WidgetTelemetry.snapshot(t0 + 60_000L)
+        assertEquals(1, s.pushesAdmitted)
+        assertEquals(59, s.pushesGated)
+        assertTrue("1 pushed / 60 offered" in s.render())
+    }
+
+    /** A rate over one minute of uptime is the figure a drain question turns on. */
+    @Test
+    fun ratesAreExtrapolatedFromUptime() {
+        repeat(10) { WidgetTelemetry.notePushAdmitted(t0 + it * 60_000L) }
+        repeat(10) { WidgetTelemetry.noteRender(bytes = 512 * 1024, elapsedMs = 4) }
+        val s = WidgetTelemetry.snapshot(t0 + 600_000L)   // 10 minutes
+        assertEquals(60.0, s.pushesPerHour!!, 0.001)      // 10 pushes in 10m = 60/h
+        assertEquals(512L, s.meanRenderBytes!! / 1024)
+        // 10 x 512KB in 10 minutes = 30MB/h.
+        assertEquals(30.0, s.renderBytesPerHour!! / 1_048_576.0, 0.01)
+    }
+
+    /**
+     * A rate computed from a few seconds of uptime is noise wearing a number's clothes, and this line
+     * goes in front of someone deciding whether to change the refresh cadence.
+     */
+    @Test
+    fun noRateIsClaimedUnderAMinuteOfUptime() {
+        WidgetTelemetry.notePushAdmitted(t0)
+        val s = WidgetTelemetry.snapshot(t0 + 5_000L)
+        assertNull(s.pushesPerHour)
+        assertNull(s.renderBytesPerHour)
+        assertEquals(1, s.pushesAdmitted)
+    }
+
+    /** The absence of widget activity is itself an answer to a drain report, so it must be stated. */
+    @Test
+    fun aSessionWithNoPushesSaysSoRatherThanRenderingNothing() {
+        assertEquals("Widgets:     no pushes this app session", WidgetTelemetry.snapshot(t0).render())
+    }
+
+    @Test
+    fun maxDrawTimeIsTheMaxNotTheLast() {
+        WidgetTelemetry.noteRender(bytes = 1024, elapsedMs = 40)
+        WidgetTelemetry.noteRender(bytes = 1024, elapsedMs = 2)
+        val s = WidgetTelemetry.snapshot(t0 + 60_000L)
+        assertEquals(40, s.renderMsMax)
+        assertEquals(21, s.renderMs / s.renders)
+    }
+
+    // MARK: - HrTraceSeen
+
+    /**
+     * A push carrying no live sample appends no point, so the next draw reproduces the previous
+     * bitmap exactly. That is the saving a future cache would take, and it is only worth taking if
+     * this counts it honestly.
+     */
+    @Test
+    fun anUnchangedSeriesIsRecognisedAsARepeat() {
+        val series = listOf(HrPoint(ts = 100, bpm = 60), HrPoint(ts = 160, bpm = 62))
+        assertFalse("the first draw is never a repeat", HrTraceSeen.repeat(series, 800, 250, false))
+        assertTrue(HrTraceSeen.repeat(series, 800, 250, false))
+        assertTrue(HrTraceSeen.repeat(series, 800, 250, false))
+    }
+
+    /** A new bucket is a different picture. */
+    @Test
+    fun anAdvancedSeriesIsNotARepeat() {
+        val series = listOf(HrPoint(ts = 100, bpm = 60))
+        HrTraceSeen.repeat(series, 800, 250, false)
+        assertFalse(HrTraceSeen.repeat(series + HrPoint(ts = 160, bpm = 62), 800, 250, false))
+    }
+
+    /**
+     * Same points, different box or theme, is a genuinely different bitmap. Counting those as
+     * redundant would overstate the saving on offer, which is the one way this measurement could
+     * mislead the decision it exists to inform.
+     */
+    @Test
+    fun aResizeOrThemeFlipIsNotARepeat() {
+        val series = listOf(HrPoint(ts = 100, bpm = 60))
+        HrTraceSeen.repeat(series, 800, 250, false)
+        assertFalse("a resize redraws", HrTraceSeen.repeat(series, 900, 250, false))
+        assertFalse("a theme flip redraws", HrTraceSeen.repeat(series, 900, 250, true))
+        assertTrue(HrTraceSeen.repeat(series, 900, 250, true))
+    }
+
+    /** The newest sample's VALUE changing at the same timestamp still redraws. */
+    @Test
+    fun aChangedBpmAtTheSameTimestampIsNotARepeat() {
+        HrTraceSeen.repeat(listOf(HrPoint(ts = 100, bpm = 60)), 800, 250, false)
+        assertFalse(HrTraceSeen.repeat(listOf(HrPoint(ts = 100, bpm = 61)), 800, 250, false))
+    }
+}


### PR DESCRIPTION
## Why

A field report that battery drain feels worse with the HR widget placed. Three exports later I could not confirm or refute it: **`widget` appears zero times in a full diagnostics bundle.** Nothing in the app records widget activity, so this measures it instead of arguing about it.

The mechanism worth measuring is specific, and it points at the newest widget. The HR widget is the only one that ships a **bitmap** — the other two send a few KB of text as RemoteViews, while the trace image is sized right up to the 512KB cap (`HrTrace.MAX_BITMAP_BYTES`, `WIDTH_HEADROOM = 2f`) and crosses a Binder transaction to the launcher on every push. Same cadence, roughly a hundred times the payload.

## What it also does now (two optimisations)

**Skips providers with nothing placed.** `push()` fetched the ids for all three widget providers and then called `updateAll` on all three regardless. Someone running only the HR widget was paying for two provider updates a minute with nothing to update.

**Skips the update entirely when nothing the widgets display changed.** This closes the Android half of a gap the Apple side has had since #1957: `WidgetPublish.saveAndReloadIfChanged` only reloads when a rendered field differs, while Android called `updateAll` on every admitted push. `PushGate` cannot close it alone — it keys on whether a heart rate *exists*, not its value, so its 60s timer clause fires whether or not anything moved.

It is deliberately **not** the Apple rule. `renderedContentChanged` also declines when only the *trace* advanced, which is safe there because WidgetKit rebuilds a timeline on its own schedule and a withheld point still reaches the screen. Glance has no such rebuild (`updatePeriodMillis="0"`), so declining would freeze the chart at rest until the number moved. This skips only when **nothing** changed, which costs nothing visible; the trace-only case is left open for the counters to price.

Where it pays: after a disconnect the trace prunes empty and the reading is dropped, so every later push is identical and the widgets stop costing anything rather than redrawing a dash once a minute forever.

### The gate's real difficulty: inputs the snapshot does not carry

Two of the things a widget renders are not in `WidgetSnapshot` at all, and both were found by asking what the widgets read rather than by reading the diff.

- **`updatedAtMs`** is in the snapshot but rendered by all three widgets (the HR card as `Updated <time>`, the others as their disconnected "last seen"). It cannot go in the key — it changes every push, so the gate would never fire — so a declined push restores the previous value and the stamp means *when the data is from*.
- **The theme is not in the snapshot at all.** Every widget reads `theme.appearance` from prefs at composition, and `AppearancePrefs.set` refreshes nothing — today a theme change reaches a widget only because every push updated unconditionally. Left out, the gate would have stranded a widget in the wrong colours until a strap reconnected or a score changed. It is in the key, and the four byte-identical copies of that resolution are now one `WidgetTheme.isDark`, because the gate being a fifth reader of an unowned value is exactly how a drift starts.

I would not assume that class is now empty.

## A finding worth recording: `WIDTH_HEADROOM` never takes effect

`MAX_BITMAP_BYTES` runs out first at every realistic widget size. Worked through: at 420dpi a 300dp card gets **1.74x**, and at 480dpi a 380dp card gets **0.99x** — narrower than it is displayed at, so the bitmap is *upscaled*, which is the exact artefact the headroom exists to prevent. The constant's comment claims two "covers the ~1.6x seen on One UI with margin"; it does not.

This closes off the obvious lever rather than opening it: the width is already budget-bound, so lowering the budget buys bytes by making the upscaling worse on the widest widgets. What is left is a coarser or shorter chart, which is a look decision. Pinned as a property rather than three magic numbers.

## What it does NOT do

- **No behaviour change.** No push is added or dropped, no draw is skipped, no cadence moved.
- **Does not slow the refresh.** The push cadence is 60s and `HrDisplay.LIVE_MS` is 120s, so a reading already ages to the edge of "live" just as the next push lands. Move to 2 minutes and the widget marks its own current reading as a dimmed stale carry-over.
- **Does not cache the bitmap.** `ImageProvider` ships it across the Binder on every update whether or not it was redrawn, so a cache saves the ~4ms draw and not the ~512KB transfer. Redundant redraws are counted, not avoided.
- **Does not change what is drawn.** Every skip is a case where the widget had nothing different to show.

  > Re-review caught that this was not true as first written. All three widgets render `updatedAtMs` — the HR card as a permanent `Updated <time>` line, the 2x2 and compact as their disconnected "last seen" — and the gate's key omitted it, so a declined push froze a visible clock while the prefs behind it moved on. Adding it to the key was not the fix: it changes every push, so the gate could never fire. Resolved in `a28159b` by treating the stamp as *when the data is from* rather than when the app last woke — a declined push restores the previous value, so a frozen stamp is the truthful one. The Apple twin sidesteps this because no widget family there renders the timestamp, which is exactly why the rule did not port cleanly.

## The counters, and why each is needed

| Counter | The question it answers |
|---|---|
| admitted vs offered pushes | `PushGate` is supposed to collapse a ~1/s live-HR stream to ~1 push/min. If offered does not dwarf admitted, the throttle is broken and nothing downstream matters. |
| renders, bytes, MB/h | The actual Binder payload. This is the figure a drain question turns on. |
| redundant renders | A push carrying no live sample appends no point, so the redraw reproduces the previous bitmap exactly. Sizes the cheapest available saving. |
| draw time (avg/max) | Separates "the drawing is expensive" from "the transfer is expensive". Different fixes, and the numbers cannot be guessed apart. |

Redundant renders are **counted, not avoided** on purpose. Skipping them means holding half a megabyte across compositions, which is a real memory trade — it belongs in the change that takes it, not the one that measures whether it is worth taking.

## Two judgement calls worth checking

**Rates are withheld under a minute of uptime** rather than extrapolated from a few seconds. This line goes in front of someone deciding whether to change the refresh cadence, and a rate from five seconds of samples is noise wearing a number's clothes.

**The repeat detector keys on the placed widget, the box and the theme, not just the series.** The same points at a different size or in a flipped theme are a genuinely different bitmap, and two placed widgets must not answer for each other. Counting either as redundant would overstate the saving on offer, which is the one way this measurement could mislead the decision it exists to inform.

> Re-review caught that the second half of that was wrong in the first commit: the memo was a single shared slot, so two same-sized HR widgets made each one's necessary first draw look like a repeat of the other's, roughly doubling the reported redundancy. Corrected in `d66bda9`, with a test for two instances. Two smaller ones alongside it: a session with draws but no pushes reported `no pushes this app session` and silently dropped the draw counts (what an export shortly after a reboot would have said), and the rates used the default locale, so a German device would print `30,0MB/h`.

A session with no pushes says so explicitly (`Widgets:     no pushes this app session`), because the absence of widget activity is itself an answer to a drain report, and an export could not previously tell that apart from the counters being missing.

## Sample output

```
Widgets:     42 pushed / 2513 offered · 60.0/h · 42 trace draws · mean 511KB · 30.0MB/h · draw 4ms avg / 11ms max · 3 redundant (over 42m)
```

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

**Android unit tests, full suite:** **5,576 tests, 664 classes, 0 failures, 0 errors**, results directory cleared first and the Room oracle synced in its own invocation. `WidgetTelemetryTest` is 13 of those and `RenderedGateTest` 10, covering the offered-count arithmetic, rate extrapolation, the sub-minute withholding, the no-pushes line, draws-without-pushes, locale-independent formatting, max-vs-last draw time, and five repeat-detector cases including the resize, theme-flip and two-widget negatives.

**Gates:** `Tools/doc_comment_lint.py` clean · `Tools/i18n_audit.py --ci origin/main` clean (the line is diagnostics output, not app copy).

**Not verified on hardware.** The counters are what a device run would report, so the next testing build is what actually answers the original question.

## iOS

Deliberately untouched. WidgetKit is timeline-driven rather than push-driven, so these counters would not describe it, and the report in hand is an Android one. Not a parity gap to close later without a matching question.

## Related issues

Follows the HR widget (#1957). No issue reference — the report arrived as a field observation, and the numbers this collects are what would make it one.
