### PR TITLE
Require an HRV baseline in the raw recovery overload

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer.swift
@@ -289,7 +289,7 @@ public enum RecoveryScorer {
     ///   - rhr: tonight's resting HR (bpm).
     ///   - resp: tonight's respiration (raw or calibrated — z is scale-invariant);
     ///           nil drops the term.
-    ///   - hrvBaseline: HRV baseline (required for a score).
+    ///   - hrvBaseline: HRV baseline (required for a score — nil returns nil).
     ///   - rhrBaseline: resting-HR baseline; nil drops the RHR term. On the `BaselineState` overload an
     ///     UNUSABLE baseline (#1988) is treated as nil, so a synthetic cold-start midpoint never scores.
     ///   - respBaseline: respiration baseline; nil drops the resp term.
@@ -328,6 +328,11 @@ public enum RecoveryScorer {
         // Cold-start gate: HRV is the dominant driver; if its baseline isn't
         // usable, refuse to score (more honest than a fabricated value).
         if !hrvBaselineUsable { return nil }
+        // Required-driver gate: the HRV baseline is REQUIRED for a score. It is Optional here only
+        // for callers that may not have one yet, and hrvBaselineUsable defaults to true, so without
+        // this an absent baseline let any other optional term (sleepPerf alone, say) produce a
+        // Charge score carrying no HRV term at all.
+        guard let hrvB = hrvBaseline else { return nil }
 
         var terms: [(z: Double, w: Double)] = []
 
@@ -338,9 +343,7 @@ public enum RecoveryScorer {
         // signature is still detected and reported out-of-band (Charge trace + ChargeDrivers verdict)
         // so real firings can be counted first. See the MARK header for why, and swap in
         // `parasympatheticSaturation(hrvZ:rhrZ:).easedHrvZ` here to enable it.
-        if let b = hrvBaseline {
-            terms.append((zScore(hrv, mean: b.mean, spread: b.spread), wHRV))
-        }
+        terms.append((zScore(hrv, mean: hrvB.mean, spread: hrvB.spread), wHRV))
         // RHR term: lower is better → (μ − x) / σ.
         if let b = rhrBaseline {
             terms.append((zScore(b.mean, mean: rhr, spread: b.spread), wRHR))

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTests.swift
@@ -275,4 +275,70 @@ final class RecoveryScorerTests: XCTestCase {
         XCTAssertEqual(neither, baselineOnly, accuracy: 1e-9, "a baseline with no value must drop the term")
         XCTAssertNotEqual(both, neither, "supplying BOTH must actually change the score")
     }
+
+    // MARK: - Required HRV baseline on the raw DriverBaseline overload (#40)
+
+    func testRawOverloadRefusesToScoreWithoutHRVBaseline() {
+        // The raw overload documents hrvBaseline as REQUIRED, but it is Optional and the
+        // cold-start gate only consults hrvBaselineUsable (default true). Without this guard any
+        // other optional term alone produced a Charge score carrying NO HRV term at all. Each
+        // case below supplies exactly one optional driver with the HRV baseline absent.
+        let rhrB = RecoveryScorer.DriverBaseline(mean: 55, spread: 3 / 1.253)
+        let respB = RecoveryScorer.DriverBaseline(mean: 14.5, spread: 1 / 1.253)
+        let effortB = RecoveryScorer.DriverBaseline(mean: 40, spread: 15 / 1.253)
+
+        // The issue's minimal reproduction: sleepPerf as the only weighted term.
+        XCTAssertNil(RecoveryScorer.recovery(
+            hrv: 50, rhr: 60, resp: nil,
+            hrvBaseline: nil, rhrBaseline: nil, respBaseline: nil,
+            sleepPerf: 0.85))
+        // RHR term alone.
+        XCTAssertNil(RecoveryScorer.recovery(
+            hrv: 50, rhr: 60, resp: nil,
+            hrvBaseline: nil, rhrBaseline: rhrB, respBaseline: nil,
+            sleepPerf: nil))
+        // Resp term alone.
+        XCTAssertNil(RecoveryScorer.recovery(
+            hrv: 50, rhr: 60, resp: 14.0,
+            hrvBaseline: nil, rhrBaseline: nil, respBaseline: respB,
+            sleepPerf: nil))
+        // Skin-temp term alone.
+        XCTAssertNil(RecoveryScorer.recovery(
+            hrv: 50, rhr: 60, resp: nil,
+            hrvBaseline: nil, rhrBaseline: nil, respBaseline: nil,
+            sleepPerf: nil, skinTempDev: 0.4))
+        // Recovery-Index term alone.
+        XCTAssertNil(RecoveryScorer.recovery(
+            hrv: 50, rhr: 60, resp: nil,
+            hrvBaseline: nil, rhrBaseline: nil, respBaseline: nil,
+            sleepPerf: nil, recoveryIndexSlope: -1.0))
+        // Activity-Balance term alone.
+        XCTAssertNil(RecoveryScorer.recovery(
+            hrv: 50, rhr: 60, resp: nil,
+            hrvBaseline: nil, rhrBaseline: nil, respBaseline: nil,
+            sleepPerf: nil, effortBaseline: effortB, priorDayEffort: 80.0))
+        // Every optional driver at once still cannot substitute for the required HRV baseline.
+        XCTAssertNil(RecoveryScorer.recovery(
+            hrv: 50, rhr: 60, resp: 14.0,
+            hrvBaseline: nil, rhrBaseline: rhrB, respBaseline: respB,
+            sleepPerf: 0.85, skinTempDev: 0.4, recoveryIndexSlope: -1.0,
+            effortBaseline: effortB, priorDayEffort: 80.0))
+    }
+
+    func testRawOverloadPreservesColdStartAndValidScores() {
+        let hrvB = RecoveryScorer.DriverBaseline(mean: 50, spread: 6 / 1.253)
+        // Cold start unchanged: baseline PRESENT but not usable → nil, as before.
+        XCTAssertNil(RecoveryScorer.recovery(
+            hrv: 50, rhr: 60, resp: nil,
+            hrvBaseline: hrvB, rhrBaseline: nil, respBaseline: nil,
+            sleepPerf: 0.85, hrvBaselineUsable: false))
+        // A present, usable baseline scores exactly as before. Expected literal from the
+        // standalone Swift oracle whose source is kept in the Kotlin twin's comment
+        // (RecoveryRequiredHrvBaselineTest.kt) — the same literal both sides pin.
+        let scored = RecoveryScorer.recovery(
+            hrv: 50, rhr: 60, resp: nil,
+            hrvBaseline: hrvB, rhrBaseline: nil, respBaseline: nil,
+            sleepPerf: 0.85)
+        XCTAssertEqual(scored!, 57.932425214874954, accuracy: 1e-12)
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt
+++ b/android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt
@@ -292,7 +292,7 @@ object RecoveryScorer {
      * @param rhr tonight's resting HR (bpm).
      * @param resp tonight's respiration (raw or calibrated — z is scale-invariant);
      *   null drops the term.
-     * @param hrvBaseline HRV baseline (required for a score).
+     * @param hrvBaseline HRV baseline (required for a score — null returns null).
      * @param rhrBaseline resting-HR baseline; null drops the RHR term. On the BaselineState overload an
      *   UNUSABLE baseline (#1988) is treated as null, so a synthetic cold-start midpoint never scores.
      * @param respBaseline respiration baseline; null drops the resp term.
@@ -335,6 +335,11 @@ object RecoveryScorer {
         // Cold-start gate: HRV is the dominant driver; if its baseline isn't
         // usable, refuse to score (more honest than a fabricated value).
         if (!hrvBaselineUsable) return null
+        // Required-driver gate: the HRV baseline is REQUIRED for a score. It is nullable here only
+        // for callers that may not have one yet, and hrvBaselineUsable defaults to true, so without
+        // this an absent baseline let any other optional term (sleepPerf alone, say) produce a
+        // Charge score carrying no HRV term at all.
+        val hrvB = hrvBaseline ?: return null
 
         val terms = ArrayList<Pair<Double, Double>>() // (z, weight)
 
@@ -345,9 +350,7 @@ object RecoveryScorer {
         // signature is still detected and reported out-of-band (Charge trace + RecoveryDrivers verdict)
         // so real firings can be counted first. See the header above for why, and swap in
         // parasympatheticSaturation(hrvZ, rhrZ).easedHrvZ here to enable it.
-        hrvBaseline?.let { b ->
-            terms.add(zScore(hrv, b.mean, b.spread) to wHRV)
-        }
+        terms.add(zScore(hrv, hrvB.mean, hrvB.spread) to wHRV)
         // RHR term: lower is better → (μ − x) / σ.
         rhrBaseline?.let { b ->
             terms.add(zScore(b.mean, rhr, b.spread) to wRHR)

--- a/android/app/src/test/java/com/noop/analytics/RecoveryRequiredHrvBaselineTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RecoveryRequiredHrvBaselineTest.kt
@@ -1,0 +1,123 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * The raw [RecoveryScorer.DriverBaseline] overload must refuse to score without the REQUIRED HRV
+ * baseline (#40). Faithful Kotlin mirror of testRawOverloadRefusesToScoreWithoutHRVBaseline /
+ * testRawOverloadPreservesColdStartAndValidScores in RecoveryScorerTests.swift — same scenarios,
+ * same expected value.
+ *
+ * The preserved-score literal below is produced by this standalone Swift oracle (swiftc -O
+ * oracle.swift -o oracle && ./oracle), a twin of RecoveryScorer.recovery(...) for that one case:
+ *
+ *     import Foundation
+ *     let wHRV = 0.55, wSleep = 0.15
+ *     let sleepPerfCenter = 0.85, sleepPerfScale = 0.12
+ *     let logisticK = 1.6, logisticZ0 = -0.20
+ *     func zScore(_ v: Double, mean: Double, spread: Double) -> Double {
+ *         let sigma = max(1.253 * spread, 1e-9)
+ *         return (v - mean) / sigma
+ *     }
+ *     var terms: [(Double, Double)] = []
+ *     terms.append((zScore(50, mean: 50, spread: 6 / 1.253), wHRV))
+ *     terms.append(((0.85 - sleepPerfCenter) / sleepPerfScale, wSleep))
+ *     let total = terms.reduce(0) { $0 + $1.1 }
+ *     let z = terms.reduce(0) { $0 + $1.0 * $1.1 } / total
+ *     let score = 100.0 / (1.0 + exp(-logisticK * (z - logisticZ0)))
+ *     print(max(0.0, min(100.0, score)).debugDescription)
+ *     // stdout: 57.932425214874954
+ */
+class RecoveryRequiredHrvBaselineTest {
+
+    @Test
+    fun rawOverloadRefusesToScoreWithoutHrvBaseline() {
+        // The raw overload documents hrvBaseline as REQUIRED, but it is nullable and the
+        // cold-start gate only consults hrvBaselineUsable (default true). Without this guard any
+        // other optional term alone produced a Charge score carrying NO HRV term at all. Each
+        // case below supplies exactly one optional driver with the HRV baseline absent.
+        val rhrB = RecoveryScorer.DriverBaseline(mean = 55.0, spread = 3.0 / 1.253)
+        val respB = RecoveryScorer.DriverBaseline(mean = 14.5, spread = 1.0 / 1.253)
+        val effortB = RecoveryScorer.DriverBaseline(mean = 40.0, spread = 15.0 / 1.253)
+
+        // The issue's minimal reproduction: sleepPerf as the only weighted term.
+        assertNull(
+            RecoveryScorer.recovery(
+                hrv = 50.0, rhr = 60.0, resp = null,
+                hrvBaseline = null, rhrBaseline = null, respBaseline = null,
+                sleepPerf = 0.85,
+            ),
+        )
+        // RHR term alone.
+        assertNull(
+            RecoveryScorer.recovery(
+                hrv = 50.0, rhr = 60.0, resp = null,
+                hrvBaseline = null, rhrBaseline = rhrB, respBaseline = null,
+                sleepPerf = null,
+            ),
+        )
+        // Resp term alone.
+        assertNull(
+            RecoveryScorer.recovery(
+                hrv = 50.0, rhr = 60.0, resp = 14.0,
+                hrvBaseline = null, rhrBaseline = null, respBaseline = respB,
+                sleepPerf = null,
+            ),
+        )
+        // Skin-temp term alone.
+        assertNull(
+            RecoveryScorer.recovery(
+                hrv = 50.0, rhr = 60.0, resp = null,
+                hrvBaseline = null, rhrBaseline = null, respBaseline = null,
+                sleepPerf = null, skinTempDev = 0.4,
+            ),
+        )
+        // Recovery-Index term alone.
+        assertNull(
+            RecoveryScorer.recovery(
+                hrv = 50.0, rhr = 60.0, resp = null,
+                hrvBaseline = null, rhrBaseline = null, respBaseline = null,
+                sleepPerf = null, recoveryIndexSlope = -1.0,
+            ),
+        )
+        // Activity-Balance term alone.
+        assertNull(
+            RecoveryScorer.recovery(
+                hrv = 50.0, rhr = 60.0, resp = null,
+                hrvBaseline = null, rhrBaseline = null, respBaseline = null,
+                sleepPerf = null, effortBaseline = effortB, priorDayEffort = 80.0,
+            ),
+        )
+        // Every optional driver at once still cannot substitute for the required HRV baseline.
+        assertNull(
+            RecoveryScorer.recovery(
+                hrv = 50.0, rhr = 60.0, resp = 14.0,
+                hrvBaseline = null, rhrBaseline = rhrB, respBaseline = respB,
+                sleepPerf = 0.85, skinTempDev = 0.4, recoveryIndexSlope = -1.0,
+                effortBaseline = effortB, priorDayEffort = 80.0,
+            ),
+        )
+    }
+
+    @Test
+    fun rawOverloadPreservesColdStartAndValidScores() {
+        val hrvB = RecoveryScorer.DriverBaseline(mean = 50.0, spread = 6.0 / 1.253)
+        // Cold start unchanged: baseline PRESENT but not usable → null, as before.
+        assertNull(
+            RecoveryScorer.recovery(
+                hrv = 50.0, rhr = 60.0, resp = null,
+                hrvBaseline = hrvB, rhrBaseline = null, respBaseline = null,
+                sleepPerf = 0.85, hrvBaselineUsable = false,
+            ),
+        )
+        // A present, usable baseline scores exactly as before (Swift oracle literal above).
+        val scored = RecoveryScorer.recovery(
+            hrv = 50.0, rhr = 60.0, resp = null,
+            hrvBaseline = hrvB, rhrBaseline = null, respBaseline = null,
+            sleepPerf = 0.85,
+        )
+        assertEquals(57.932425214874954, scored!!, 1e-12)
+    }
+}


### PR DESCRIPTION
## Problem

The raw `RecoveryScorer.recovery(…)` overload documents the HRV baseline as required, but only
enforces it through the separate `hrvBaselineUsable` flag — which defaults to `true`. The HRV term
itself is then added inside `if let b = hrvBaseline` / `hrvBaseline?.let`, so a caller passing
`hrvBaseline: nil` with the default flag still receives a Charge score built from whatever other
optional driver happens to be present (sleep performance alone, for example) with **no HRV term in
it at all**. Reported as bhelm/noop#40; both platforms behaved the same way.

## Change

Two lines of product code, mirrored:

- `Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer.swift`:
  `guard let hrvB = hrvBaseline else { return nil }`, placed after the existing `hrvBaselineUsable`
  gate; the HRV term becomes unconditional.
- `android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt`: the twin
  `val hrvB = hrvBaseline ?: return null`, same position, same unconditional term.
- One clause added to each doc comment ("required for a score — nil returns nil").
- Tests: `RecoveryScorerTests.swift` (+66) and a new
  `android/app/src/test/java/com/noop/analytics/RecoveryRequiredHrvBaselineTest.kt` — each optional
  driver alone with the HRV baseline absent (sleep performance, RHR, respiration, skin temperature,
  Recovery Index, Activity Balance), all of them at once, plus the cold-start path and a
  valid-score-preserved case.

## Verification

- Oracle for the preserved-score literal: `swiftc -O oracle.swift -o oracle && ./oracle` →
  `57.932425214874954` (the same value the issue quotes for the broken path). The oracle source is
  reproduced in the Kotlin test's KDoc; the Swift test pins the same literal, so a Swift-side drift
  also fails.
- Red before the change: `swift test --filter RecoveryScorerTests` → `Executed 15 tests, with 7
  failures` — the seven new `XCTAssertNil` cases each returned a score (`57.932425214874954`,
  `8.733108846720262`, `75.3988716448948`, `42.06757478512505`, `1.895284142733052`,
  `27.882388421888063`). `./gradlew testFullDebugUnitTest --tests
  "com.noop.analytics.RecoveryRequiredHrvBaselineTest"` → `2 tests completed, 1 failed`.
- Green after: `swift test --filter "Recovery|ChargeDrivers|WatchRecovery"` → **Executed 105 tests,
  with 0 failures**. The Kotlin run over `com.noop.analytics.Recovery*`,
  `ChargeEffortRestScoringTest`, `WatchRecoveryTest` and `agreement.RecoveryAgreementTest` →
  **96 tests, 1 skipped, 0 failures, 0 errors**.
- `python3 Tools/doc_comment_lint.py` → `OK no NEW detached doc comments`. `i18n_audit.py` not
  applicable (no translatable strings touched).
- Rebased onto current main after #1990/#1991 (conflicts were doc-comment lines only); the Swift and Kotlin suites for the rebased tree rest on CI.
- **Not run:** macOS/iOS app targets, `StrandTests`, watch — no macOS/Xcode available to me. No
  app-target Swift was touched, so both changed sources are covered by `swift-packages.yml` and
  `android.yml`. No hardware involved (pure analytics).

## Behaviour change / user-visible effects

**None for users.** Outside tests, nothing outside `RecoveryScorer` itself constructs a
`DriverBaseline` anywhere in the tree, and no production code passes `hrvBaselineUsable`. The raw
overload therefore has no in-tree production caller at all. The change is confined to the public
raw overload: it now returns `nil` where it previously returned a Charge score with no HRV
contribution. No stored value moves, no migration.

## Scope limits and follow-ups

- The narrow gate was chosen over "make absence unrepresentable" (a non-optional parameter): that
  is a source-breaking public API change, larger than the issue asks, and the acceptance criteria
  list a `nil`/`null` return as the first sufficient option. Stated assumption: keeping the
  parameter optional is acceptable. An absent *and* unusable baseline returns `nil` either way, so
  the new guard sits second and leaves the cold-start path and its diagnostics untouched.
- No changes to `ChargeDrivers`, the recovery trace, or any caller — none of them reaches the raw
  overload with a nil HRV baseline, so touching them would be outside the issue.

Branch: `fix/issue-40-recovery-hrv-baseline-required`. Contribution offered under the repository's
PolyForm Noncommercial 1.0.0 license.

