### PR TITLE
test: import WhoopProtocol in SleepFragmentedNightTests

### DIFF
--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepFragmentedNightTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/SleepFragmentedNightTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import StrandAnalytics
+import WhoopProtocol
 
 /// Swift twin of `SleepFragmentedNightTest`.
 ///


### PR DESCRIPTION
The end-to-end fixture added in #1984 builds GravitySample and HRSample
values, which live in WhoopProtocol, not StrandAnalytics. The file imported
only StrandAnalytics, so test (StrandAnalytics) failed to compile with
"cannot find type 'GravitySample' in scope". The sibling fixture file this
was modelled on, SleepStagerActiveBridgeTests, carries the same import for
the same reason.

Swift cannot be compiled in the WSL dev environment, so this was invisible
until CI ran the package leg.

Restores `test (StrandAnalytics)`, which is red on main.