### PR TITLE
Retire the duplicate Gregorian day formatter in TrainingLoadEngine

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/TrainingLoadEngine.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/TrainingLoadEngine.swift
@@ -218,7 +218,7 @@ public enum TrainingLoadEngine {
                                      configuration: Configuration = .standard) -> Result {
         let baseOrdinal = dayOrdinal("2000-01-01")!
         let days = loads.enumerated().map { offset, load in
-            DailyLoad(day: dayString(ordinal: baseOrdinal + offset), load: load)
+            DailyLoad(day: LocalCalendarDate(daysSinceEpoch: baseOrdinal + offset).key, load: load)
         }
         return evaluate(days: days, configuration: configuration)
     }
@@ -251,20 +251,6 @@ public enum TrainingLoadEngine {
         let dayOfYear = (153 * shiftedMonth + 2) / 5 + day - 1
         let dayOfEra = yearOfEra * 365 + yearOfEra / 4 - yearOfEra / 100 + dayOfYear
         return era * 146_097 + dayOfEra - 719_468
-    }
-
-    private static func dayString(ordinal: Int) -> String {
-        let z = ordinal + 719_468
-        let era = floorDiv(z, 146_097)
-        let dayOfEra = z - era * 146_097
-        let yearOfEra = (dayOfEra - dayOfEra / 1_460 + dayOfEra / 36_524 - dayOfEra / 146_096) / 365
-        var year = yearOfEra + era * 400
-        let dayOfYear = dayOfEra - (365 * yearOfEra + yearOfEra / 4 - yearOfEra / 100)
-        let monthPrime = (5 * dayOfYear + 2) / 153
-        let day = dayOfYear - (153 * monthPrime + 2) / 5 + 1
-        let month = monthPrime + (monthPrime < 10 ? 3 : -9)
-        year += month <= 2 ? 1 : 0
-        return String(format: "%04d-%02d-%02d", year, month, day)
     }
 
     private static func isLeapYear(_ year: Int) -> Bool {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LocalDayWindowsTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/LocalDayWindowsTests.swift
@@ -431,4 +431,33 @@ final class LocalDayWindowsTests: XCTestCase {
         XCTAssertTrue(blind.contains("cannot observe"))
         XCTAssertTrue(blind.contains("unavailable"))
     }
+
+    /// Edge coverage for the day-number to `YYYY-MM-DD` conversion, held here because issue #71 retired
+    /// `TrainingLoadEngine`'s private duplicate of it in favour of this helper. Leap years (including
+    /// the century rules), negative epoch days, and the round trip back to the day number are exactly
+    /// what the duplicate covered, so they must keep being covered somewhere.
+    /// Kotlin twin: `LocalDayWindowsTest.dayNumberKeysCoverLeapYearsNegativeEpochsAndRoundTrips`.
+    func testDayNumberKeysCoverLeapYearsNegativeEpochsAndRoundTrips() {
+        let expected: [(Int, String)] = [
+            (0, "1970-01-01"),
+            (-1, "1969-12-31"),
+            (11_016, "2000-02-29"),     // 400-divisible century IS a leap year
+            (19_782, "2024-02-29"),
+            (-25_509, "1900-02-28"),    // 100-divisible non-400 century is NOT
+            (-25_508, "1900-03-01"),
+            (47_540, "2100-02-28"),
+            (-135_081, "1600-02-29"),   // negative epoch day, leap century
+            (-719_162, "0001-01-01"),   // the floor the engine's day parser accepts
+            (2_932_896, "9999-12-31"),
+        ]
+        for (ordinal, key) in expected {
+            XCTAssertEqual(LocalCalendarDate(daysSinceEpoch: ordinal).key, key, "ordinal \(ordinal)")
+        }
+        // Round trip over both signs, stepping by a prime so the sweep does not land on month starts.
+        for ordinal in stride(from: -719_162, through: 2_932_896, by: 9_973) {
+            let date = LocalCalendarDate(daysSinceEpoch: ordinal)
+            XCTAssertEqual(date.daysSinceEpoch, ordinal, "ordinal \(ordinal)")
+            XCTAssertEqual(self.date(date.key).key, date.key, "ordinal \(ordinal)")
+        }
+    }
 }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/TrainingLoadEngineTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/TrainingLoadEngineTests.swift
