### PR TITLE
fix(sleep): drop a stagesJSON write that would make a stored night less complete

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -198,11 +198,29 @@ extension WhoopStore {
     // MARK: - Upserts (idempotent by natural key; latest server value wins on conflict)
 
     /// Upsert cached sleep sessions. Natural key (deviceId, startTs). Returns rows changed.
+    ///
+    /// A non-user-edited candidate whose stage timeline is LESS complete than what's already stored for
+    /// the same (deviceId, startTs) is dropped whole rather than written: a device can serve the same
+    /// night's hypnogram more than once (a reconnect mid-day, a resumed drain), and a later, shorter
+    /// decode has no business overwriting an earlier, fuller one — the two would otherwise silently
+    /// disagree on `stagesJSON` vs. `efficiency`/`endTs` for the same row. `HypnogramCoverage`'s 0/1/2
+    /// richness rank (none / holed / covers-its-span) is the same scale `SleepMerge` already judges a
+    /// day's best session on for DISPLAY; this applies the identical comparison at WRITE time so it
+    /// protects every caller (BLE live sources, importers, recomputes), not just the ones a caller
+    /// happens to gate behind their own dedup toggle.
     @discardableResult
     public func upsertSleepSessions(_ sessions: [CachedSleepSession], deviceId: String) async throws -> Int {
         try syncWrite { db in
             var n = 0
             for s in sessions {
+                if !s.userEdited, let existing = try Self.storedSleepSession(db, deviceId: deviceId, startTs: s.startTs),
+                   !existing.userEdited {
+                    let candidate = CachedSleepSession(startTs: s.startTs, endTs: s.endTs, efficiency: nil,
+                                                       restingHr: nil, avgHrv: nil, stagesJSON: s.stagesJSON)
+                    if SleepMerge.richness(candidate) < SleepMerge.richness(existing) {
+                        continue   // a less-complete re-serve of this night must never clobber the stored one
+                    }
+                }
                 try db.execute(sql: """
                     INSERT INTO sleepSession
                         (deviceId, startTs, endTs, efficiency, restingHr, avgHrv, stagesJSON,
@@ -229,6 +247,18 @@ extension WhoopStore {
             }
             return n
         }
+    }
+
+    /// The stored row at (deviceId, startTs), or nil when there is none yet — the completeness check
+    /// `upsertSleepSessions` runs before deciding whether a candidate may overwrite it. Only the fields
+    /// that check needs are read; `efficiency`/`restingHr`/`avgHrv` are left nil since richness never
+    /// looks at them.
+    private static func storedSleepSession(_ db: Database, deviceId: String, startTs: Int) throws -> CachedSleepSession? {
+        guard let row = try Row.fetchOne(db, sql: """
+            SELECT endTs, stagesJSON, userEdited FROM sleepSession WHERE deviceId = ? AND startTs = ?
+            """, arguments: [deviceId, startTs]) else { return nil }
+        return CachedSleepSession(startTs: startTs, endTs: row["endTs"], efficiency: nil, restingHr: nil,
+                                  avgHrv: nil, stagesJSON: row["stagesJSON"], userEdited: row["userEdited"])
     }
 
     /// Hand-correct a sleep session's bed (onset) and/or wake (end) time. Sets `userEdited = 1` so the

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/MetricsCacheTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/MetricsCacheTests.swift
@@ -32,15 +32,87 @@ final class MetricsCacheTests: XCTestCase {
         XCTAssertEqual(rows.count, 1)
         XCTAssertEqual(rows[0], s)
 
-        // Re-upsert the same natural key with updated values → no duplicate, value updated.
+        // Re-upsert the same natural key with updated values, stages covering their (shorter) new span
+        // just as fully as before → no duplicate, value updated (an ordinary refresh, not a regression).
         let s2 = CachedSleepSession(startTs: 1000, endTs: 6000, efficiency: 0.95,
-                                    restingHr: 50, avgHrv: 70.0, stagesJSON: nil)
+                                    restingHr: 50, avgHrv: 70.0,
+                                    stagesJSON: "[{\"start\":1000,\"end\":6000,\"stage\":\"light\"}]")
         try await store.upsertSleepSessions([s2], deviceId: "devA")
         rows = try await store.sleepSessions(deviceId: "devA", from: 0, to: 100_000, limit: 100)
         XCTAssertEqual(rows.count, 1, "same (deviceId,startTs) must not duplicate")
         XCTAssertEqual(rows[0].endTs, 6000)
         XCTAssertEqual(rows[0].efficiency, 0.95)
-        XCTAssertNil(rows[0].stagesJSON)
+        XCTAssertEqual(rows[0].stagesJSON, s2.stagesJSON)
+    }
+
+    /// A candidate whose stage timeline is LESS complete than what's already stored for the same
+    /// (deviceId, startTs) must be dropped whole — a device serving the same night's hypnogram twice (a
+    /// reconnect mid-day, a resumed drain) must never have its later, thinner decode clobber an earlier,
+    /// fuller one. Reproduces the exact shape of a real incident: a full-night hypnogram (96 segments,
+    /// fully covering its span) overwritten by a 5-segment tail slice covering only ~10% of the same
+    /// claimed span.
+    func testUpsertSleepSessionsDropsALessCompleteCandidate() async throws {
+        let store = try await WhoopStore.inMemory()
+        let full = CachedSleepSession(startTs: 1_000_000, endTs: 1_032_531, efficiency: 0.886,
+                                      restingHr: 50, avgHrv: 60,
+                                      stagesJSON: "[{\"start\":1000000,\"end\":1032531,\"stage\":\"light\"}]")
+        try await store.upsertSleepSessions([full], deviceId: "oura-ring")
+
+        // Same night, same key, but the "candidate" only covers the tail ~10% of the claimed span —
+        // holed, per HypnogramCoverage — with a bogus efficiency recomputed off just that slice.
+        let holedTail = CachedSleepSession(startTs: 1_000_000, endTs: 1_032_532, efficiency: 0.99,
+                                           restingHr: 48, avgHrv: 58,
+                                           stagesJSON: "[{\"start\":1029411,\"end\":1032532,\"stage\":\"rem\"}]")
+        try await store.upsertSleepSessions([holedTail], deviceId: "oura-ring")
+
+        let rows = try await store.sleepSessions(deviceId: "oura-ring", from: 0, to: 2_000_000, limit: 100)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0], full, "the fuller, previously-stored night must survive untouched")
+    }
+
+    /// The mirror case: a candidate that IMPROVES on a holed stored row (fills in more of the same span)
+    /// must still win — the guard compares richness, it does not freeze the row forever.
+    func testUpsertSleepSessionsAcceptsAMoreCompleteCandidate() async throws {
+        let store = try await WhoopStore.inMemory()
+        let holed = CachedSleepSession(startTs: 1_000_000, endTs: 1_032_531, efficiency: 0.5,
+                                       restingHr: 50, avgHrv: 60,
+                                       stagesJSON: "[{\"start\":1000000,\"end\":1004000,\"stage\":\"light\"}]")
+        try await store.upsertSleepSessions([holed], deviceId: "oura-ring")
+
+        let full = CachedSleepSession(startTs: 1_000_000, endTs: 1_032_531, efficiency: 0.886,
+                                      restingHr: 48, avgHrv: 58,
+                                      stagesJSON: "[{\"start\":1000000,\"end\":1032531,\"stage\":\"light\"}]")
+        try await store.upsertSleepSessions([full], deviceId: "oura-ring")
+
+        let rows = try await store.sleepSessions(deviceId: "oura-ring", from: 0, to: 2_000_000, limit: 100)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0], full, "a candidate that covers more of the night must still win")
+    }
+
+    /// The completeness guard must never engage for a user-edited row — `applySleepEdit`'s bounds/stages
+    /// are the dedicated correction path, and `upsertSleepSessions` already protects them unconditionally
+    /// regardless of richness. (Guards against the new check accidentally widening what "protected" means.)
+    func testUpsertSleepSessionsGuardNeverOverridesUserEditedProtection() async throws {
+        let store = try await WhoopStore.inMemory()
+        let full = CachedSleepSession(startTs: 1_000_000, endTs: 1_032_531, efficiency: 0.886,
+                                      restingHr: 50, avgHrv: 60,
+                                      stagesJSON: "[{\"start\":1000000,\"end\":1032531,\"stage\":\"light\"}]")
+        try await store.upsertSleepSessions([full], deviceId: "oura-ring")
+        _ = try await store.applySleepEdit(deviceId: "oura-ring", detectedStartTs: 1_000_000,
+                                           newStartTs: 1_000_000, newEndTs: 1_032_531,
+                                           stagesJSON: "[{\"start\":1000000,\"end\":1032531,\"stage\":\"deep\"}]")
+
+        // A richer-still re-decode arrives; the user's edit must still win untouched.
+        let richer = CachedSleepSession(startTs: 1_000_000, endTs: 1_032_531, efficiency: 0.9,
+                                        restingHr: 47, avgHrv: 57,
+                                        stagesJSON: "[{\"start\":1000000,\"end\":1016000,\"stage\":\"light\"}," +
+                                                    "{\"start\":1016000,\"end\":1032531,\"stage\":\"rem\"}]")
+        try await store.upsertSleepSessions([richer], deviceId: "oura-ring")
+
+        let rows = try await store.sleepSessions(deviceId: "oura-ring", from: 0, to: 2_000_000, limit: 100)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertTrue(rows[0].userEdited)
+        XCTAssertEqual(rows[0].stagesJSON, "[{\"start\":1000000,\"end\":1032531,\"stage\":\"deep\"}]")
     }
 
     /// #345: the persisted sparse-coverage flag survives write→read, REFRESHES on a recompute (excluded


### PR DESCRIPTION
## The problem

`WhoopStore.upsertSleepSessions`'s `ON CONFLICT` clause takes whatever `stagesJSON` a caller passes,
unconditionally, whenever the stored row isn't `userEdited`:

```sql
stagesJSON = CASE WHEN sleepSession.userEdited THEN sleepSession.stagesJSON ELSE excluded.stagesJSON END
```

A device can serve the same night's hypnogram more than once — a reconnect mid-day, a resumed drain —
and nothing compares the new payload against what's already stored before writing it.

Reproduced from a real `.noopbak` pair (05:14 and 13:23 exports of the same day). The SAME primary key
(`oura-2H3B2405003655`, one `startTs`) held:

| | morning | afternoon |
|---|---|---|
| `stagesJSON` | 96 segments, full night | **5 segments, 52 minutes** |
| coverage of its own claimed span | ~100% | **~10% (holed)** |
| `efficiency` | 88.6% | 99.0% (recomputed off just the 52-min slice) |

The 5 surviving segments are real, correctly-decoded data — the ring's **last** 52 minutes of the night —
but they silently replaced the full night. No new/second row was involved; same key, same row,
overwritten in place. Not a `userEdited` interaction either (`userEdited=0` on both sides).

## The fix

Before the write, compare the candidate's stage-timeline richness against what's already stored, using
the SAME 0/1/2 scale (`none` / `holed` / `covers-its-span`) `SleepMerge.dayRichness` already uses to pick
a day's best session for **display** — `HypnogramCoverage.isHoled` underneath. If the candidate is
strictly less complete than the stored, non-`userEdited` row, the whole write for that session is
dropped (not partially applied — `stagesJSON`/`efficiency`/`endTs` all stay as they were, so the row
never ends up internally inconsistent).

This runs inside `upsertSleepSessions` itself, so it protects **every** caller — BLE live sources,
importers, recomputes — rather than relying on a caller's own dedup logic to have already filtered a
worse candidate out.

A `userEdited` row is untouched either way: the guard only engages when the *stored* row is not
`userEdited` (a `userEdited` row is already fully protected by the existing `CASE` clauses), so the new
check can never widen what "protected" means for a hand-corrected night.

## Verification

| | |
|---|---|
| `WhoopStore` (`swift test`) | **515/515**, 0 failures |
| New tests | `testUpsertSleepSessionsDropsALessCompleteCandidate` (reproduces the incident's exact shape), `testUpsertSleepSessionsAcceptsAMoreCompleteCandidate` (the mirror case still wins), `testUpsertSleepSessionsGuardNeverOverridesUserEditedProtection` |
| Fixed | `testSleepSessionUpsertReadAndIdempotency` — its second write regressed `stagesJSON` from one segment to `nil`, which is now (correctly) dropped by the new guard; changed the fixture to a legitimate same-richness refresh so the test still covers ordinary update-in-place idempotency |
| `doc_comment_lint.py` | clean |
| macOS/iOS app targets | **not built this pass** — the change is entirely inside `Packages/WhoopStore`, covered by `swift-packages.yml`'s active `test` job; no app-target Swift touched |

No BLE surface changed — nothing to validate on hardware beyond the two `.noopbak` exports the fix was
built against.

## What this does not do

- **It does not flip `ouraOnsetKeying`'s default to ON.** That's a separate, already-agreed action item
  from #1382/onset-keying's closure (2026-08-26) — a completeness-guarded *dedup* mechanism that decides
  whether a same-night candidate at a *different* key should be banked or suppressed before it ever
  reaches the store. This PR is a narrower, always-on backstop at the store's own write path, for the
  case that guard doesn't cover: a candidate at the exact *same* key. The two are complementary, not
  substitutes for each other.
- **It does not touch Android.** `WhoopRepository.upsertSleepSessions` there is a thin pass-through to a
  plain Room `@Upsert` (no per-field `CASE` preservation the way the Swift raw SQL has one for
  `userEdited`), so an equivalent guard needs a different shape — flagged as a follow-up rather than
  rushed into this PR.