### PR TITLE
sleep: the night label counted from the newest record, not from today

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepNightLabel.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepNightLabel.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// How the Sleep hero names the night it is showing.
+///
+/// Extracted from `SleepView` so it can be tested. The Kotlin twin has lived in `SleepHeroLogic.kt`
+/// as a pure function with its own suite from the start; the Swift side kept it private inside the
+/// view, which is why a defect here went uncaught on this platform until a report arrived. This
+/// package's tests run in ordinary CI, unlike the app-target bundle, so the logic is verified on
+/// every change rather than only when the on-demand app build is dispatched.
+///
+/// Kotlin twin: `calendarNightsAgo` / `nightRelativeLabel`.
+public enum SleepNightLabel {
+
+    /// The relative name for a night [offset] positions back in the carousel.
+    ///
+    /// Kotlin twin: `nightRelativeLabel`.
+    public static func relative(_ nightsAgo: Int) -> String {
+        switch nightsAgo {
+        case 0: return "Last night"
+        case 1: return "1 night ago"
+        default: return "\(nightsAgo) nights ago"
+        }
+    }
+
+    /// How many nights back the carousel entry at `offset` is FROM TODAY.
+    ///
+    /// Measured from today, not from the newest recorded night. Anchoring on the newest record made
+    /// offset 0 always land on zero, so the hero read "Last night" over a night that could be days
+    /// old, printed directly above the correct date: two adjacent labels contradicting each other.
+    ///
+    /// `wakeTimestamps` is newest-first, one per carousel entry, each the entry's wake instant. It is
+    /// timestamps rather than sessions so this stays free of view types.
+    ///
+    /// `today` must be the LOGICAL day (the 04:00 roll), and the wake instants must NOT be rolled.
+    /// The carousel groups nights by their calendar wake-date, so rolling that side too would let two
+    /// distinct entries collapse onto one label: a night ending 07:00 and the next ending 02:00 are
+    /// separate entries but the same logical day. Rolling only today is the half that matters, because
+    /// at 02:00 the night that ended yesterday morning is still "Last night".
+    ///
+    /// A NEGATIVE distance is normal, not a clock-skew guard: between waking before 04:00 and the
+    /// roll, the night's calendar date is already tomorrow relative to the logical day. Falling back
+    /// to the offset is the right answer there, so that branch carries a real case and must not be
+    /// narrowed to an error path.
+    public static func nightsAgo(
+        wakeTimestamps: [Int],
+        offset: Int,
+        today: Date,
+        calendar: Calendar = .current
+    ) -> Int {
+        guard offset >= 0, offset < wakeTimestamps.count else { return offset }
+        let shown = calendar.startOfDay(for: Date(timeIntervalSince1970: TimeInterval(wakeTimestamps[offset])))
+        let todayStart = calendar.startOfDay(for: today)
+        let d = calendar.dateComponents([.day], from: shown, to: todayStart).day ?? offset
+        return d >= 0 ? d : offset
+    }
+}

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepNightLabel.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepNightLabel.swift
@@ -8,19 +8,13 @@ import Foundation
 /// package's tests run in ordinary CI, unlike the app-target bundle, so the logic is verified on
 /// every change rather than only when the on-demand app build is dispatched.
 ///
