### PR TITLE
sleep: bridge nights fragmented under minSleepMin (#1937)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/SleepStager.swift
@@ -779,6 +779,23 @@ public enum SleepStager {
         let reason: String
     }
 
+    /// True when this night's sleep runs will ALL be dropped by `minSleepMin` yet add up to a plausible
+    /// night. Pure, so the rule can be tested without building gravity.
+    ///
+    /// The predicate is deliberately "today's answer is zero". Every run being under the floor means the
+    /// survival pass keeps none of them, so a bridge enabled on this basis can only turn nothing into
+    /// something; if any single run already clears the floor this is false, the sparse rule decides as
+    /// before, and a night that currently scores cannot change.
+    ///
+    /// Two runs at minimum, because one fragment is not a fragmented night. The SUM must clear the floor
+    /// so a handful of brief stirs does not become a night. Neither condition weakens what the bridge
+    /// itself checks. Kotlin twin: `isFragmentedToNothing`.
+    static func isFragmentedToNothing(_ sleepRunSpansS: [Int], minSleepS: Int) -> Bool {
+        sleepRunSpansS.count >= 2
+            && !sleepRunSpansS.contains { $0 >= minSleepS }
+            && sleepRunSpansS.reduce(0, +) >= minSleepS
+    }
+
     /// Per-pair explanation of `bridgeSparseSleep`, mirroring its rule EXACTLY (same adjacency walk,
     /// same `gap >= 0 && gap <= sparseBridgeGapMin*60`, same HR-band check) so the reasons describe what
     /// actually happened rather than an approximation. Only pairs the bridge itself CONSIDERS (two
@@ -1387,21 +1404,57 @@ public enum SleepStager {
         let flags = classifyStill(grav, deltas)
         var runs = buildRuns(grav, flags, sparse: sparse, hr: hrS, baseline: baseline)
         runs = mergePeriods(runs)
-        // Re-stitch sleep runs fragmented by pure gravity dropouts (sparse only) before minSleepMin.
+        let minSleepS = minSleepMin * 60
+        // #1937: a night whose sleep runs are ALL shorter than minSleepMin yields NO session at all,
+        // however much sleep they add up to. A real capture: five runs, 298 minutes of detected sleep,
+        // every one dropped for being about a minute short, and the night vanished.
+        //
+        // The bridge that exists to re-stitch fragments was switched off, because it is gated on the
+        // night being SPARSE (#308, so a dense night kept its original path byte-for-byte) and the night
+        // was dense. On the reporting device gravity coverage was 99.9%: the rescue was declined
+        // precisely because the data was good.
+        //
+        // So the bridge also runs when the night is fragmented to nothing. The gate is deliberately
+        // "today's answer is zero": if any single run already clears the floor this is false and the
+        // sparse rule decides exactly as before, so a night that currently scores cannot change. It can
+        // only turn nothing into something.
+        //
+        // Requiring the SUM to clear the floor keeps a handful of brief stirs from becoming a night, and
+        // the bridge's own rules still apply underneath — a gap longer than sparseBridgeGapMin, an
+        // intervening active run that is too long, or HR above the sleep band all still refuse. This
+        // enables the attempt; it does not weaken what the attempt checks.
+        //
+        // Deliberately NOT passed to buildRuns above, which takes its own `sparse` for the HR-vouched
+        // gap rule. That decides how runs are FORMED, so widening it would change the input to
+        // everything downstream including nights that currently score. This only re-stitches runs that
+        // are already built, and only when every one of them was about to be discarded.
+        // Evaluated unconditionally rather than short-circuited behind `sparse`, so the trace can
+        // report what it actually was on a sparse night too. It is a filter/map/sum over a handful of
+        // runs.
+        let fragmentedToNothing = isFragmentedToNothing(
+            runs.filter { $0.stage == "sleep" }.map { $0.end - $0.start }, minSleepS: minSleepS)
+        let bridgeEnabled = sparse || fragmentedToNothing
+        // Re-stitch sleep runs fragmented by gravity dropouts, before minSleepMin.
         let runsBeforeBridge = traceSink == nil ? 0 : runs.filter { $0.stage == "sleep" }.count
         // #737: capture the per-pair reasons BEFORE the merge mutates `runs`, so a bridge that changed
         // nothing still says why (gapTooLong / hrOutOfBand / overlap) instead of only before==after.
-        let bridgeResult = bridgeSparseSleepTraced(runs, sparse: sparse, hr: hrS, baseline: baseline)
+        let bridgeResult = bridgeSparseSleepTraced(runs, sparse: bridgeEnabled, hr: hrS, baseline: baseline)
         let bridgeAttempts = bridgeResult.1
         runs = bridgeResult.0
-        // Sleep & Rest test mode (E3): record the sparse-gravity bridge result, so a sparse 5.0 night
-        // rescued from fragmentation is visible. Only emitted when gravity is sparse (the only case the
-        // bridge can act) and only when tracing. Side-effect-only.
-        if let traceSink, sparse {
+        // Sleep & Rest test mode (E3): record the bridge result, so a night rescued from fragmentation
+        // is visible. Emitted whenever the bridge was ENABLED (sparse, or #1937's fragmented-to-nothing
+        // night) and only when tracing. Side-effect-only.
+        if let traceSink, bridgeEnabled {
             let runsAfterBridge = runs.filter { $0.stage == "sleep" }.count
+            // BOTH gates are reported, always, as their own k=v keys. The line used to hardcode
+            // `sparse=true`, which since #1937 could contradict the `sparse=false` on the summary line
+            // beside it. Emitting both (rather than one "why" naming the winner) keeps the key set
+            // identical on every night, which is what a reader diffing two nights, and any k=v parser,
+            // needs.
             traceSink(GateTrace.runLine(index: -1, startTs: 0, endTs: 0,
                 verdict: runsAfterBridge < runsBeforeBridge ? .kept : .dropped, gate: "sparseBridge",
-                detail: "sparse=true gapMin=\(sparseBridgeGapMin) runsBefore=\(runsBeforeBridge) runsAfter=\(runsAfterBridge)"))
+                detail: "sparse=\(sparse) fragmentedToNothing=\(fragmentedToNothing) "
+                    + "gapMin=\(sparseBridgeGapMin) runsBefore=\(runsBeforeBridge) runsAfter=\(runsAfterBridge)"))
             // #737: one line per pair the bridge CONSIDERED, each naming what it decided.
             //
             // #1657 changed what an empty list MEANS, so the wording changed with it. It used to mean
@@ -1422,8 +1475,6 @@ public enum SleepStager {
                         + "hrInSleepBand=\(a.hrInSleepBand) reason=\(a.reason)"))
             }
         }