@@ -152,4 +152,22 @@ final class TrainingLoadEngineTests: XCTestCase {
         XCTAssertEqual(result.ctl!, 30, accuracy: 1e-12)
         XCTAssertEqual(result.atl!, 30, accuracy: 1e-12)
     }
+
+    /// Pins the synthetic day labels `evaluateDense` hands out, which issue #71 moved off a private
+    /// Gregorian formatter onto the shared `LocalCalendarDate`. The literals are the verbatim stdout of
+    /// the pre-move formatter compiled standalone (`swiftc -O`), so a label that shifts by a day around
+    /// the leap day or the year boundary fails here instead of surfacing as two disagreeing platforms.
+    /// Kotlin twin: `TrainingLoadEngineTest.denseDayLabelsCrossLeapDayAndYearBoundary`.
+    func testDenseDayLabelsCrossLeapDayAndYearBoundary() {
+        let result = TrainingLoadEngine.evaluateDense(Array(repeating: 30, count: 367))
+        XCTAssertEqual(result.startDay, "2000-01-01")
+        XCTAssertEqual(result.endDay, "2001-01-01")
+        // Points begin at the last priming day (offset 6), so offset N is points[N - 6].
+        XCTAssertEqual(result.points.first?.day, "2000-01-07")
+        XCTAssertEqual(result.points[52].day, "2000-02-28")
+        XCTAssertEqual(result.points[53].day, "2000-02-29")
+        XCTAssertEqual(result.points[54].day, "2000-03-01")
+        XCTAssertEqual(result.points[359].day, "2000-12-31")
+        XCTAssertEqual(result.points.last?.day, "2001-01-01")
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/TrainingLoadEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/TrainingLoadEngine.kt
@@ -163,7 +163,9 @@ object TrainingLoadEngine {
     /** Convenience for dense load arrays. Day labels are synthetic but deterministic; math is identical. */
     fun evaluateDense(loads: List<Double>, configuration: Configuration = standard): Result {
         val baseOrdinal = dayOrdinal("2000-01-01")!!
-        val days = loads.mapIndexed { index, load -> DailyLoad(dayString(baseOrdinal + index), load) }
+        val days = loads.mapIndexed { index, load ->
+            DailyLoad(LocalCalendarDate(daysSinceEpoch = baseOrdinal + index).key, load)
+        }
         return evaluate(days, configuration = configuration)
     }
 
@@ -193,20 +195,6 @@ object TrainingLoadEngine {
         val dayOfYear = (153 * shiftedMonth + 2) / 5 + day - 1
         val dayOfEra = yearOfEra * 365 + yearOfEra / 4 - yearOfEra / 100 + dayOfYear
         return era * 146_097 + dayOfEra - 719_468
-    }
-
-    private fun dayString(ordinal: Int): String {
-        val z = ordinal + 719_468
-        val era = floorDiv(z, 146_097)
-        val dayOfEra = z - era * 146_097
-        val yearOfEra = (dayOfEra - dayOfEra / 1_460 + dayOfEra / 36_524 - dayOfEra / 146_096) / 365
-        var year = yearOfEra + era * 400
-        val dayOfYear = dayOfEra - (365 * yearOfEra + yearOfEra / 4 - yearOfEra / 100)
-        val monthPrime = (5 * dayOfYear + 2) / 153
-        val day = dayOfYear - (153 * monthPrime + 2) / 5 + 1
-        val month = monthPrime + if (monthPrime < 10) 3 else -9
-        if (month <= 2) year += 1
-        return "%04d-%02d-%02d".format(java.util.Locale.US, year, month, day)
     }
 
     private fun isLeapYear(year: Int) = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)

--- a/android/app/src/test/java/com/noop/analytics/LocalDayWindowsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/LocalDayWindowsTest.kt
@@ -543,6 +543,42 @@ class LocalDayWindowsTest {
         }
     }
 