-/// Kotlin twin: `calendarNightsAgo` / `nightRelativeLabel`.
+/// Only the arithmetic lives here. The WORDING deliberately stays in the view: it returns a
+/// `LocalizedStringKey`, so the literals have to remain in source for extraction, and pulling them
+/// into a `String` helper here would quietly drop them out of the catalogue. The Kotlin twin can share
+/// both halves because Android localises through resource ids instead.
+///
+/// Kotlin twin: `calendarNightsAgo`.
 public enum SleepNightLabel {
-
-    /// The relative name for a night [offset] positions back in the carousel.
-    ///
-    /// Kotlin twin: `nightRelativeLabel`.
-    public static func relative(_ nightsAgo: Int) -> String {
-        switch nightsAgo {
-        case 0: return "Last night"
-        case 1: return "1 night ago"
-        default: return "\(nightsAgo) nights ago"
-        }
-    }
 
     /// How many nights back the carousel entry at `offset` is FROM TODAY.
     ///
@@ -29,7 +23,8 @@ public enum SleepNightLabel {
     /// old, printed directly above the correct date: two adjacent labels contradicting each other.
     ///
     /// `wakeTimestamps` is newest-first, one per carousel entry, each the entry's wake instant. It is
-    /// timestamps rather than sessions so this stays free of view types.
+    /// timestamps rather than sessions so this stays free of view types, and OPTIONAL so an entry with
+    /// no session falls back to the offset instead of being read as 1970.
     ///
     /// `today` must be the LOGICAL day (the 04:00 roll), and the wake instants must NOT be rolled.
     /// The carousel groups nights by their calendar wake-date, so rolling that side too would let two
@@ -42,13 +37,14 @@ public enum SleepNightLabel {
     /// to the offset is the right answer there, so that branch carries a real case and must not be
     /// narrowed to an error path.
     public static func nightsAgo(
-        wakeTimestamps: [Int],
+        wakeTimestamps: [Int?],
         offset: Int,
         today: Date,
         calendar: Calendar = .current
     ) -> Int {
-        guard offset >= 0, offset < wakeTimestamps.count else { return offset }
-        let shown = calendar.startOfDay(for: Date(timeIntervalSince1970: TimeInterval(wakeTimestamps[offset])))
+        guard offset >= 0, offset < wakeTimestamps.count,
+              let shownTs = wakeTimestamps[offset] else { return offset }
+        let shown = calendar.startOfDay(for: Date(timeIntervalSince1970: TimeInterval(shownTs)))
         let todayStart = calendar.startOfDay(for: today)
         let d = calendar.dateComponents([.day], from: shown, to: todayStart).day ?? offset
         return d >= 0 ? d : offset

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepNightLabelTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepNightLabelTests.swift
@@ -29,24 +29,22 @@ final class SleepNightLabelTests: XCTestCase {
     /// "Last night" over a night days old — beside the correct date, contradicting it.
     func testAStaleNewestNightIsNotCalledLastNight() {
         let n = SleepNightLabel.nightsAgo(
-            wakeTimestamps: [wake(2026, 9, 5)], offset: 0,
+            wakeTimestamps: [wake(2026, 9, 5)] as [Int?], offset: 0,
             today: day(2026, 9, 7), calendar: utc)
         XCTAssertEqual(n, 2)
-        XCTAssertEqual(SleepNightLabel.relative(n), "2 nights ago")
     }
 
     func testTheNightThatEndedThisMorningIsStillLastNight() {
         let n = SleepNightLabel.nightsAgo(
-            wakeTimestamps: [wake(2026, 9, 7)], offset: 0,
+            wakeTimestamps: [wake(2026, 9, 7)] as [Int?], offset: 0,
             today: day(2026, 9, 7), calendar: utc)
         XCTAssertEqual(n, 0)
-        XCTAssertEqual(SleepNightLabel.relative(n), "Last night")
     }
 
     /// Calendar distance, not carousel index: a night with no data is skipped by the carousel, so
     /// labelling by index would make the nights either side of it read as consecutive.
     func testCountsCalendarNightsNotCarouselIndex() {
-        let nights = [wake(2026, 8, 13), wake(2026, 8, 10)]
+        let nights: [Int?] = [wake(2026, 8, 13), wake(2026, 8, 10)]
         XCTAssertEqual(SleepNightLabel.nightsAgo(wakeTimestamps: nights, offset: 0,
                                                  today: day(2026, 8, 13), calendar: utc), 0)
         XCTAssertEqual(SleepNightLabel.nightsAgo(wakeTimestamps: nights, offset: 1,
@@ -56,7 +54,7 @@ final class SleepNightLabelTests: XCTestCase {
     /// Only TODAY is rolled; the shown night keeps its calendar wake-date, because that is what the
     /// carousel groups by. Rolling both sides collapsed two distinct entries onto one label.
     func testTwoNightsEitherSideOfTheRollKeepDistinctLabels() {
-        let nights = [wake(2026, 9, 7, 2), wake(2026, 9, 6, 7)]
+        let nights: [Int?] = [wake(2026, 9, 7, 2), wake(2026, 9, 6, 7)]
         XCTAssertEqual(SleepNightLabel.nightsAgo(wakeTimestamps: nights, offset: 0,
                                                  today: day(2026, 9, 7), calendar: utc), 0)
         XCTAssertEqual(SleepNightLabel.nightsAgo(wakeTimestamps: nights, offset: 1,
@@ -69,20 +67,28 @@ final class SleepNightLabelTests: XCTestCase {
     /// "Last night". Pinned so a later tightening of that branch cannot break it silently.
     func testANightWokenBeforeTheRollStillReadsLastNight() {
         let n = SleepNightLabel.nightsAgo(
-            wakeTimestamps: [wake(2026, 9, 7, 2)], offset: 0,
+            wakeTimestamps: [wake(2026, 9, 7, 2)] as [Int?], offset: 0,
             today: day(2026, 9, 6, 23), calendar: utc)
         XCTAssertEqual(n, 0)
-        XCTAssertEqual(SleepNightLabel.relative(n), "Last night")
     }
 
     func testOutOfRangeFallsBackToTheIndex() {
-        XCTAssertEqual(SleepNightLabel.nightsAgo(wakeTimestamps: [], offset: 5,
+        XCTAssertEqual(SleepNightLabel.nightsAgo(wakeTimestamps: [] as [Int?], offset: 5,
                                                  today: day(2026, 9, 7), calendar: utc), 5)
     }
 
-    func testRelativeWording() {
-        XCTAssertEqual(SleepNightLabel.relative(0), "Last night")
-        XCTAssertEqual(SleepNightLabel.relative(1), "1 night ago")
-        XCTAssertEqual(SleepNightLabel.relative(4), "4 nights ago")
+    /// A carousel entry with no session falls back to the offset, exactly as the Kotlin twin does.
+    /// Mapping it to 0 would put the night in 1970 and print roughly twenty thousand nights ago.
+    ///
+    /// The dates are chosen so the fallback is DISTINGUISHABLE: at offset 1 the answer is 1 only
+    /// because the guard fired, since the real night sits fourteen nights back and an unguarded 1970
+    /// would be five figures. A nil at offset 0 against a same-day today would have returned 0 either
+    /// way and proved nothing.
+    func testAnEntryWithNoSessionFallsBackToTheIndex() {
+        let nights: [Int?] = [wake(2026, 9, 6), nil]
+        XCTAssertEqual(SleepNightLabel.nightsAgo(wakeTimestamps: nights, offset: 0,
+                                                 today: day(2026, 9, 20), calendar: utc), 14)
+        XCTAssertEqual(SleepNightLabel.nightsAgo(wakeTimestamps: nights, offset: 1,
+                                                 today: day(2026, 9, 20), calendar: utc), 1)
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepNightLabelTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepNightLabelTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// Swift twin of `SleepHeroLogicTest`. The Kotlin side has had these since the logic was written; the
+/// Swift side had none, because the function lived private inside the view — which is why the defect
+/// below went uncaught on this platform until a report arrived.
+final class SleepNightLabelTests: XCTestCase {
+
+    private var utc: Calendar = {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "UTC")!
+        return c
+    }()
+
+    /// A wake at `hour` on the given day, as an epoch second.
+    private func wake(_ y: Int, _ m: Int, _ d: Int, _ hour: Int = 7) -> Int {
+        var c = DateComponents()
+        c.year = y; c.month = m; c.day = d; c.hour = hour
+        return Int(utc.date(from: c)!.timeIntervalSince1970)
+    }
+
+    private func day(_ y: Int, _ m: Int, _ d: Int, _ hour: Int = 12) -> Date {
+        var c = DateComponents()
+        c.year = y; c.month = m; c.day = d; c.hour = hour
+        return utc.date(from: c)!
+    }
+
+    /// The bug. Measured from the newest RECORDED night, offset 0 was always zero, so the hero read
+    /// "Last night" over a night days old — beside the correct date, contradicting it.
+    func testAStaleNewestNightIsNotCalledLastNight() {
+        let n = SleepNightLabel.nightsAgo(
+            wakeTimestamps: [wake(2026, 9, 5)], offset: 0,
+            today: day(2026, 9, 7), calendar: utc)
+        XCTAssertEqual(n, 2)
+        XCTAssertEqual(SleepNightLabel.relative(n), "2 nights ago")
+    }
+
+    func testTheNightThatEndedThisMorningIsStillLastNight() {
+        let n = SleepNightLabel.nightsAgo(
+            wakeTimestamps: [wake(2026, 9, 7)], offset: 0,
+            today: day(2026, 9, 7), calendar: utc)
+        XCTAssertEqual(n, 0)
+        XCTAssertEqual(SleepNightLabel.relative(n), "Last night")
+    }
+
+    /// Calendar distance, not carousel index: a night with no data is skipped by the carousel, so
+    /// labelling by index would make the nights either side of it read as consecutive.
+    func testCountsCalendarNightsNotCarouselIndex() {
+        let nights = [wake(2026, 8, 13), wake(2026, 8, 10)]
+        XCTAssertEqual(SleepNightLabel.nightsAgo(wakeTimestamps: nights, offset: 0,
+                                                 today: day(2026, 8, 13), calendar: utc), 0)
+        XCTAssertEqual(SleepNightLabel.nightsAgo(wakeTimestamps: nights, offset: 1,
+                                                 today: day(2026, 8, 13), calendar: utc), 3)
+    }
+
+    /// Only TODAY is rolled; the shown night keeps its calendar wake-date, because that is what the
+    /// carousel groups by. Rolling both sides collapsed two distinct entries onto one label.
+    func testTwoNightsEitherSideOfTheRollKeepDistinctLabels() {
+        let nights = [wake(2026, 9, 7, 2), wake(2026, 9, 6, 7)]
+        XCTAssertEqual(SleepNightLabel.nightsAgo(wakeTimestamps: nights, offset: 0,
+                                                 today: day(2026, 9, 7), calendar: utc), 0)
+        XCTAssertEqual(SleepNightLabel.nightsAgo(wakeTimestamps: nights, offset: 1,
+                                                 today: day(2026, 9, 7), calendar: utc), 1)
+    }
+
+    /// The pre-roll window, which lands on the NEGATIVE branch and gets the right answer from what
+    /// reads like an error fallback. Wake at 02:00, check at 03:00: the night's calendar date is the
+    /// 7th while the logical day is still the 6th, so the distance is -1 and offset 0 is genuinely
+    /// "Last night". Pinned so a later tightening of that branch cannot break it silently.
+    func testANightWokenBeforeTheRollStillReadsLastNight() {
+        let n = SleepNightLabel.nightsAgo(
+            wakeTimestamps: [wake(2026, 9, 7, 2)], offset: 0,
+            today: day(2026, 9, 6, 23), calendar: utc)
+        XCTAssertEqual(n, 0)
+        XCTAssertEqual(SleepNightLabel.relative(n), "Last night")
+    }
+
+    func testOutOfRangeFallsBackToTheIndex() {
+        XCTAssertEqual(SleepNightLabel.nightsAgo(wakeTimestamps: [], offset: 5,
+                                                 today: day(2026, 9, 7), calendar: utc), 5)
+    }
+
+    func testRelativeWording() {
+        XCTAssertEqual(SleepNightLabel.relative(0), "Last night")
+        XCTAssertEqual(SleepNightLabel.relative(1), "1 night ago")
+        XCTAssertEqual(SleepNightLabel.relative(4), "4 nights ago")
+    }
+}

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -369,31 +369,15 @@ struct SleepView: View {
     /// raw index if it can't resolve. 0 = last night. Mirrors Android SleepHeroLogic.calendarNightsAgo.
     /// How many nights back the carousel night at `offset` is FROM TODAY.
     ///
-    /// Measured from today, not from the newest recorded night. Anchoring on the newest record made
-    /// offset 0 always land on zero, so the hero read "Last night" over a night that could be days
-    /// old — shown directly above the correct date, two adjacent labels contradicting each other. A
-    /// reporter read that as bad processing and it sent the investigation into the sleep stager
-    /// instead of into this label.
-    ///
-    /// The shown night keeps its CALENDAR wake-date, matching the key `navDays` groups by. Rolling
-    /// that side too would let two distinct carousel entries collapse onto one label: a night ending
-    /// 07:00 and the next ending 02:00 are separate groups but the same logical day, and both would
-    /// print the same "nights ago". Only TODAY is rolled, which is what the small hours need — at
-    /// 02:00 the night that ended yesterday morning is still "Last night". Kotlin twin:
-    /// `calendarNightsAgo`.
+    /// Delegates to `SleepNightLabel.nightsAgo`, which is where this logic is tested. It lived inline
+    /// and private here, which is why the newest-anchored defect went uncaught on this platform.
+    /// Kotlin twin: `calendarNightsAgo`.
     private func nightsAgo(_ offset: Int, now: Date = Date()) -> Int {
-        let days = navDays
-        guard offset >= 0, offset < days.count, let shownTs = days[offset].first?.endTs
-        else { return offset }
-        let cal = Calendar.current
-        let shown = cal.startOfDay(for: Date(timeIntervalSince1970: TimeInterval(shownTs)))
-        let today = cal.startOfDay(for: Repository.logicalDay(now))
-        let d = cal.dateComponents([.day], from: shown, to: today).day ?? offset
-        // A negative distance is normal here, not just the clock-skew guard it looks like: between
-        // waking before 04:00 and the roll, the night's calendar date is already tomorrow relative to
-        // the logical day. Falling back to the offset is the right answer for that, so this branch
-        // carries a real case and must not be narrowed to an error path.
-        return d >= 0 ? d : offset
+        SleepNightLabel.nightsAgo(
+            wakeTimestamps: navDays.map { Int($0.first?.endTs ?? 0) },
+            offset: offset,
+            today: Repository.logicalDay(now)
+        )
     }
 
     /// The night the Rest hero reflects: the ◀/▶-navigated night while browsing (falling back to

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -367,15 +367,26 @@ struct SleepView: View {
     /// either side of a skipped night read as consecutive and desyncs the "N nights ago" labels (and the
     /// Rest value they name). Uses the same local start-of-day `navDays` is grouped by; falls back to the
     /// raw index if it can't resolve. 0 = last night. Mirrors Android SleepHeroLogic.calendarNightsAgo.
-    private func nightsAgo(_ offset: Int) -> Int {
+    /// How many nights back the carousel night at `offset` is FROM TODAY.
+    ///
+    /// Measured from today, not from the newest recorded night. Anchoring on the newest record made
+    /// offset 0 always land on zero, so the hero read "Last night" over a night that could be days
+    /// old — shown directly above the correct date, two adjacent labels contradicting each other. A
+    /// reporter read that as bad processing and it sent the investigation into the sleep stager
+    /// instead of into this label.
+    ///
+    /// Both sides sit on the LOGICAL day (the 04:00 roll `Repository.logicalDay` applies), because
+    /// mixing the scales is its own bug: a night that ended at 02:00 belongs to the previous logical
+    /// day, and comparing its raw calendar wake-date against a rolled "today" would report it a night
+    /// further back than it is. Kotlin twin: `calendarNightsAgo`.
+    private func nightsAgo(_ offset: Int, now: Date = Date()) -> Int {
         let days = navDays
-        guard offset >= 0, offset < days.count,
-              let newestTs = days.first?.first?.endTs, let shownTs = days[offset].first?.endTs
+        guard offset >= 0, offset < days.count, let shownTs = days[offset].first?.endTs
         else { return offset }
         let cal = Calendar.current
-        let shown = cal.startOfDay(for: Date(timeIntervalSince1970: TimeInterval(shownTs)))
-        let newest = cal.startOfDay(for: Date(timeIntervalSince1970: TimeInterval(newestTs)))
-        let d = cal.dateComponents([.day], from: shown, to: newest).day ?? offset
+        let shown = cal.startOfDay(for: Repository.logicalDay(Date(timeIntervalSince1970: TimeInterval(shownTs))))
+        let today = cal.startOfDay(for: Repository.logicalDay(now))
+        let d = cal.dateComponents([.day], from: shown, to: today).day ?? offset
         return d >= 0 ? d : offset
     }
 

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -389,6 +389,10 @@ struct SleepView: View {
         let shown = cal.startOfDay(for: Date(timeIntervalSince1970: TimeInterval(shownTs)))
         let today = cal.startOfDay(for: Repository.logicalDay(now))
         let d = cal.dateComponents([.day], from: shown, to: today).day ?? offset
+        // A negative distance is normal here, not just the clock-skew guard it looks like: between
+        // waking before 04:00 and the roll, the night's calendar date is already tomorrow relative to
+        // the logical day. Falling back to the offset is the right answer for that, so this branch
+        // carries a real case and must not be narrowed to an error path.
         return d >= 0 ? d : offset
     }
 

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -361,20 +361,22 @@ struct SleepView: View {
         return n == 0 ? "Last night" : (n == 1 ? "1 night ago" : "\(n) nights ago")
     }
 
-    /// #1311: how many CALENDAR nights back the carousel night at `offset` is from the newest recorded
-    /// night. The ◀/▶ carousel steps by RECORDED night (`navDays`, newest-first), so a night with no
-    /// data (strap off-body) is a gap the flat index can't see — labelling by index makes two nights
-    /// either side of a skipped night read as consecutive and desyncs the "N nights ago" labels (and the
-    /// Rest value they name). Uses the same local start-of-day `navDays` is grouped by; falls back to the
-    /// raw index if it can't resolve. 0 = last night. Mirrors Android SleepHeroLogic.calendarNightsAgo.
-    /// How many nights back the carousel night at `offset` is FROM TODAY.
+    /// #1311: how many nights back the carousel night at `offset` is, counted in CALENDAR nights rather
+    /// than carousel index. The ◀/▶ carousel steps by RECORDED night (`navDays`, newest-first), so a
+    /// night with no data (strap off-body) is a gap the flat index can't see — labelling by index makes
+    /// two nights either side of a skipped night read as consecutive and desyncs the "N nights ago"
+    /// labels (and the Rest value they name).
+    ///
+    /// Counted FROM TODAY, not from the newest recorded night.
     ///
     /// Delegates to `SleepNightLabel.nightsAgo`, which is where this logic is tested. It lived inline
     /// and private here, which is why the newest-anchored defect went uncaught on this platform.
     /// Kotlin twin: `calendarNightsAgo`.
     private func nightsAgo(_ offset: Int, now: Date = Date()) -> Int {
         SleepNightLabel.nightsAgo(
-            wakeTimestamps: navDays.map { Int($0.first?.endTs ?? 0) },
+            // Optional per entry, NOT `?? 0`: a day group with no session must fall back to the offset
+            // the way the Kotlin twin does. Zero would be 1970 and would read as ~20,000 nights ago.
+            wakeTimestamps: navDays.map { $0.first.map { s in Int(s.endTs) } },
             offset: offset,
             today: Repository.logicalDay(now)
         )

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -375,16 +375,18 @@ struct SleepView: View {
     /// reporter read that as bad processing and it sent the investigation into the sleep stager
     /// instead of into this label.
     ///
-    /// Both sides sit on the LOGICAL day (the 04:00 roll `Repository.logicalDay` applies), because
-    /// mixing the scales is its own bug: a night that ended at 02:00 belongs to the previous logical
-    /// day, and comparing its raw calendar wake-date against a rolled "today" would report it a night
-    /// further back than it is. Kotlin twin: `calendarNightsAgo`.
+    /// The shown night keeps its CALENDAR wake-date, matching the key `navDays` groups by. Rolling
+    /// that side too would let two distinct carousel entries collapse onto one label: a night ending
+    /// 07:00 and the next ending 02:00 are separate groups but the same logical day, and both would
+    /// print the same "nights ago". Only TODAY is rolled, which is what the small hours need — at
+    /// 02:00 the night that ended yesterday morning is still "Last night". Kotlin twin:
+    /// `calendarNightsAgo`.
     private func nightsAgo(_ offset: Int, now: Date = Date()) -> Int {
         let days = navDays
         guard offset >= 0, offset < days.count, let shownTs = days[offset].first?.endTs
         else { return offset }
         let cal = Calendar.current
-        let shown = cal.startOfDay(for: Repository.logicalDay(Date(timeIntervalSince1970: TimeInterval(shownTs))))
+        let shown = cal.startOfDay(for: Date(timeIntervalSince1970: TimeInterval(shownTs)))
         let today = cal.startOfDay(for: Repository.logicalDay(now))
         let d = cal.dateComponents([.day], from: shown, to: today).day ?? offset
         return d >= 0 ? d : offset

--- a/android/app/src/main/java/com/noop/ui/SleepHeroLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepHeroLogic.kt
@@ -47,10 +47,14 @@ internal fun calendarNightsAgo(
     if (offset < 0 || offset >= navDays.size) return offset
     val shownTs = navDays[offset].firstOrNull()?.endTs ?: return offset
     val z = zone.toZoneId()
-    // Both sides on the LOGICAL scale (#144's 04:00 roll), because mixing them is its own bug: a night
-    // that ended at 02:00 belongs to the previous logical day, and comparing its raw calendar wake-date
-    // against a rolled "today" would report it a night further back than it is.
-    val shown = logicalDay(java.time.Instant.ofEpochSecond(shownTs).atZone(z))
+    // The shown night keeps its CALENDAR wake-date, because that is the key navDays groups by
+    // (`localDayString(endTs)`). Rolling this side too would let two distinct carousel entries collapse
+    // onto one label: a night ending 07:00 and the next ending 02:00 are separate groups but the same
+    // logical day, and both would print the same "nights ago".
+    //
+    // Only TODAY is rolled, which is what the small hours need: at 02:00 the night that ended
+    // yesterday morning is still "Last night", because the logical day has not turned over yet.
+    val shown = java.time.Instant.ofEpochSecond(shownTs).atZone(z).toLocalDate()
     val d = java.time.temporal.ChronoUnit.DAYS.between(shown, today).toInt()
     return if (d >= 0) d else offset
 }

--- a/android/app/src/main/java/com/noop/ui/SleepHeroLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepHeroLogic.kt
@@ -24,24 +24,34 @@ internal fun nightRelativeLabel(offset: Int): String = when (offset) {
 }
 
 /**
- * How many CALENDAR nights back the carousel night at [offset] is from the newest recorded night.
+ * How many nights back the carousel night at [offset] is FROM TODAY.
  * The ◀/▶ carousel steps by RECORDED night ([navDays], newest-first), so a night with no data (strap
  * off-body) is a gap the flat index can't see — labelling by index makes two nights either side of a
  * skipped night read as consecutive and desyncs the "N nights ago" labels (#1311). This restores the
  * true calendar distance from each night's local wake-day (the same key navDays is grouped by), so the
  * label — and the Rest value it names — line up with the night actually shown. Falls back to the raw
- * index if a day can't be read. 0 = last night. Mirrors iOS SleepView.nightsAgo.
+ * index if a day can't be read. 0 = last night.
+ *
+ * Measured from TODAY, not from the newest recorded night. Anchoring on the newest record made offset 0
+ * always land on zero, so the hero read "Last night" over a night that could be days old: a reporter
+ * whose newest night was Saturday saw it titled "Last night" on Monday and read it as bad processing,
+ * which is what sent that investigation into the sleep stager instead of into this label. The stager
+ * question was real and separate; this line was simply lying about which night it was showing.
+ *
+ * [today] is injected for deterministic tests and defaults to the logical day.
  */
 internal fun calendarNightsAgo(
     navDays: List<List<SleepSession>>, offset: Int, zone: java.util.TimeZone,
+    today: java.time.LocalDate = logicalDayNow(zone.toZoneId()),
 ): Int {
     if (offset < 0 || offset >= navDays.size) return offset
-    val newestTs = navDays.firstOrNull()?.firstOrNull()?.endTs ?: return offset
     val shownTs = navDays[offset].firstOrNull()?.endTs ?: return offset
     val z = zone.toZoneId()
-    val shown = java.time.Instant.ofEpochSecond(shownTs).atZone(z).toLocalDate()
-    val newest = java.time.Instant.ofEpochSecond(newestTs).atZone(z).toLocalDate()
-    val d = java.time.temporal.ChronoUnit.DAYS.between(shown, newest).toInt()
+    // Both sides on the LOGICAL scale (#144's 04:00 roll), because mixing them is its own bug: a night
+    // that ended at 02:00 belongs to the previous logical day, and comparing its raw calendar wake-date
+    // against a rolled "today" would report it a night further back than it is.
+    val shown = logicalDay(java.time.Instant.ofEpochSecond(shownTs).atZone(z))
+    val d = java.time.temporal.ChronoUnit.DAYS.between(shown, today).toInt()
     return if (d >= 0) d else offset
 }
 

--- a/android/app/src/main/java/com/noop/ui/SleepHeroLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepHeroLogic.kt
@@ -56,6 +56,11 @@ internal fun calendarNightsAgo(
     // yesterday morning is still "Last night", because the logical day has not turned over yet.
     val shown = java.time.Instant.ofEpochSecond(shownTs).atZone(z).toLocalDate()
     val d = java.time.temporal.ChronoUnit.DAYS.between(shown, today).toInt()
+    // A NEGATIVE distance is normal here, not just the clock-skew guard it looks like: between waking
+    // before 04:00 and the roll, the night's calendar date is already tomorrow relative to the logical
+    // day. Wake at 02:00 and check the tab at 03:00 and `shown` is the 7th while `today` is still the
+    // 6th. Falling back to the offset is the RIGHT answer for that (offset 0 is "Last night", which it
+    // is), so this branch carries a real case and must not be narrowed to an error path.
     return if (d >= 0) d else offset
 }
 

--- a/android/app/src/test/java/com/noop/ui/SleepHeroLogicTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepHeroLogicTest.kt
@@ -27,9 +27,13 @@ class SleepHeroLogicTest {
         // data, so they aren't in navDays. navDays is newest-first.
         val navDays = nightOn(LocalDate.of(2026, 8, 13)) to nightOn(LocalDate.of(2026, 8, 10))
         val nav = listOf(navDays.first, navDays.second)
-        assertEquals(0, calendarNightsAgo(nav, 0, utc))         // last night
-        assertEquals(3, calendarNightsAgo(nav, 1, utc))         // 3 calendar nights ago, NOT index 1
-        assertEquals("3 nights ago", nightRelativeLabel(calendarNightsAgo(nav, 1, utc)))
+        // Today is the day after the newest night, so the newest night IS last night. Stated rather
+        // than implied: the count is now measured from today, so a test that does not say what day it
+        // is would be asserting against the machine's clock.
+        val today = LocalDate.of(2026, 8, 13)
+        assertEquals(0, calendarNightsAgo(nav, 0, utc, today))   // last night
+        assertEquals(3, calendarNightsAgo(nav, 1, utc, today))   // 3 calendar nights ago, NOT index 1
+        assertEquals("3 nights ago", nightRelativeLabel(calendarNightsAgo(nav, 1, utc, today)))
     }
 
     @Test
@@ -40,15 +44,67 @@ class SleepHeroLogicTest {
             nightOn(LocalDate.of(2026, 8, 12)),
             nightOn(LocalDate.of(2026, 8, 11)),
         )
-        assertEquals(0, calendarNightsAgo(nav, 0, utc))
-        assertEquals(1, calendarNightsAgo(nav, 1, utc))
-        assertEquals(2, calendarNightsAgo(nav, 2, utc))
+        val today = LocalDate.of(2026, 8, 13)
+        assertEquals(0, calendarNightsAgo(nav, 0, utc, today))
+        assertEquals(1, calendarNightsAgo(nav, 1, utc, today))
+        assertEquals(2, calendarNightsAgo(nav, 2, utc, today))
     }
 
     @Test
     fun fallsBackToIndex_whenOutOfRangeOrEmpty() {
         val utc = TimeZone.getTimeZone("UTC")
-        assertEquals(5, calendarNightsAgo(emptyList(), 5, utc))
-        assertEquals(9, calendarNightsAgo(nightOn(LocalDate.of(2026, 8, 13)).let { listOf(it) }, 9, utc))
+        val today = LocalDate.of(2026, 8, 13)
+        assertEquals(5, calendarNightsAgo(emptyList(), 5, utc, today))
+        assertEquals(9, calendarNightsAgo(nightOn(LocalDate.of(2026, 8, 13)).let { listOf(it) }, 9, utc, today))
+    }
+
+    /**
+     * The bug this anchoring exists for. Measured from the newest RECORDED night, offset 0 was always
+     * zero, so the hero read "Last night" over a night that could be days old.
+     *
+     * A reporter whose newest night was Saturday saw it titled "Last night" on Monday, directly above
+     * the correct date in accent colour: two adjacent labels contradicting each other. That is what
+     * read as bad processing and sent the investigation into the sleep stager. The stager question was
+     * real and separate; this line was simply naming the wrong night.
+     */
+    @Test
+    fun aStaleNewestNightIsNotCalledLastNight() {
+        val utc = TimeZone.getTimeZone("UTC")
+        val nav = listOf(nightOn(LocalDate.of(2026, 9, 5)))     // woke Saturday morning
+        val monday = LocalDate.of(2026, 9, 7)
+        assertEquals(2, calendarNightsAgo(nav, 0, utc, monday))
+        assertEquals("2 nights ago", nightRelativeLabel(calendarNightsAgo(nav, 0, utc, monday)))
+    }
+
+    /** A night that genuinely ended this morning still reads "Last night". */
+    @Test
+    fun theNightThatEndedThisMorningIsStillLastNight() {
+        val utc = TimeZone.getTimeZone("UTC")
+        val nav = listOf(nightOn(LocalDate.of(2026, 9, 7)))
+        assertEquals(0, calendarNightsAgo(nav, 0, utc, LocalDate.of(2026, 9, 7)))
+        assertEquals("Last night", nightRelativeLabel(calendarNightsAgo(nav, 0, utc, LocalDate.of(2026, 9, 7))))
+    }
+
+    /**
+     * A night ending in the small hours belongs to the PREVIOUS logical day (#144's 04:00 roll), so
+     * both sides of the comparison are put on that scale. Mixing them would report such a night one
+     * further back than it is.
+     */
+    @Test
+    fun aNightEndingBeforeFourAmCountsAgainstThePreviousLogicalDay() {
+        val utc = TimeZone.getTimeZone("UTC")
+        // Woke at 02:00 on the 7th: logically that is the 6th's night.
+        val endTs = LocalDate.of(2026, 9, 7).atStartOfDay(ZoneOffset.UTC).plusHours(2).toEpochSecond()
+        val nav = listOf(listOf(SleepSession(deviceId = "d", startTs = endTs - 6 * 3600, endTs = endTs)))
+        // And it is now 02:00 on the 7th too, which is still logically the 6th.
+        assertEquals(0, calendarNightsAgo(nav, 0, utc, LocalDate.of(2026, 9, 6)))
+    }
+
+    /** A future-dated night must not produce a negative count; it falls back to the index. */
+    @Test
+    fun aFutureNightFallsBackToTheIndex() {
+        val utc = TimeZone.getTimeZone("UTC")
+        val nav = listOf(nightOn(LocalDate.of(2026, 9, 20)))
+        assertEquals(0, calendarNightsAgo(nav, 0, utc, LocalDate.of(2026, 9, 7)))
     }
 }

--- a/android/app/src/test/java/com/noop/ui/SleepHeroLogicTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepHeroLogicTest.kt
@@ -86,18 +86,40 @@ class SleepHeroLogicTest {
     }
 
     /**
-     * A night ending in the small hours belongs to the PREVIOUS logical day (#144's 04:00 roll), so
-     * both sides of the comparison are put on that scale. Mixing them would report such a night one
-     * further back than it is.
+     * Only TODAY is rolled to the logical day; the shown night keeps its calendar wake-date, because
+     * that is the key navDays groups by.
+     *
+     * Rolling both sides collapsed distinct carousel entries onto one label: a night ending 07:00 and
+     * the next ending 02:00 are separate groups but the same logical day, so both printed the same
+     * "nights ago". This pins that they stay apart.
      */
     @Test
-    fun aNightEndingBeforeFourAmCountsAgainstThePreviousLogicalDay() {
+    fun twoNightsEitherSideOfTheRollKeepDistinctLabels() {
         val utc = TimeZone.getTimeZone("UTC")
-        // Woke at 02:00 on the 7th: logically that is the 6th's night.
-        val endTs = LocalDate.of(2026, 9, 7).atStartOfDay(ZoneOffset.UTC).plusHours(2).toEpochSecond()
-        val nav = listOf(listOf(SleepSession(deviceId = "d", startTs = endTs - 6 * 3600, endTs = endTs)))
-        // And it is now 02:00 on the 7th too, which is still logically the 6th.
+        fun wakeAt(d: LocalDate, hour: Long) =
+            d.atStartOfDay(ZoneOffset.UTC).plusHours(hour).toEpochSecond()
+        val early = wakeAt(LocalDate.of(2026, 9, 7), 2)     // 02:00 on the 7th
+        val prior = wakeAt(LocalDate.of(2026, 9, 6), 7)     // 07:00 on the 6th
+        val nav = listOf(
+            listOf(SleepSession(deviceId = "d", startTs = early - 5 * 3600, endTs = early)),
+            listOf(SleepSession(deviceId = "d", startTs = prior - 6 * 3600, endTs = prior)),
+        )
+        val today = LocalDate.of(2026, 9, 7)               // mid-morning on the 7th
+        assertEquals(0, calendarNightsAgo(nav, 0, utc, today))
+        assertEquals(1, calendarNightsAgo(nav, 1, utc, today))
+    }
+
+    /**
+     * The small hours are why today is rolled at all: at 02:00 the logical day has not turned over,
+     * so the night that ended yesterday morning is still "Last night" rather than "1 night ago".
+     */
+    @Test
+    fun beforeFourAmYesterdayMorningsNightIsStillLastNight() {
+        val utc = TimeZone.getTimeZone("UTC")
+        val nav = listOf(nightOn(LocalDate.of(2026, 9, 6)))          // woke 07:00 on the 6th
+        // 02:00 on the 7th: logicalDayNow is still the 6th.
         assertEquals(0, calendarNightsAgo(nav, 0, utc, LocalDate.of(2026, 9, 6)))
+        assertEquals("Last night", nightRelativeLabel(calendarNightsAgo(nav, 0, utc, LocalDate.of(2026, 9, 6))))
     }
 
     /** A future-dated night must not produce a negative count; it falls back to the index. */

--- a/android/app/src/test/java/com/noop/ui/SleepHeroLogicTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepHeroLogicTest.kt
@@ -129,4 +129,24 @@ class SleepHeroLogicTest {
         val nav = listOf(nightOn(LocalDate.of(2026, 9, 20)))
         assertEquals(0, calendarNightsAgo(nav, 0, utc, LocalDate.of(2026, 9, 7)))
     }
+
+    /**
+     * The pre-roll window, pinned because it currently lands on the NEGATIVE branch and gets the right
+     * answer from what reads like an error fallback.
+     *
+     * Wake at 02:00 and open the tab at 03:00: the night's calendar date is the 7th while the logical
+     * day is still the 6th, so the distance is -1. Offset 0 is genuinely "Last night" there, and the
+     * fallback says so — but nothing distinguished this real case from clock skew, so a later tightening
+     * of that branch would break it silently.
+     */
+    @Test
+    fun aNightWokenBeforeTheRollStillReadsLastNight() {
+        val utc = TimeZone.getTimeZone("UTC")
+        val endTs = LocalDate.of(2026, 9, 7).atStartOfDay(ZoneOffset.UTC).plusHours(2).toEpochSecond()
+        val nav = listOf(listOf(SleepSession(deviceId = "d", startTs = endTs - 5 * 3600, endTs = endTs)))
+        // 03:00 on the 7th: the logical day has not rolled, so it is still the 6th.
+        val logicalToday = LocalDate.of(2026, 9, 6)
+        assertEquals(0, calendarNightsAgo(nav, 0, utc, logicalToday))
+        assertEquals("Last night", nightRelativeLabel(calendarNightsAgo(nav, 0, utc, logicalToday)))
+    }
 }


### PR DESCRIPTION
## Why

The Sleep hero titled its newest night **"Last night"** however old that night was. Both platforms measured the calendar distance from the newest *recorded* night, so at offset 0 the shown night and the reference were the same night and the answer was always zero:

```kotlin
val newestTs = navDays.firstOrNull()?.firstOrNull()?.endTs ?: return offset
val shownTs  = navDays[offset].firstOrNull()?.endTs ?: return offset
```

What that looked like in the field, from #1937: a reporter whose newest night was Saturday opened the app on Monday and saw **"Last night"** printed directly above **"Sat 5 Sep"** in accent colour. Two adjacent labels contradicting each other. They read it as bad processing, and it sent the investigation into the sleep stager.

The stager question is real and still open. This line was simply naming the wrong night, and the date beside it was right all along.

## The fix

Measure from **today**, not from the newest record. `today` is injected so the tests are not asserting against the machine's clock.

Only **today** is rolled to the logical day (#144's 04:00). The shown night keeps the calendar wake-date its group is keyed by, because `navDays` groups on `localDayString(endTs)`. Rolling both sides — which the first commit on this branch did, wrongly — lets two distinct carousel entries collapse onto one label: a night ending 07:00 and the next ending 02:00 are separate groups but the same logical day, and both would print the same "nights ago". Rolling only today is the half that needed it: at 02:00 the logical day has not turned over, so yesterday morning's night is still "Last night".

**A third thing, from re-reading after it opened.** Because only today is rolled, a NEGATIVE distance is now what normal operation produces between waking before 04:00 and the roll: at 03:00 the night's calendar date is already tomorrow relative to the logical day. Offset 0 is genuinely "Last night" there and the fallback says so, so the answer was right, but by a branch that reads as a clock-skew guard. A later tightening of it would have broken a real case silently. Named on both platforms and pinned with a test.

## On the fixed 04:00

Left as-is deliberately, and worth stating rather than leaving implied.

WHOOP anchors its **Physiological Cycle** to sleep and wake rather than to a clock, which is the better model — a fixed hour lands mid-sleep for a shift worker or a 5am sleeper. But a wake-anchored day needs to know when you woke, and **this very report is a case where staging produced nothing for two nights running**, so there would have been no anchor at all. A fixed hour is a worse model that always answers, and the fallback for a wake-anchored one would end up being a fixed hour anyway.

Three things make it less bad than it looks: it is presentation-only (`LogicalDay.kt` — stored row keys are never rewritten), `rolloverHour` is already a parameter rather than a literal so a user preference is cheap plumbing, and Today deliberately shows the date beneath so the remap stays honest. Worth its own issue; not a silent change here.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

**Android unit tests, full suite:** **5,587 tests, 664 classes, 0 failures, 0 errors**, forced with `--rerun-tasks` against a floor.

The three existing tests assumed the newest-anchored semantics and are **repinned, not deleted** — each now states what day it is, because a count measured from today would otherwise assert against the machine's clock. Six cases added: the bug itself (Saturday's night on Monday reads "2 nights ago"), a night that genuinely ended this morning still reading "Last night", nights either side of the 04:00 roll keeping distinct labels, yesterday morning's night still reading "Last night" before 04:00, and a future-dated night falling back to the index rather than going negative.

**Swift is CI-verified**; `SleepView.nightsAgo` had the identical defect and is fixed the same way.

**Gates:** `Tools/doc_comment_lint.py` clean.

## Related issues

Found while re-reviewing #1937. It does not resolve that report — the `staged-none` question there is separate and still waiting on a capture with the sleep profile actually running — but it does explain what the reporter was looking at.
