### PR TITLE
widget: measure the rates after the startup burst, and give the counters an iOS twin

### DIFF
--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -92,6 +92,14 @@ enum DebugDataDiagnostics {
         }
         if restoreAt > 0 { lines.append("Last restore: \(relTime(now - restoreAt))") }
         #if os(iOS)
+        // What the home-screen widgets cost. Reported unconditionally, including the no-publish case,
+        // because the absence of widget activity is itself the answer to a drain report.
+        //
+        // iOS only: `WidgetTelemetry` lives in StrandiOSShared, which project.yml deliberately keeps
+        // OUT of the macOS application module. macOS has no home-screen widget to account for.
+        lines.append(WidgetTelemetry.snapshot().render())
+        #endif
+        #if os(iOS)
         // #52: iOS Backup & Sync folder-picker health. When users report "won't let me pick a folder",
         // this pins the failure stage: "cancelled"/"never used" ⇒ the picker's Open button never fired
         // (an iOS-side picker issue — the in-app "Use NOOP's own folder" fallback sidesteps it);

--- a/StrandTests/WidgetTelemetryTests.swift
+++ b/StrandTests/WidgetTelemetryTests.swift
@@ -92,4 +92,35 @@ final class WidgetTelemetryTests: XCTestCase {
         XCTAssertTrue(line.contains("60.0/h"), line)
         XCTAssertFalse(line.contains("60,0/h"), line)
     }
+
+    /// The widget-removed export is half of the comparison the counters exist for, so a reload with
+    /// nothing installed must not read as one. Android had exactly this bug; iOS never checks whether
+    /// a widget is placed before calling `reloadAllTimelines`, so without this the figure would be
+    /// just as blind here.
+    func testAReloadWithNoWidgetInstalledIsNotCountedAsOne() {
+        WidgetTelemetry.noteWidgetsInstalled(false)
+        WidgetTelemetry.noteAdmitted(now: t0)
+        for m in 1...10 {
+            let at = t0.addingTimeInterval(Double(m) * 60)
+            WidgetTelemetry.noteAdmitted(now: at)
+            WidgetTelemetry.noteNoWidget()
+        }
+        let s = WidgetTelemetry.snapshot(now: t0.addingTimeInterval(660))
+        XCTAssertEqual(s.admitted, 11)
+        XCTAssertEqual(s.reloaded, 0)
+        XCTAssertEqual(s.noWidget, 10)
+        XCTAssertEqual(s.reloadsPerHour ?? -1, 0, accuracy: 0.001)
+        XCTAssertTrue(s.render().contains("10 with no widget installed"), s.render())
+    }
+
+    /// Unknown must count as installed. Over-reporting reloads is the safe direction for a figure
+    /// whose whole purpose is to show a cost: a wrong "nothing was spent" is the one answer that would
+    /// end an investigation early.
+    func testPresenceDefaultsToInstalledBeforeWidgetKitHasAnswered() {
+        XCTAssertTrue(WidgetTelemetry.widgetsInstalled)
+        WidgetTelemetry.noteWidgetsInstalled(false)
+        XCTAssertFalse(WidgetTelemetry.widgetsInstalled)
+        WidgetTelemetry.resetForTest()
+        XCTAssertTrue(WidgetTelemetry.widgetsInstalled, "reset returns it to unknown, not to false")
+    }
 }

--- a/StrandTests/WidgetTelemetryTests.swift
+++ b/StrandTests/WidgetTelemetryTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+
+/// Pins the widget cost counters. Twin of Android's `WidgetTelemetryTest`, minus the bitmap half,
+/// which has no analogue here.
+///
+/// The Android side has had three defects in these counters and none of them were arithmetic: each
+/// time a counter's NAME claimed more than its wiring delivered. So the cases below are written
+/// against the questions the numbers are supposed to answer rather than against the sums.
+final class WidgetTelemetryTests: XCTestCase {
+
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+
+    override func setUp() {
+        super.setUp()
+        WidgetTelemetry.resetForTest()
+    }
+
+    /// The throttle is the whole reason a live-HR stream does not become a publish per tick, so the
+    /// offered count has to include what it dropped. Reporting only what got through would make a
+    /// broken throttle look like a quiet one.
+    func testOfferedIncludesWhatTheThrottleDropped() {
+        WidgetTelemetry.noteAdmitted(now: t0)
+        for i in 0..<59 { WidgetTelemetry.noteGated(now: t0.addingTimeInterval(Double(i))) }
+        let s = WidgetTelemetry.snapshot(now: t0.addingTimeInterval(60))
+        XCTAssertEqual(s.admitted, 1)
+        XCTAssertEqual(s.gated, 59)
+        XCTAssertEqual(s.offered, 60)
+        XCTAssertTrue(s.render().contains("0 reloaded / 1 admitted / 60 offered"), s.render())
+    }
+
+    /// Reloads, not publishes. A publish that declined the reload cost nothing and spent none of
+    /// WidgetKit's budget, so counting it here would make the figure unable to fall when the dedup in
+    /// `saveAndReloadIfChanged` did its job — the one thing that dedup is for.
+    func testTheRateCountsReloadsNotPublishes() {
+        WidgetTelemetry.noteAdmitted(now: t0)
+        for m in 1...10 {
+            let at = t0.addingTimeInterval(Double(m) * 60)
+            WidgetTelemetry.noteAdmitted(now: at)
+            if m > 5 { WidgetTelemetry.noteDeclined() } else { WidgetTelemetry.noteReloaded(now: at) }
+        }
+        let s = WidgetTelemetry.snapshot(now: t0.addingTimeInterval(660))
+        XCTAssertEqual(s.admitted, 11)
+        XCTAssertEqual(s.reloaded, 5)
+        XCTAssertEqual(s.declined, 5)
+        // Five reloads in a ten-minute steady window is 30/h, not the 60/h the publishes would claim.
+        XCTAssertEqual(s.reloadsPerHour ?? 0, 30, accuracy: 0.001)
+    }
+
+    /// The startup burst must not be quoted as a rate. The snapshot's fields arrive one by one at
+    /// launch and each publishes on the spot, so a launch produces activity the once-a-minute throttle
+    /// had nothing to do with. An Android capture reported six in a hundred seconds as 215/h against a
+    /// steady state of about sixty.
+    func testAStartupBurstIsNotQuotedAsARate() {
+        for offset in [0.0, 2, 5, 9, 30, 95] {
+            WidgetTelemetry.noteAdmitted(now: t0.addingTimeInterval(offset))
+            WidgetTelemetry.noteReloaded(now: t0.addingTimeInterval(offset))
+        }
+        let s = WidgetTelemetry.snapshot(now: t0.addingTimeInterval(100))
+        XCTAssertEqual(s.admitted, 6)
+        XCTAssertNil(s.reloadsPerHour, "a burst is not a rate")
+        XCTAssertTrue(s.render().contains("steady"), s.render())
+    }
+
+    /// The withheld-rate message has to name the window it waits on. Phrasing it as a minimum UPTIME
+    /// was wrong on Android: publishes can be sparse enough that the steady window opens late, so the
+    /// line would sit twenty minutes in still claiming it needed six.
+    func testAWithheldRateNamesTheSteadyWindow() {
+        WidgetTelemetry.noteAdmitted(now: t0)
+        WidgetTelemetry.noteAdmitted(now: t0.addingTimeInterval(19 * 60))
+        let line = WidgetTelemetry.snapshot(now: t0.addingTimeInterval(20 * 60)).render()
+        XCTAssertTrue(line.contains("over 20m"), line)
+        XCTAssertTrue(line.contains("steady 1m of 5m"), line)
+    }
+
+    /// The absence of widget activity is itself an answer to a drain report, so it must be stated
+    /// rather than rendered as an empty line.
+    func testASessionWithNoPublishesSaysSo() {
+        XCTAssertEqual(WidgetTelemetry.snapshot(now: t0).render(),
+                       "Widgets:     no publishes this app session")
+    }
+
+    /// The rate is a diagnostics field read by eye and by grep, so it must not pick up a locale's
+    /// decimal comma.
+    func testTheRateFormatsWithADot() {
+        WidgetTelemetry.noteAdmitted(now: t0)
+        for m in 1...10 {
+            let at = t0.addingTimeInterval(Double(m) * 60)
+            WidgetTelemetry.noteAdmitted(now: at)
+            WidgetTelemetry.noteReloaded(now: at)
+        }
+        let line = WidgetTelemetry.snapshot(now: t0.addingTimeInterval(660)).render()
+        XCTAssertTrue(line.contains("60.0/h"), line)
+        XCTAssertFalse(line.contains("60,0/h"), line)
+    }
+}

