### PR TITLE
fix(sleep): Hypnogram axis no longer mislabels a partial timeline as starting at onset

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/Hypnogram.swift
@@ -154,14 +154,26 @@ public struct Hypnogram: View {
         let f = DateFormatter(); f.locale = Locale.current; f.setLocalizedDateFormatFromTemplate("jmm"); return f
     }()
 
-    /// Format a seconds-from-origin offset either as wall-clock (if nightStart
-    /// is set) or as elapsed H:MM from the start of the night.
-    private func timeLabel(_ secondsFromOrigin: TimeInterval) -> String {
+    /// Format a seconds-from-night-start offset (per `SleepInterval`'s own doc: `start`/`end` are
+    /// already "seconds from the start of the night", not from `origin`) either as wall-clock (if
+    /// `nightStart` is set) or as elapsed H:MM from the start of the night.
+    ///
+    /// Deliberately does NOT subtract `origin` here. `origin` (`intervals.first?.start`) exists so
+    /// `bandRect`/`risers`/`intervalIndex` can lay bars out to fill the plot's width starting from
+    /// whatever the first VISIBLE interval is — a layout concern. Reusing it here to compute a clock
+    /// time would silently assume the first visible interval always sits at the night's true onset. That
+    /// holds for an ordinary night (the first stage code lands a few seconds after onset, so `origin` is
+    /// negligible), but not for a holed/partial timeline, where the surviving stages can start hours into
+    /// the night — subtracting `origin` there forced the leading axis label to read as `nightStart`
+    /// verbatim regardless, mislabeling e.g. a night's last 52 minutes as its first 52.
+    /// `internal`, not `private`: exposed so `StrandDesignTests` can pin this exact math without a live
+    /// SwiftUI render.
+    func timeLabel(_ secondsFromNightStart: TimeInterval) -> String {
         if let nightStart {
-            let d = nightStart.addingTimeInterval(secondsFromOrigin - origin)
+            let d = nightStart.addingTimeInterval(secondsFromNightStart)
             return Hypnogram.clockFormatter.string(from: d)
         }
-        let total = Int((secondsFromOrigin - origin).rounded())
+        let total = Int(secondsFromNightStart.rounded())
         let h = total / 3600
         let m = (total % 3600) / 60
         return String(format: "%d:%02d", h, m)

--- a/Packages/StrandDesign/Tests/StrandDesignTests/HypnogramTimeLabelTests.swift
+++ b/Packages/StrandDesign/Tests/StrandDesignTests/HypnogramTimeLabelTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import StrandDesign
+
+/// Pins `Hypnogram.timeLabel` against the exact regression it used to have: subtracting `origin`
+/// (`intervals.first?.start`) forced the leading axis label to always read as `nightStart` verbatim,
+/// no matter where the first VISIBLE interval's own timestamp actually fell. That is harmless for an
+/// ordinary night (the first stage code lands a few seconds after onset), but for a holed/partial
+/// timeline — the surviving stages start hours into the night — it mislabeled the LAST part of a night
+/// as its FIRST, which is exactly what a real corrupted `sleepSession` row rendered as.
+final class HypnogramTimeLabelTests: XCTestCase {
+
+    /// A holed timeline: the only two surviving stage segments start 8h10m11s (29,411s) into the night,
+    /// not at its true onset. Real shape from a night whose stored hypnogram was overwritten with a
+    /// tail slice: the segments carry real timestamps, but they are not the night's first.
+    private let holedIntervals = [
+        SleepInterval(stage: .light, start: 29_411, end: 31_061),
+        SleepInterval(stage: .rem, start: 31_061, end: 31_091),
+    ]
+
+    func testElapsedLabelReadsTheIntervalsOwnTimeNotZero() {
+        let h = Hypnogram(intervals: holedIntervals, nightStart: nil, showsTimeAxis: true, smoothingSeconds: 0)
+        // 29,411s = 8h 10m (11s dropped by the H:MM format) — the segment's TRUE elapsed offset.
+        XCTAssertEqual(h.timeLabel(holedIntervals[0].start), "8:10",
+                       "the leading label must read the interval's own elapsed time, not 0:00")
+    }
+
+    func testWallClockLabelReadsTheIntervalsOwnTimeNotNightStart() {
+        let nightStart = Date(timeIntervalSince1970: 1_788_551_940)   // 2026-09-04 19:59:00 UTC
+        let h = Hypnogram(intervals: holedIntervals, nightStart: nightStart, showsTimeAxis: true, smoothingSeconds: 0)
+
+        // Independent oracle: a locally-built formatter using the SAME template `timeLabel` uses, so the
+        // comparison holds regardless of the test machine's locale/12-24h setting.
+        let fmt = DateFormatter()
+        fmt.locale = Locale.current
+        fmt.setLocalizedDateFormatFromTemplate("jmm")
+
+        let nightStartLabel = fmt.string(from: nightStart)
+        let trueLeadingLabel = fmt.string(from: nightStart.addingTimeInterval(holedIntervals[0].start))
+        XCTAssertNotEqual(nightStartLabel, trueLeadingLabel, "fixture sanity: 8h10m apart must format differently")
+
+        XCTAssertEqual(h.timeLabel(holedIntervals[0].start), trueLeadingLabel,
+                       "the leading axis label must read the segment's TRUE clock time")
+        XCTAssertNotEqual(h.timeLabel(holedIntervals[0].start), nightStartLabel,
+                          "must not collapse to the night's onset the way the old subtract-origin code did")
+    }
+
+    func testOrdinaryNightWithNegligibleSlackStillReadsAsTheStartOfTheNight() {
+        // The common case: the first real stage code lands a few seconds after the technical onset.
+        let ordinary = [
+            SleepInterval(stage: .awake, start: 10, end: 370),
+            SleepInterval(stage: .light, start: 370, end: 1000),
+        ]
+        let h = Hypnogram(intervals: ordinary, nightStart: nil, showsTimeAxis: true, smoothingSeconds: 0)
+        XCTAssertEqual(h.timeLabel(ordinary[0].start), "0:00",
+                       "a few seconds of slack must still round to the start of the night")
+    }
+}


### PR DESCRIPTION
## The problem

`Hypnogram.timeLabel` computed a requested offset as `nightStart.addingTimeInterval(t - origin)`, where
`origin = intervals.first?.start`. Every call site — the leading/mid/trailing axis labels, and the hover
tooltip — already passes values in `SleepInterval`'s own documented coordinate space ("seconds from the
start of the night"), so subtracting `origin` a second time silently assumed the first VISIBLE interval
always sits at the night's true onset.

That assumption holds for an ordinary night — the first stage code lands a few seconds after onset, so
`origin` is negligible — but not for a holed/partial timeline, where the surviving stages can start
hours into the night. `timeLabel(origin)`, the leading label's actual argument, always evaluated to
`nightStart` verbatim **regardless of what `origin` was**.

Concretely: a real corrupted `sleepSession` row whose surviving 52 minutes of stage data were the
night's true **last** 52 minutes (06:09→07:01 local) rendered on the Sleep card as **"21:59–22:51"** —
the tail of the night mislabeled as its beginning, drawn right after bedtime.

## The fix

`timeLabel` no longer subtracts `origin`. `origin`/`span` are unchanged and still used exactly as before
for layout (`bandRect`/`risers`/`intervalIndex` still need a normalized 0…1 plotting domain to fill the
chart's width) — only the wall-clock/elapsed-time math drops the extra subtraction, since the inputs it
receives are already absolute-from-night-start.

## Verification

| | |
|---|---|
| `StrandDesign` (`swift test`) | **73/73**, 0 failures |
| New tests (`HypnogramTimeLabelTests`) | leading label reads the interval's own elapsed/clock time, not `0:00`/`nightStart` (reproduces the incident's exact shape); an ordinary night's few seconds of slack still rounds to "start of the night" (no behavior change for the common case) |
| `doc_comment_lint.py` | clean |
| macOS/iOS app targets | **not built this pass** — the change is entirely inside `Packages/StrandDesign`, covered by `swift-packages.yml`'s active `test` job; no app-target Swift touched |
| Android `FilledHypnogram` twin | **checked, not changed** — see below |

## What this does not do

**It does not touch Android.** Traced `com.noop.ui.FilledHypnogram` / `hypnogramAxisTicks`: Android's
version takes `onsetTs`/`wakeTs` as separate parameters sourced from the session's own bounds
(`session.effectiveStartTs`/`session.endTs`), not re-derived from the segments the way Swift's `origin`
is, and only renders an axis at all when both are present. A holed night's bars there stay honestly
positioned within the true claimed span (compressed toward one edge) instead of being stretched to fill
the chart and mislabeled — the platforms already agree on the *correct* behavior via different means, so
there's nothing to port.