### PR TITLE
ui: gate the Today RHR driver row on a usable baseline (#1988)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScoring.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScoring.kt
@@ -69,7 +69,14 @@ internal fun recoveryChargeDrivers(
     val ordered = days.sortedBy { it.day }
     val hrvBase = Baselines.foldHistory(ordered.map { it.avgHrv }, Baselines.hrvCfg)
     if (!hrvBase.usable) return emptyList()
+    // #1988: gated on `usable`, exactly as the resp baseline below and as the iOS twins
+    // (TodayView / CoupledView) already do. foldHistory returns the config's SYNTHETIC midpoint
+    // (about 75 bpm for resting HR) when the history is empty or entirely out of range, which is
+    // nobody's resting HR, so an ungated baseline scored the RHR row against a number the user has
+    // never had. With it null the term drops and RecoveryDrivers renormalises, the same path taken
+    // when today's reading is missing.
     val rhrBase = Baselines.foldHistory(ordered.map { it.restingHr?.toDouble() }, Baselines.restingHRCfg)
+        .takeIf { it.usable }
     val respBase = Baselines.foldHistory(ordered.map { it.respRateBpm }, Baselines.respCfg).takeIf { it.usable }
 
     // sleepPerf: the Rest COMPOSITE (/100) when stages exist, else raw efficiency, the SAME derivation

--- a/android/app/src/test/java/com/noop/ui/RecoveryDriversUiTest.kt
+++ b/android/app/src/test/java/com/noop/ui/RecoveryDriversUiTest.kt
@@ -67,4 +67,33 @@ class RecoveryDriversUiTest {
     @Test fun nullDayProducesNoRows() {
         assertTrue(recoveryChargeDrivers(scoredHistory(), null).isEmpty())
     }
+
+    // ---- #1988: the RHR row needs a USABLE resting-HR baseline ----------------------------------
+
+    /**
+     * A history with no banked resting HR folds to `foldHistory`'s synthetic midpoint (about 75 bpm),
+     * which is nobody's resting HR. Scoring the RHR row against it moves a bar on a baseline the user
+     * has never had, so the row must be absent. The HRV row still stands, since that baseline is real.
+     *
+     * The display day itself carries a reading, so this is specifically the BASELINE being unusable,
+     * not the reading being missing.
+     */
+    @Test fun rhrRowIsAbsentWhenTheRestingHrBaselineIsNotUsable() {
+        val history = (1..6).map { day("2026-01-0$it", rhr = null) }
+        val today = day("2026-01-07", rhr = 55)
+        val drivers = recoveryChargeDrivers(history + today, today)
+        val labels = drivers.map { it.label }
+        assertTrue("the HRV baseline is real, so its row must still be there",
+            labels.contains(ChargeDriverLabel.HEART_RATE_VARIABILITY))
+        assertTrue("no usable resting-HR baseline, so no RHR row: got $labels",
+            !labels.contains(ChargeDriverLabel.RESTING_HEART_RATE))
+    }
+
+    /** Control: once the resting-HR baseline IS usable the row returns, so the gate is not a blanket off. */
+    @Test fun rhrRowReturnsOnceTheBaselineIsUsable() {
+        val days = scoredHistory()
+        val labels = recoveryChargeDrivers(days, days.last()).map { it.label }
+        assertTrue("a usable resting-HR baseline must still produce its row: got $labels",
+            labels.contains(ChargeDriverLabel.RESTING_HEART_RATE))
+    }
 }


### PR DESCRIPTION
Addresses #1988.

## The change

`recoveryChargeDrivers` in `TodayScoring.kt` folded a resting-HR baseline and passed it straight to `RecoveryDrivers.chargeDrivers`. `Baselines.foldHistory` returns the config's **synthetic midpoint** (about 75 bpm for resting HR) when the history is empty or entirely out of physiological range, so a user with no banked resting HR got an RHR driver bar scored against a number they have never had.

One line, using the idiom already on the next line down:

```kotlin
val rhrBase = Baselines.foldHistory(ordered.map { it.restingHr?.toDouble() }, Baselines.restingHRCfg)
    .takeIf { it.usable }
```

## Why this is small

It is an inconsistency **inside one function** as much as a cross-platform one. `recoveryChargeDrivers` already gates the HRV baseline (early return) and the respiration baseline (`takeIf { it.usable }`); resting HR was the only one left ungated. The iOS twins of this exact call, `TodayView.swift:814` and `CoupledView.swift:545`, have always gated both.

Android-only on purpose. The iOS side is already correct, so there is no Swift twin owed here.

## Tests

Two, added to the existing UI wiring suite:

- the RHR row is **absent** when the baseline is unusable, while the HRV row still stands (the display day carries a reading, so this pins the *baseline* being unusable rather than the reading being missing);
- a control proving the row **returns** once the baseline is usable, so the gate is not a blanket off.

The first is genuinely red without the production change. I reverted the one-line gate and confirmed `rhrRowIsAbsentWhenTheRestingHrBaselineIsNotUsable` fails while the control still passes, so it discriminates rather than agreeing with itself.

Full Android suite: 667 classes, 5,642 tests, 0 failures. `doc_comment_lint.py` clean. No Swift touched.

## What this does not do

Neither `AnalyticsEngine` gates this baseline, on **either** platform, so the headline Charge is still scored against the synthetic midpoint when the resting-HR history is thin. That is the larger half of the same question and it is deliberately untouched here, because changing it moves everyone's headline number and deserves its own discussion. It is written up on the issue rather than left implicit.

One consequence worth stating plainly: after this lands, Android matches iOS, and on both platforms the driver breakdown can gate a term the headline ring did not. That is pre-existing on iOS, not introduced here, and it is exactly what the engine question above would settle.

## User-visible effect

For a user with fewer than four valid resting-HR nights, or an all-implausible history, the RHR row disappears from "What shaped it" and the remaining rows renormalise. No stored value changes and no headline number moves.