+    /**
+     * Edge coverage for the day-number to `YYYY-MM-DD` conversion, held here because issue #71 retired
+     * `TrainingLoadEngine`'s private duplicate of it in favour of this helper. Leap years (including the
+     * century rules), negative epoch days, and the round trip back to the day number are exactly what
+     * the duplicate covered, so they must keep being covered somewhere.
+     *
+     * The expected literals below are the VERBATIM stdout of the Swift twin compiled standalone
+     * (`swiftc -O twin.swift`), not values re-derived here — that is what makes this an oracle rather
+     * than a second opinion. Swift twin:
+     * `LocalDayWindowsTests.testDayNumberKeysCoverLeapYearsNegativeEpochsAndRoundTrips`.
+     */
+    @Test
+    fun dayNumberKeysCoverLeapYearsNegativeEpochsAndRoundTrips() {
+        val expected = listOf(
+            0 to "1970-01-01",
+            -1 to "1969-12-31",
+            11_016 to "2000-02-29", // 400-divisible century IS a leap year
+            19_782 to "2024-02-29",
+            -25_509 to "1900-02-28", // 100-divisible non-400 century is NOT
+            -25_508 to "1900-03-01",
+            47_540 to "2100-02-28",
+            -135_081 to "1600-02-29", // negative epoch day, leap century
+            -719_162 to "0001-01-01", // the floor the engine's day parser accepts
+            2_932_896 to "9999-12-31",
+        )
+        for ((ordinal, key) in expected) {
+            assertEquals("ordinal $ordinal", key, LocalCalendarDate(daysSinceEpoch = ordinal).key)
+        }
+        // Round trip over both signs, stepping by a prime so the sweep does not land on month starts.
+        for (ordinal in -719_162..2_932_896 step 9_973) {
+            val date = LocalCalendarDate(daysSinceEpoch = ordinal)
+            assertEquals("ordinal $ordinal", ordinal, date.daysSinceEpoch)
+            assertEquals("ordinal $ordinal", date.key, date(date.key).key)
+        }
+    }
+
     private companion object {
 
         /** The oracle file package 1 committed under the Android test resources. */

--- a/android/app/src/test/java/com/noop/analytics/TrainingLoadEngineTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/TrainingLoadEngineTest.kt
@@ -149,4 +149,27 @@ class TrainingLoadEngineTest {
         assertEquals(30.0, result.ctl!!, 1e-12)
         assertEquals(30.0, result.atl!!, 1e-12)
     }
+
+    /**
+     * Pins the synthetic day labels `evaluateDense` hands out, which issue #71 moved off a private
+     * Gregorian formatter onto the shared `LocalCalendarDate`.
+     *
+     * The expected literals below are the VERBATIM stdout of the Swift twin compiled standalone
+     * (`swiftc -O twin.swift`), not values re-derived here — that is what makes this an oracle rather
+     * than a second opinion. Swift twin:
+     * `TrainingLoadEngineTests.testDenseDayLabelsCrossLeapDayAndYearBoundary`.
+     */
+    @Test
+    fun denseDayLabelsCrossLeapDayAndYearBoundary() {
+        val result = TrainingLoadEngine.evaluateDense(List(367) { 30.0 })
+        assertEquals("2000-01-01", result.startDay)
+        assertEquals("2001-01-01", result.endDay)
+        // Points begin at the last priming day (offset 6), so offset N is points[N - 6].
+        assertEquals("2000-01-07", result.points.first().day)
+        assertEquals("2000-02-28", result.points[52].day)
+        assertEquals("2000-02-29", result.points[53].day)
+        assertEquals("2000-03-01", result.points[54].day)
+        assertEquals("2000-12-31", result.points[359].day)
+        assertEquals("2001-01-01", result.points.last().day)
+    }
 }


### PR DESCRIPTION
## Problem

`TrainingLoadEngine` carries its own private `dayString(ordinal:)` on both platforms — a hand-rolled
civil-from-days conversion that duplicates the audited `LocalCalendarDate` day-number → `key`
formatter added by #1938. Two copies of the same Gregorian arithmetic in two languages is exactly
the drift surface the parity contract exists to remove: a leap-rule fix applied to one copy would
silently leave the other producing different day labels. Reported as bhelm/noop#71.

## Change

