### PR TITLE
Reject an out-of-domain strain denominator on both platforms

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
@@ -291,7 +291,8 @@ public enum StrainScorer {
     // MARK: - Logarithmic map
 
     /// Map accumulated TRIMP onto [0, 100] via 100 × ln(TRIMP+1) / ln(D), 2 dp.
-    /// TRIMP ≤ 0 → 0, and D ≤ 1 (or NaN) → 0, being outside the map's domain (#36).
+    /// TRIMP ≤ 0 → 0, and D ≤ 1 (or NaN) → 0, being outside the map's domain (#36). The output is
+    /// unbounded as D → 1⁺ — an upper clamp is tracked separately (#12).
     ///
     /// The default D is **Edwards'**. A Banister TRIMP passed here without an explicit denominator is
     /// scored against the wrong ceiling and reads low — prefer `strain(…)`, which resolves the

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
@@ -291,8 +291,8 @@ public enum StrainScorer {
     // MARK: - Logarithmic map
 
     /// Map accumulated TRIMP onto [0, 100] via 100 × ln(TRIMP+1) / ln(D), 2 dp.
-    /// TRIMP ≤ 0 → 0, and D ≤ 1 (or NaN) → 0, being outside the map's domain (#36). The output is
-    /// unbounded as D → 1⁺ — an upper clamp is tracked separately (#12).
+    /// TRIMP ≤ 0 → 0, and D ≤ 1 (or NaN) → 0, being outside the map's domain. The output is
+    /// unbounded as D → 1⁺ — an upper clamp is tracked separately.
     ///
     /// The default D is **Edwards'**. A Banister TRIMP passed here without an explicit denominator is
     /// scored against the wrong ceiling and reads low — prefer `strain(…)`, which resolves the
@@ -302,7 +302,7 @@ public enum StrainScorer {
         // D ≤ 1 (and NaN) is outside the map's domain: ln(1) = 0 divides to ±∞, ln(D) < 0 below 1
         // flips the sign, and ln(D) is NaN at or below 0. Out-of-domain D is no score, like
         // TRIMP ≤ 0 — before this guard D = 1 returned +Inf here and a saturated 9.2e16 on Android
-        // for the same input (#36). The default 7201 is unaffected.
+        // for the same input (the denominator-domain fix). The default 7201 is unaffected.
         guard denominator > 1 else { return 0 }
         let value = maxStrain * log(trimp + 1.0) / log(denominator)
         return (value * 100).rounded() / 100

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift
@@ -291,13 +291,18 @@ public enum StrainScorer {
     // MARK: - Logarithmic map
 
     /// Map accumulated TRIMP onto [0, 100] via 100 × ln(TRIMP+1) / ln(D), 2 dp.
-    /// TRIMP ≤ 0 → 0.
+    /// TRIMP ≤ 0 → 0, and D ≤ 1 (or NaN) → 0, being outside the map's domain (#36).
     ///
     /// The default D is **Edwards'**. A Banister TRIMP passed here without an explicit denominator is
     /// scored against the wrong ceiling and reads low — prefer `strain(…)`, which resolves the
     /// method's own denominator, or pass `logMapDenominator(method:sex:)` yourself. (#1545)
     public static func trimpToStrain(_ trimp: Double, denominator: Double = strainDenominator) -> Double {
         if trimp <= 0 { return 0 }
+        // D ≤ 1 (and NaN) is outside the map's domain: ln(1) = 0 divides to ±∞, ln(D) < 0 below 1
+        // flips the sign, and ln(D) is NaN at or below 0. Out-of-domain D is no score, like
+        // TRIMP ≤ 0 — before this guard D = 1 returned +Inf here and a saturated 9.2e16 on Android
+        // for the same input (#36). The default 7201 is unaffected.
+        guard denominator > 1 else { return 0 }
         let value = maxStrain * log(trimp + 1.0) / log(denominator)
         return (value * 100).rounded() / 100
     }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainDenominatorDomainTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainDenominatorDomainTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import StrandAnalytics
 
-/// Domain of the log map's denominator D (#36).
+/// Log-map denominator behavior outside the map's domain.
 ///
 /// D ≤ 1 has no ln-based score: ln(1) = 0 divides to ±∞, ln(D) < 0 below 1 flips the sign, and ln(D)
 /// is NaN at or below 0. Before the guard, Swift returned `+Inf` for D = 1 while Kotlin's
@@ -39,7 +39,7 @@ final class StrainDenominatorDomainTests: XCTestCase {
 
     /// Non-finite TRIMP propagates rather than being caught by the domain guard — the guard is about
     /// D, not TRIMP. Both platforms agree here only because Kotlin no longer rounds through Long
-    /// (`roundToLong()` mapped +∞ to Long.MAX), so pin it (#36).
+    /// (`roundToLong()` mapped +∞ to Long.MAX), so pin the non-finite propagation behavior.
     func testNonFiniteTrimpPropagates() {
         let inf = StrainScorer.trimpToStrain(.infinity, denominator: 7201)
         XCTAssertFalse(inf.isFinite)

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainDenominatorDomainTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainDenominatorDomainTests.swift
@@ -27,9 +27,24 @@ final class StrainDenominatorDomainTests: XCTestCase {
 
     /// Just above the boundary the score is enormous but finite, and it must stay a Double on both
     /// platforms — this is the value Kotlin's `roundToLong()` clipped to Long.MAX / 100.
+    ///
+    /// Loosely toleranced on purpose: ln(1 + 2⁻⁵²) is ~2.2e-16, so a 1-ulp difference between
+    /// Darwin's and glibc's `log` moves the quotient by ~±30 absolute. Linux/glibc observes exactly
+    /// 3.1216573840826803e+17; the assertion checks the magnitude, not the last bits.
     func testDenominatorJustAboveOneStaysFinite() {
         let s = StrainScorer.trimpToStrain(1, denominator: 1.0000000000000002)
         XCTAssertTrue(s.isFinite)
-        XCTAssertEqual(s, 3.1216573840826803e+17, accuracy: 0)
+        XCTAssertEqual(s, 3.1216573840826803e+17, accuracy: 1e4)
+    }
+
+    /// Non-finite TRIMP propagates rather than being caught by the domain guard — the guard is about
+    /// D, not TRIMP. Both platforms agree here only because Kotlin no longer rounds through Long
+    /// (`roundToLong()` mapped +∞ to Long.MAX), so pin it (#36).
+    func testNonFiniteTrimpPropagates() {
+        let inf = StrainScorer.trimpToStrain(.infinity, denominator: 7201)
+        XCTAssertFalse(inf.isFinite)
+        XCTAssertFalse(inf.isNaN)
+        XCTAssertGreaterThan(inf, 0)
+        XCTAssertTrue(StrainScorer.trimpToStrain(.nan, denominator: 7201).isNaN)
     }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainDenominatorDomainTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StrainDenominatorDomainTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// Domain of the log map's denominator D (#36).
+///
+/// D ≤ 1 has no ln-based score: ln(1) = 0 divides to ±∞, ln(D) < 0 below 1 flips the sign, and ln(D)
+/// is NaN at or below 0. Before the guard, Swift returned `+Inf` for D = 1 while Kotlin's
+/// `roundToLong()` saturated to 9.223372036854776E16 — the same input, two different answers.
+/// The Kotlin twin is `StrainScorerDenominatorDomainTest`; its expected literals are the stdout of
+/// this file's formula compiled standalone.
+final class StrainDenominatorDomainTests: XCTestCase {
+
+    func testDenominatorAtOrBelowOneScoresZero() {
+        for denominator in [1.0, 0.5, 0.0, -3.0, Double.nan] {
+            let s = StrainScorer.trimpToStrain(1, denominator: denominator)
+            XCTAssertTrue(s.isFinite, "D = \(denominator) produced a non-finite Effort")
+            XCTAssertEqual(s, 0.0, accuracy: 0, "D = \(denominator)")
+        }
+    }
+
+    func testValidDenominatorsAreUnchanged() {
+        XCTAssertEqual(StrainScorer.trimpToStrain(1, denominator: 7201), 7.8, accuracy: 1e-9)
+        XCTAssertEqual(StrainScorer.trimpToStrain(100, denominator: 7201), 51.96, accuracy: 1e-9)
+        XCTAssertEqual(StrainScorer.trimpToStrain(7200, denominator: 7201), 100.0, accuracy: 1e-9)
+        XCTAssertEqual(StrainScorer.trimpToStrain(1, denominator: 2), 100.0, accuracy: 1e-9)
+    }
+
+    /// Just above the boundary the score is enormous but finite, and it must stay a Double on both
+    /// platforms — this is the value Kotlin's `roundToLong()` clipped to Long.MAX / 100.
+    func testDenominatorJustAboveOneStaysFinite() {
+        let s = StrainScorer.trimpToStrain(1, denominator: 1.0000000000000002)
+        XCTAssertTrue(s.isFinite)
+        XCTAssertEqual(s, 3.1216573840826803e+17, accuracy: 0)
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
+++ b/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
@@ -340,8 +340,8 @@ object StrainScorer {
 
     /**
      * Map accumulated TRIMP onto [0, 100] via 100 × ln(TRIMP+1) / ln(D), 2 dp.
-     * TRIMP ≤ 0 → 0, and D ≤ 1 (or NaN) → 0, being outside the map's domain (#36). The output is
-     * unbounded as D → 1⁺ — an upper clamp is tracked separately (#12).
+     * TRIMP ≤ 0 → 0, and D ≤ 1 (or NaN) → 0, being outside the map's domain. The output is
+     * unbounded as D → 1⁺ — an upper clamp is tracked separately.
      *
      * The default D is **Edwards'**. A Banister TRIMP passed here without an explicit denominator is
      * scored against the wrong ceiling and reads low — prefer [strain], which resolves the method's own
@@ -352,13 +352,17 @@ object StrainScorer {
         // D ≤ 1 (and NaN) is outside the map's domain: ln(1) = 0 divides to ±∞, ln(D) < 0 below 1
         // flips the sign, and ln(D) is NaN at or below 0. Out-of-domain D is no score, like
         // TRIMP ≤ 0 — before this guard D = 1 returned a saturated 9.2e16 here and +Inf on Swift
-        // for the same input (#36). The default 7201 is unaffected.
+        // for the same input (the denominator-domain fix). The default 7201 is unaffected.
         if (!(denominator > 1)) return 0.0
         val value = maxStrain * ln(trimp + 1.0) / ln(denominator)
         val scaled = value * 100
         // Round in Double space: roundToLong() clips anything past Long.MAX_VALUE, which Swift's
-        // .rounded() does not, so a D just above 1 still disagreed across platforms (#36). Above
-        // 2^53 every Double is already an integer, so passing it through IS the rounded value.
+        // .rounded() does not, so a D just above 1 still disagreed across platforms (the
+        // denominator-domain fix). Above 2^53 every Double is already an integer, so passing it
+        // through IS the rounded value.
+        // Keep this comparison in this direction: abs(NaN) < 2^53 is false, so NaN intentionally
+        // takes the pass-through; reversing it to `>= 2^53` would send NaN through `roundToLong()`,
+        // collapse it to 0.0, and break parity with Swift.
         val rounded = if (abs(scaled) < 9007199254740992.0) scaled.roundToLong().toDouble() else scaled
         return rounded / 100.0
     }

--- a/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
+++ b/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
@@ -340,7 +340,8 @@ object StrainScorer {
 
     /**
      * Map accumulated TRIMP onto [0, 100] via 100 × ln(TRIMP+1) / ln(D), 2 dp.
-     * TRIMP ≤ 0 → 0, and D ≤ 1 (or NaN) → 0, being outside the map's domain (#36).
+     * TRIMP ≤ 0 → 0, and D ≤ 1 (or NaN) → 0, being outside the map's domain (#36). The output is
+     * unbounded as D → 1⁺ — an upper clamp is tracked separately (#12).
      *
      * The default D is **Edwards'**. A Banister TRIMP passed here without an explicit denominator is
      * scored against the wrong ceiling and reads low — prefer [strain], which resolves the method's own

--- a/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
+++ b/android/app/src/main/java/com/noop/analytics/StrainScorer.kt
@@ -340,7 +340,7 @@ object StrainScorer {
 
     /**
      * Map accumulated TRIMP onto [0, 100] via 100 × ln(TRIMP+1) / ln(D), 2 dp.
-     * TRIMP ≤ 0 → 0.
+     * TRIMP ≤ 0 → 0, and D ≤ 1 (or NaN) → 0, being outside the map's domain (#36).
      *
      * The default D is **Edwards'**. A Banister TRIMP passed here without an explicit denominator is
      * scored against the wrong ceiling and reads low — prefer [strain], which resolves the method's own
@@ -348,8 +348,18 @@ object StrainScorer {
      */
     fun trimpToStrain(trimp: Double, denominator: Double = strainDenominator): Double {
         if (trimp <= 0) return 0.0
+        // D ≤ 1 (and NaN) is outside the map's domain: ln(1) = 0 divides to ±∞, ln(D) < 0 below 1
+        // flips the sign, and ln(D) is NaN at or below 0. Out-of-domain D is no score, like
+        // TRIMP ≤ 0 — before this guard D = 1 returned a saturated 9.2e16 here and +Inf on Swift
+        // for the same input (#36). The default 7201 is unaffected.
+        if (!(denominator > 1)) return 0.0
         val value = maxStrain * ln(trimp + 1.0) / ln(denominator)
-        return (value * 100).roundToLong() / 100.0
+        val scaled = value * 100
+        // Round in Double space: roundToLong() clips anything past Long.MAX_VALUE, which Swift's
+        // .rounded() does not, so a D just above 1 still disagreed across platforms (#36). Above
+        // 2^53 every Double is already an integer, so passing it through IS the rounded value.
+        val rounded = if (abs(scaled) < 9007199254740992.0) scaled.roundToLong().toDouble() else scaled
+        return rounded / 100.0
     }
 
     // ---- Denominator calibration ----

--- a/android/app/src/test/java/com/noop/analytics/StrainScorerDenominatorDomainTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StrainScorerDenominatorDomainTest.kt
@@ -51,11 +51,30 @@ class StrainScorerDenominatorDomainTest {
     /**
      * Just above the boundary the score is enormous but finite, and it must stay a Double on both
      * platforms — this is the value `roundToLong()` clipped to Long.MAX / 100.
+     *
+     * Loosely toleranced on purpose: ln(1 + 2⁻⁵²) is ~2.2e-16, so a 1-ulp difference between the
+     * JVM's and Darwin's `log` moves the quotient by ~±30 absolute. Linux observes exactly
+     * 3.1216573840826803e+17 on both sides; the assertion checks the magnitude, not the last bits.
      */
     @Test
     fun `denominator just above one stays finite`() {
         val s = StrainScorer.trimpToStrain(1.0, 1.0000000000000002)
         assertTrue(s.isFinite())
-        assertEquals(3.1216573840826803e+17, s, 0.0)
+        assertEquals(3.1216573840826803e+17, s, 1e4)
+    }
+
+    /**
+     * Non-finite TRIMP propagates rather than being caught by the domain guard — the guard is about
+     * D, not TRIMP. Both platforms agree here only because this side no longer rounds through Long
+     * (`roundToLong()` mapped +∞ to Long.MAX), so pin it (#36). Swift oracle, same formula:
+     * `inf|7201.0|inf`, `nan|7201.0|nan`.
+     */
+    @Test
+    fun `non-finite trimp propagates`() {
+        val inf = StrainScorer.trimpToStrain(Double.POSITIVE_INFINITY, 7201.0)
+        assertTrue(!inf.isFinite())
+        assertTrue(!inf.isNaN())
+        assertTrue(inf > 0)
+        assertTrue(StrainScorer.trimpToStrain(Double.NaN, 7201.0).isNaN())
     }
 }

--- a/android/app/src/test/java/com/noop/analytics/StrainScorerDenominatorDomainTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StrainScorerDenominatorDomainTest.kt
@@ -1,0 +1,61 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Domain of the log map's denominator D (#36), against the compiled Swift twin.
+ *
+ * D ≤ 1 has no ln-based score: ln(1) = 0 divides to ±∞, ln(D) < 0 below 1 flips the sign, and ln(D)
+ * is NaN at or below 0. Before the guard, Swift returned `+Inf` for D = 1 while this side's
+ * `roundToLong()` saturated to 9.223372036854776E16 — the same input, two different answers.
+ *
+ * Every expected value below is the verbatim stdout of `StrainScorer.swift`'s `trimpToStrain`,
+ * extracted and compiled standalone on Linux (`swiftc -O main.swift -o t && ./t`), printed as
+ * `trimp|D|effort` with `%.17g`:
+ *
+ * ```
+ * 1.0000|1|0
+ * 1.0000|0.5|0
+ * 1.0000|0|0
+ * 1.0000|-3|0
+ * 1.0000|nan|0
+ * 0.0000|7201|0
+ * 1.0000|7201|7.7999999999999998
+ * 100.0000|7201|51.960000000000001
+ * 7200.0000|7201|100
+ * 1.0000|1.0000000000000002|3.1216573840826803e+17
+ * 1.0000|2|100
+ * ```
+ */
+class StrainScorerDenominatorDomainTest {
+
+    @Test
+    fun `denominator at or below one scores zero`() {
+        for (denominator in listOf(1.0, 0.5, 0.0, -3.0, Double.NaN)) {
+            val s = StrainScorer.trimpToStrain(1.0, denominator)
+            assertTrue("D = $denominator produced a non-finite Effort", s.isFinite())
+            assertEquals("D = $denominator", 0.0, s, 0.0)
+        }
+    }
+
+    @Test
+    fun `valid denominators are unchanged`() {
+        assertEquals(7.7999999999999998, StrainScorer.trimpToStrain(1.0, 7201.0), 1e-9)
+        assertEquals(51.960000000000001, StrainScorer.trimpToStrain(100.0, 7201.0), 1e-9)
+        assertEquals(100.0, StrainScorer.trimpToStrain(7200.0, 7201.0), 1e-9)
+        assertEquals(100.0, StrainScorer.trimpToStrain(1.0, 2.0), 1e-9)
+    }
+
+    /**
+     * Just above the boundary the score is enormous but finite, and it must stay a Double on both
+     * platforms — this is the value `roundToLong()` clipped to Long.MAX / 100.
+     */
+    @Test
+    fun `denominator just above one stays finite`() {
+        val s = StrainScorer.trimpToStrain(1.0, 1.0000000000000002)
+        assertTrue(s.isFinite())
+        assertEquals(3.1216573840826803e+17, s, 0.0)
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/StrainScorerDenominatorDomainTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StrainScorerDenominatorDomainTest.kt
@@ -5,7 +5,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Domain of the log map's denominator D (#36), against the compiled Swift twin.
+ * Log-map denominator behavior outside the map's domain, against the compiled Swift twin.
  *
  * D ≤ 1 has no ln-based score: ln(1) = 0 divides to ±∞, ln(D) < 0 below 1 flips the sign, and ln(D)
  * is NaN at or below 0. Before the guard, Swift returned `+Inf` for D = 1 while this side's
@@ -66,7 +66,8 @@ class StrainScorerDenominatorDomainTest {
     /**
      * Non-finite TRIMP propagates rather than being caught by the domain guard — the guard is about
      * D, not TRIMP. Both platforms agree here only because this side no longer rounds through Long
-     * (`roundToLong()` mapped +∞ to Long.MAX), so pin it (#36). Swift oracle, same formula:
+     * (`roundToLong()` mapped +∞ to Long.MAX), so pin the non-finite propagation behavior. Swift
+     * oracle, same formula:
      * `inf|7201.0|inf`, `nan|7201.0|nan`.
      */
     @Test


### PR DESCRIPTION
## Problem

`trimpToStrain` maps TRIMP onto [0, 100] with `maxStrain * log(trimp + 1) / log(D)`, but never
checks that `D` is inside the map's domain. At `D == 1` the divisor is `ln(1) = 0`: Swift returns
`+Inf`, while Kotlin's `(value * 100).roundToLong() / 100.0` saturates at the `Long` ceiling and
returns `9.223372036854776E16` for the same input. Below 1 the sign flips; at or below 0 the result
is NaN. Two platforms, one input, two different numbers — reported as bhelm/noop#36.

## Change

- `Packages/StrandAnalytics/Sources/StrandAnalytics/StrainScorer.swift`: `guard denominator > 1
  else { return 0 }` after the existing `trimp <= 0` gate. NaN fails the predicate too.
- `android/app/src/main/java/com/noop/analytics/StrainScorer.kt`: the identical guard
  (`if (!(denominator > 1)) return 0.0`), plus rounding moved into the Double domain —
  `if (abs(scaled) < 2^53) scaled.roundToLong().toDouble() else scaled`. The guard alone still left
  `D = 1.0000000000000002` diverging (Swift `3.12e17` vs the clipped `9.22e16`), the same
  saturation the issue names. Below 2^53 the new expression is bit-for-bit what `roundToLong()`
  did; at or above 2^53 every Double is already integral, so the pass-through *is* the rounded
  value.
- Mirrored tests (`StrainDenominatorDomainTests.swift`, `StrainScorerDenominatorDomainTest.kt`)
  pinning the same out-of-domain cases, valid cases, boundary literal and non-finite `trimp`
  propagation.

## Verification

- Oracle: the post-guard formula was extracted verbatim, compiled standalone (`swiftc -O main.swift
  -o t && ./t`), and its stdout pasted into the Kotlin test's KDoc as the expected literals
  (`1|7201 → 7.7999999999999998`, `7200|7201 → 100`, `1|2 → 100`, all `D <= 1` and NaN → `0`). The
  Swift test pins the same values, so the guard is held in both directions.
- Red before: `swift test --filter StrainDenominatorDomainTests` → 3 tests, 7 failures (`D = 1.0` →
  `inf`, `D = 0.5` → `-100.0`, `D = -3.0` → `-nan`, `D = nan` → `nan`). `./gradlew
  testFullDebugUnitTest --tests "com.noop.analytics.StrainScorerDenominatorDomainTest"` → 3 tests,
  2 failed.
- Green after: `cd Packages/StrandAnalytics && swift test --filter Strain` → **46 tests, 0
  failures**. `./gradlew testFullDebugUnitTest --tests "com.noop.analytics.Strain*"` → **19 tests,
  0 failures, 0 errors**; the wider Kotlin run including `BanisterParityOracleTest` and
  `ChargeEffortRestScoringTest` is 54 tests green.
- `python3 Tools/doc_comment_lint.py` → `OK no NEW detached doc comments`. `i18n_audit.py` not
  applicable (no user-facing strings).
- The near-boundary assertion uses a `1e4` tolerance rather than bit equality: the expected value
  divides by `ln(1 + 2^-52) ≈ 2.22e-16`, so a 1-ulp difference in `log` between glibc (where the
  oracle ran) and Darwin libm (where `swift-packages.yml` runs) lands as ~±30 absolute. The exact
  observed Linux literal stays in the comment as the centre.
- **Not run:** macOS/iOS app targets and `StrandTests` — no macOS/Xcode available to me. Neither
  changed source is app-target code, so `swift-packages.yml` and `android.yml` do cover this diff.
  No hardware involved; this is pure analytics.

## Behaviour change / user-visible effects

**No shipped number moves.** The only caller on each platform is `strain(…)`, whose resolved
denominator is `7201` or the Banister ceiling + 1 (≈6175 / ≈5300) — far above 1 and far below 2^53,
so they take the identical rounding path. There is no app-layer or preference-supplied denominator
override in the tree; the `denominator:` parameter is unused outside tests. Existing goldens
(51.96 / 69.99 / 77.78 / 92.20 / 100.0) are unchanged.

The one real behaviour change is on the public API: a non-finite `trimp` on Android now propagates
(`+Inf` → `+Inf`, `NaN` → `NaN`) instead of collapsing to `9.2e16` / `0.0`. That makes Kotlin match
Swift, and it is pinned on both sides.

## Scope limits and follow-ups

- The missing **upper** clamp is out of scope: output is still unbounded as `D → 1⁺`, tracked as
  bhelm/noop#12 and now noted in both doc comments. `sampleDurationsMinutes` (same file, also #12)
  is untouched. `D = +Inf` was already identical (divides to `0.0`) and was left alone.
- The issue asks to re-run the strain differential corpus. That harness is external to this
  repository — nothing under `Tools/` references `trimpToStrain` — so it could not be run here. The
  in-repo substitutes actually run are `BanisterParityOracleTest` and the new mirrored oracle pair.

Branch: `fix/issue-36-strain-denominator-domain`. Contribution offered under the repository's
PolyForm Noncommercial 1.0.0 license.