--- a/StrandiOS/Widgets/WidgetPublish.swift
+++ b/StrandiOS/Widgets/WidgetPublish.swift
@@ -21,6 +21,7 @@ extension WidgetSnapshot {
     /// the rollover yet always describes today.
     @MainActor
     static func publish(from model: AppModel) async {
+        await refreshWidgetPresence()
         let days = model.repo.days
         let now = Date()
         // The recovery-derived anchor: today's row when it's scored, else the freshest STRICTLY-PRIOR
@@ -112,7 +113,15 @@ extension WidgetSnapshot {
         if renderedContentChanged(from: previous, to: snap) {
             snap.save(previousSeries: previous?.hrSeries ?? [])
             WidgetCenter.shared.reloadAllTimelines()
-            WidgetTelemetry.noteReloaded()
+            // Android skips the update entirely when no widget is placed; WidgetKit offers no
+            // synchronous way to know, so the reload still goes out and is instead recorded honestly.
+            // Counting it as a reload would make a widget-removed export read exactly like a
+            // widget-installed one, which is half the comparison the counters exist for.
+            if WidgetTelemetry.widgetsInstalled {
+                WidgetTelemetry.noteReloaded()
+            } else {
+                WidgetTelemetry.noteNoWidget()
+            }
         } else if WidgetSnapshot.traceNeedsPoint(previous: previous, bpm: snap.bpm, now: snap.updated) {
             // A steady heart changes nothing the header renders, so the branch above declines — but the
             // TRACE still wants this minute's point, or it stops advancing at rest and prunes to empty
@@ -131,6 +140,28 @@ extension WidgetSnapshot {
             // went anywhere as if they had.
             WidgetTelemetry.noteDeclined()
         }
+    }
+
+    /// Ask WidgetKit whether any widget is actually installed, and remember the answer.
+    ///
+    /// Only on the full publish path: it is already `async`, and the once-a-minute live path has no
+    /// `await` to spend on an XPC round trip it does not need. The answer changes when a user adds or
+    /// removes a widget, which is exactly when the app is being foregrounded anyway, so a value from
+    /// the last full publish is fresh enough for a diagnostic.
+    ///
+    /// A failure leaves the previous answer in place rather than guessing, and "never asked" counts as
+    /// installed — over-reporting reloads is the safe direction for a figure meant to show a cost.
+    @MainActor
+    private static func refreshWidgetPresence() async {
+        let installed: Bool? = await withCheckedContinuation { continuation in
+            WidgetCenter.shared.getCurrentConfigurations { result in
+                switch result {
+                case .success(let widgets): continuation.resume(returning: !widgets.isEmpty)
+                case .failure: continuation.resume(returning: nil)
+                }
+            }
+        }
+        if let installed { WidgetTelemetry.noteWidgetsInstalled(installed) }
     }
 
     /// #114/#169: HR is the ONE high-frequency widget-publish trigger — `model.bpm` moves every few

--- a/StrandiOS/Widgets/WidgetPublish.swift
+++ b/StrandiOS/Widgets/WidgetPublish.swift
@@ -112,16 +112,24 @@ extension WidgetSnapshot {
         if renderedContentChanged(from: previous, to: snap) {
             snap.save(previousSeries: previous?.hrSeries ?? [])
             WidgetCenter.shared.reloadAllTimelines()
+            WidgetTelemetry.noteReloaded()
         } else if WidgetSnapshot.traceNeedsPoint(previous: previous, bpm: snap.bpm, now: snap.updated) {
             // A steady heart changes nothing the header renders, so the branch above declines — but the
             // TRACE still wants this minute's point, or it stops advancing at rest and prunes to empty
             // (#1957). Persist without a reload: the point is for the next timeline WidgetKit builds,
             // and spending a reload a minute is exactly what the dedup above exists to avoid.
             snap.save(previousSeries: previous?.hrSeries ?? [])
+            WidgetTelemetry.noteDeclined()
         } else if liveUpdateRequiresFullBuild(previous: previous, now: snap.updated) {
             // The rollover's visible values can legitimately match yesterday's. Persist the fresh day
             // stamp once without spending a redundant WidgetKit reload, so later live ticks stay fast.
             snap.save(previousSeries: previous?.hrSeries ?? [])
+            WidgetTelemetry.noteDeclined()
+        } else {
+            // Nothing at all to do. Counted rather than left as a silent fall-through: an outcome that
+            // records nothing is exactly how the Android counters came to report publishes that never
+            // went anywhere as if they had.
+            WidgetTelemetry.noteDeclined()
         }
     }
 
@@ -139,8 +147,12 @@ extension WidgetSnapshot {
         /// True (and stamps `now`) when at least `interval` has elapsed since the last HR-driven publish;
         /// false to skip this HR change. The first call always admits (`.distantPast`).
         static func admit(now: Date = Date()) -> Bool {
-            guard now.timeIntervalSince(lastPublishedAt) >= interval else { return false }
+            guard now.timeIntervalSince(lastPublishedAt) >= interval else {
+                WidgetTelemetry.noteGated(now: now)
+                return false
+            }
             lastPublishedAt = now
+            WidgetTelemetry.noteAdmitted(now: now)
             return true
         }
     }

--- a/StrandiOSShared/WidgetTelemetry.swift
+++ b/StrandiOSShared/WidgetTelemetry.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// Counters for what the home-screen widgets cost, so "the widget drains my battery" is decidable
+/// from an export instead of being argued from the code.
+///
+/// Twin of Android's `WidgetTelemetry`, and deliberately only HALF of it. The push accounting maps
+/// one to one — `HRPublishThrottle` gates, `saveAndReloadIfChanged` either reloads or declines — so
+/// the same four outcomes exist here and are worth the same counters. The bitmap accounting does not
+/// map at all: this widget draws a SwiftUI `Path` inside the extension, with no bitmap and no Binder
+/// transaction, so draws, bytes and MB/h would be measuring something that does not happen.
+///
+/// One cost is iOS-ONLY and is the reason this is worth having rather than merely symmetrical.
+/// WidgetKit budgets timeline reloads, and spending the budget does not cost battery — it makes the
+/// widget go STALE, which is a correctness failure the user sees. A reloads-per-hour figure is the
+/// only way to know how close the app runs to that ceiling, and nothing has ever measured it.
+///
+/// Process-lifetime, reset when the process dies, reported as a rate over the steady window so a
+/// short session and a long one are comparable. Not persisted: writing to disk on every publish to
+/// measure the cost of publishing would be its own answer to the question.
+public enum WidgetTelemetry {
+
+    /// How long after the first publish to ignore before the rates start counting.
+    ///
+    /// The snapshot's fields populate one after another at launch and each is a content change that
+    /// publishes immediately, so a launch produces a burst that the once-a-minute HR throttle has
+    /// nothing to do with. An Android capture reported six pushes in a hundred seconds as 215/h
+    /// against a steady state of about sixty; the same shape applies here.
+    private static let warmup: TimeInterval = 60
+
+    private static let lock = NSLock()
+    private static var startedAt: Date?
+    private static var steadyStartedAt: Date?
+    private static var offered = 0
+    private static var gated = 0
+    private static var admitted = 0
+    private static var reloaded = 0
+    private static var declined = 0
+    private static var steadyReloads = 0
+
+    /// A publish that `HRPublishThrottle` let through.
+    public static func noteAdmitted(now: Date = Date()) {
+        lock.lock(); defer { lock.unlock() }
+        if startedAt == nil { startedAt = now }
+        offered += 1
+        admitted += 1
+        if let started = startedAt, now.timeIntervalSince(started) >= warmup, steadyStartedAt == nil {
+            steadyStartedAt = now
+        }
+    }
+
+    /// A publish the throttle dropped. At live-HR cadence this should dwarf the admitted count.
+    public static func noteGated(now: Date = Date()) {
+        lock.lock(); defer { lock.unlock() }
+        if startedAt == nil { startedAt = now }
+        offered += 1
+        gated += 1
+    }
+
+    /// A publish that actually asked WidgetKit for a new timeline. THE figure that matters here: this
+    /// is what spends the reload budget.
+    public static func noteReloaded(now: Date = Date()) {
+        lock.lock(); defer { lock.unlock() }
+        reloaded += 1
+        if steadyStartedAt != nil { steadyReloads += 1 }
+    }
+
+    /// A publish that persisted but declined the reload, because nothing a widget renders had changed
+    /// (or only the trace advanced, which the next timeline picks up anyway).
+    public static func noteDeclined() {
+        lock.lock(); defer { lock.unlock() }
+        declined += 1
+    }
+
+    public static func snapshot(now: Date = Date()) -> Snapshot {
+        lock.lock(); defer { lock.unlock() }
+        return Snapshot(
+            uptime: startedAt.map { now.timeIntervalSince($0) } ?? 0,
+            steady: steadyStartedAt.map { now.timeIntervalSince($0) } ?? 0,
+            offered: offered,
+            gated: gated,
+            admitted: admitted,
+            reloaded: reloaded,
+            declined: declined,
+            steadyReloads: steadyReloads
+        )
+    }
+
+    public static func resetForTest() {
+        lock.lock(); defer { lock.unlock() }
+        startedAt = nil; steadyStartedAt = nil
+        offered = 0; gated = 0; admitted = 0; reloaded = 0; declined = 0; steadyReloads = 0
+    }
+
+    public struct Snapshot: Sendable, Equatable {
+        public let uptime: TimeInterval
+        public let steady: TimeInterval
+        public let offered: Int
+        public let gated: Int
+        public let admitted: Int
+        public let reloaded: Int
+        public let declined: Int
+        public let steadyReloads: Int
+
+        /// A rate is only quoted once the steady window is long enough to mean something. Five minutes
+        /// of ordinary running is a handful of one-a-minute publishes; less is arithmetic.
+        private var steadyEnough: Bool { steady >= 5 * 60 }
+
+        /// Timeline reloads per hour, over the steady window.
+        ///
+        /// Reloads and not publishes, because a publish that declined the reload cost nothing and
+        /// spent none of the budget. Counting those would make this figure unable to fall when the
+        /// dedup in `saveAndReloadIfChanged` did its job, which is the one thing it is for.
+        ///
+        /// Elapsed WALL-CLOCK time is the denominator, not time spent streaming: the ceiling this runs
+        /// against is expressed per hour of real time, as is a battery question.
+        public var reloadsPerHour: Double? {
+            guard steadyEnough, steady > 0 else { return nil }
+            return Double(steadyReloads) * 3600 / steady
+        }
+
+        /// One line for the diagnostics header, matching the Android wording so two exports from the
+        /// same household read the same way.
+        public func render() -> String {
+            guard offered > 0 else { return "Widgets:     no publishes this app session" }
+            var parts: [String] = ["\(reloaded) reloaded / \(admitted) admitted / \(offered) offered"]
+            if let rate = reloadsPerHour {
+                parts.append(String(format: "%.1f/h", rate))
+            }
+            if declined > 0 { parts.append("\(declined) unchanged") }
+            let mins = Int(uptime / 60)
+            let span = steadyEnough
+                ? "over \(mins)m"
+                : "over \(mins)m, steady \(Int(steady / 60))m of 5m"
+            return "Widgets:     " + parts.joined(separator: " · ") + " (\(span))"
+        }
+    }
+}

--- a/StrandiOSShared/WidgetTelemetry.swift
+++ b/StrandiOSShared/WidgetTelemetry.swift
@@ -36,6 +36,9 @@ public enum WidgetTelemetry {
     private static var reloaded = 0
     private static var declined = 0
     private static var steadyReloads = 0
+    private static var noWidget = 0
+    private static var steadyNoWidget = 0
+    private static var installedKnown: Bool?
 
     /// A publish that `HRPublishThrottle` let through.
     public static func noteAdmitted(now: Date = Date()) {
@@ -71,6 +74,35 @@ public enum WidgetTelemetry {
         declined += 1
     }
 
+    /// A reload asked for with no widget installed to receive it.
+    ///
+    /// Android learned this the hard way: an export taken with the widget REMOVED is half of the
+    /// comparison that answers whether the widget costs anything, and counting these as reloads made
+    /// both halves read alike. iOS never checks whether a widget is placed before calling
+    /// `reloadAllTimelines`, so without this the same figure would be just as blind here.
+    public static func noteNoWidget() {
+        lock.lock(); defer { lock.unlock() }
+        noWidget += 1
+        if steadyStartedAt != nil { steadyNoWidget += 1 }
+    }
+
+    /// Record what WidgetKit says about installed widgets. Refreshed on the async publish paths, which
+    /// is the only place an `await` is available; the synchronous live path reads the last answer.
+    ///
+    /// Nil means never asked, and nil counts as INSTALLED at the call site. Unknown must not be able to
+    /// invent a saving that was never made — over-reporting reloads is the safe direction for a figure
+    /// whose purpose is to show a cost.
+    public static func noteWidgetsInstalled(_ installed: Bool) {
+        lock.lock(); defer { lock.unlock() }
+        installedKnown = installed
+    }
+
+    /// The last known answer, defaulting to true. See [noteWidgetsInstalled].
+    public static var widgetsInstalled: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return installedKnown ?? true
+    }
+
     public static func snapshot(now: Date = Date()) -> Snapshot {
         lock.lock(); defer { lock.unlock() }
         return Snapshot(
@@ -81,7 +113,9 @@ public enum WidgetTelemetry {
             admitted: admitted,
             reloaded: reloaded,
             declined: declined,
-            steadyReloads: steadyReloads
+            noWidget: noWidget,
+            steadyReloads: steadyReloads,
+            steadyNoWidget: steadyNoWidget
         )
     }
 
@@ -89,6 +123,7 @@ public enum WidgetTelemetry {
         lock.lock(); defer { lock.unlock() }
         startedAt = nil; steadyStartedAt = nil
         offered = 0; gated = 0; admitted = 0; reloaded = 0; declined = 0; steadyReloads = 0
+        noWidget = 0; steadyNoWidget = 0; installedKnown = nil
     }
 
     public struct Snapshot: Sendable, Equatable {
@@ -99,7 +134,9 @@ public enum WidgetTelemetry {
         public let admitted: Int
         public let reloaded: Int
         public let declined: Int
+        public let noWidget: Int
         public let steadyReloads: Int
+        public let steadyNoWidget: Int
 
         /// A rate is only quoted once the steady window is long enough to mean something. Five minutes
         /// of ordinary running is a handful of one-a-minute publishes; less is arithmetic.
@@ -110,6 +147,10 @@ public enum WidgetTelemetry {
         /// Reloads and not publishes, because a publish that declined the reload cost nothing and
         /// spent none of the budget. Counting those would make this figure unable to fall when the
         /// dedup in `saveAndReloadIfChanged` did its job, which is the one thing it is for.
+        ///
+        /// A reload asked for with no widget installed is not counted here either — it is recorded as
+        /// [noWidget] instead of as a reload, so this figure never claims a cost that had nowhere to
+        /// land.
         ///
         /// Elapsed WALL-CLOCK time is the denominator, not time spent streaming: the ceiling this runs
         /// against is expressed per hour of real time, as is a battery question.
@@ -127,6 +168,7 @@ public enum WidgetTelemetry {
                 parts.append(String(format: "%.1f/h", rate))
             }
             if declined > 0 { parts.append("\(declined) unchanged") }
+            if noWidget > 0 { parts.append("\(noWidget) with no widget installed") }
             let mins = Int(uptime / 60)
             let span = steadyEnough
                 ? "over \(mins)m"

--- a/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
@@ -80,7 +80,13 @@ object WidgetSnapshotStore {
         val hrIds = runCatching {
             GlanceAppWidgetManager(app).getGlanceIds(HrGlanceWidget::class.java)
         }.getOrDefault(emptyList())
-        if (standardIds.isEmpty() && compactIds.isEmpty() && hrIds.isEmpty()) return
+        if (standardIds.isEmpty() && compactIds.isEmpty() && hrIds.isEmpty()) {
+            // Admitted, but there is nowhere for it to go. Recorded rather than returned silently: an
+            // export taken with the widget removed is half of the comparison that answers whether it
+            // costs anything, and counting this as a send would have made both halves look alike.
+            WidgetTelemetry.notePushNoWidget()
+            return
+        }
 
         // Nothing the widgets DISPLAY changed, so there is nothing to send. Read back what they will
         // actually render rather than re-deriving it: `load` resolves staleness and prunes the trace,

--- a/android/app/src/main/java/com/noop/widget/WidgetTelemetry.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetTelemetry.kt
@@ -147,7 +147,15 @@ object WidgetTelemetry {
         val renderMsMax: Long,
         val lastPushAgoMs: Long?,
     ) {
-        /** Mean bitmap in bytes, or null before the first render. */
+        /**
+         * Mean bitmap in bytes, or null before the first render.
+         *
+         * Deliberately over EVERY draw, unlike the rates: this is a property of one bitmap, set by the
+         * widget's size and the screen's density, not something a startup burst distorts. Worth
+         * knowing when reading the line, since `mean` and `MB/h` beside each other do not span the
+         * same window and so will not divide into each other exactly. The same is true of the draw
+         * times below it.
+         */
         val meanRenderBytes: Long? get() = if (renders > 0) renderBytes / renders else null
 
         /** A rate is only quoted once the steady window is long enough to mean something. Five
@@ -185,8 +193,15 @@ object WidgetTelemetry {
                 return "Widgets:     no pushes this app session"
             }
             val mins = uptimeMs / 60_000
-            // Say when a rate is being withheld rather than leaving its absence to be read as zero.
-            val span = if (steadyEnough) "over ${mins}m" else "over ${mins}m, rates need 6m+"
+            // Say when a rate is being withheld, and say it in terms of the window it is actually
+            // waiting on. "needs 6m+" would read as a claim about UPTIME, and with sparse pushes the
+            // steady window opens late — twenty minutes in and still withholding would look broken
+            // rather than explained.
+            val span = if (steadyEnough) {
+                "over ${mins}m"
+            } else {
+                "over ${mins}m, steady ${steadyMs / 60_000}m of 5m"
+            }
             val parts = ArrayList<String>(6)
             if (pushesAdmitted > 0L || pushesGated > 0L) {
                 parts.add("$pushesAdmitted pushed / ${pushesAdmitted + pushesGated} offered")

--- a/android/app/src/main/java/com/noop/widget/WidgetTelemetry.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetTelemetry.kt
@@ -48,6 +48,7 @@ object WidgetTelemetry {
     private var steadyStartMs = 0L
     private var steadyPushes = 0L
     private var steadyUnchanged = 0L
+    private var steadyNoWidget = 0L
     private var steadyRenderBytes = 0L
     private var pushesAdmitted = 0L
     private var pushesGated = 0L
@@ -57,6 +58,7 @@ object WidgetTelemetry {
     private var renderMs = 0L
     private var renderMsMax = 0L
     private var pushesUnchanged = 0L
+    private var pushesNoWidget = 0L
     private var lastPushAtMs = 0L
 
     /** A push [PushGate] let through: prefs written and every placed widget recomposed. */
@@ -89,6 +91,21 @@ object WidgetTelemetry {
         if (steadyStartMs != 0L) steadyUnchanged += 1
     }
 
+    /**
+     * A push admitted with no widget placed to receive it.
+     *
+     * A DIFFERENT outcome from [notePushUnchanged], and worth its own counter rather than folding the
+     * two together: "there was nothing new to show" and "there was nobody to show it to" answer
+     * different questions, and the second is exactly what an export taken with the widget removed is
+     * for. Counting it as a send would have made a widget-removed capture look identical to a
+     * widget-placed one on every figure except the draws.
+     */
+    @Synchronized
+    fun notePushNoWidget() {
+        pushesNoWidget += 1
+        if (steadyStartMs != 0L) steadyNoWidget += 1
+    }
+
     /** One trace bitmap built: [bytes] is what crosses the Binder, [elapsedMs] is the draw alone. */
     @Synchronized
     fun noteRender(bytes: Int, elapsedMs: Long) {
@@ -115,10 +132,12 @@ object WidgetTelemetry {
         steadyMs = if (steadyStartMs == 0L) 0L else nowMs - steadyStartMs,
         steadyPushes = steadyPushes,
         steadyUnchanged = steadyUnchanged,
+        steadyNoWidget = steadyNoWidget,
         steadyRenderBytes = steadyRenderBytes,
         pushesAdmitted = pushesAdmitted,
         pushesGated = pushesGated,
         pushesUnchanged = pushesUnchanged,
+        pushesNoWidget = pushesNoWidget,
         renders = renders,
         rendersRedundant = rendersRedundant,
         renderBytes = renderBytes,
@@ -131,7 +150,8 @@ object WidgetTelemetry {
     fun resetForTest() {
         startedAtMs = 0L; steadyStartMs = 0L; steadyPushes = 0L; steadyRenderBytes = 0L
         steadyUnchanged = 0L
-        pushesAdmitted = 0L; pushesGated = 0L; pushesUnchanged = 0L
+        pushesAdmitted = 0L; pushesGated = 0L; pushesUnchanged = 0L; pushesNoWidget = 0L
+        steadyNoWidget = 0L
         renders = 0L; rendersRedundant = 0L; renderBytes = 0L; renderMs = 0L; renderMsMax = 0L
         lastPushAtMs = 0L
     }
@@ -141,10 +161,12 @@ object WidgetTelemetry {
         val steadyMs: Long,
         val steadyPushes: Long,
         val steadyUnchanged: Long,
+        val steadyNoWidget: Long,
         val steadyRenderBytes: Long,
         val pushesAdmitted: Long,
         val pushesGated: Long,
         val pushesUnchanged: Long,
+        val pushesNoWidget: Long,
         val renders: Long,
         val rendersRedundant: Long,
         val renderBytes: Long,
@@ -167,8 +189,11 @@ object WidgetTelemetry {
          *  minutes of ordinary running is a handful of one-a-minute pushes; less is arithmetic. */
         private val steadyEnough: Boolean get() = steadyMs >= 5 * 60_000L
 
-        /** Pushes that actually became a widget update: admitted, then not dropped by [RenderedGate]. */
-        val pushesSent: Long get() = pushesAdmitted - pushesUnchanged
+        /**
+         * Pushes that actually became a widget update: admitted, then neither dropped by
+         * [RenderedGate] nor discarded for having no widget to go to.
+         */
+        val pushesSent: Long get() = pushesAdmitted - pushesUnchanged - pushesNoWidget
 
         /**
          * Widget updates SENT per hour, over the steady window rather than since process start.
@@ -189,7 +214,7 @@ object WidgetTelemetry {
          * that hour, and the rate should say so.
          */
         val pushesPerHour: Double?
-            get() = if (steadyEnough) (steadyPushes - steadyUnchanged) * 3_600_000.0 / steadyMs else null
+            get() = if (steadyEnough) (steadyPushes - steadyUnchanged - steadyNoWidget) * 3_600_000.0 / steadyMs else null
 
         /**
          * Bitmap bytes per hour — the figure the drain question turns on, since this is what crosses a
@@ -240,6 +265,7 @@ object WidgetTelemetry {
                 parts.add("draw ${renderMs / renders}ms avg / ${renderMsMax}ms max")
             }
             if (pushesUnchanged > 0) parts.add("$pushesUnchanged unchanged")
+            if (pushesNoWidget > 0) parts.add("$pushesNoWidget with no widget placed")
             if (rendersRedundant > 0) parts.add("$rendersRedundant redundant")
             return "Widgets:     ${parts.joinToString(" · ")} ($span)"
         }

--- a/android/app/src/main/java/com/noop/widget/WidgetTelemetry.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetTelemetry.kt
@@ -32,7 +32,22 @@ import java.util.Locale
  */
 object WidgetTelemetry {
 
+    /**
+     * How long after the first push to ignore before the rates start counting.
+     *
+     * The snapshot's fields populate one after another at startup — recovery, then rest, then effort,
+     * then battery, then connection — and each one is a key change [PushGate] admits immediately. So a
+     * launch produces a burst that the 60-second refresh clause has nothing to do with. The first field
+     * sample showed six pushes in a hundred seconds reported as 215/h, against a steady state of about
+     * sixty: the number that matters most was wrong by three and a half times, in exactly the situation
+     * where someone looks at it first.
+     */
+    private const val WARMUP_MS = 60_000L
+
     private var startedAtMs = 0L
+    private var steadyStartMs = 0L
+    private var steadyPushes = 0L
+    private var steadyRenderBytes = 0L
     private var pushesAdmitted = 0L
     private var pushesGated = 0L
     private var renders = 0L
@@ -49,6 +64,10 @@ object WidgetTelemetry {
         if (startedAtMs == 0L) startedAtMs = nowMs
         pushesAdmitted += 1
         lastPushAtMs = nowMs
+        if (nowMs - startedAtMs >= WARMUP_MS) {
+            if (steadyStartMs == 0L) steadyStartMs = nowMs
+            steadyPushes += 1
+        }
     }
 
     /** A push the gate dropped. At live-HR cadence this should dwarf the admitted count. */
@@ -75,6 +94,7 @@ object WidgetTelemetry {
         renderBytes += bytes.toLong()
         renderMs += elapsedMs
         if (elapsedMs > renderMsMax) renderMsMax = elapsedMs
+        if (steadyStartMs != 0L) steadyRenderBytes += bytes.toLong()
     }
 
     /**
@@ -90,6 +110,9 @@ object WidgetTelemetry {
     @Synchronized
     fun snapshot(nowMs: Long): Snapshot = Snapshot(
         uptimeMs = if (startedAtMs == 0L) 0L else nowMs - startedAtMs,
+        steadyMs = if (steadyStartMs == 0L) 0L else nowMs - steadyStartMs,
+        steadyPushes = steadyPushes,
+        steadyRenderBytes = steadyRenderBytes,
         pushesAdmitted = pushesAdmitted,
         pushesGated = pushesGated,
         pushesUnchanged = pushesUnchanged,
@@ -103,13 +126,17 @@ object WidgetTelemetry {
 
     @Synchronized
     fun resetForTest() {
-        startedAtMs = 0L; pushesAdmitted = 0L; pushesGated = 0L; pushesUnchanged = 0L
+        startedAtMs = 0L; steadyStartMs = 0L; steadyPushes = 0L; steadyRenderBytes = 0L
+        pushesAdmitted = 0L; pushesGated = 0L; pushesUnchanged = 0L
         renders = 0L; rendersRedundant = 0L; renderBytes = 0L; renderMs = 0L; renderMsMax = 0L
         lastPushAtMs = 0L
     }
 
     data class Snapshot(
         val uptimeMs: Long,
+        val steadyMs: Long,
+        val steadyPushes: Long,
+        val steadyRenderBytes: Long,
         val pushesAdmitted: Long,
         val pushesGated: Long,
         val pushesUnchanged: Long,
@@ -123,19 +150,27 @@ object WidgetTelemetry {
         /** Mean bitmap in bytes, or null before the first render. */
         val meanRenderBytes: Long? get() = if (renders > 0) renderBytes / renders else null
 
-        /**
-         * Pushes per hour, extrapolated from this process's uptime. Null under a minute of uptime:
-         * a rate from a few seconds of samples is noise wearing a number's clothes.
-         */
-        val pushesPerHour: Double?
-            get() = if (uptimeMs >= 60_000L) pushesAdmitted * 3_600_000.0 / uptimeMs else null
+        /** A rate is only quoted once the steady window is long enough to mean something. Five
+         *  minutes of ordinary running is a handful of one-a-minute pushes; less is arithmetic. */
+        private val steadyEnough: Boolean get() = steadyMs >= 5 * 60_000L
 
         /**
-         * Bitmap bytes per hour at the observed rate — the figure the drain question turns on, since
-         * this is what crosses a Binder transaction to the launcher.
+         * Pushes per hour, measured over the STEADY window rather than since process start.
+         *
+         * The startup burst is excluded because it is not what the widget costs to keep running: the
+         * snapshot's fields arrive one by one and each is a key change admitted on the spot, so a
+         * launch produces pushes the 60-second clause had nothing to do with. Quoting them as a rate
+         * overstated the cost by three and a half times on the first sample from a device.
+         */
+        val pushesPerHour: Double?
+            get() = if (steadyEnough) steadyPushes * 3_600_000.0 / steadyMs else null
+
+        /**
+         * Bitmap bytes per hour — the figure the drain question turns on, since this is what crosses a
+         * Binder transaction to the launcher. Same steady window, for the same reason.
          */
         val renderBytesPerHour: Double?
-            get() = if (uptimeMs >= 60_000L) renderBytes * 3_600_000.0 / uptimeMs else null
+            get() = if (steadyEnough) steadyRenderBytes * 3_600_000.0 / steadyMs else null
 
         /**
          * One line for the diagnostics header. Deliberately reports the RATE alongside the raw counts:
@@ -150,6 +185,8 @@ object WidgetTelemetry {
                 return "Widgets:     no pushes this app session"
             }
             val mins = uptimeMs / 60_000
+            // Say when a rate is being withheld rather than leaving its absence to be read as zero.
+            val span = if (steadyEnough) "over ${mins}m" else "over ${mins}m, rates need 6m+"
             val parts = ArrayList<String>(6)
             if (pushesAdmitted > 0L || pushesGated > 0L) {
                 parts.add("$pushesAdmitted pushed / ${pushesAdmitted + pushesGated} offered")
@@ -165,7 +202,7 @@ object WidgetTelemetry {
             }
             if (pushesUnchanged > 0) parts.add("$pushesUnchanged unchanged")
             if (rendersRedundant > 0) parts.add("$rendersRedundant redundant")
-            return "Widgets:     ${parts.joinToString(" · ")} (over ${mins}m)"
+            return "Widgets:     ${parts.joinToString(" · ")} ($span)"
         }
     }
 }

--- a/android/app/src/main/java/com/noop/widget/WidgetTelemetry.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetTelemetry.kt
@@ -47,6 +47,7 @@ object WidgetTelemetry {
     private var startedAtMs = 0L
     private var steadyStartMs = 0L
     private var steadyPushes = 0L
+    private var steadyUnchanged = 0L
     private var steadyRenderBytes = 0L
     private var pushesAdmitted = 0L
     private var pushesGated = 0L
@@ -85,6 +86,7 @@ object WidgetTelemetry {
     @Synchronized
     fun notePushUnchanged() {
         pushesUnchanged += 1
+        if (steadyStartMs != 0L) steadyUnchanged += 1
     }
 
     /** One trace bitmap built: [bytes] is what crosses the Binder, [elapsedMs] is the draw alone. */
@@ -112,6 +114,7 @@ object WidgetTelemetry {
         uptimeMs = if (startedAtMs == 0L) 0L else nowMs - startedAtMs,
         steadyMs = if (steadyStartMs == 0L) 0L else nowMs - steadyStartMs,
         steadyPushes = steadyPushes,
+        steadyUnchanged = steadyUnchanged,
         steadyRenderBytes = steadyRenderBytes,
         pushesAdmitted = pushesAdmitted,
         pushesGated = pushesGated,
@@ -127,6 +130,7 @@ object WidgetTelemetry {
     @Synchronized
     fun resetForTest() {
         startedAtMs = 0L; steadyStartMs = 0L; steadyPushes = 0L; steadyRenderBytes = 0L
+        steadyUnchanged = 0L
         pushesAdmitted = 0L; pushesGated = 0L; pushesUnchanged = 0L
         renders = 0L; rendersRedundant = 0L; renderBytes = 0L; renderMs = 0L; renderMsMax = 0L
         lastPushAtMs = 0L
@@ -136,6 +140,7 @@ object WidgetTelemetry {
         val uptimeMs: Long,
         val steadyMs: Long,
         val steadyPushes: Long,
+        val steadyUnchanged: Long,
         val steadyRenderBytes: Long,
         val pushesAdmitted: Long,
         val pushesGated: Long,
@@ -162,16 +167,29 @@ object WidgetTelemetry {
          *  minutes of ordinary running is a handful of one-a-minute pushes; less is arithmetic. */
         private val steadyEnough: Boolean get() = steadyMs >= 5 * 60_000L
 
+        /** Pushes that actually became a widget update: admitted, then not dropped by [RenderedGate]. */
+        val pushesSent: Long get() = pushesAdmitted - pushesUnchanged
+
         /**
-         * Pushes per hour, measured over the STEADY window rather than since process start.
+         * Widget updates SENT per hour, over the steady window rather than since process start.
          *
-         * The startup burst is excluded because it is not what the widget costs to keep running: the
-         * snapshot's fields arrive one by one and each is a key change admitted on the spot, so a
-         * launch produces pushes the 60-second clause had nothing to do with. Quoting them as a rate
-         * overstated the cost by three and a half times on the first sample from a device.
+         * Two exclusions, for two different reasons. The startup burst goes because it is not what the
+         * widget costs to keep running — the snapshot's fields arrive one by one and each is a key
+         * change admitted on the spot, so a launch produces pushes the 60-second clause had nothing to
+         * do with, and quoting them overstated the cost by three and a half times on the first sample
+         * from a device.
+         *
+         * And pushes [RenderedGate] declined go because they never reached a widget. Counting them
+         * here would have made this rate blind to the one optimisation it exists to price: the gate's
+         * whole purpose is to lower this number, so a figure that could not fall when the gate fired
+         * would be measuring the wrong thing.
+         *
+         * Elapsed WALL-CLOCK time is the denominator, not time spent streaming, because that is what a
+         * battery question is asked in. A process that idles for an hour genuinely cost nothing over
+         * that hour, and the rate should say so.
          */
         val pushesPerHour: Double?
-            get() = if (steadyEnough) steadyPushes * 3_600_000.0 / steadyMs else null
+            get() = if (steadyEnough) (steadyPushes - steadyUnchanged) * 3_600_000.0 / steadyMs else null
 
         /**
          * Bitmap bytes per hour — the figure the drain question turns on, since this is what crosses a
@@ -204,7 +222,13 @@ object WidgetTelemetry {
             }
             val parts = ArrayList<String>(6)
             if (pushesAdmitted > 0L || pushesGated > 0L) {
-                parts.add("$pushesAdmitted pushed / ${pushesAdmitted + pushesGated} offered")
+                // SENT first, because it is the one that means "a widget was updated". `pushesAdmitted`
+                // alone read as that and was not: a push the rendered gate declined is admitted and
+                // never sent.
+                parts.add(
+                    "$pushesSent sent / $pushesAdmitted admitted / " +
+                        "${pushesAdmitted + pushesGated} offered",
+                )
             } else {
                 parts.add("no pushes")
             }

--- a/android/app/src/test/java/com/noop/widget/WidgetTelemetryTest.kt
+++ b/android/app/src/test/java/com/noop/widget/WidgetTelemetryTest.kt
@@ -283,4 +283,43 @@ class WidgetTelemetryTest {
         assertTrue(line, "6 sent / 11 admitted" in line)
         assertTrue(line, "5 unchanged" in line)
     }
+
+    /**
+     * The widget-removed capture is half of the comparison that answers whether the widget costs
+     * anything, so a push with nowhere to go must not read as a send. Left as one, both halves of the
+     * A/B would have shown identical sent counts and rates, and only the draw count would have
+     * differed — which is a much weaker signal than the one the counters are supposed to give.
+     */
+    @Test
+    fun aPushWithNoWidgetPlacedIsNotASend() {
+        WidgetTelemetry.notePushAdmitted(t0)                       // warm-up
+        for (m in 1..10) {
+            WidgetTelemetry.notePushAdmitted(t0 + m * 60_000L)
+            WidgetTelemetry.notePushNoWidget()
+        }
+        val s = WidgetTelemetry.snapshot(t0 + 660_000L)
+        assertEquals(11, s.pushesAdmitted)
+        assertEquals(1, s.pushesSent)                              // only the warm-up push had a widget
+        assertEquals(0.0, s.pushesPerHour!!, 0.001)                // nothing was sent in the window
+        val line = s.render()
+        assertTrue(line, "1 sent / 11 admitted" in line)
+        assertTrue(line, "10 with no widget placed" in line)
+    }
+
+    /**
+     * The two non-send outcomes are different answers and must not be conflated: "nothing new to
+     * show" is the rendered gate doing its job, "nobody to show it to" is the widget being absent.
+     */
+    @Test
+    fun theTwoNonSendOutcomesAreReportedApart() {
+        WidgetTelemetry.notePushAdmitted(t0)
+        for (m in 1..10) WidgetTelemetry.notePushAdmitted(t0 + m * 60_000L)
+        repeat(3) { WidgetTelemetry.notePushUnchanged() }
+        repeat(2) { WidgetTelemetry.notePushNoWidget() }
+        val s = WidgetTelemetry.snapshot(t0 + 660_000L)
+        assertEquals(6, s.pushesSent)                              // 11 - 3 - 2
+        val line = s.render()
+        assertTrue(line, "3 unchanged" in line)
+        assertTrue(line, "2 with no widget placed" in line)
+    }
 }

--- a/android/app/src/test/java/com/noop/widget/WidgetTelemetryTest.kt
+++ b/android/app/src/test/java/com/noop/widget/WidgetTelemetryTest.kt
@@ -35,7 +35,7 @@ class WidgetTelemetryTest {
         val s = WidgetTelemetry.snapshot(t0 + 60_000L)
         assertEquals(1, s.pushesAdmitted)
         assertEquals(59, s.pushesGated)
-        assertTrue("1 pushed / 60 offered" in s.render())
+        assertTrue(s.render(), "1 sent / 1 admitted / 60 offered" in s.render())
     }
 
     /** The rate is measured over the steady window, one push a minute being the ordinary cadence. */
@@ -72,7 +72,7 @@ class WidgetTelemetryTest {
         assertEquals(6, s.pushesAdmitted)
         assertNull("a burst is not a rate", s.pushesPerHour)
         val line = s.render()
-        assertTrue(line, "6 pushed" in line)
+        assertTrue(line, "6 sent / 6 admitted" in line)
         assertTrue("the line must say the rate is withheld: $line", "steady" in line)
     }
 
@@ -258,5 +258,29 @@ class WidgetTelemetryTest {
         assertTrue("uptime should read twenty minutes: $line", "over 20m" in line)
         assertTrue("and the wait should be stated against the steady window: $line",
             "steady 1m of 5m" in line)
+    }
+
+    /**
+     * The rate has to be blind to nothing except what never reached a widget. A push RenderedGate
+     * declines is admitted and then dropped, so counting it here would have made this figure unable
+     * to fall when the gate fired — and lowering it is the gate's entire purpose. An instrument that
+     * cannot show the effect of the optimisation shipped beside it is measuring the wrong thing.
+     */
+    @Test
+    fun declinedPushesAreNotCountedAsSentOrRated() {
+        WidgetTelemetry.notePushAdmitted(t0)                       // warm-up
+        for (m in 1..10) {
+            WidgetTelemetry.notePushAdmitted(t0 + m * 60_000L)
+            if (m > 5) WidgetTelemetry.notePushUnchanged()          // five of the ten never went out
+        }
+        val s = WidgetTelemetry.snapshot(t0 + 660_000L)
+        assertEquals(11, s.pushesAdmitted)
+        assertEquals(6, s.pushesSent)                              // 11 admitted - 5 declined
+        // Steady window holds ten pushes over ten minutes, five of them declined: five sends an hour
+        // at that cadence would be 30/h, not the 60/h the admitted count alone would have claimed.
+        assertEquals(30.0, s.pushesPerHour!!, 0.001)
+        val line = s.render()
+        assertTrue(line, "6 sent / 11 admitted" in line)
+        assertTrue(line, "5 unchanged" in line)
     }
 }

--- a/android/app/src/test/java/com/noop/widget/WidgetTelemetryTest.kt
+++ b/android/app/src/test/java/com/noop/widget/WidgetTelemetryTest.kt
@@ -73,7 +73,7 @@ class WidgetTelemetryTest {
         assertNull("a burst is not a rate", s.pushesPerHour)
         val line = s.render()
         assertTrue(line, "6 pushed" in line)
-        assertTrue("the line must say the rate is withheld: $line", "rates need" in line)
+        assertTrue("the line must say the rate is withheld: $line", "steady" in line)
     }
 
     /**
@@ -241,5 +241,22 @@ class WidgetTelemetryTest {
         assertTrue("480dpi/380dp should be upscaled", effective(480f, 380f) < 1.0)
         // And a small card is where the intent survives best, though still short of the nominal 2x.
         assertTrue("420dpi/300dp should have the most headroom", effective(420f, 300f) > 1.5)
+    }
+
+    /**
+     * The withheld-rate message has to name the window it is actually waiting on. Phrasing it as a
+     * minimum UPTIME was wrong: pushes can be sparse enough that the steady window opens late, so the
+     * line would sit twenty minutes in still claiming it needed six, which reads as broken rather than
+     * explained.
+     */
+    @Test
+    fun aWithheldRateNamesTheSteadyWindowNotTheUptime() {
+        WidgetTelemetry.notePushAdmitted(t0)                    // opens warm-up
+        WidgetTelemetry.notePushAdmitted(t0 + 19 * 60_000L)     // opens steady, nineteen minutes in
+        val line = WidgetTelemetry.snapshot(t0 + 20 * 60_000L).render()
+        assertNull(WidgetTelemetry.snapshot(t0 + 20 * 60_000L).pushesPerHour)
+        assertTrue("uptime should read twenty minutes: $line", "over 20m" in line)
+        assertTrue("and the wait should be stated against the steady window: $line",
+            "steady 1m of 5m" in line)
     }
 }

--- a/android/app/src/test/java/com/noop/widget/WidgetTelemetryTest.kt
+++ b/android/app/src/test/java/com/noop/widget/WidgetTelemetryTest.kt
@@ -38,16 +38,42 @@ class WidgetTelemetryTest {
         assertTrue("1 pushed / 60 offered" in s.render())
     }
 
-    /** A rate over one minute of uptime is the figure a drain question turns on. */
+    /** The rate is measured over the steady window, one push a minute being the ordinary cadence. */
     @Test
-    fun ratesAreExtrapolatedFromUptime() {
-        repeat(10) { WidgetTelemetry.notePushAdmitted(t0 + it * 60_000L) }
-        repeat(10) { WidgetTelemetry.noteRender(bytes = 512 * 1024, elapsedMs = 4) }
-        val s = WidgetTelemetry.snapshot(t0 + 600_000L)   // 10 minutes
-        assertEquals(60.0, s.pushesPerHour!!, 0.001)      // 10 pushes in 10m = 60/h
+    fun ratesAreExtrapolatedFromTheSteadyWindow() {
+        // One push at t0 opens the warm-up; the rest land a minute apart beyond it.
+        WidgetTelemetry.notePushAdmitted(t0)
+        for (m in 1..10) {
+            WidgetTelemetry.notePushAdmitted(t0 + m * 60_000L)
+            WidgetTelemetry.noteRender(bytes = 512 * 1024, elapsedMs = 4)
+        }
+        val s = WidgetTelemetry.snapshot(t0 + 660_000L)
+        // Steady window opens at the first post-warm-up push (t0+60s) and runs 10 minutes; ten pushes
+        // and ten draws inside it.
+        assertEquals(60.0, s.pushesPerHour!!, 0.001)
         assertEquals(512L, s.meanRenderBytes!! / 1024)
-        // 10 x 512KB in 10 minutes = 30MB/h.
         assertEquals(30.0, s.renderBytesPerHour!! / 1_048_576.0, 0.01)
+    }
+
+    /**
+     * The startup burst must not be quoted as a rate. The snapshot's fields arrive one by one at
+     * launch and each is a key change PushGate admits on the spot, so a launch produces pushes the
+     * 60-second clause had nothing to do with. A device reported six pushes in a hundred seconds as
+     * 215/h against a steady state of about sixty — the headline number wrong by three and a half
+     * times, in the situation where it is looked at first.
+     */
+    @Test
+    fun aStartupBurstIsNotQuotedAsARate() {
+        // Six pushes inside the first hundred seconds, as the real capture showed.
+        for (ms in listOf(0L, 2_000L, 5_000L, 9_000L, 30_000L, 95_000L)) {
+            WidgetTelemetry.notePushAdmitted(t0 + ms)
+        }
+        val s = WidgetTelemetry.snapshot(t0 + 100_000L)
+        assertEquals(6, s.pushesAdmitted)
+        assertNull("a burst is not a rate", s.pushesPerHour)
+        val line = s.render()
+        assertTrue(line, "6 pushed" in line)
+        assertTrue("the line must say the rate is withheld: $line", "rates need" in line)
     }
 
     /**
@@ -55,7 +81,7 @@ class WidgetTelemetryTest {
      * goes in front of someone deciding whether to change the refresh cadence.
      */
     @Test
-    fun noRateIsClaimedUnderAMinuteOfUptime() {
+    fun noRateIsClaimedUnderASteadyWindow() {
         WidgetTelemetry.notePushAdmitted(t0)
         val s = WidgetTelemetry.snapshot(t0 + 5_000L)
         assertNull(s.pushesPerHour)
@@ -169,9 +195,12 @@ class WidgetTelemetryTest {
         val original = Locale.getDefault()
         try {
             Locale.setDefault(Locale.GERMANY)
-            repeat(10) { WidgetTelemetry.notePushAdmitted(t0 + it * 60_000L) }
-            repeat(10) { WidgetTelemetry.noteRender(bytes = 512 * 1024, elapsedMs = 4) }
-            val line = WidgetTelemetry.snapshot(t0 + 600_000L).render()
+            WidgetTelemetry.notePushAdmitted(t0)
+            for (m in 1..10) {
+                WidgetTelemetry.notePushAdmitted(t0 + m * 60_000L)
+                WidgetTelemetry.noteRender(bytes = 512 * 1024, elapsedMs = 4)
+            }
+            val line = WidgetTelemetry.snapshot(t0 + 660_000L).render()
             assertTrue(line, "60.0/h" in line)
             assertTrue(line, "30.0MB/h" in line)
             assertFalse(line, "," in line.substringAfter("Widgets:"))

--- a/project.yml
+++ b/project.yml
@@ -168,6 +168,9 @@ targets:
       # worth testing lives, and it is iOS/widget-only, so it is compiled into the test bundle rather
       # than added to the macOS app.
       - StrandiOSShared/HrTrace.swift
+      # And the widget cost counters, for the same reason again: pure, iOS-only, and the arithmetic is
+      # exactly the part that has been wrong twice on the Android side.
+      - StrandiOSShared/WidgetTelemetry.swift
     # Same wrapper as the app target, so the OURA_CLOUD_IMPORT-gated Oura tests compile exactly
     # when the app's Oura lane does (flag + creds both come from the untracked OuraSecrets.xcconfig).
     configFiles:


### PR DESCRIPTION
## Why

The first capture from a device, on build 455:

```
Widgets:  6 pushed / 53 offered · 215.5/h · 2 trace draws · mean 464KB · 32.6MB/h · draw 3ms avg / 4ms max (over 1m)
```

**215.5/h against a steady state of about sixty.** `PushGate`'s refresh clause is 60s, so at most two of those six pushes could have come from it. The rest are the snapshot's fields arriving one at a time at launch — recovery, then rest, then effort, then battery, then connection — and each is a key change admitted on the spot. A launch produces a burst the cadence had nothing to do with.

So this is a bug in the instrument, not in the widget, and it mattered: the rate is the headline figure someone uses to judge whether the widget is expensive, and it was wrong by three and a half times in exactly the situation where it is looked at first.

## The fix

A minute of uptime was not a long enough floor, because the problem is not sample size — the early samples are a **different population**. Rates now run over a **steady window** that opens a minute after the first push, and are withheld until that window is five minutes long. Raw counts still cover everything including the burst, because the burst is real work.

The line says when a rate is being withheld, and says it against the window it is actually waiting on:

```
Widgets:  8 pushed / 291 offered · 2 trace draws · mean 464KB · draw 3ms avg / 4ms max (over 20m, steady 1m of 5m)
```

## A third, from re-reviewing after it opened

**The counters could not measure the optimisation that shipped beside them**, which is worse than the rate bug this branch opened for.

A push `RenderedGate` declines has already been counted by `notePushAdmitted` — `pushesUnchanged` is a *sub-count* of it, not a separate outcome. So `8 pushed` read as "eight widget updates went out" when some never left, and `pushesPerHour` counted declined pushes as sends. The gate exists to lower that number, and the number structurally could not fall when it fired.

Now split: `sent = admitted − unchanged`, and the rate is over sends. The line reads `5 sent / 8 admitted / 291 offered`, distinguishing what we were asked to do, what the throttle let through, and what actually reached a widget.

**And a second exit, one further up.** Between `notePushAdmitted` and the rendered gate sits "no widget placed at all", which returned without recording anything — so on an install with no widget on the home screen, every admitted push counted as a send.

That is the worst place for it: an export taken with the widget **removed** is half of the comparison that answers whether the widget costs anything. Both halves would have shown identical sent counts and rates, leaving only the draw count to tell them apart. It is now its own outcome, not folded into `unchanged`, because "nothing new to show" and "nobody to show it to" answer different questions.

## Two things the re-review caught before this opened

- **The withheld message named the wrong thing.** It read `rates need 6m+`, which sounds like a claim about uptime. The gate is on the steady window, which opens at the first push after the warm-up and so opens late when pushes are sparse — a session could sit twenty minutes in still saying it needed six. It now reports the steady span against its threshold.
- **`mean` and `MB/h` do not divide into each other**, because the mean spans every draw while the rate spans only the steady window. Deliberate — a bitmap's size is set by the widget's dimensions and the screen's density, not by when it was drawn, so a burst does not distort it and excluding those draws would just discard data. Now said in the code rather than left to be puzzled out from a log.

## What the same capture already tells us about the widget

All consistent with what the code predicted, and none of it affected by the rate bug:

- **The throttle works** — 6 admitted from 53 offered.
- **The bitmap saturates its budget** — 464KB mean against a 512KB cap, which is what the `WIDTH_HEADROOM` finding predicted.
- **Drawing is 3ms avg / 4ms max**, so the cost is the Binder transfer and not the drawing. That confirms a bitmap cache would buy almost nothing, which is why this PR does not add one.
- **`unchanged` is zero.** Expected while every field is still moving at startup, but it means the rendered gate added last round is still unproven in the field. That is the number a longer capture is for.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

**Android unit tests, full suite:** **5,581 tests, 664 classes, 0 failures, 0 errors**, results directory cleared first and the Room oracle synced in its own invocation. `WidgetTelemetryTest` is 18 of those.

Six tests carry the findings: the six-pushes-in-a-hundred-seconds burst from the real capture yields **no** rate; a steady ten-minutes-of-one-a-minute yields exactly 60/h; and a session twenty minutes in with a one-minute steady window reports `over 20m, steady 1m of 5m` rather than a figure or a misleading condition; and ten steady pushes of which five are declined rate at 30/h rather than the 60/h the admitted count alone would have claimed.

**Gates:** `Tools/doc_comment_lint.py` clean · `Tools/i18n_audit.py --ci origin/main` clean.

**No behaviour change** to the widgets: counters and one diagnostics line only.

## iOS

I claimed "not applicable" when this opened. That was wrong, and half of it maps exactly, so the twin is here.

**Maps:** the push accounting. `HRPublishThrottle` gates, `saveAndReloadIfChanged` either reloads or declines, and `DebugDataDiagnostics` has the same header block with `Data write:` and `Last restore:` — the exact place the Android line went. Nothing there had ever measured any of it.

**Does not map:** the bitmap accounting. The iOS widget draws a SwiftUI `Path` in the extension, so draws, bytes, MB/h and redundant redraws would count something that does not happen. Left out rather than faked.

**And one cost Android does not have**, which is why this is worth building rather than merely symmetrical: WidgetKit budgets timeline reloads, and spending that budget does not drain the battery — it makes the widget go **stale**, a correctness failure the user sees. So the rate counts *reloads*, not publishes: a publish that declined the reload spent none of the budget, and counting those would repeat the mistake this branch corrected twice on the Android side.

Three things verified against the project rather than assumed, since Swift does not compile in this environment: `StrandiOSShared` is deliberately kept out of the macOS application module (project.yml says so), so the diagnostics line is behind `#if os(iOS)`; the test bundle compiles the source directly as it already does for `WidgetSnapshot` and `HrTrace`, so the tests import only `XCTest` as those two do rather than the `Strand` module the other 211 files import; and `SWIFT_STRICT_CONCURRENCY` is `minimal`, so the static counters need no isolation annotation.

Note `StrandTests` runs in the on-demand app-build workflow, not default CI.

## Related issues

Follows the widget cost counters merged in `c753493`. No issue reference — the report arrived as a field observation.
