### PR TITLE
Round recovery-trace values in the double domain on Android

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer+Trace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer+Trace.swift
@@ -11,6 +11,19 @@ import Foundation
 
 extension RecoveryScorer {
 
+    /// The trace's two-decimal rounding contract, shared by both platforms: round `x * 100` to the
+    /// nearest integer with half-ties AWAY FROM ZERO, divide by 100, and keep the IEEE sign bit — so a
+    /// driver term that rounds to zero from below still renders `-0.0`, as it does on Android (#1437).
+    ///
+    /// The rounding stays in the DOUBLE domain on purpose. Kotlin's `Math.round` returns a `Long`, which
+    /// saturates at 2^63-1, so `1e20` came back as `9.223372036854776e16` there while this side kept
+    /// `1e20` (#47). Nothing here is clamped: any finite input round-trips, and a non-finite one (or a
+    /// finite one whose `x * 100` overflows) passes through as the matching infinity or NaN. The Kotlin
+    /// twin is `RecoveryScorerTrace.r2`.
+    static func traceRound2(_ x: Double) -> Double {
+        (x * 100.0).rounded(.toNearestOrAwayFromZero) / 100.0
+    }
+
     /// Side-effect-free diagnostic twin of `recovery(...)`: returns the SAME score recovery(...) would,
     /// plus the per-term Charge breakdown trace. The four inputs (hrv / rhr / resp / sleepPerf) plus the
     /// skin-temp deviation each get a baseline line (mean / spread / nValid / status), a term line
@@ -36,9 +49,7 @@ extension RecoveryScorer {
         -> (score: Double?, trace: [String]) {
 
         // Trace numbers use nearest rounding with half-ties away from zero on both platforms.
-        func r2(_ x: Double) -> Double {
-            (x * 100.0).rounded(.toNearestOrAwayFromZero) / 100.0
-        }
+        func r2(_ x: Double) -> Double { traceRound2(x) }
 
         var lines: [String] = []
         var nilTerms: [String] = []

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryScorerTraceTests.swift
@@ -151,4 +151,61 @@ final class RecoveryScorerTraceTests: XCTestCase {
             "charge term skinTempDev z=-0.12 w=0.05 (dev=0.12C penalty=-|dev|/1.0)"
         )
     }
+
+    /// #47: the two-decimal trace-rounding contract itself, pinned as RAW BITS rather than as text.
+    /// Text would hide what this pins: Swift and Kotlin print the same Double differently ("1e+20" vs
+    /// "1.0E20"), and -0.0 vs 0.0 is a one-bit difference. This side is the oracle — the Kotlin twin
+    /// carries these same bit patterns as literals, so a change here without a change there fails over
+    /// there. Twin: `traceRound2MatchesTheSwiftContract`.
+    func testTraceRound2MatchesTheSwiftContract() {
+        let cases: [(String, Double, String)] = [
+            ("-0.004", -0.004, "8000000000000000"), // -0.0: sign survives rounding to zero
+            ("0.004", 0.004, "0"),
+            ("1e20", 1e20, "4415af1d78b58c40"), // large finite value, not a signed-64 ceiling
+            ("-1e20", -1e20, "c415af1d78b58c40"),
+            ("0.0", 0.0, "0"),
+            ("-0.0", -0.0, "8000000000000000"),
+            ("0.125", 0.125, "3fc0a3d70a3d70a4"), // positive half-tie -> away from zero (0.13)
+            ("-0.125", -0.125, "bfc0a3d70a3d70a4"), // negative half-tie -> -0.13
+            ("1.2349", 1.2349, "3ff3ae147ae147ae"), // ordinary non-ties
+            ("-1.2349", -1.2349, "bff3ae147ae147ae"),
+            // Just below the half-tie: a floor(m + 0.5) implementation would round this UP.
+            ("0.0049999999999999994", 0.0049999999999999994, "0"),
+            ("-0.0049999999999999994", -0.0049999999999999994, "8000000000000000"),
+            ("1e306", 1e306, "7f76c8e5ca239029"), // largest magnitudes whose *100 is still finite
+            ("-1e306", -1e306, "ff76c8e5ca239029"),
+            // Finite input whose intermediate x * 100 overflows: both platforms yield an infinity.
+            ("1e307", 1e307, "7ff0000000000000"),
+            ("-1e307", -1e307, "fff0000000000000"),
+        ]
+        for (label, input, bits) in cases {
+            XCTAssertEqual(String(RecoveryScorer.traceRound2(input).bitPattern, radix: 16), bits,
+                           "traceRound2(\(label))")
+        }
+    }
+
+    /// #47: the exact differential fixture. Every line of one full-term night, pinned verbatim, so a
+    /// rounding change on either platform shows up as a text diff rather than as two field logs that
+    /// quietly disagree. The skin-temp deviation is 0.004, the issue's near-zero negative: it must
+    /// render `z=-0.0` and `dev=0.0C`. Twin: `traceFixtureIsByteIdenticalAcrossPlatforms`.
+    func testTraceFixtureIsByteIdenticalAcrossPlatforms() {
+        let (_, lines) = RecoveryScorer.recoveryTrace(
+            hrv: 62, rhr: 51, resp: 15,
+            hrvBaseline: baseline(mean: 50, sigma: 6), rhrBaseline: baseline(mean: 55, sigma: 3),
+            respBaseline: baseline(mean: 16, sigma: 2),
+            sleepPerf: 0.9, skinTempDev: 0.004)
+        XCTAssertEqual(lines, [
+            "charge baseline hrv mean=50.0 spread=4.79 nValid=14 status=trusted",
+            "charge baseline rhr mean=55.0 spread=2.39 nValid=14 status=trusted",
+            "charge baseline resp mean=16.0 spread=1.6 nValid=14 status=trusted",
+            "charge term hrv z=2.0 w=0.55 (higher HRV is better)",
+            "charge term rhr z=1.33 w=0.2 (lower RHR is better)",
+            "charge term resp z=0.5 w=0.05 (lower resp is better)",
+            "charge term sleepPerf z=0.42 w=0.15 (rest=0.9 center=0.85)",
+            "charge term skinTempDev z=-0.0 w=0.05 (dev=0.0C penalty=-|dev|/1.0)",
+            "charge nilTerm dropped=[] (each dropped term renormalizes the remaining weights)",
+            "charge renorm totalWeight=1.0 compositeZ=1.45 (z = sum(z*w)/sum(w))",
+            "charge score=93.38 band=green (logistic k=1.6 z0=-0.2)",
+        ])
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/RecoveryScorerTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/RecoveryScorerTrace.kt
@@ -15,23 +15,35 @@ import kotlin.math.abs
 object RecoveryScorerTrace {
 
     /**
-     * Trace numbers use nearest rounding with half-ties away from zero on both platforms.
+     * Trace numbers use nearest rounding with half-ties away from zero on both platforms. Twin of the
+     * Swift RecoveryScorer.traceRound2, which is the contract this reproduces.
      *
      * Round the MAGNITUDE and reapply the sign, rather than branching on `scaled < 0.0`. Two traps sit
      * here, and Swift's `.rounded(.toNearestOrAwayFromZero)` avoids both for free:
      *
-     *  * Math.round returns a Long, which has no negative zero, so negating it before the division
-     *    collapses -0.0 to +0.0 for any value that rounds to zero;
+     *  * a Long has no negative zero, so negating a rounded Long before the division collapses -0.0 to
+     *    +0.0 for any value that rounds to zero;
      *  * `-0.0 < 0.0` is FALSE, so a sign test cannot even route an exact -0.0 to a negating branch —
      *    and -0.0 is reachable here, since a skin-temp deviation of exactly 0.0 gives z = -|dev| = -0.0.
      *
      * These values are interpolated straight into the trace, so either trap printed `z=0.0` on Android
      * against `z=-0.0` on Apple. copySign carries the IEEE sign bit itself and handles both (#1437
      * follow-up).
+     *
+     * The rounding itself stays in the DOUBLE domain, because Math.round returns a Long and therefore
+     * SATURATES: |x * 100| >= 2^63 came back as Long.MAX_VALUE, so 1e20 rendered as 9.223372036854776e16
+     * where Swift kept 1e20 (#47). rint is half-to-EVEN, so an exact tie (the fraction is exactly 0.5,
+     * only possible below 2^52, where floor is exact) is stepped up by hand to reach half-away-from-zero;
+     * `floor(m + 0.5)` is not usable for that, since m + 0.5 is itself rounded and would push
+     * 0.49999999999999994 up to 1. Nothing is clamped: any finite input round-trips, and a non-finite one
+     * (or a finite one whose x * 100 overflows) passes through as the matching infinity or NaN.
      */
-    private fun r2(x: Double): Double {
+    internal fun r2(x: Double): Double {
         val scaled = x * 100.0
-        return Math.copySign(Math.round(abs(scaled)) / 100.0, scaled)
+        val magnitude = abs(scaled)
+        val floored = Math.floor(magnitude)
+        val rounded = if (magnitude - floored == 0.5) floored + 1.0 else Math.rint(magnitude)
+        return Math.copySign(rounded / 100.0, scaled)
     }
 
     /**

--- a/android/app/src/test/java/com/noop/analytics/RecoveryScorerTraceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RecoveryScorerTraceTest.kt
@@ -171,4 +171,89 @@ class RecoveryScorerTraceTest {
             lines.first { it.startsWith("charge term skinTempDev ") },
         )
     }
+
+    /**
+     * #47: the two-decimal trace-rounding contract itself, pinned as RAW BITS rather than as text.
+     * Text would hide the divergence: Swift and Kotlin print the same Double differently ("1e+20" vs
+     * "1.0E20"), and -0.0 vs 0.0 is a one-bit difference. Both cases the issue names live here — the
+     * signed zero of a near-baseline driver term, and the large finite value that Math.round (a Long)
+     * saturated at 2^63-1, turning 1e20 into 9.223372036854776e16 where Swift kept 1e20.
+     *
+     * The expected bit patterns are the VERBATIM stdout of the Swift twin compiled standalone
+     * (`swiftc -O twin.swift -o t -Xlinker -lm && ./t`), not values re-derived here — that is what makes
+     * this an oracle rather than a second opinion. The twin:
+     *
+     *     func traceRound2(_ x: Double) -> Double {
+     *         (x * 100.0).rounded(.toNearestOrAwayFromZero) / 100.0
+     *     }
+     *     for (label, v) in cases {
+     *         let r = traceRound2(v)
+     *         print("\(label) -> \(r) bits=0x\(String(r.bitPattern, radix: 16))")
+     *     }
+     *
+     * Twin: `testTraceRound2MatchesTheSwiftContract`.
+     */
+    @Test fun traceRound2MatchesTheSwiftContract() {
+        val cases = listOf(
+            Triple("-0.004", -0.004, "8000000000000000"), // -0.0: sign survives rounding to zero
+            Triple("0.004", 0.004, "0"),
+            Triple("1e20", 1e20, "4415af1d78b58c40"), // 1e+20, NOT the signed-64 ceiling
+            Triple("-1e20", -1e20, "c415af1d78b58c40"),
+            Triple("0.0", 0.0, "0"),
+            Triple("-0.0", -0.0, "8000000000000000"),
+            Triple("0.125", 0.125, "3fc0a3d70a3d70a4"), // positive half-tie -> away from zero (0.13)
+            Triple("-0.125", -0.125, "bfc0a3d70a3d70a4"), // negative half-tie -> -0.13
+            Triple("1.2349", 1.2349, "3ff3ae147ae147ae"), // ordinary non-ties
+            Triple("-1.2349", -1.2349, "bff3ae147ae147ae"),
+            // Just below the half-tie: floor(m + 0.5) would round this UP because m + 0.5 is not exact.
+            Triple("0.0049999999999999994", 0.0049999999999999994, "0"),
+            Triple("-0.0049999999999999994", -0.0049999999999999994, "8000000000000000"),
+            Triple("1e306", 1e306, "7f76c8e5ca239029"), // largest magnitudes whose *100 is still finite
+            Triple("-1e306", -1e306, "ff76c8e5ca239029"),
+            // Finite input whose intermediate x * 100 overflows: both platforms yield an infinity.
+            Triple("1e307", 1e307, "7ff0000000000000"),
+            Triple("-1e307", -1e307, "fff0000000000000"),
+        )
+        for ((label, input, bits) in cases) {
+            assertEquals(
+                "r2($label)",
+                bits,
+                java.lang.Long.toHexString(java.lang.Double.doubleToRawLongBits(RecoveryScorerTrace.r2(input))),
+            )
+        }
+    }
+
+    /**
+     * #47: the exact differential fixture. Every line of one full-term night, pinned verbatim, so a
+     * rounding change on either platform shows up as a text diff rather than as two field logs that
+     * quietly disagree. The skin-temp deviation is 0.004, the issue's near-zero negative: it must render
+     * `z=-0.0` and `dev=0.0C`.
+     *
+     * The expected lines are the VERBATIM stdout of the Swift twin (RecoveryScorer.recoveryTrace on the
+     * same inputs), not text re-derived here. Twin: `testTraceFixtureIsByteIdenticalAcrossPlatforms`.
+     */
+    @Test fun traceFixtureIsByteIdenticalAcrossPlatforms() {
+        val (_, lines) = RecoveryScorerTrace.recoveryTrace(
+            hrv = 62.0, rhr = 51.0, resp = 15.0,
+            hrvBaseline = baseline(50.0, 6.0), rhrBaseline = baseline(55.0, 3.0),
+            respBaseline = baseline(16.0, 2.0),
+            sleepPerf = 0.9, skinTempDev = 0.004,
+        )
+        assertEquals(
+            listOf(
+                "charge baseline hrv mean=50.0 spread=4.79 nValid=14 status=trusted",
+                "charge baseline rhr mean=55.0 spread=2.39 nValid=14 status=trusted",
+                "charge baseline resp mean=16.0 spread=1.6 nValid=14 status=trusted",
+                "charge term hrv z=2.0 w=0.55 (higher HRV is better)",
+                "charge term rhr z=1.33 w=0.2 (lower RHR is better)",
+                "charge term resp z=0.5 w=0.05 (lower resp is better)",
+                "charge term sleepPerf z=0.42 w=0.15 (rest=0.9 center=0.85)",
+                "charge term skinTempDev z=-0.0 w=0.05 (dev=0.0C penalty=-|dev|/1.0)",
+                "charge nilTerm dropped=[] (each dropped term renormalizes the remaining weights)",
+                "charge renorm totalWeight=1.0 compositeZ=1.45 (z = sum(z*w)/sum(w))",
+                "charge score=93.38 band=green (logistic k=1.6 z0=-0.2)",
+            ),
+            lines,
+        )
+    }
 }


### PR DESCRIPTION
## Problem

The recovery trace rounds each rendered number to two decimals. Swift does
`(x * 100).rounded(.toNearestOrAwayFromZero) / 100`; Kotlin routed the same value through
`Math.round`, which returns a **`Long`** and therefore saturates. Any `|x * 100| >= 2^63` came back
as `Long.MAX_VALUE`, so `1e20` rendered as `9.223372036854776e16` on Android where Apple kept
`1e20` — the same trace line, two different numbers. The signed-zero half of bhelm/noop#47 was
already fixed by the #1437 follow-up (`copySign`); this is the remaining large-finite half.

## Change

- `android/app/src/main/java/com/noop/analytics/RecoveryScorerTrace.kt`: `r2` now rounds the
  magnitude in the Double domain — `Math.rint` plus an explicit half-away-from-zero step for an
  exact `.5` tie — and reapplies the sign with `copySign`. `Math.rint` is half-to-**even**, so the
  tie step is required; `floor(m + 0.5)` is not usable for it, because `m + 0.5` is itself rounded
  and would push `0.49999999999999994` up to `1`.
- `Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer+Trace.swift`: the Swift math is
  unchanged, but the local `r2` closure now forwards to a new named
  `RecoveryScorer.traceRound2(_:)` carrying the contract in its doc comment. Kotlin's `r2` went
  `private` → `internal` for the same reason: without one named declaration per side, `±1e20` is
  untestable through the public trace API at all, since Swift renders it `1e+20` and Kotlin
  `1.0E20` — the trace *strings* differ on formatting regardless of rounding. That is why the
  contract test compares raw IEEE bit patterns, not text.
- Mirrored tests: `RecoveryScorerTraceTests.swift` (+57) and `RecoveryScorerTraceTest.kt` (+85),
  including a full 11-line trace fixture for one complete night with identical expected strings on
  both platforms.

## Verification

- Oracle: a standalone Swift twin (`swiftc -O twin.swift -o t && ./t`) produced every expected
  literal in the Kotlin test, used verbatim — e.g. `-0.004 -> -0.0 bits=0x8000000000000000`,
  `1e20 -> 1e+20 bits=0x4415af1d78b58c40`, `1e307 -> inf bits=0x7ff0000000000000`. The twin source
  is reproduced in both test files' comments, per the existing repo convention.
- Red before the change (with `r2` made testable but its body unchanged):
  `./gradlew testFullDebugUnitTest --tests "com.noop.analytics.RecoveryScorerTraceTest"` →
  `10 tests completed, 1 failed` — `ComparisonFailure: r2(1e20) expected:<4[415af1d78b58c40]> but
  was:<4[3747ae147ae147b]>` (= `9.223372036854776e16`, the `Long` ceiling).
- Green after: the same command with `--rerun-tasks` → `BUILD SUCCESSFUL`, XML `tests="10"
  failures="0" errors="0"`, including `traceRound2MatchesTheSwiftContract` and
  `traceFixtureIsByteIdenticalAcrossPlatforms`.
  `cd Packages/StrandAnalytics && swift test --filter RecoveryScorerTraceTests` → **Executed 10
  tests, with 0 failures** (green before and after; the Swift math did not change).
- `python3 Tools/doc_comment_lint.py` → `OK no NEW detached doc comments`, exit 0.
  `Tools/i18n_audit.py` not applicable: no user-facing strings.
- **Not run:** macOS/iOS/watch app targets — no macOS/Xcode available to me. Neither changed file
  is compiled into an app-only target beyond `StrandAnalytics`, which is covered above. No hardware
  required.

## Behaviour change / user-visible effects

Diagnostic trace text only. Charge, and every stored value, are unaffected. On Android a driver
term whose magnitude exceeds the `Long` ceiling now prints its real value instead of the saturated
`9.2e16`; in normal physiological ranges nothing changes. Documented in both doc comments: the
contract is defined for finite inputs, and non-finite inputs — or finite ones whose `x * 100`
overflows (|x| > ~1.79e306) — pass through as the matching infinity or NaN on both platforms. That
is pinned by the `1e306` / `1e307` rows rather than rejected, because Swift already behaved that
way and rejecting would have changed Swift.

## Scope limits and follow-ups

- **Only `RecoveryScorerTrace.r2` was changed.** The identical `Math.round`-to-`Long` saturation
  pattern still exists at four other Android sites: `HrvAnalyzerTrace.kt:15`,
  `SleepStagerTrace.kt:75`, `StepsEstimateEngineTrace.kt:29`, and `AnalyticsEngine.kt:1567,1585`.
  Deliberately untouched here to keep one concern per PR — happy to follow up with a single PR that
  routes all five through one shared helper if you'd prefer that shape.
- There is no pre-existing shared trace-fixture file to extend, so the mirrored fixture lives in the
  two twin test classes.

Branch: `fix/issue-47-recovery-trace-double-rounding`. Contribution offered under the repository's
PolyForm Noncommercial 1.0.0 license.