- `Packages/StrandAnalytics/Sources/StrandAnalytics/TrainingLoadEngine.swift` (+1 / −15):
  `evaluateDense` now builds its labels with `LocalCalendarDate(daysSinceEpoch:).key`; the private
  `dayString(ordinal:)` is deleted.
- `android/app/src/main/java/com/noop/analytics/TrainingLoadEngine.kt` (+3 / −15): the same
  substitution and deletion.
- Edge coverage was **moved, not dropped**: leap years, negative epoch days and round-trips are now
  asserted against the shared `LocalCalendarDate` in mirrored `LocalDayWindows` suites
  (`LocalDayWindowsTests.swift` +29, `LocalDayWindowsTest.kt` +36), and the engine-facing labels are
  pinned separately in the mirrored `TrainingLoadEngine` suites (+18 Swift / +23 Kotlin).

## Verification

This is a behaviour-preserving consolidation, so **there is no red-then-green transition** — the new
tests pass against the pre-change code by construction, since their expected literals are the
stdout of the pre-change formatter. Stating that rather than dressing it up. The discriminating
evidence is the sweep and the negative control:

1. **Byte-equivalence sweep** (`swiftc -O main.swift -o o71 && ./o71`): the removed
   `dayString(ordinal:)` and `LocalCalendarDate`'s conversion compiled side by side and compared
   over the engine's entire reachable ordinal domain →
   `sweep ordinals -719162...2932896 (3652059 values) mismatches=0`.
   The only behavioural difference the sweep found is sign padding for years below 1
   (`ordinal -719529: engine=-001-12-31 vs local=-0001-12-31`), which is unreachable: `dayOrdinal`
   rejects `year < 1`, and `evaluateDense`'s ordinals start at `2000-01-01` and increase.
2. **Negative control**: a variant formatter with the 400-year leap rule dropped is caught by 2 of
   the 10 pinned edge literals (`11016` and `-135081`, both Feb 29 vs Mar 1), so the literals
   discriminate rather than merely agree.
3. **Swift**: `swift test --filter 'TrainingLoadEngineTests|LocalDayWindowsTests'` in
   `Packages/StrandAnalytics` → **Executed 40 tests, with 0 failures**, both new tests among them.
4. **Kotlin**: `./gradlew cleanTestFullDebugUnitTest testFullDebugUnitTest --tests
   "com.noop.analytics.TrainingLoadEngineTest" --tests "com.noop.analytics.LocalDayWindowsTest"` →
   `TrainingLoadEngineTest tests="11" failures="0" errors="0"`, `LocalDayWindowsTest tests="26"
   failures="0" errors="0"`; both new tests present by name.
5. `python3 Tools/doc_comment_lint.py` → `OK no NEW detached doc comments`, exit 0.
6. `grep -n dayString` over both engine files → no matches; the duplicate is gone on both sides.

The oracle source is preserved in the two Kotlin twin tests' comments, following the existing
convention rather than adding a file under `Tools/`. The Kotlin round-trip sweep and its Swift twin
walk the same range with the same stride (`9_973`), so both suites cover identical ordinals.

**Not run:** macOS/iOS/watch app targets — no macOS/Xcode available to me. No file under `Strand/`,
`StrandiOS*/` or the watch targets was touched, and `project.yml` was not edited, so no app-target
rebuild is implied by this diff. No hardware involved.

## Behaviour change / user-visible effects

**None — behaviour-preserving.** Every day label `evaluateDense` can produce is byte-identical
before and after, proven over the full reachable domain by the sweep above (3 652 059 ordinals,
zero mismatches). No stored value, no displayed value, no migration.

## Scope limits and follow-ups

- `dayOrdinal`, `isLeapYear` and `floorDiv` were **left in place** on both platforms. They are also
  Gregorian logic, but the issue names only the two `dayString/1` duplicates, and routing the
  strict, validating string parser through `LocalCalendarDate` would change its rejection semantics
  — outside a byte-equivalent refactor.
- **The parity-ledger half of the acceptance criteria is deferred.** The issue also asks to retire
  the two findings and return the ledger counter to its previous bound; that tooling is not in this
  tree, and lands with #1534. This PR is the code half.

Branch: `refactor/issue-71-training-load-day-string`. Contribution offered under the repository's
PolyForm Noncommercial 1.0.0 license.
