### PR TITLE
diagnostics: three lines that told triage the wrong thing

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/CaptureCompleteness.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/CaptureCompleteness.swift
@@ -72,7 +72,10 @@ public enum CaptureCompleteness {
         .dataImport: ["import stage=", "rowsIn="],
         .steps:      ["stepsRaw", "stepsCal"],
         .battery:    ["bank soc=", "socSeries"],
-        .recovery:   ["charge term", "charge score=", "charge nilScore"],
+        // "charge day=" for the same reason as the Kotlin twin: IntelligenceEngine re-emits every
+        // recovery trace line as `charge day=<day> ` + the body, so none of the three variants this
+        // used to name could ever match and the domain reported MISSING on every capture.
+        .recovery:   ["charge day="],
         .hrv:        ["hrv rmssd=", "hrv result=", "hrv nightSummary"],
         .universal:  ["dayOwner ", "strapClock "],
     ]

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/CaptureCompletenessTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/CaptureCompletenessTests.swift
@@ -19,7 +19,7 @@ final class CaptureCompletenessTests: XCTestCase {
     [import] import stage=sleep rowsIn=10 rowsOut=10
     [steps] stepsRaw day=2026-06-28 counterSamples=4 deltas kept=3 dropped=0
     [battery] bank soc=82.0 t=1700000000s
-    [recovery] charge term hrv z=0.20 w=0.40 (higher HRV is better)
+    [recovery] charge day=2026-06-28 term hrv z=0.20 w=0.40 (higher HRV is better)
     [hrv] hrv rmssd=42.10ms sdnn=55.00ms meanNN=900.00ms
     [universal] dayOwner day=2026-06-28 readId=my-whoop writeActiveId=my-whoop hrRows=120 provenance=measured
     """
@@ -126,9 +126,16 @@ final class CaptureCompletenessTests: XCTestCase {
     }
 
     func testTokenMapMatchesEmitterTokensExactly() {
-        // Guard against a silent emitter rename: each token must be the verbatim leading text the live
-        // emitter writes. These literals mirror the *Trace files (verified at authoring time).
-        XCTAssertEqual(CaptureCompleteness.expectedTokens(for: .recovery).first, "charge term")
+        // Guard against a silent emitter rename: each token must be the verbatim leading text that
+        // reaches the REPORT.
+        //
+        // "mirror the *Trace files" is how the recovery token came to be wrong for as long as it was.
+        // RecoveryScorer+Trace really does write "charge term ...", but IntelligenceEngine re-emits
+        // every one of those lines as `charge day=<day> ` + the body before it is logged, so the
+        // literal this guard was protecting could not occur in a single report. A token has to mirror
+        // the END of the pipeline, not the start, or a guard like this passes while the thing it
+        // guards is dead.
+        XCTAssertEqual(CaptureCompleteness.expectedTokens(for: .recovery).first, "charge day=")
         XCTAssertTrue(CaptureCompleteness.expectedTokens(for: .hrv).contains("hrv rmssd="))
         XCTAssertTrue(CaptureCompleteness.expectedTokens(for: .steps).contains("stepsRaw"))
         XCTAssertTrue(CaptureCompleteness.expectedTokens(for: .universal).contains("dayOwner "))

--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -36,7 +36,7 @@ enum DebugDataDiagnostics {
     /// strap simply not worn for two days would be reported as incapable of motion — the opposite kind of
     /// wrong from the one this line exists to prevent. Over a window of actual wear, delivered and capable
     /// are the same thing; the label keeps that assumption visible instead of implied.
-    /// The label is padded to 13 like every other in this block ("Model:", "Data write:"), and the window
+    /// The label is padded to 13 like every other in this block ("Model:", "Offload:"), and the window
     /// rides the VALUE. "Provides(48h):" is 15 and overhung the column in a report that is aligned by hand
     /// and read by eye.
     /// Byte-identical to the Kotlin `AndroidDiagnostics.strapProvidesLine`.
@@ -85,7 +85,13 @@ enum DebugDataDiagnostics {
         let okAt = d.double(forKey: "sync.lastWriteOkAt")
         let stalledAt = d.double(forKey: "sync.lastWriteStalledAt")
         let restoreAt = d.double(forKey: "backup.lastRestoreAt")
-        lines.append("Data write:  \(okAt > 0 ? "rows last landed \(relTime(now - okAt))" : "no rows ever persisted")")
+        // "Offload:", not "Data write:". The stamp is written ONLY when a backfill session persists
+        // rows, so it says nothing about live streaming, and the old label read as "this app has stored
+        // nothing from your strap" on a strap that offloads nothing but streams happily. Twin of the
+        // Kotlin change.
+        lines.append("Offload:     " + (okAt > 0
+            ? "rows last landed \(relTime(now - okAt))"
+            : "no history rows ever persisted (live HR/R-R are not counted here)"))
         if stalledAt > 0, stalledAt >= okAt {
             lines.append("             ⚠ history NOT persisting — last offload STALLED \(relTime(now - stalledAt)) "
                 + "(if you restored a backup, fully restart the app — #57)")
@@ -140,7 +146,7 @@ enum DebugDataDiagnostics {
         // EXISTS seeks, not counts — see WhoopStore.streamPresence for why that distinction matters on a
         // table holding ~190k motion rows a night.
         //
-        // HERE and not in strapStateLines() beside `Data write:`, where it belongs by subject: that
+        // HERE and not in strapStateLines() beside `Offload:`, where it belongs by subject: that
         // function is synchronous and holds neither `repo` nor a store handle. The first attempt put it
         // there and would not have compiled — in a file the comment below already notes needs macOS to
         // build, which is exactly why it went unnoticed locally. Appended first so the output order is

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -55,6 +55,25 @@ object AndroidDiagnostics {
     }
 
     /**
+     * The history-offload write-health line.
+     *
+     * "Offload:", not "Data write:". The stamp behind it is written ONLY when a backfill session
+     * persists rows, so it says nothing about live streaming - and on a strap that offloads nothing but
+     * streams happily (an unbonded 5/MG, the designed end state of #1635) the old label read as "this
+     * app has stored nothing from your strap" while a hundred thousand HR rows sat under that very
+     * device id. The scope now lives in the label, and the zero case says outright what it excludes.
+     *
+     * Pure and extracted for the same reason [strapProvidesLine] is: [summaryLines] needs a real
+     * Context, and the wording is the part a change would silently break.
+     */
+    internal fun offloadLine(okAtSec: Long, ageMs: Long): String =
+        "Offload:     " + if (okAtSec > 0L) {
+            "rows last landed ${relTime(ageMs)}"
+        } else {
+            "no history rows ever persisted (live HR/R-R are not counted here)"
+        }
+
+    /**
      * What the active strap actually delivered over the window — the line that says which scores can
      * exist at all.
      *
@@ -68,7 +87,7 @@ object AndroidDiagnostics {
      * strap simply not worn for two days would be reported as incapable of motion — the opposite kind of
      * wrong from the one this line exists to prevent. Over a window of actual wear, delivered and capable
      * are the same thing; the label keeps that assumption visible instead of implied.
-     * The label is padded to 13 like every other in this block ("Model:", "Data write:"), and the window
+     * The label is padded to 13 like every other in this block ("Model:", "Offload:"), and the window
      * rides the VALUE. "Provides(48h):" is 15 and overhung the column in a report that is aligned by hand
      * and read by eye.
      * Pure so it is unit-tested directly; byte-identical to the Swift twin.
@@ -144,7 +163,15 @@ object AndroidDiagnostics {
             ) ?: 0L
             val restoreAt = p.getLong("backup.lastRestoreAt", 0L)
             val now = System.currentTimeMillis()
-            add("Data write:  ${if (okAt > 0L) "rows last landed ${relTime(now - okAt * 1000L)}" else "no rows ever persisted"}")
+            // "Offload:", not "Data write:". The stamp behind it is written ONLY when a backfill session
+            // persists rows, so it says nothing about live streaming - and on a strap that offloads
+            // nothing but streams happily (an unbonded 5/MG, the designed end state of #1635) the old
+            // label read as "this app has stored nothing from your strap" while a hundred thousand HR
+            // rows sat under that very device id. The scope now lives in the label, and the zero case
+            // says outright what it does not cover.
+            // Age only means anything when something landed; pass 0 otherwise rather than `now`, which
+            // would be a 56-year "age" sitting unused in an argument a reader has to check is unused.
+            add(offloadLine(okAt, if (okAt > 0L) now - okAt * 1000L else 0L))
             if (stalledAt > 0L && stalledAt >= okAt) {
                 add("             ⚠ history NOT persisting — last offload STALLED ${relTime(now - stalledAt * 1000L)} " +
                     "(if you restored a backup, fully restart the app — #57)")

--- a/android/app/src/main/java/com/noop/testcentre/ReportCompleteness.kt
+++ b/android/app/src/main/java/com/noop/testcentre/ReportCompleteness.kt
@@ -49,7 +49,13 @@ object ReportCompleteness {
         TestDomain.IMPORT to "import parser=",
         TestDomain.STEPS to "stepsEst ",
         TestDomain.BATTERY to "battery series=",
-        TestDomain.RECOVERY to "charge score=",
+        // "charge day=", not "charge score=". Every recovery trace line is re-emitted by
+        // IntelligenceEngine.recoveryTraceLines as `charge day=<day> ` + the body, so the bare
+        // "charge score=" this used to look for CANNOT occur and the domain reported MISSING on every
+        // capture that had a perfectly healthy trace. The day prefix is also the one part shared by
+        // every variant the trace emits - score, nilScore and each term - so it cannot go stale the
+        // way a token naming one variant did.
+        TestDomain.RECOVERY to "charge day=",
         TestDomain.HRV to "hrv rmssd=",
     )
 
@@ -130,6 +136,21 @@ object ReportCompleteness {
     }
 
     /**
+     * How long a profile must have been running before "complete" means anything.
+     *
+     * A trace only records while its profile is on, so a capture started seconds before the export
+     * contains none of the passes it is meant to evidence. That is not hypothetical: a sleep bundle
+     * arrived with its profile started NINE SECONDS before the export, carrying no `[sleep]` lines at
+     * all, and this section still said "complete: all active traces present" - which is exactly what
+     * told the reporter it was ready to send, and cost a full round trip to discover.
+     *
+     * Two minutes, because the thing most captures need to contain is a scoring pass, and one takes
+     * about forty seconds on a large library. Short enough not to nag, long enough that a capture
+     * clearing it plausibly holds one.
+     */
+    const val MIN_PROFILE_SECONDS = 120L
+
+    /**
      * The "Capture check" section appended to report.txt: a header, then one line per checked domain in
      * deterministic order, then a footer flag when any active domain's trace is MISSING (the at-a-glance
      * "this report carries no diagnostic for X" signal). The parenthetical names the token that ACTUALLY
@@ -137,8 +158,16 @@ object ReportCompleteness {
      * `(<killer>)`, an evidence-only match (#127) reads `(via <evidence>)`, and MISSING reads
      * `(expected <killer>)` — the Swift renderer's "expected …" wording for the missing case. Returns
      * the section WITHOUT a leading newline; the assembler joins it.
+     *
+     * @param profileRanSeconds how long the profile had been running when the bundle was assembled,
+     *   or null when that is unknown. Null is treated as "cannot judge" and says nothing, because
+     *   inventing a warning from a missing timestamp would be its own false signal.
      */
-    fun captureCheckSection(reportText: String, active: Set<TestDomain>): String {
+    fun captureCheckSection(
+        reportText: String,
+        active: Set<TestDomain>,
+        profileRanSeconds: Long? = null,
+    ): String {
         val statuses = statuses(reportText, active)
         val sb = StringBuilder()
         sb.append("=== Capture check ===")
@@ -170,6 +199,19 @@ object ReportCompleteness {
             sb.append("complete: all active traces present")
         } else {
             sb.append("INCOMPLETE: missing ").append(missingActive.joinToString(", "))
+        }
+        // A short profile is reported WHATEVER the trace verdict was, and deliberately after it: a
+        // capture can hold every token it needs and still be too young to hold the pass that explains
+        // the bug, and a reader who has just been told "complete" is precisely the one who needs to
+        // know that. Phrased as what to do, not as a fault.
+        // `in 0 until MIN`, not `< MIN`: a clock moved backwards between starting the profile and
+        // exporting yields a NEGATIVE age, and "the profile ran -412s before this export" is a worse
+        // line than saying nothing. A nonsense age is unknown, and unknown says nothing.
+        if (profileRanSeconds != null && profileRanSeconds in 0 until MIN_PROFILE_SECONDS) {
+            sb.append("\nTOO SHORT: the profile ran ").append(profileRanSeconds)
+                .append("s before this export. Traces only record while the profile is on, so a scoring")
+                .append(" pass may not have happened yet. Leave it running a couple of minutes, then")
+                .append(" export again.")
         }
         return sb.toString()
     }

--- a/android/app/src/main/java/com/noop/testcentre/ReportCompleteness.kt
+++ b/android/app/src/main/java/com/noop/testcentre/ReportCompleteness.kt
@@ -218,7 +218,12 @@ object ReportCompleteness {
 
     /** The meta.json `capture_check` value: a {domainId -> "present"|"MISSING"} map plus the `complete`
      *  flag, for the machine-readable tie. Keys are the wire ids; emitted in sorted order by TestBundleMeta
-     *  so the JSON bytes line up with the Swift twin. */
+     *  so the JSON bytes line up with the Swift twin.
+     *
+     *  `complete` means TRACES PRESENT and nothing more, so it can read true on a capture whose section
+     *  carries the short-profile note. That is deliberate rather than an oversight: widening the flag
+     *  would change what every existing consumer thinks it asks. The duration a machine reader needs is
+     *  already in the meta beside this, as `profile_started_at`. */
     fun captureCheckMeta(reportText: String, active: Set<TestDomain>): CaptureCheckMeta {
         val statuses = statuses(reportText, active)
         val map = LinkedHashMap<String, String>()

--- a/android/app/src/main/java/com/noop/testcentre/TestBundleAssembler.kt
+++ b/android/app/src/main/java/com/noop/testcentre/TestBundleAssembler.kt
@@ -116,7 +116,11 @@ object TestBundleAssembler {
         // domain, whether its killer trace landed. Computed over the header+body that will ship (the guard
         // reads exactly what the maintainer reads). Byte-identical section to the Swift twin.
         val reportBody = header + "\n" + body
-        val captureCheck = ReportCompleteness.captureCheckSection(reportBody, activeDomains)
+        // The profile's age is part of whether this capture can be believed, so it is computed BEFORE
+        // the section rather than only stamped into meta.json where nobody reading report.txt sees it.
+        val ranSeconds = tc.startedAt(profile)?.let { (System.currentTimeMillis() / 1000L) - it }
+        val captureCheck =
+            ReportCompleteness.captureCheckSection(reportBody, activeDomains, ranSeconds)
         val reportText = reportBody + "\n" + captureCheck
         val entries = ArrayList<Pair<String, ByteArray>>()
         entries.add("report.txt" to reportText.toByteArray())

--- a/android/app/src/test/java/com/noop/testcentre/AndroidDiagnosticsTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/AndroidDiagnosticsTest.kt
@@ -1,6 +1,7 @@
 package com.noop.testcentre
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -30,5 +31,35 @@ class AndroidDiagnosticsTest {
     @Test fun heuristicIsCaseInsensitive() {
         assertTrue(AndroidDiagnostics.oemKillHeuristic("XIAOMI").startsWith("aggressive vendor"))
         assertTrue(AndroidDiagnostics.oemKillHeuristic("xiaomi").startsWith("aggressive vendor"))
+    }
+
+    /**
+     * The write-health line is stamped ONLY when a backfill session persists rows, so it says nothing
+     * about live streaming. Labelled "Data write:" it read as "this app has stored nothing from your
+     * strap" on an unbonded 5/MG that offloads nothing but streams happily, while a hundred thousand
+     * HR rows sat under that very device id. The scope has to be in the words.
+     */
+    @Test
+    fun theOffloadLineNamesItsScopeInsteadOfReadingAsEveryWrite() {
+        val never = AndroidDiagnostics.offloadLine(okAtSec = 0L, ageMs = 0L)
+        assertTrue(never, never.startsWith("Offload:"))
+        assertTrue(never, never.contains("no history rows ever persisted"))
+        assertTrue("the zero case must say what it does NOT cover: $never",
+            never.contains("live HR/R-R are not counted here"))
+    }
+
+    /** With rows landed it reports when, and drops the disclaimer it no longer needs. */
+    @Test
+    fun theOffloadLineReportsTheLandingWhenThereIsOne() {
+        val landed = AndroidDiagnostics.offloadLine(okAtSec = 1_700_000_000L, ageMs = 3 * 3_600_000L)
+        assertTrue(landed, landed.startsWith("Offload:"))
+        assertTrue(landed, landed.contains("rows last landed"))
+        assertFalse(landed, landed.contains("not counted here"))
+    }
+
+    /** The label is padded to 13 like every other in this block, so the values stay in one column. */
+    @Test
+    fun theOffloadLabelKeepsTheColumn() {
+        assertEquals(13, AndroidDiagnostics.offloadLine(0L, 0L).indexOf("no history"))
     }
 }

--- a/android/app/src/test/java/com/noop/testcentre/ReportCompletenessContractTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/ReportCompletenessContractTest.kt
@@ -319,6 +319,26 @@ class ReportCompletenessContractTest {
         assertTrue(short, short.contains("9s"))
     }
 
+    /**
+     * The short-profile note goes AFTER the verdict, deliberately.
+     *
+     * Three tests above assert the section ENDS with the verdict line, and that invariant now holds
+     * only while no duration is passed. Keeping the note last is the right trade: it is the line that
+     * invalidates the verdict a reader has just been given, so burying it above would put the weaker
+     * statement in the more prominent place. Pinned here so the change of shape is a decision on the
+     * record rather than something a future endsWith assertion discovers.
+     */
+    @Test
+    fun theShortProfileNoteFollowsTheVerdictRatherThanReplacingIt() {
+        val line = ReportCompleteness.captureCheckSection(
+            "charge day=2026-09-07 score=1", setOf(TestDomain.RECOVERY), profileRanSeconds = 9,
+        )
+        val verdict = line.indexOf("complete: all active traces present")
+        val note = line.indexOf("TOO SHORT")
+        assertTrue(line, verdict in 0 until note)
+        assertTrue("the note is the footer when it fires", line.trimEnd().endsWith("export again."))
+    }
+
     /** Past the threshold it says nothing extra. */
     @Test
     fun aLongEnoughProfileAddsNoWarning() {

--- a/android/app/src/test/java/com/noop/testcentre/ReportCompletenessContractTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/ReportCompletenessContractTest.kt
@@ -34,7 +34,9 @@ class ReportCompletenessContractTest {
         assertEquals("import parser=", ReportCompleteness.killerTokens[TestDomain.IMPORT])
         assertEquals("stepsEst ", ReportCompleteness.killerTokens[TestDomain.STEPS])
         assertEquals("battery series=", ReportCompleteness.killerTokens[TestDomain.BATTERY])
-        assertEquals("charge score=", ReportCompleteness.killerTokens[TestDomain.RECOVERY])
+        // "charge day=", not "charge score=": the engine re-emits every recovery trace line with a day
+        // prefix, so the old token could never match and this domain read MISSING on every capture.
+        assertEquals("charge day=", ReportCompleteness.killerTokens[TestDomain.RECOVERY])
         assertEquals("hrv rmssd=", ReportCompleteness.killerTokens[TestDomain.HRV])
         assertEquals(10, ReportCompleteness.killerTokens.size)
         // No Phase-3 token claims (we never report MISSING for a trace we never promised to emit).
@@ -268,5 +270,97 @@ class ReportCompletenessContractTest {
         // And it satisfies a Connection-active completeness check end-to-end.
         val s = ReportCompleteness.statuses(asShipped, active = setOf(TestDomain.CONNECTION))
         assertEquals(ReportCompleteness.Status.PRESENT, s[TestDomain.CONNECTION])
+    }
+
+    /**
+     * The recovery token could never match. Every trace line is re-emitted by
+     * `IntelligenceEngine.recoveryTraceLines` as `charge day=<day> ` + the body, so the bare
+     * "charge score=" this used to look for does not occur in any report, and the domain read MISSING
+     * on every capture carrying a perfectly healthy trace. Two real bundles held 1020 and 816 of these.
+     */
+    @Test
+    fun theRecoveryTokenMatchesTheLineTheEngineActuallyEmits() {
+        val real = "[recovery] charge day=2026-08-31 term hrv z=0.58 w=0.55 (higher HRV is better)\n" +
+            "[recovery] charge day=2026-08-31 score=77.12 band=green (logistic k=1.6 z0=-0.2)"
+        assertEquals(
+            ReportCompleteness.Status.PRESENT,
+            ReportCompleteness.statuses(real, setOf(TestDomain.RECOVERY))[TestDomain.RECOVERY],
+        )
+        // The nilScore variant is the same trace running, and must count too.
+        val nilScore = "[recovery] charge day=2026-09-07 nilScore reason=missingInput (hrv/rhr required)"
+        assertEquals(
+            ReportCompleteness.Status.PRESENT,
+            ReportCompleteness.statuses(nilScore, setOf(TestDomain.RECOVERY))[TestDomain.RECOVERY],
+        )
+    }
+
+    /** A report with no recovery trace at all must still read MISSING. */
+    @Test
+    fun theRecoveryTokenStillReportsAGenuinelyAbsentTrace() {
+        assertEquals(
+            ReportCompleteness.Status.MISSING,
+            ReportCompleteness.statuses("nothing here", setOf(TestDomain.RECOVERY))[TestDomain.RECOVERY],
+        )
+    }
+
+    /**
+     * A capture younger than a scoring pass cannot evidence one, whatever its tokens say. A sleep
+     * bundle arrived with a nine-second profile and no `[sleep]` lines at all, and this section told
+     * the reporter it was "complete", which is why they sent it.
+     */
+    @Test
+    fun aProfileTooYoungToHoldAPassSaysSoEvenWhenEveryTokenIsPresent() {
+        val full = "charge day=2026-09-07 score=1"
+        val short = ReportCompleteness.captureCheckSection(
+            full, setOf(TestDomain.RECOVERY), profileRanSeconds = 9,
+        )
+        assertTrue(short, short.contains("complete: all active traces present"))
+        assertTrue(short, short.contains("TOO SHORT"))
+        assertTrue(short, short.contains("9s"))
+    }
+
+    /** Past the threshold it says nothing extra. */
+    @Test
+    fun aLongEnoughProfileAddsNoWarning() {
+        val ok = ReportCompleteness.captureCheckSection(
+            "charge day=2026-09-07 score=1", setOf(TestDomain.RECOVERY), 600,
+        )
+        assertFalse(ok, ok.contains("TOO SHORT"))
+    }
+
+    /**
+     * An unknown start time must not manufacture a warning: guessing from a missing timestamp would be
+     * its own false signal, and this section exists to stop those.
+     */
+    @Test
+    fun anUnknownProfileAgeSaysNothing() {
+        val unknown = ReportCompleteness.captureCheckSection(
+            "charge day=2026-09-07 score=1", setOf(TestDomain.RECOVERY), null,
+        )
+        assertFalse(unknown, unknown.contains("TOO SHORT"))
+    }
+
+    /**
+     * A clock moved backwards between starting the profile and exporting yields a negative age, and
+     * "the profile ran -412s before this export" is a worse line than saying nothing. A nonsense age
+     * is unknown, and unknown says nothing.
+     */
+    @Test
+    fun aNegativeProfileAgeSaysNothingRatherThanPrintingNonsense() {
+        val line = ReportCompleteness.captureCheckSection(
+            "charge day=2026-09-07 score=1", setOf(TestDomain.RECOVERY), profileRanSeconds = -412,
+        )
+        assertFalse(line, line.contains("TOO SHORT"))
+        assertFalse(line, line.contains("-412"))
+    }
+
+    /** Exactly at the threshold is long enough; the warning is for what falls short of it. */
+    @Test
+    fun theThresholdItselfIsLongEnough() {
+        val line = ReportCompleteness.captureCheckSection(
+            "charge day=2026-09-07 score=1", setOf(TestDomain.RECOVERY),
+            ReportCompleteness.MIN_PROFILE_SECONDS,
+        )
+        assertFalse(line, line.contains("TOO SHORT"))
     }
 }


### PR DESCRIPTION
## Why

Three diagnostic lines that told triage the wrong thing. All three surfaced in real captures this week, and all three cost a maintainer or a reporter time.

### 1. The recovery trace was reported MISSING on every capture that had one

The killer token was `"charge score="`. But `IntelligenceEngine.recoveryTraceLines` re-emits every recovery line as `charge day=<day> ` + the body, so that bare token **cannot occur in any report**. Two bundles in hand carry **1020 and 816** of these lines, and both reported the trace as absent.

The token is now `"charge day="` — the one part every variant shares (`score`, `nilScore`, and each `term`), so it cannot go stale the way a token naming a single variant did.

**Apple had the identical defect** and is fixed the same way: `CaptureCompleteness` named three variants (`"charge term"`, `"charge score="`, `"charge nilScore"`), and the Swift engine applies the same day prefix, so none of them could match either.

### 2. `Data write:` reads as every write and is only about the offload

The stamp behind it is written **only** when a backfill session persists rows, so it says nothing about live streaming. On an unbonded 5/MG — which offloads nothing and streams happily, the designed end state of #1635 — it announced that the app had stored nothing from the strap while **103,590 HR rows** sat under that very device id.

It fooled me for several minutes on my own export before I traced the pref. Now `Offload:`, with the exclusion stated outright in the zero case:

```
Offload:     no history rows ever persisted (live HR/R-R are not counted here)
```

### 3. A nine-second capture reported itself "complete"

A bundle arrived on an open sleep report with `profile_started_at` **nine seconds** before the export, carrying no `[sleep]` lines at all, while the capture check said `complete: all active traces present`. That is what told the reporter it was ready to send, and it cost a full round trip to discover.

The check never consulted the profile's age. It does now, and is phrased as what to do rather than as a fault:

```
TOO SHORT: the profile ran 9s before this export. Traces only record while the
profile is on, so a scoring pass may not have happened yet. Leave it running a
couple of minutes, then export again.
```

Two minutes, because what most captures need to contain is a scoring pass and one takes about forty seconds on a large library.

## Two edges caught re-reading before this opened

- **A backwards clock made the age negative.** "the profile ran -412s before this export" is worse than silence, so a nonsense age is treated as unknown and says nothing.
- **The offload helper was handed `now` as an age it never reads** when nothing has landed — an argument a reader has to check is unused. It gets `0`.

**And two shape questions, from re-reading after it opened.** Three existing tests assert the section *ends with* the verdict line, and the note goes after it, so that invariant now holds only while no duration is passed. Those tests stayed green by accident rather than intent. Keeping the note last is the right trade, since it is the line that invalidates the verdict a reader has just been given, so the new shape is pinned deliberately. Separately, `captureCheckMeta` still computes `complete` from missing traces alone and can read true on a capture whose section carries the note. That is correct rather than an oversight, since widening the flag would change what every consumer thinks it asks, but nothing said so and the scope is now documented alongside where the duration actually lives (`profile_started_at`).

## What is deliberately NOT done

The completeness warning is **Android-only**. The Swift section has a different shape (per-domain trace *counts* rather than a present/absent verdict), so the failure mode is weaker there; its renderer takes only the checks, and threading a duration through it is a signature change I cannot compile in this environment. Worth doing when that section next gets attention, not blind.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

**Android unit tests, full suite:** **5,592 tests, 664 classes, 0 failures, 0 errors**, forced with `--rerun-tasks`.

> Worth recording: deleting the results directory does **not** invalidate Gradle's up-to-date check. A run skipped that way leaves an empty directory that a naive count reads as a pass, which happened once while writing this. The count now carries a floor so an empty directory can never read as green.

Thirteen new tests. The token is asserted against the line the engine actually emits and against a genuinely absent trace, so it cannot be fixed into a false positive. The offload line is tested through a pure helper extracted for the purpose (`summaryLines` needs a real Context this suite has no Robolectric for — the same reason `strapProvidesLine` is already extracted), covering both branches and the column padding. The profile guard covers short, long, exactly-at-threshold, unknown and negative.

`ReportCompletenessContractTest.killerTokenMapIsTheCanonicalContract` was **repinned**, not deleted: it asserted the old broken token, so it is now asserting the new one in the same shape with a note saying why.

**Gates:** `Tools/doc_comment_lint.py` clean · `Tools/i18n_audit.py --ci origin/main` clean (diagnostics output, not app copy).

## Related issues

The nine-second capture came up on #1937. Fixing it does not resolve that report, which is a separate staging question still waiting on a longer capture.