-
-        let minSleepS = minSleepMin * 60
 
         var sessions: [SleepSession] = []
         // Continuous-sleep chain tracking so a real overnight sleep that runs PAST the daytime-band

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/TestModeRegistry.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/TestModeRegistry.swift
@@ -72,7 +72,7 @@ public enum TestModeRegistry {
         // (the offWristFrac field of the offWrist gate) and restSubScores. Dropped, all unemitted, same
         // rationale Import used for firstFailingRow/failingFileSample/dedupMerge: hrDensity, perEpochFeatures,
         // hypnogramV1V2 (flipLine has no call site), ppgOnlyNight, gravityCoverage (only the sparseBridge
-        // gate's sparse= flag, which already rides gateTrace) and skinTempDsp (skin-temp is a Recovery input,
+        // gate's sparse=/fragmentedToNothing= flags, which already ride gateTrace) and skinTempDsp (skin-temp is a Recovery input,
         // never written to the sleep sink). The live-readout keys (hrDensityNow/gravityCoverageNow) are separate.
         captures: ["gateTrace", "wristOff", "restSubScores"],
         questionnaire: [

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepFragmentedNightTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepFragmentedNightTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// Swift twin of `SleepFragmentedNightTest`.
+///
+/// #1937: a night whose sleep runs are ALL under `minSleepMin` produced no session at all, however much
+/// sleep they added up to. The capture that found it: `sleepRuns=5 droppedMinSleep=5 kept=0
+/// detectedSpanMin=298 survivingSpanMin=0 sparse=false` — five hours of detected sleep, five runs
+/// averaging 59.6 minutes, every one a minute short, and the night vanished. The rescue that exists for
+/// exactly this was gated on the night being SPARSE, and the night was dense.
+final class SleepFragmentedNightTests: XCTestCase {
+
+    private let minSleepS = 60 * 60
+
+    private func mins(_ m: Int...) -> [Int] { m.map { $0 * 60 } }
+
+    /// The reported shape: 298 minutes of detected sleep across five runs, none of them clearing the
+    /// floor. Note this night CANNOT be written in whole minutes: five runs each at most 59 min sum to
+    /// 295. Runs are second-granular, and 298/5 = 59.6 min, so each one falls 24 seconds short.
+    func testTheReportedFiveFragmentNightQualifies() {
+        let runs = [Int](repeating: 3576, count: 5)            // 59.6 min each
+        XCTAssertEqual(runs.reduce(0, +) / 60, 298)            // the reported detectedSpanMin
+        XCTAssertTrue(runs.allSatisfy { $0 < minSleepS })      // and every one is dropped by the floor
+        XCTAssertTrue(SleepStager.isFragmentedToNothing(runs, minSleepS: minSleepS))
+    }
+
+    /// THE safety property. A night where any single run already clears the floor keeps at least one
+    /// session today, so the predicate must decline and leave the sparse rule to decide exactly as
+    /// before. Without this the change could alter a night that currently scores.
+    func testANightWithOneQualifyingRunIsNeverTouched() {
+        XCTAssertFalse(SleepStager.isFragmentedToNothing(mins(90, 20, 15), minSleepS: minSleepS))
+        XCTAssertFalse(SleepStager.isFragmentedToNothing(mins(60, 20, 15), minSleepS: minSleepS))
+        XCTAssertFalse(SleepStager.isFragmentedToNothing(mins(20, 15, 90), minSleepS: minSleepS))
+    }
+
+    /// A handful of brief stirs is not a night. The SUM has to clear the floor too.
+    func testBriefStirsDoNotBecomeANight() {
+        XCTAssertFalse(SleepStager.isFragmentedToNothing(mins(5, 8, 12), minSleepS: minSleepS))
+        XCTAssertFalse(SleepStager.isFragmentedToNothing(mins(30, 29), minSleepS: minSleepS))
+        XCTAssertTrue(SleepStager.isFragmentedToNothing(mins(30, 30), minSleepS: minSleepS))
+    }
+
+    /// One fragment is not a fragmented night; there is nothing to bridge it to.
+    func testASingleShortRunIsNotAFragmentedNight() {
+        XCTAssertFalse(SleepStager.isFragmentedToNothing(mins(59), minSleepS: minSleepS))
+        XCTAssertFalse(SleepStager.isFragmentedToNothing([], minSleepS: minSleepS))
+    }
+
+    /// The predicate only ever opens the bridge; the bridge's own rules still decide. Stated here
+    /// because the predicate's name suggests more authority than it has.
+    func testThePredicateEnablesAnAttemptRatherThanGrantingIt() {
+        XCTAssertTrue(SleepStager.isFragmentedToNothing(mins(40, 40), minSleepS: minSleepS))
+        let far = SleepStager.bridgeSparseSleepTraced(
+            [SleepStager.Period(stage: "sleep", start: 0, end: 40 * 60),
+             SleepStager.Period(stage: "sleep", start: 40 * 60 + 10 * 3600,
+                                end: 40 * 60 + 10 * 3600 + 40 * 60)],
+            sparse: true, hr: [], baseline: nil)
+        XCTAssertEqual(far.0.filter { $0.stage == "sleep" }.count, 2,
+                       "a gap of hours must not be bridged")
+    }
+
+    // MARK: - end-to-end: the reported night through detectSleep
+
+    private let refMidnight = 1_749_513_600            // 2025-06-10 00:00:00 UTC
+    private func at(_ min: Int) -> Int { refMidnight + min * 60 }
+
+    /// Still gravity at 1/min: continuous, so the night reads DENSE, which is the point of #1937.
+    private func stillG(_ fromMin: Int, _ toMin: Int) -> [GravitySample] {
+        stride(from: at(fromMin), to: at(toMin), by: 60).map { GravitySample(ts: $0, x: 0, y: 0, z: 1.0) }
+    }
+
+    /// Moving gravity at 1/min: orientation swings every sample, so this reads as an active run.
+    private func movingG(_ fromMin: Int, _ toMin: Int) -> [GravitySample] {
+        stride(from: at(fromMin), to: at(toMin), by: 60).enumerated().map { i, t in
+            i % 2 == 0 ? GravitySample(ts: t, x: 1.0, y: 0, z: 0)
+                       : GravitySample(ts: t, x: 0, y: 1.0, z: 0)
+        }
+    }
+
+    private func hr1Hz(_ fromMin: Int, _ toMin: Int, _ bpm: Int) -> [HRSample] {
+        (at(fromMin) ..< at(toMin)).map { HRSample(ts: $0, bpm: bpm) }
+    }
+
+    /// The reported night end to end: five sleep runs of 59 minutes, each separated by a 20-minute
+    /// stir, gravity continuous throughout so the night is DENSE. Every run is under the 60-minute
+    /// floor, so before this change the night scored nothing at all.
+    ///
+    /// Five runs means the bridge has to chain FOUR consecutive absorptions, which is the part the pure
+    /// predicate tests cannot reach.
+    ///
+    /// The stir length is load-bearing at BOTH ends and a first attempt at 3 minutes made this test pass
+    /// for the wrong reason. `mergePeriods` absorbs any run under `mergeMin` (15) and rejoins the
+    /// same-stage neighbours, so short stirs never fragmented the night: it arrived as ONE 306-minute
+    /// run that always scored, and the rescue under test never ran. The stir must therefore be at least
+    /// mergeMin to survive the merge, and at most sparseBridgeActiveMaxInBandMin (60, since HR stays in
+    /// the sleep band) for the bridge to absorb it.
+    private func fragmentedDenseNight() -> ([HRSample], [GravitySample]) {
+        var g: [GravitySample] = []
+        var t = 0
+        for i in 0 ..< 5 {
+            g += stillG(t, t + 59)
+            t += 59
+            if i < 4 { g += movingG(t, t + 20); t += 20 }
+        }
+        return (hr1Hz(0, t, 50), g)
+    }
+
+    func testTheFragmentedDenseNightIsRescuedEndToEnd() {
+        let (hr, grav) = fragmentedDenseNight()
+        XCTAssertFalse(SleepStager.isGravitySparse(grav, hr: hr),
+                       "the fixture must be DENSE, or the old sparse gate would already rescue it")
+
+        var lines: [String] = []
+        let sessions = SleepStager.detectSleep(hr: hr, gravity: grav, traceSink: { lines.append($0) })
+
+        XCTAssertFalse(sessions.isEmpty,
+                       "a night of five 59-minute runs must now produce a session, got none.\n"
+                        + lines.joined(separator: "\n"))
+        let spanMin = sessions.reduce(0) { $0 + ($1.end - $1.start) / 60 }
+        XCTAssertGreaterThanOrEqual(spanMin, 240, "expected most of the 295 sleeping minutes, got \(spanMin)")
+        // Anti-vacuity: the session must exist BECAUSE the rescue fired. Without this the test passes
+        // when the fixture is not actually fragmented, which is exactly what a 3-minute stir did.
+        XCTAssertTrue(lines.contains { $0.contains("gate=sparseBridge ") && $0.contains("fragmentedToNothing=true") },
+                      "the session must come from the #1937 rescue, not an unfragmented fixture.\n"
+                        + lines.joined(separator: "\n"))
+    }
+
+    /// The trace must name BOTH gates, so a dense rescue cannot contradict the summary line beside it.
+    ///
+    /// The contiguous substring pins key ORDER and spacing, not just presence. Nothing in the tree
+    /// compares the two languages' trace output automatically, so a format change on one side would
+    /// otherwise diverge in silence; the Kotlin twin asserts this identical fragment.
+    func testTheTraceNamesBothGates() {
+        let (hr, grav) = fragmentedDenseNight()
+        var lines: [String] = []
+        _ = SleepStager.detectSleep(hr: hr, gravity: grav, traceSink: { lines.append($0) })
+        let bridge = lines.first { $0.contains("gate=sparseBridge ") }
+        XCTAssertNotNil(bridge, "expected a sparseBridge line, got:\n" + lines.joined(separator: "\n"))
+        XCTAssertTrue(bridge!.contains("sparse=false fragmentedToNothing=true gapMin="),
+                      "unexpected sparseBridge detail format: \(bridge!)")
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepStagerTraceTests.swift
@@ -106,8 +106,10 @@ final class SleepStagerTraceTests: XCTestCase {
 
     // MARK: - E3: sparse-gravity bridge trace
 
-    func testSparseBridgeTraceEmittedOnlyWhenSparse() {
-        // A dense overnight night is NOT sparse, so no sparse-bridge line appears.
+    func testSparseBridgeTraceEmittedOnlyWhenBridgeEnabled() {
+        // The line follows the bridge being ENABLED, not density: since #1937 a dense night whose runs
+        // are all under minSleepMin enables it too. This night is dense AND its single run clears the
+        // floor, so neither gate opens and no sparse-bridge line appears.
         let start = 1_749_513_600 + 2 * 3600
         let dur = 90 * 60
         var lines: [String] = []

--- a/android/app/src/main/java/com/noop/analytics/SleepStager.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepStager.kt
@@ -969,6 +969,25 @@ object SleepStager {
     )
 
     /**
+     * True when this night's sleep runs will ALL be dropped by `minSleepMin` yet add up to a plausible
+     * night. Pure, so the rule can be tested without building gravity.
+     *
+     * The predicate is deliberately "today's answer is zero". Every run being under the floor means the
+     * survival pass keeps none of them, so a bridge enabled on this basis can only turn nothing into
+     * something; if any single run already clears the floor this is false, the sparse rule decides as
+     * before, and a night that currently scores cannot change.
+     *
+     * Two runs at minimum, because one fragment is not a fragmented night. The SUM must clear the floor
+     * so a handful of brief stirs does not become a night. Neither condition weakens what the bridge
+     * itself checks — gap length, intervening active length and HR staying in the sleep band all still
+     * apply, so this enables an attempt rather than granting its outcome.
+     */
+    internal fun isFragmentedToNothing(sleepRunSpansS: List<Long>, minSleepS: Long): Boolean =
+        sleepRunSpansS.size >= 2 &&
+            sleepRunSpansS.none { it >= minSleepS } &&
+            sleepRunSpansS.sum() >= minSleepS
+
+    /**
      * The bridge, plus what it considered. See [bridgeSparseSleep] for the merge rule.
      *
      * #1657: an intervening ACTIVE run no longer blocks the merge permanently. The original loop could
@@ -1574,17 +1593,54 @@ object SleepStager {
         val flags = classifyStill(grav, deltas)
         var runs = buildRuns(grav, flags, sparse = sparse, hr = hrS, baseline = baseline)
         runs = mergePeriods(runs)
-        // Re-stitch sleep runs fragmented by pure gravity dropouts (sparse only) before minSleepMin.
+        val minSleepS = (minSleepMin * 60).toLong()
+        // #1937: a night whose sleep runs are ALL shorter than minSleepMin yields NO session at all,
+        // however much sleep they add up to. A real capture: five runs, 298 minutes of detected sleep,
+        // every one dropped for being about a minute short, and the night vanished.
+        //
+        // The bridge that exists to re-stitch fragments was switched off, because it is gated on the
+        // night being SPARSE (#308, so a dense night kept its original path byte-for-byte) and the night
+        // was dense. On the reporting device gravity coverage was 99.9%: the rescue was declined
+        // precisely because the data was good.
+        //
+        // So the bridge also runs when the night is fragmented to nothing. The gate is deliberately
+        // "today's answer is zero": if any single run already clears the floor this is false and the
+        // sparse rule decides exactly as before, so a night that currently scores cannot change. It can
+        // only turn nothing into something.
+        //
+        // Requiring the SUM to clear the floor keeps a handful of brief stirs from becoming a night, and
+        // the bridge's own rules still apply underneath — a gap longer than sparseBridgeGapMin, an
+        // intervening active run that is too long, or HR above the sleep band all still refuse. This
+        // enables the attempt; it does not weaken what the attempt checks.
+        //
+        // Deliberately NOT passed to buildRuns above, which takes its own `sparse` for the HR-vouched
+        // gap rule. That decides how runs are FORMED, so widening it would change the input to
+        // everything downstream including nights that currently score. This only re-stitches runs that
+        // are already built, and only when every one of them was about to be discarded.
+        // Evaluated unconditionally rather than short-circuited behind `sparse`, so the trace can
+        // report what it actually was on a sparse night too. It is a filter/map/sum over a handful of
+        // runs.
+        val fragmentedToNothing = isFragmentedToNothing(
+            runs.filter { it.stage == "sleep" }.map { it.end - it.start }, minSleepS)
+        val bridgeEnabled = sparse || fragmentedToNothing
+        // Re-stitch sleep runs fragmented by gravity dropouts, before minSleepMin.
         val runsBeforeBridge = if (traceSink == null) 0 else runs.count { it.stage == "sleep" }
-        val bridged = bridgeSparseSleepTraced(runs, sparse = sparse, hr = hrS, baseline = baseline)
+        val bridged = bridgeSparseSleepTraced(runs, sparse = bridgeEnabled, hr = hrS, baseline = baseline)
         runs = bridged.first
-        // Sleep & Rest test mode (E10): record the sparse-gravity bridge result, so a sparse 5.0 night
-        // rescued from fragmentation is visible. Only when gravity is sparse and only when tracing.
-        if (traceSink != null && sparse) {
+        // Sleep & Rest test mode (E10): record the bridge result, so a night rescued from fragmentation
+        // is visible. Emitted whenever the bridge was ENABLED (sparse, or #1937's fragmented-to-nothing
+        // night) and only when tracing.
+        if (traceSink != null && bridgeEnabled) {
             val runsAfterBridge = runs.count { it.stage == "sleep" }
+            // BOTH gates are reported, always, as their own k=v keys. The line used to hardcode
+            // `sparse=true`, which since #1937 could contradict the `sparse=false` on the summary line
+            // beside it. Emitting both (rather than one "why" naming the winner) keeps the key set
+            // identical on every night, which is what a reader diffing two nights, and any k=v parser,
+            // needs.
             traceSink(SleepStagerTrace.runLine(-1, 0, 0,
                 if (runsAfterBridge < runsBeforeBridge) SleepStagerTrace.Verdict.KEPT else SleepStagerTrace.Verdict.DROPPED,
-                "sparseBridge", "sparse=true gapMin=$sparseBridgeGapMin runsBefore=$runsBeforeBridge runsAfter=$runsAfterBridge"))
+                "sparseBridge", "sparse=$sparse fragmentedToNothing=$fragmentedToNothing " +
+                    "gapMin=$sparseBridgeGapMin runsBefore=$runsBeforeBridge runsAfter=$runsAfterBridge"))
             // #1657: one line per pair the bridge CONSIDERED, ported from Swift and extended with the
             // intervening active run's length. No lines at all still means no candidate pair existed;
             // an activeTooLong line names the bound that blocked one, which is the number a future
@@ -1604,8 +1660,6 @@ object SleepStager {
                         "hrInSleepBand=${a.hrInSleepBand} reason=${a.reason}"))
             }
         }
-
-        val minSleepS = (minSleepMin * 60).toLong()
 
         val sessions = ArrayList<DetectedSleep>()
         // Continuous-sleep chain tracking so a real overnight sleep that runs PAST the daytime-band

--- a/android/app/src/main/java/com/noop/testcentre/TestModeRegistry.kt
+++ b/android/app/src/main/java/com/noop/testcentre/TestModeRegistry.kt
@@ -60,8 +60,8 @@ object TestModeRegistry {
         // composite, so gateTrace, wristOff (the offWristFrac field of the offWrist gate) and restSubScores
         // are the whole set. Dropped, all unemitted, same rationale the Import mode used for
         // firstFailingRow/failingFileSample/dedupMerge: hrDensity, perEpochFeatures, hypnogramV1V2 (flipLine
-        // has no call site), ppgOnlyNight, gravityCoverage (only the sparseBridge gate's sparse= flag, which
-        // already rides gateTrace) and skinTempDsp (skin-temp is a Recovery input, never written to the
+        // has no call site), ppgOnlyNight, gravityCoverage (only the sparseBridge gate's
+        // sparse=/fragmentedToNothing= flags, which already ride gateTrace) and skinTempDsp (skin-temp is a Recovery input, never written to the
         // sleep sink). The live-readout keys (hrDensityNow/gravityCoverageNow) are separate and unchanged.
         captures = listOf("gateTrace", "wristOff", "restSubScores"),
         questionnaire = listOf(

--- a/android/app/src/test/java/com/noop/analytics/SleepFragmentedNightTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepFragmentedNightTest.kt
@@ -1,0 +1,175 @@
+package com.noop.analytics
+
+import com.noop.data.GravitySample
+import com.noop.data.HrSample
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1937: a night whose sleep runs are ALL under `minSleepMin` produced no session at all, however much
+ * sleep they added up to.
+ *
+ * The capture that found it: `sleepRuns=5 droppedMinSleep=5 kept=0 detectedSpanMin=298
+ * survivingSpanMin=0 sparse=false`. Five hours of detected sleep, five runs averaging 59.6 minutes,
+ * every one a minute short of the floor, and the night vanished. The rescue that exists for exactly
+ * this was gated on the night being SPARSE, and the night was dense — on the reporting device gravity
+ * coverage was 99.9%, so the bridge was declined precisely because the data was good.
+ *
+ * These pin the predicate that now also opens the bridge. Its safety property is the one that matters:
+ * it can only turn nothing into something.
+ */
+class SleepFragmentedNightTest {
+
+    private val minSleepS = 60L * 60      // the 60-minute session floor, in seconds
+
+    private fun mins(vararg m: Long): List<Long> = m.map { it * 60 }
+
+    /**
+     * The reported shape: 298 minutes of detected sleep across five runs, none of them clearing the
+     * floor. Note this night CANNOT be written in whole minutes: five runs each at most 59 min sum to
+     * 295. Runs are second-granular, and 298/5 = 59.6 min, so each one falls 24 seconds short.
+     */
+    @Test
+    fun theReportedFiveFragmentNightQualifies() {
+        val runs = List(5) { 3576L }                       // 59.6 min each
+        assertEquals(298L, runs.sum() / 60)                // the reported detectedSpanMin
+        assertTrue(runs.all { it < minSleepS })            // and every one is dropped by the floor
+        assertTrue(SleepStager.isFragmentedToNothing(runs, minSleepS))
+    }
+
+    /**
+     * THE safety property. A night where any single run already clears the floor keeps at least one
+     * session today, so the predicate must decline and leave the sparse rule to decide exactly as
+     * before. Without this the change could alter a night that currently scores.
+     */
+    @Test
+    fun aNightWithOneQualifyingRunIsNeverTouched() {
+        // One 90-minute run plus fragments: today this scores, so the rescue must not engage.
+        assertFalse(SleepStager.isFragmentedToNothing(mins(90, 20, 15), minSleepS))
+        // Even when the qualifying run is exactly at the floor.
+        assertFalse(SleepStager.isFragmentedToNothing(mins(60, 20, 15), minSleepS))
+        // And when it is last rather than first.
+        assertFalse(SleepStager.isFragmentedToNothing(mins(20, 15, 90), minSleepS))
+    }
+
+    /** A handful of brief stirs is not a night. The SUM has to clear the floor too. */
+    @Test
+    fun briefStirsDoNotBecomeANight() {
+        assertFalse(SleepStager.isFragmentedToNothing(mins(5, 8, 12), minSleepS))
+        // Just under the floor in total still declines.
+        assertFalse(SleepStager.isFragmentedToNothing(mins(30, 29), minSleepS))
+        // Exactly at it qualifies: the floor is what a night has to reach, not exceed.
+        assertTrue(SleepStager.isFragmentedToNothing(mins(30, 30), minSleepS))
+    }
+
+    /** One fragment is not a fragmented night; there is nothing to bridge it to. */
+    @Test
+    fun aSingleShortRunIsNotAFragmentedNight() {
+        assertFalse(SleepStager.isFragmentedToNothing(mins(59), minSleepS))
+        assertFalse(SleepStager.isFragmentedToNothing(emptyList(), minSleepS))
+    }
+
+    /**
+     * The predicate only ever opens the bridge. It cannot decide the outcome, because the bridge's own
+     * rules still apply underneath — this test states the contract in the one place a future reader
+     * would look for it, since the predicate's name suggests more authority than it has.
+     */
+    @Test
+    fun thePredicateEnablesAnAttemptRatherThanGrantingIt() {
+        val fragmented = mins(40, 40)
+        assertTrue(SleepStager.isFragmentedToNothing(fragmented, minSleepS))
+        // Two 40-minute runs separated by a gap far beyond the bridge's limit are still refused by the
+        // bridge itself, which is where gap, intervening-active and HR-band checks live.
+        val far = SleepStager.bridgeSparseSleepTraced(
+            listOf(SleepStager.Period("sleep", 0, 40 * 60),
+                   SleepStager.Period("sleep", 40 * 60 + 10 * 3600, 40 * 60 + 10 * 3600 + 40 * 60)),
+            sparse = true, hr = emptyList(), baseline = null,
+        )
+        assertEquals("a gap of hours must not be bridged", 2, far.first.count { it.stage == "sleep" })
+    }
+
+    // ---- end-to-end: the reported night through detectSleep ----
+
+    private val dev = "test"
+    private val refMidnight = 1_749_513_600L                    // 2025-06-10 00:00:00 UTC
+    private fun at(min: Int) = refMidnight + min * 60L
+
+    /** Still gravity at 1/min: continuous, so the night reads DENSE, which is the point of #1937. */
+    private fun still(fromMin: Int, toMin: Int) =
+        (at(fromMin) until at(toMin) step 60).map {
+            GravitySample(deviceId = dev, ts = it, x = 0.0, y = 0.0, z = 1.0)
+        }
+
+    /** Moving gravity at 1/min: orientation swings every sample, so this reads as an active run. */
+    private fun moving(fromMin: Int, toMin: Int) =
+        (at(fromMin) until at(toMin) step 60).mapIndexed { i, t ->
+            if (i % 2 == 0) GravitySample(deviceId = dev, ts = t, x = 1.0, y = 0.0, z = 0.0)
+            else GravitySample(deviceId = dev, ts = t, x = 0.0, y = 1.0, z = 0.0)
+        }
+
+    private fun hr1Hz(fromMin: Int, toMin: Int, bpm: Int) =
+        (at(fromMin) until at(toMin)).map { HrSample(deviceId = dev, ts = it, bpm = bpm) }
+
+    /**
+     * The reported night end to end: five sleep runs of 59 minutes, each separated by a 20-minute
+     * stir, gravity continuous throughout so the night is DENSE. Every run is under the 60-minute
+     * floor, so before this change the night scored nothing at all.
+     *
+     * Five runs means the bridge has to chain FOUR consecutive absorptions, which is the part the pure
+     * predicate tests cannot reach.
+     *
+     * The stir length is load-bearing at BOTH ends and a first attempt at 3 minutes made this test pass
+     * for the wrong reason. `mergePeriods` absorbs any run under `mergeMin` (15) and rejoins the
+     * same-stage neighbours, so short stirs never fragmented the night: it arrived as ONE 306-minute
+     * run that always scored, and the rescue under test never ran. The stir must therefore be at least
+     * mergeMin to survive the merge, and at most sparseBridgeActiveMaxInBandMin (60, since HR stays in
+     * the sleep band) for the bridge to absorb it.
+     */
+    private fun fragmentedDenseNight(): Pair<List<HrSample>, List<GravitySample>> {
+        var g = emptyList<GravitySample>()
+        var t = 0
+        repeat(5) { i ->
+            g = g + still(t, t + 59)
+            t += 59
+            if (i < 4) { g = g + moving(t, t + 20); t += 20 }
+        }
+        return hr1Hz(0, t, 50) to g
+    }
+
+    @Test
+    fun theFragmentedDenseNightIsRescuedEndToEnd() {
+        val (hr, grav) = fragmentedDenseNight()
+        assertFalse("the fixture must be DENSE, or the old sparse gate would already rescue it",
+            SleepStager.isGravitySparse(grav, hr))
+
+        val lines = ArrayList<String>()
+        val sessions = SleepStager.detectSleep(hr = hr, gravity = grav, traceSink = { lines.add(it) })
+
+        assertTrue("a night of five 59-minute runs must now produce a session, got none.\n" +
+            lines.joinToString("\n"), sessions.isNotEmpty())
+        val spanMin = sessions.sumOf { (it.end - it.start) / 60 }
+        assertTrue("expected most of the 295 sleeping minutes, got $spanMin", spanMin >= 240)
+        // Anti-vacuity: the session must exist BECAUSE the rescue fired. Without this the test passes
+        // when the fixture is not actually fragmented, which is exactly what a 3-minute stir did.
+        assertTrue("the session must come from the #1937 rescue, not from an unfragmented fixture.\n" +
+            lines.joinToString("\n"),
+            lines.any { it.contains("gate=sparseBridge ") && it.contains("fragmentedToNothing=true") })
+    }
+
+    /** The trace must name BOTH gates, so a dense rescue cannot contradict the summary line beside it. */
+    @Test
+    fun theTraceNamesBothGates() {
+        val (hr, grav) = fragmentedDenseNight()
+        val lines = ArrayList<String>()
+        SleepStager.detectSleep(hr = hr, gravity = grav, traceSink = { lines.add(it) })
+        val bridge = lines.firstOrNull { it.contains("gate=sparseBridge ") }
+        assertTrue("expected a sparseBridge line, got:\n" + lines.joinToString("\n"), bridge != null)
+        // The contiguous substring pins key ORDER and spacing, not just presence. Nothing in the tree
+        // compares the two languages' trace output automatically, so a format change on one side would
+        // otherwise diverge in silence; the Swift twin asserts this identical fragment.
+        assertTrue("unexpected sparseBridge detail format: $bridge",
+            bridge!!.contains("sparse=false fragmentedToNothing=true gapMin="))
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/SleepStagerTraceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepStagerTraceTest.kt
@@ -77,7 +77,10 @@ class SleepStagerTraceTest {
         assertEquals(untraced, traced)
     }
 
-    @Test fun denseNightHasNoSparseBridgeLine() {
+    @Test fun denseNightWithAQualifyingRunHasNoSparseBridgeLine() {
+        // The line follows the bridge being ENABLED, not density: since #1937 a dense night whose runs
+        // are all under minSleepMin enables it too. This night is dense AND its single run clears the
+        // floor, so neither gate opens.
         val start = refMidnight + 2 * 3600
         val dur = 90 * 60
         val lines = ArrayList<String>()


### PR DESCRIPTION
Reported in #1937.

## What is happening

Staging is not failing. From the report's own diagnostics:

```
sleep-detect summary: sleepRuns=5 droppedMinSleep=5 kept=0
detectedSpanMin=298 survivingSpanMin=0 sparse=false
```

The detector **found 298 minutes of sleep across five runs, and dropped every one**, because each run individually fell about a minute under the 60-minute `minSleepMin` floor. Five runs averaging 59.6 minutes, so a whole night of real sleep scored nothing.

## Why the existing rescue declined

`bridgeSparseSleep` exists precisely to re-stitch runs fragmented by gravity dropouts. It was switched off, because it is gated on the night being **sparse** (#308 kept a dense night's original path byte-for-byte) and this night was dense: gravity coverage on the reporting device was 99.9%, and 48% on mine.

The rescue was declined because the data was good.

## The change

The bridge also runs when the night is *fragmented to nothing*:

```kotlin
internal fun isFragmentedToNothing(sleepRunSpansS: List<Long>, minSleepS: Long): Boolean =
    sleepRunSpansS.size >= 2 &&
        sleepRunSpansS.none { it >= minSleepS } &&
        sleepRunSpansS.sum() >= minSleepS
```

**The safety property.** The gate is deliberately "today's answer is zero". If any single run already clears the floor the predicate is false, the sparse rule decides exactly as before, and a night that currently scores cannot change. It can only turn nothing into something.

Two runs at minimum, because one fragment is not a fragmented night. The sum must clear the floor, so a handful of brief stirs does not become a night. And the bridge's own rules still apply underneath: a gap over `sparseBridgeGapMin`, an intervening active run that is too long, or HR above the sleep band all still refuse. This enables the attempt; it does not weaken what the attempt checks. One of the tests pins exactly that, by giving a fragmented night a 10-hour gap and asserting the bridge still declines.

The predicate is deliberately **not** passed to `buildRuns`, which takes its own `sparse` flag for the HR-vouched gap rule. That decides how runs are *formed*, so widening it would change the input to everything downstream, including nights that currently score. This only re-stitches runs that are already built, and only when every one of them was about to be discarded.

## Diagnostics

The E10 trace line now carries **both** gates as their own `k=v` keys (`sparse=false fragmentedToNothing=true`), rather than one flag naming the winner. It used to hardcode `sparse=true`, which since this change could print next to a summary line saying `sparse=false`: the kind of quiet disagreement that costs a reader an hour. Emitting both keeps the key set identical on every night, which is what a reader diffing two nights, and any `k=v` parser of the detail field, needs. Both platforms pin the rendered fragment `sparse=false fragmentedToNothing=true gapMin=` so the two languages cannot drift apart in silence.

## Tests

Swift and Kotlin twins covering the reported five-fragment night, the safety property (a night with one qualifying run is untouched), brief stirs declining, a single short run declining, and the bridge's own gap rule still refusing.

Plus an **end-to-end** test on both platforms, which is the only one that proves the change does anything: it runs the reported shape (five 59-minute sleep runs, continuous gravity so the night is dense, four stirs the bridge has to chain through) all the way through `detectSleep`, and asserts both that a session now appears and, via the trace, that the rescue is what produced it.

That last assertion exists because the first version of this test passed for the wrong reason. With 3-minute stirs, `mergePeriods` (which absorbs any run under `mergeMin` = 15 and rejoins the same-stage neighbours) swallowed them, so the night arrived as one 306-minute run that always scored: `sleepRuns=1 kept=1`. The fixture was never fragmented and the code under test never ran. The stir is now 20 minutes, which is above `mergeMin` and below `sparseBridgeActiveMaxInBandMin`, and the anti-vacuity assertion makes that failure mode impossible to reintroduce silently.

Android suite green locally: 666 classes, 5625 tests, 0 failures. Swift is CI-verified.

The two existing "dense night has no sparse-bridge line" trace tests still pass, but their names and comments asserted *density* as the reason. Since a dense night can now open the bridge, they are repinned to the real invariant: this night is dense **and** its single run clears the floor, so neither gate opens.
