### PR TITLE
Hold the strap ack when the Android trim cursor fails to commit

### DIFF
--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -1,6 +1,7 @@
 package com.noop.ble
 
 import android.content.Context
+import android.content.SharedPreferences
 import com.noop.data.DynAccelDiag
 import com.noop.data.InsertCounts
 import com.noop.data.StreamBatch
@@ -15,6 +16,7 @@ import com.noop.protocol.decodeHistorical
 import com.noop.protocol.extractHistoricalStreams
 import com.noop.protocol.isEmptyRecordFrame
 import com.noop.protocol.rejectedHistoricalRecords
+import java.io.IOException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -934,13 +936,22 @@ interface TrimCursorStore {
 }
 
 /** Default [TrimCursorStore] backed by a private SharedPreferences file. */
-class PrefsTrimCursorStore(context: Context) : TrimCursorStore {
-    private val prefs = context.applicationContext
-        .getSharedPreferences("noop_backfill_cursors", Context.MODE_PRIVATE)
+class PrefsTrimCursorStore(private val prefs: SharedPreferences) : TrimCursorStore {
+
+    /** Production entry point: the app's private cursor prefs file. */
+    constructor(context: Context) : this(
+        context.applicationContext.getSharedPreferences("noop_backfill_cursors", Context.MODE_PRIVATE),
+    )
 
     override suspend fun set(name: String, value: Long) {
         // commit() (synchronous) so durability is established before we ack the strap.
-        prefs.edit().putLong(name, value).commit()
+        // #8: commit() reports a FAILED write (full storage, unwritable prefs file) by RETURNING
+        // false — it does not throw. Discarding that result made a failed persist look identical to
+        // a successful one, so the caller's try/catch never fired and the strap got acked without a
+        // durable cursor. Surface it as the throw that guard already handles by HOLDING the ack.
+        if (!prefs.edit().putLong(name, value).commit()) {
+            throw IOException("SharedPreferences.commit() returned false for cursor '$name'=$value")
+        }
     }
 
     override suspend fun get(name: String): Long? =

--- a/android/app/src/test/java/com/noop/ble/TrimCursorCommitDurabilityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/TrimCursorCommitDurabilityTest.kt
@@ -34,8 +34,6 @@ class TrimCursorCommitDurabilityTest {
             thrown = t
         }
         assertTrue("a commit() that returned false must surface as a throw, got $thrown", thrown != null)
-        // And nothing durable was written, so the next session must re-offer the chunk.
-        assertNull(runBlocking { store.get(Backfiller.STRAP_TRIM_CURSOR) })
     }
 
     /** Storage-full surfacing as an exception from the editor stays an exception (guard still fires). */
@@ -101,10 +99,11 @@ class TrimCursorCommitDurabilityTest {
             override fun clear(): SharedPreferences.Editor { prefs.map.clear(); return this }
             override fun commit(): Boolean {
                 if (prefs.commitThrows) throw java.io.IOException("simulated storage failure")
-                // A failed commit leaves the store untouched, exactly like the platform does.
-                if (!prefs.commitResult) return false
+                // The platform commits to the in-memory map FIRST and returns only the disk-write
+                // result, so a false commit is still visible to an in-process get(); only durability
+                // across a restart is lost. Model that: apply, then report the failure.
                 flush()
-                return true
+                return prefs.commitResult
             }
             override fun apply() { flush() }
             private fun flush() {

--- a/android/app/src/test/java/com/noop/ble/TrimCursorCommitDurabilityTest.kt
+++ b/android/app/src/test/java/com/noop/ble/TrimCursorCommitDurabilityTest.kt
@@ -1,0 +1,117 @@
+package com.noop.ble
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #8: the `strap_trim` cursor must not report success when its write did not land.
+ *
+ * [PrefsTrimCursorStore.set] uses `SharedPreferences.commit()` for durability before the strap is
+ * acked, but `commit()` signals a failed write (full storage, unwritable prefs file) by RETURNING
+ * false — it does not throw. Discarding that result made a failed persist indistinguishable from a
+ * successful one, so the Backfiller's try/catch guard never fired and the strap was acked without a
+ * durable cursor, breaking the safe-trim invariant. `set` must surface the false as a throw, which
+ * is what the existing guard (Backfiller.finishChunk) already converts into "hold the ack".
+ *
+ * No Robolectric (junit only) — the real store runs over an in-memory [FakeSharedPreferences] whose
+ * `commit()` result is scriptable, the same fake-prefs convention as ProfileStoreAgeMigrationTest.
+ */
+class TrimCursorCommitDurabilityTest {
+
+    /** A failed commit must throw, so the caller holds the ack instead of trimming the strap. */
+    @Test
+    fun set_throwsWhenCommitReturnsFalse() {
+        val prefs = FakeSharedPreferences(commitResult = false)
+        val store = PrefsTrimCursorStore(prefs)
+        var thrown: Throwable? = null
+        try {
+            runBlocking { store.set(Backfiller.STRAP_TRIM_CURSOR, 12_345L) }
+        } catch (t: Throwable) {
+            thrown = t
+        }
+        assertTrue("a commit() that returned false must surface as a throw, got $thrown", thrown != null)
+        // And nothing durable was written, so the next session must re-offer the chunk.
+        assertNull(runBlocking { store.get(Backfiller.STRAP_TRIM_CURSOR) })
+    }
+
+    /** Storage-full surfacing as an exception from the editor stays an exception (guard still fires). */
+    @Test
+    fun set_propagatesWhenCommitThrows() {
+        val prefs = FakeSharedPreferences(commitResult = true, commitThrows = true)
+        val store = PrefsTrimCursorStore(prefs)
+        var thrown: Throwable? = null
+        try {
+            runBlocking { store.set(Backfiller.STRAP_TRIM_CURSOR, 7L) }
+        } catch (t: Throwable) {
+            thrown = t
+        }
+        assertTrue("an exception from commit() must reach the caller, got $thrown", thrown != null)
+    }
+
+    /** Happy path unchanged: a successful commit persists and reads back without throwing. */
+    @Test
+    fun set_persistsWhenCommitSucceeds() {
+        val prefs = FakeSharedPreferences(commitResult = true)
+        val store = PrefsTrimCursorStore(prefs)
+        runBlocking { store.set(Backfiller.STRAP_TRIM_CURSOR, 4_294_967_295L) }
+        assertEquals(4_294_967_295L, runBlocking { store.get(Backfiller.STRAP_TRIM_CURSOR) })
+    }
+
+    /** An unset cursor still reads as absent (the "no cursor yet" sentinel path). */
+    @Test
+    fun get_returnsNullWhenUnset() {
+        val store = PrefsTrimCursorStore(FakeSharedPreferences(commitResult = true))
+        assertNull(runBlocking { store.get(Backfiller.STRAP_TRIM_CURSOR) })
+    }
+
+    /** In-memory SharedPreferences whose `commit()` outcome the test scripts. */
+    private class FakeSharedPreferences(
+        private val commitResult: Boolean,
+        private val commitThrows: Boolean = false,
+    ) : SharedPreferences {
+        val map = HashMap<String, Any?>()
+        override fun getInt(key: String, defValue: Int): Int = map[key] as? Int ?: defValue
+        override fun getLong(key: String, defValue: Long): Long = map[key] as? Long ?: defValue
+        override fun getFloat(key: String, defValue: Float): Float = map[key] as? Float ?: defValue
+        override fun getBoolean(key: String, defValue: Boolean): Boolean = map[key] as? Boolean ?: defValue
+        override fun getString(key: String, defValue: String?): String? = map[key] as? String ?: defValue
+        @Suppress("UNCHECKED_CAST")
+        override fun getStringSet(key: String, defValues: MutableSet<String>?): MutableSet<String>? =
+            map[key] as? MutableSet<String> ?: defValues
+        override fun getAll(): MutableMap<String, *> = HashMap(map)
+        override fun contains(key: String): Boolean = map.containsKey(key)
+        override fun registerOnSharedPreferenceChangeListener(l: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+        override fun unregisterOnSharedPreferenceChangeListener(l: SharedPreferences.OnSharedPreferenceChangeListener?) {}
+        override fun edit(): SharedPreferences.Editor = FakeEditor(this)
+
+        private class FakeEditor(private val prefs: FakeSharedPreferences) : SharedPreferences.Editor {
+            private val pending = HashMap<String, Any?>()
+            private val removals = HashSet<String>()
+            override fun putString(key: String, value: String?): SharedPreferences.Editor { pending[key] = value; return this }
+            override fun putStringSet(key: String, values: MutableSet<String>?): SharedPreferences.Editor { pending[key] = values; return this }
+            override fun putInt(key: String, value: Int): SharedPreferences.Editor { pending[key] = value; return this }
+            override fun putLong(key: String, value: Long): SharedPreferences.Editor { pending[key] = value; return this }
+            override fun putFloat(key: String, value: Float): SharedPreferences.Editor { pending[key] = value; return this }
+            override fun putBoolean(key: String, value: Boolean): SharedPreferences.Editor { pending[key] = value; return this }
+            override fun remove(key: String): SharedPreferences.Editor { removals.add(key); return this }
+            override fun clear(): SharedPreferences.Editor { prefs.map.clear(); return this }
+            override fun commit(): Boolean {
+                if (prefs.commitThrows) throw java.io.IOException("simulated storage failure")
+                // A failed commit leaves the store untouched, exactly like the platform does.
+                if (!prefs.commitResult) return false
+                flush()
+                return true
+            }
+            override fun apply() { flush() }
+            private fun flush() {
+                for (k in removals) prefs.map.remove(k)
+                prefs.map.putAll(pending)
+                pending.clear(); removals.clear()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`PrefsTrimCursorStore.set` persisted the safe-trim cursor with
`prefs.edit().putLong(name, value).commit()` and **discarded the return value**, directly under the
comment explaining that `commit()` is used synchronously so durability is established before the
strap is acked. `commit()` reports a failed disk write by returning `false`, not by throwing, so a
full or unwritable prefs file looked exactly like a success: the caller's `try`/`catch` never
fired, and the strap was acked to trim data whose cursor had not survived. Reported as
bhelm/noop#8; this is the Android half of the safe-trim invariant.

## Change

`android/app/src/main/java/com/noop/ble/Backfiller.kt` (+19 / −4):

- `set` now throws `IOException` when `commit()` returns `false`, so the failure arrives at the
  pre-existing guard as a throw. That guard (unmodified) logs once, sets `persistStalled = true`
  and `return`s **before** `ackTrim(…)` — so the ack is held and the strap keeps the chunk.
- `PrefsTrimCursorStore` now takes a `SharedPreferences` as its primary constructor parameter, with
  a secondary `(Context)` constructor retained for production. Same prefs file name, same mode,
  same `applicationContext`, same eager creation as the old property initializer; the single
  production call site is unchanged. This is a test seam, not a refactor.
- New `android/app/src/test/java/com/noop/ble/TrimCursorCommitDurabilityTest.kt` (+117): four tests
  over an in-memory fake with a scriptable `commit()`, covering a `false` return (the full-storage
  case) and an editor that throws.

## Verification

- Red before the change (test seam in place, fix not yet applied):
  `./gradlew testFullDebugUnitTest --tests "com.noop.ble.TrimCursorCommitDurabilityTest"` →
  `4 tests completed, 1 failed` — `set_throwsWhenCommitReturnsFalse FAILED
  java.lang.AssertionError`.
- Green after: the same command plus `--tests "com.noop.ble.Backfill*"` → `BUILD SUCCESSFUL`.
  Result XML: `TrimCursorCommitDurabilityTest` 4, `BackfillContinuationTest` 24,
  `BackfillerSessionTallyTest` 26, `BackfillPolicyTest` 7, `BackfillDrainGateTest` 4 — **65 tests,
  0 failures, 0 errors**.
- The fake models the platform faithfully: `commit()` applies the edit to the in-memory map first
  and returns only the *disk-write* result, so an in-process read after a failed set still sees the
  new value — only durability across a restart is lost. The test asserts what the fix guarantees.
- `python3 Tools/doc_comment_lint.py` → `OK no NEW detached doc comments`, exit 0.
  `python3 Tools/i18n_audit.py --ci` → OK, no new gaps.
- **Not run:** macOS/iOS app targets and `StrandTests` — no macOS/Xcode available to me; no Swift
  source was touched. **No strap and no emulator:** the BLE ack path itself was not exercised on
  hardware. What is proven is the changed unit — that a failed `commit()` now reaches the existing
  hold-ack guard as a throw rather than passing silently; that guard is pre-existing, unmodified
  code on a path exercised in production.

## Behaviour change / user-visible effects

Only on a failing write. Previously: silent data loss risk — the strap was told to trim while the
cursor was not durable. Now: one log line, `persistStalled` set, the session stalls and ends
without acking, and a fresh session resets the flag. No forever-retry — `lastAckedTrim` is not
advanced on the hold path, so the auto-continue does not re-kick. Decoded rows are already durable
and idempotent by natural key, and the strap keeps the chunk, so nothing is lost. On the healthy
path (`commit()` returns `true`) nothing changes at all.

## Scope limits and follow-ups

- The issue's "minimum" option was taken (throw so the existing guard holds the ack), not the
  "better" one (moving the cursor into a Room table or an fsynced ack journal) — that is a schema +
  migration change, well beyond this fix.
- **Kotlin only.** The Swift twin already surfaces a failed cursor write as a throw that holds the
  ack with the same log wording, so no numeric or stored value crosses platforms here and no oracle
  test is owed. The *Swift* durability gap is bhelm/noop#6 (no checkpoint between cursor write and
  ack) and is deliberately untouched — it needs a design decision, not a few lines.
- The hold-ack guard itself remains untested: constructing a `Backfiller` in a plain-JVM test needs
  a repository over a 152-method DAO with no fake in the tree, and Robolectric is not a test
  dependency. Declared rather than worked around.
- Worth knowing: on Android the trim cursor is currently **write-only** (`get` has no production
  caller), so the safe-trim invariant rests entirely on withholding the ack, unlike Swift where the
  cursor lives in the store. Pre-existing, out of scope here.

Branch: `fix/issue-8-trim-cursor-commit-result`. Contribution offered under the repository's
PolyForm Noncommercial 1.0.0 license.
