### PR TITLE
recovery: treat an unusable resting-HR baseline as absent (#1988)

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/ChargeDrivers.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/ChargeDrivers.swift
@@ -130,8 +130,13 @@ extension RecoveryScorer {
 
         // No score => no real contributions to attribute (cold-start). recovery(...) enforces
         // the usable gate; mirror it so a nil headline never yields fabricated driver rows.
+        // #1988: the ROW is built from this baseline directly (its z, its mean, its verdict), not only
+        // through recovery(...), so gating the scorer alone would emit an RHR row scored against the
+        // synthetic midpoint while the headline excluded it. Normalised once here so every use below,
+        // score and row alike, sees the same thing. Twin of the Kotlin `rhrB`.
+        let rhrB = rhrBaseline.flatMap { $0.usable ? $0 : nil }
         guard let full = recovery(hrv: hrv, rhr: rhr, resp: resp,
-                                  hrvBaseline: hrvBaseline, rhrBaseline: rhrBaseline,
+                                  hrvBaseline: hrvBaseline, rhrBaseline: rhrB,
                                   respBaseline: respBaseline, sleepPerf: sleepPerf,
                                   skinTempDev: skinTempDev) else {
             return []
@@ -160,7 +165,7 @@ extension RecoveryScorer {
         // below is the full, unguarded HRV penalty. The verdict merely NAMES the detected pattern so the
         // UI can surface it while real firings accumulate. See the MARK header in RecoveryScorer.swift.
         let hrvZFull = zScore(hrv, mean: hrvBaseline.baseline, spread: hrvBaseline.spread)
-        let rhrZFull: Double? = rhrBaseline.map { zScore($0.baseline, mean: rhr, spread: $0.spread) }
+        let rhrZFull: Double? = rhrB.map { zScore($0.baseline, mean: rhr, spread: $0.spread) }
         let hrvSaturationDetected = parasympatheticSaturation(hrvZ: hrvZFull, rhrZ: rhrZFull).active
 
         // ── HRV (dominant driver; always present once the score exists) ──────────
@@ -168,7 +173,7 @@ extension RecoveryScorer {
         drivers.append(ChargeDriver(
             label: "Heart rate variability",
             deltaPoints: points(recovery(hrv: hrvBaseline.baseline, rhr: rhr, resp: resp,
-                                         hrvBaseline: hrvBaseline, rhrBaseline: rhrBaseline,
+                                         hrvBaseline: hrvBaseline, rhrBaseline: rhrB,
                                          respBaseline: respBaseline, sleepPerf: sleepPerf,
                                          skinTempDev: skinTempDev)),
             valueText: "\(Int(hrv.rounded())) ms",
@@ -178,11 +183,11 @@ extension RecoveryScorer {
 
         // ── Resting HR (lower vs baseline supports recovery) ─────────────────────
         // Neutral = resting HR at the baseline mean.
-        if let b = rhrBaseline {
+        if let b = rhrB {
             drivers.append(ChargeDriver(
                 label: "Resting heart rate",
                 deltaPoints: points(recovery(hrv: hrv, rhr: b.baseline, resp: resp,
-                                             hrvBaseline: hrvBaseline, rhrBaseline: rhrBaseline,
+                                             hrvBaseline: hrvBaseline, rhrBaseline: rhrB,
                                              respBaseline: respBaseline, sleepPerf: sleepPerf,
                                              skinTempDev: skinTempDev)),
                 valueText: "\(Int(rhr.rounded())) bpm",
@@ -195,7 +200,7 @@ extension RecoveryScorer {
             drivers.append(ChargeDriver(
                 label: "Sleep quality",
                 deltaPoints: points(recovery(hrv: hrv, rhr: rhr, resp: resp,
-                                             hrvBaseline: hrvBaseline, rhrBaseline: rhrBaseline,
+                                             hrvBaseline: hrvBaseline, rhrBaseline: rhrB,
                                              respBaseline: respBaseline, sleepPerf: sleepPerfCenter,
                                              skinTempDev: skinTempDev)),
                 valueText: "\(Int((sp * 100).rounded()))%",
@@ -209,7 +214,7 @@ extension RecoveryScorer {
             drivers.append(ChargeDriver(
                 label: "Respiratory rate",
                 deltaPoints: points(recovery(hrv: hrv, rhr: rhr, resp: b.baseline,
-                                             hrvBaseline: hrvBaseline, rhrBaseline: rhrBaseline,
+                                             hrvBaseline: hrvBaseline, rhrBaseline: rhrB,
                                              respBaseline: respBaseline, sleepPerf: sleepPerf,
                                              skinTempDev: skinTempDev)),
                 valueText: String(format: "%.1f br/min", locale: Locale(identifier: "en_US_POSIX"), r),
@@ -223,7 +228,7 @@ extension RecoveryScorer {
             drivers.append(ChargeDriver(
                 label: "Skin temperature",
                 deltaPoints: points(recovery(hrv: hrv, rhr: rhr, resp: resp,
-                                             hrvBaseline: hrvBaseline, rhrBaseline: rhrBaseline,
+                                             hrvBaseline: hrvBaseline, rhrBaseline: rhrB,
                                              respBaseline: respBaseline, sleepPerf: sleepPerf,
                                              skinTempDev: 0)),
                 valueText: skinTempDevText(dev),

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer+Trace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer+Trace.swift
@@ -54,9 +54,15 @@ extension RecoveryScorer {
         var lines: [String] = []
         var nilTerms: [String] = []
 
+        // #1988: the trace reads this baseline DIRECTLY for its own `charge baseline rhr` line, its
+        // rhrZ and the saturation guard, not only through recovery(). recovery() now drops an
+        // unusable one, so without the same gate here the trace would list an rhr term the score
+        // did not use, which is precisely the divergence the line below promises cannot happen.
+        let rhrB = rhrBaseline.flatMap { $0.usable ? $0 : nil }
+
         // The score the dashboard reads, verbatim, so the trace cannot diverge from it.
         let score = recovery(hrv: hrv, rhr: rhr, resp: resp,
-                             hrvBaseline: hrvBaseline, rhrBaseline: rhrBaseline,
+                             hrvBaseline: hrvBaseline, rhrBaseline: rhrB,
                              respBaseline: respBaseline, sleepPerf: sleepPerf,
                              skinTempDev: skinTempDev)
 
@@ -73,7 +79,7 @@ extension RecoveryScorer {
         // baseline arg here (skinTempDev is already a deviation), so it has no baseline line.
         lines.append("charge baseline hrv mean=\(r2(hrvBaseline.baseline)) spread=\(r2(hrvBaseline.spread)) "
             + "nValid=\(hrvBaseline.nValid) status=\(hrvBaseline.status.rawValue)")
-        if let b = rhrBaseline {
+        if let b = rhrB {
             lines.append("charge baseline rhr mean=\(r2(b.baseline)) spread=\(r2(b.spread)) "
                 + "nValid=\(b.nValid) status=\(b.status.rawValue)")
         }
@@ -89,7 +95,7 @@ extension RecoveryScorer {
         // Resting-HR z, computed up front so the saturation guard can read the HRV<->RHR coupling
         // before the HRV term is built. nil when there is no RHR baseline. Numerically identical to
         // the z recovery() builds for the RHR term (same expression, same inputs).
-        let rhrZForGuard: Double? = rhrBaseline.map { zScore($0.baseline, mean: rhr, spread: $0.spread) }
+        let rhrZForGuard: Double? = rhrB.map { zScore($0.baseline, mean: rhr, spread: $0.spread) }
 
         // HRV term: higher is better. (Always present once usable; the cold-start guard above returned.)
         // This is the RAW z, exactly as recovery() scores it: the parasympathetic-saturation easing is

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/RecoveryScorer.swift
@@ -290,7 +290,8 @@ public enum RecoveryScorer {
     ///   - resp: tonight's respiration (raw or calibrated — z is scale-invariant);
     ///           nil drops the term.
     ///   - hrvBaseline: HRV baseline (required for a score).
-    ///   - rhrBaseline: resting-HR baseline; nil drops the RHR term.
+    ///   - rhrBaseline: resting-HR baseline; nil drops the RHR term. On the `BaselineState` overload an
+    ///     UNUSABLE baseline (#1988) is treated as nil, so a synthetic cold-start midpoint never scores.
     ///   - respBaseline: respiration baseline; nil drops the resp term.
     ///   - sleepPerf: Rest quality (Rest composite ÷100, 0..1; was raw efficiency);
     ///     nil drops the term.
@@ -404,7 +405,13 @@ public enum RecoveryScorer {
                  rhr: rhr,
                  resp: resp,
                  hrvBaseline: DriverBaseline(hrvBaseline),
-                 rhrBaseline: rhrBaseline.map(DriverBaseline.init),
+                 // #1988: an UNUSABLE resting-HR baseline is treated as absent. foldHistory returns
+                 // the config's synthetic midpoint (about 75 bpm) for an empty or all-implausible
+                 // history, which is nobody's resting HR, so scoring against it moved Charge on a
+                 // baseline the user never had. Gated here, in the one place every BaselineState
+                 // caller passes through, rather than at each call site: the headline and the driver
+                 // breakdown then agree by construction. Mirrors hrvBaselineUsable below.
+                 rhrBaseline: rhrBaseline.flatMap { $0.usable ? $0 : nil }.map(DriverBaseline.init),
                  respBaseline: respBaseline.map(DriverBaseline.init),
                  sleepPerf: sleepPerf,
                  skinTempDev: skinTempDev,

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryRhrBaselineUsableTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/RecoveryRhrBaselineUsableTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// #1988: an UNUSABLE resting-HR baseline must be treated as absent, everywhere.
+///
+/// `Baselines.foldHistory` returns the config's SYNTHETIC midpoint (about 75 bpm for resting HR) when the
+/// history is empty or entirely out of physiological range. That is nobody's resting HR, so scoring
+/// against it moved Charge, and a driver bar, on a baseline the user never had.
+///
+/// The gate lives in two places on purpose, and both are pinned here: `RecoveryScorer.recovery`'s
+/// `BaselineState` overload (every headline caller passes through it) and `chargeDrivers` (which builds
+/// the ROW from the baseline directly, not only through the scorer). Gating one without the other would
+/// let the breakdown disagree with the headline, which is exactly what `chargeDrivers`' own contract
+/// promises never happens. Kotlin twin: `RecoveryRhrBaselineUsableTest`.
+final class RecoveryRhrBaselineUsableTests: XCTestCase {
+
+    private func state(_ mean: Double, _ sigma: Double,
+                       _ status: BaselineStatus, nValid: Int) -> BaselineState {
+        BaselineState(baseline: mean, spread: sigma / 1.253, nValid: nValid,
+                      nightsSinceUpdate: status == .stale ? 20 : 0, status: status)
+    }
+
+    private var hrvBase: BaselineState { state(55, 12, .trusted, nValid: 20) }
+    private var usableRhr: BaselineState { state(52, 3, .provisional, nValid: 5) }
+    /// What an empty or all-implausible history folds to: the config midpoint, never banked.
+    private var syntheticRhr: BaselineState { state(75, 6, .calibrating, nValid: 0) }
+    private var staleRhr: BaselineState { state(52, 3, .stale, nValid: 20) }
+
+    private func score(_ rhrBaseline: BaselineState?) -> Double? {
+        RecoveryScorer.recovery(hrv: 55, rhr: 62, resp: nil,
+                                hrvBaseline: hrvBase, rhrBaseline: rhrBaseline,
+                                respBaseline: nil, sleepPerf: 0.85)
+    }
+
+    private func rows(_ rhrBaseline: BaselineState?) -> [ChargeDriver] {
+        RecoveryScorer.chargeDrivers(hrv: 55, rhr: 62, resp: nil,
+                                     hrvBaseline: hrvBase, rhrBaseline: rhrBaseline,
+                                     respBaseline: nil, sleepPerf: 0.85)
+    }
+
+    func testASyntheticRhrBaselineScoresLikeAnAbsentOne() {
+        XCTAssertEqual(score(syntheticRhr)!, score(nil)!, accuracy: 1e-12)
+    }
+
+    func testAStaleRhrBaselineScoresLikeAnAbsentOne() {
+        // `usable` is provisional-or-trusted, so a real personal baseline that has gone stale is dropped
+        // too. That is the same reading of "usable" the rest of the codebase uses.
+        XCTAssertEqual(score(staleRhr)!, score(nil)!, accuracy: 1e-12)
+    }
+
+    func testAUsableRhrBaselineStillContributes() {
+        // The control: the gate is not a blanket off. A resting HR well above a usable baseline must pull
+        // the score away from the HRV-only number.
+        XCTAssertNotEqual(score(usableRhr)!, score(nil)!, accuracy: 1e-9)
+    }
+
+    func testASyntheticRhrBaselineProducesNoRhrDriverRow() {
+        let labels = rows(syntheticRhr).map(\.label)
+        XCTAssertTrue(labels.contains("Heart rate variability"),
+                      "the HRV row must still be present: \(labels)")
+        XCTAssertFalse(labels.contains("Resting heart rate"),
+                       "no usable resting-HR baseline, so no RHR row: \(labels)")
+    }
+
+    func testAUsableRhrBaselineProducesItsRow() {
+        XCTAssertTrue(rows(usableRhr).map(\.label).contains("Resting heart rate"))
+    }
+
+    /// THE invariant this change exists to keep. `chargeDrivers` documents that its rows are scored
+    /// "against the identical inputs as the headline number", so the two gates must agree: passing an
+    /// unusable baseline has to be indistinguishable from passing none, row for row.
+    func testTheDriverRowsAndTheHeadlineApplyTheSameGate() {
+        XCTAssertEqual(rows(syntheticRhr), rows(nil))
+        XCTAssertEqual(rows(staleRhr), rows(nil))
+    }
+
+    /// The trace is the THIRD place that reads this baseline directly, for its own
+    /// `charge baseline rhr` line, its rhrZ and the saturation guard. Its own contract is that the score
+    /// it reports is the dashboard's "verbatim, so the trace cannot diverge from it", so an unusable
+    /// baseline has to drop the rhr TERM there too. Without the gate the trace would name a term the
+    /// score never used, which is the one thing a trace must never do.
+    func testTheTraceDropsTheRhrTermForAnUnusableBaseline() {
+        let (traced, lines) = RecoveryScorer.recoveryTrace(
+            hrv: 55, rhr: 62, resp: nil,
+            hrvBaseline: hrvBase, rhrBaseline: syntheticRhr, respBaseline: nil, sleepPerf: 0.85)
+        XCTAssertEqual(traced!, score(syntheticRhr)!, accuracy: 1e-12)
+        XCTAssertFalse(lines.contains { $0.contains("charge term rhr ") },
+                       "the trace must not name an rhr term the score did not use: \(lines)")
+        XCTAssertTrue(lines.contains { $0.contains("nilTerm dropped=") && $0.contains("rhr") },
+                      "rhr must be reported as a dropped term: \(lines)")
+        XCTAssertFalse(lines.contains { $0.contains("charge baseline rhr ") },
+                       "no baseline line for a baseline that was not used: \(lines)")
+    }
+
+    /// Control: a usable baseline still produces the trace's rhr term and its baseline line.
+    func testTheTraceKeepsTheRhrTermForAUsableBaseline() {
+        let (_, lines) = RecoveryScorer.recoveryTrace(
+            hrv: 55, rhr: 62, resp: nil,
+            hrvBaseline: hrvBase, rhrBaseline: usableRhr, respBaseline: nil, sleepPerf: 0.85)
+        XCTAssertTrue(lines.contains { $0.contains("charge term rhr ") })
+        XCTAssertTrue(lines.contains { $0.contains("charge baseline rhr ") })
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/RecoveryDrivers.kt
+++ b/android/app/src/main/java/com/noop/analytics/RecoveryDrivers.kt
@@ -91,7 +91,8 @@ object RecoveryDrivers {
      * @param resp tonight's respiration (rpm); null drops the resp row.
      * @param hrvBaseline HRV baseline (required; an unusable one yields an empty list, matching the
      *   recovery cold-start gate).
-     * @param rhrBaseline resting-HR baseline; null drops the RHR row.
+     * @param rhrBaseline resting-HR baseline; null drops the RHR row, and an UNUSABLE one (#1988) is
+     *   treated as null, so a synthetic cold-start midpoint never scores a row.
      * @param respBaseline respiration baseline; null drops the resp row.
      * @param sleepPerf rest-quality proxy in 0..1 (Rest composite / 100, or efficiency); null drops the
      *   Sleep row.
@@ -110,9 +111,15 @@ object RecoveryDrivers {
     ): List<ChargeDriver> {
         // No score => no real contributions to attribute (cold-start). recovery(...) enforces the usable
         // gate; mirror it so a nil headline never yields fabricated driver rows.
+        // #1988: the ROW is built from this baseline directly (its z, its mean, its verdict), not only
+        // through recovery(...), so gating the scorer alone would emit an RHR row scored against the
+        // synthetic midpoint while the headline excluded it. Normalised once here so every use below,
+        // score and row alike, sees the same thing. Named rather than shadowing the parameter, which
+        // would warn.
+        val rhrB = rhrBaseline?.takeIf { it.usable }
         val full = RecoveryScorer.recovery(
             hrv = hrv, rhr = rhr, resp = resp,
-            hrvBaseline = hrvBaseline, rhrBaseline = rhrBaseline,
+            hrvBaseline = hrvBaseline, rhrBaseline = rhrB,
             respBaseline = respBaseline, sleepPerf = sleepPerf, skinTempDev = skinTempDev,
         ) ?: return emptyList()
 
@@ -133,7 +140,7 @@ object RecoveryDrivers {
         // the full, unguarded HRV penalty. The verdict merely NAMES the detected pattern so the UI can
         // surface it while real firings accumulate. See the header in RecoveryScorer.kt.
         val hrvZFull = RecoveryScorer.zScore(hrv, hrvBaseline.baseline, hrvBaseline.spread)
-        val rhrZFull: Double? = rhrBaseline?.let { RecoveryScorer.zScore(it.baseline, rhr, it.spread) }
+        val rhrZFull: Double? = rhrB?.let { RecoveryScorer.zScore(it.baseline, rhr, it.spread) }
         val hrvSaturationDetected =
             RecoveryScorer.parasympatheticSaturation(hrvZ = hrvZFull, rhrZ = rhrZFull).active
 
@@ -149,7 +156,7 @@ object RecoveryDrivers {
                 deltaPoints = points(
                     RecoveryScorer.recovery(
                         hrv = hrvBaseline.baseline, rhr = rhr, resp = resp,
-                        hrvBaseline = hrvBaseline, rhrBaseline = rhrBaseline,
+                        hrvBaseline = hrvBaseline, rhrBaseline = rhrB,
                         respBaseline = respBaseline, sleepPerf = sleepPerf, skinTempDev = skinTempDev,
                     ),
                 ),
@@ -164,21 +171,21 @@ object RecoveryDrivers {
             ),
         )
         // Resting HR (lower vs baseline supports recovery). Neutral = resting HR at the baseline mean.
-        if (rhrBaseline != null) {
+        if (rhrB != null) {
             drivers.add(
                 ChargeDriver(
                     label = ChargeDriverLabel.RESTING_HEART_RATE,
                     deltaPoints = points(
                         RecoveryScorer.recovery(
-                            hrv = hrv, rhr = rhrBaseline.baseline, resp = resp,
-                            hrvBaseline = hrvBaseline, rhrBaseline = rhrBaseline,
+                            hrv = hrv, rhr = rhrB.baseline, resp = resp,
+                            hrvBaseline = hrvBaseline, rhrBaseline = rhrB,
                             respBaseline = respBaseline, sleepPerf = sleepPerf, skinTempDev = skinTempDev,
                         ),
                     ),
                     value = rhr,
-                    baseline = rhrBaseline.baseline,
+                    baseline = rhrB.baseline,
                     unit = ChargeDriverUnit.BEATS_PER_MINUTE,
-                    verdict = rhrVerdict(value = rhr, baseline = rhrBaseline.baseline),
+                    verdict = rhrVerdict(value = rhr, baseline = rhrB.baseline),
                 ),
             )
         }
@@ -190,7 +197,7 @@ object RecoveryDrivers {
                     deltaPoints = points(
                         RecoveryScorer.recovery(
                             hrv = hrv, rhr = rhr, resp = resp,
-                            hrvBaseline = hrvBaseline, rhrBaseline = rhrBaseline,
+                            hrvBaseline = hrvBaseline, rhrBaseline = rhrB,
                             respBaseline = respBaseline, sleepPerf = RecoveryScorer.sleepPerfCenter,
                             skinTempDev = skinTempDev,
                         ),
@@ -210,7 +217,7 @@ object RecoveryDrivers {
                     deltaPoints = points(
                         RecoveryScorer.recovery(
                             hrv = hrv, rhr = rhr, resp = respBaseline.baseline,
-                            hrvBaseline = hrvBaseline, rhrBaseline = rhrBaseline,
+                            hrvBaseline = hrvBaseline, rhrBaseline = rhrB,
                             respBaseline = respBaseline, sleepPerf = sleepPerf, skinTempDev = skinTempDev,
                         ),
                     ),
@@ -230,7 +237,7 @@ object RecoveryDrivers {
                     deltaPoints = points(
                         RecoveryScorer.recovery(
                             hrv = hrv, rhr = rhr, resp = resp,
-                            hrvBaseline = hrvBaseline, rhrBaseline = rhrBaseline,
+                            hrvBaseline = hrvBaseline, rhrBaseline = rhrB,
                             respBaseline = respBaseline, sleepPerf = sleepPerf, skinTempDev = 0.0,
                         ),
                     ),

--- a/android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt
+++ b/android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt
@@ -420,7 +420,13 @@ object RecoveryScorer {
         rhr = rhr,
         resp = resp,
         hrvBaseline = DriverBaseline(hrvBaseline),
-        rhrBaseline = rhrBaseline?.let { DriverBaseline(it) },
+        // #1988: an UNUSABLE resting-HR baseline is treated as absent. foldHistory returns the
+        // config's synthetic midpoint (about 75 bpm) for an empty or all-implausible history, which is
+        // nobody's resting HR, so scoring against it moved Charge on a baseline the user never had.
+        // Gated here, in the one place every BaselineState caller passes through, rather than at each
+        // call site: the headline and the driver breakdown then agree by construction. Mirrors how
+        // hrvBaselineUsable is already derived below.
+        rhrBaseline = rhrBaseline?.takeIf { it.usable }?.let { DriverBaseline(it) },
         respBaseline = respBaseline?.let { DriverBaseline(it) },
         sleepPerf = sleepPerf,
         skinTempDev = skinTempDev,

--- a/android/app/src/main/java/com/noop/analytics/RecoveryScorerTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/RecoveryScorerTrace.kt
@@ -70,10 +70,16 @@ object RecoveryScorerTrace {
         val lines = ArrayList<String>()
         val nilTerms = ArrayList<String>()
 
+        // #1988: the trace reads this baseline DIRECTLY for its own `charge baseline rhr` line, its
+        // rhrZ and the saturation guard, not only through recovery(). recovery() now drops an
+        // unusable one, so without the same gate here the trace would list an rhr term the score
+        // did not use, which is precisely the divergence the line below promises cannot happen.
+        val rhrB = rhrBaseline?.takeIf { it.usable }
+
         // The score the dashboard reads, verbatim, so the trace cannot diverge from it.
         val score = RecoveryScorer.recovery(
             hrv = hrv, rhr = rhr, resp = resp,
-            hrvBaseline = hrvBaseline, rhrBaseline = rhrBaseline,
+            hrvBaseline = hrvBaseline, rhrBaseline = rhrB,
             respBaseline = respBaseline, sleepPerf = sleepPerf, skinTempDev = skinTempDev,
         )
 
@@ -92,7 +98,7 @@ object RecoveryScorerTrace {
             "charge baseline hrv mean=${r2(hrvBaseline.baseline)} spread=${r2(hrvBaseline.spread)} " +
                 "nValid=${hrvBaseline.nValid} status=${hrvBaseline.status.raw}",
         )
-        rhrBaseline?.let { b ->
+        rhrB?.let { b ->
             lines.add(
                 "charge baseline rhr mean=${r2(b.baseline)} spread=${r2(b.spread)} " +
                     "nValid=${b.nValid} status=${b.status.raw}",
@@ -111,7 +117,7 @@ object RecoveryScorerTrace {
         // Resting-HR z, computed up front so the saturation guard can read the HRV<->RHR coupling before
         // the HRV term is built. null when there is no RHR baseline. Numerically identical to the z
         // recovery() builds for the RHR term (same expression, same inputs).
-        val rhrZForGuard: Double? = rhrBaseline?.let { RecoveryScorer.zScore(it.baseline, rhr, it.spread) }
+        val rhrZForGuard: Double? = rhrB?.let { RecoveryScorer.zScore(it.baseline, rhr, it.spread) }
 
         // L9: every WEIGHT / SCALE / centre constant goes through r2() too (not just the z-scores), so a
         // future non-round weight (e.g. 0.333) renders identically on Swift and Kotlin and the parity

--- a/android/app/src/test/java/com/noop/analytics/RecoveryRhrBaselineUsableTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RecoveryRhrBaselineUsableTest.kt
@@ -1,0 +1,112 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1988: an UNUSABLE resting-HR baseline must be treated as absent, everywhere.
+ *
+ * `Baselines.foldHistory` returns the config's SYNTHETIC midpoint (about 75 bpm for resting HR) when the
+ * history is empty or entirely out of physiological range. That is nobody's resting HR, so scoring
+ * against it moved Charge, and a driver bar, on a baseline the user never had.
+ *
+ * The gate lives in two places on purpose, and both are pinned here: `RecoveryScorer.recovery`'s
+ * BaselineState overload (every headline caller passes through it) and `RecoveryDrivers.chargeDrivers`
+ * (which builds the ROW from the baseline directly, not only through the scorer). Gating one without the
+ * other would let the breakdown disagree with the headline, which is exactly what chargeDrivers'
+ * own contract promises never happens. Swift twin: `RecoveryRhrBaselineUsableTests`.
+ */
+class RecoveryRhrBaselineUsableTest {
+
+    private fun state(mean: Double, sigma: Double, status: BaselineStatus, nValid: Int) =
+        BaselineState(baseline = mean, spread = sigma / 1.253, nValid = nValid,
+                      nightsSinceUpdate = if (status == BaselineStatus.STALE) 20 else 0, status = status)
+
+    private val hrvBase = state(55.0, 12.0, BaselineStatus.TRUSTED, 20)
+    private val usableRhr = state(52.0, 3.0, BaselineStatus.PROVISIONAL, 5)
+    /** What an empty or all-implausible history folds to: the config midpoint, never banked. */
+    private val syntheticRhr = state(75.0, 6.0, BaselineStatus.CALIBRATING, 0)
+    private val staleRhr = state(52.0, 3.0, BaselineStatus.STALE, 20)
+
+    private fun score(rhrBaseline: BaselineState?): Double? = RecoveryScorer.recovery(
+        hrv = 55.0, rhr = 62.0, resp = null,
+        hrvBaseline = hrvBase, rhrBaseline = rhrBaseline, respBaseline = null, sleepPerf = 0.85,
+    )
+
+    private fun rows(rhrBaseline: BaselineState?) = RecoveryDrivers.chargeDrivers(
+        hrv = 55.0, rhr = 62.0, resp = null,
+        hrvBaseline = hrvBase, rhrBaseline = rhrBaseline, respBaseline = null, sleepPerf = 0.85,
+    )
+
+    @Test fun aSyntheticRhrBaselineScoresLikeAnAbsentOne() {
+        assertEquals(score(null)!!, score(syntheticRhr)!!, 1e-12)
+    }
+
+    @Test fun aStaleRhrBaselineScoresLikeAnAbsentOne() {
+        // `usable` is provisional-or-trusted, so a real personal baseline that has gone stale is dropped
+        // too. That is the same reading of "usable" the rest of the codebase uses.
+        assertEquals(score(null)!!, score(staleRhr)!!, 1e-12)
+    }
+
+    @Test fun aUsableRhrBaselineStillContributes() {
+        // The control: the gate is not a blanket off. A resting HR well above a usable baseline must pull
+        // the score away from the HRV-only number.
+        assertNotEquals(score(null)!!, score(usableRhr)!!, 1e-9)
+    }
+
+    @Test fun aSyntheticRhrBaselineProducesNoRhrDriverRow() {
+        val labels = rows(syntheticRhr).map { it.label }
+        assertTrue("the HRV row must still be present: $labels",
+            labels.contains(ChargeDriverLabel.HEART_RATE_VARIABILITY))
+        assertFalse("no usable resting-HR baseline, so no RHR row: $labels",
+            labels.contains(ChargeDriverLabel.RESTING_HEART_RATE))
+    }
+
+    @Test fun aUsableRhrBaselineProducesItsRow() {
+        assertTrue(rows(usableRhr).map { it.label }.contains(ChargeDriverLabel.RESTING_HEART_RATE))
+    }
+
+    /**
+     * THE invariant this change exists to keep. `chargeDrivers` documents that its rows are scored
+     * "against the identical inputs as the headline number", so the two gates must agree: passing an
+     * unusable baseline has to be indistinguishable from passing none, row for row.
+     */
+    @Test fun theDriverRowsAndTheHeadlineApplyTheSameGate() {
+        assertEquals(rows(null), rows(syntheticRhr))
+        assertEquals(rows(null), rows(staleRhr))
+    }
+
+    /**
+     * The trace is the THIRD place that reads this baseline directly, for its own
+     * `charge baseline rhr` line, its rhrZ and the saturation guard. Its own contract is that the score
+     * it reports is the dashboard's "verbatim, so the trace cannot diverge from it", so an unusable
+     * baseline has to drop the rhr TERM there too. Without the gate the trace would name a term the
+     * score never used, which is the one thing a trace must never do.
+     */
+    @Test fun theTraceDropsTheRhrTermForAnUnusableBaseline() {
+        val (score, lines) = RecoveryScorerTrace.recoveryTrace(
+            hrv = 55.0, rhr = 62.0, resp = null,
+            hrvBaseline = hrvBase, rhrBaseline = syntheticRhr, respBaseline = null, sleepPerf = 0.85,
+        )
+        assertEquals(score(syntheticRhr)!!, score!!, 1e-12)
+        assertFalse("the trace must not name an rhr term the score did not use: $lines",
+            lines.any { it.contains("charge term rhr ") })
+        assertTrue("rhr must be reported as a dropped term: $lines",
+            lines.any { it.contains("nilTerm dropped=") && it.contains("rhr") })
+        assertFalse("no baseline line for a baseline that was not used: $lines",
+            lines.any { it.contains("charge baseline rhr ") })
+    }
+
+    /** Control: a usable baseline still produces the trace's rhr term and its baseline line. */
+    @Test fun theTraceKeepsTheRhrTermForAUsableBaseline() {
+        val (_, lines) = RecoveryScorerTrace.recoveryTrace(
+            hrv = 55.0, rhr = 62.0, resp = null,
+            hrvBaseline = hrvBase, rhrBaseline = usableRhr, respBaseline = null, sleepPerf = 0.85,
+        )
+        assertTrue(lines.any { it.contains("charge term rhr ") })
+        assertTrue(lines.any { it.contains("charge baseline rhr ") })
+    }
+}


### PR DESCRIPTION
Addresses #1988. Supersedes #1989, which gated only the Android driver row; see below for why that was the wrong shape.

## The defect

`Baselines.foldHistory` returns the config's **synthetic midpoint** (about 75 bpm for resting HR) when the history is empty or entirely out of physiological range. Every engine passed that straight through, so the **headline Charge** on both platforms was z-scored against a baseline the user has never had. This is the same defect #1982 addressed for `WatchRecovery`, in the path that reaches the ring.

## Where the gate goes, and why three places

Not at the eight call sites, but at the three places that read this baseline:

1. **`RecoveryScorer.recovery`'s `BaselineState` overload.** `AnalyticsEngine` and `IntelligenceEngine` reach it on both platforms. This mirrors how `hrvBaselineUsable` is already derived one line below, so the two baselines are now handled the same way.
2. **`chargeDrivers`.** This one is easy to miss and it is why the first attempt was wrong: `chargeDrivers` builds the **row** from the baseline directly, its z, its mean and its verdict, not only through the scorer. Gating the scorer alone would have emitted an RHR row scored against the midpoint while the headline excluded it, which is worse than the original defect and would falsify the contract `chargeDrivers` documents, that its rows are scored "against the identical inputs as the headline number".

3. **`RecoveryScorerTrace`.** Found on a re-review, and the same shape a third time: the trace builds its own `charge baseline rhr` line, its `rhrZ` and the saturation guard from the baseline directly. Ungated, it would have named an rhr term the score did not use, which is the one thing a trace must never do, and which its own comment promises cannot happen: "The score the dashboard reads, verbatim, so the trace cannot diverge from it."

Gating all three keeps that invariant true, which is the point. Gating any subset is worse than gating none: the score and the thing describing the score would disagree.

## Why not #1989

#1989 gated only Android's `TodayScoring`, to match the iOS views. Re-reviewing it showed that would have made things worse in a specific way: Android currently satisfies the identical-inputs contract (drivers and headline both ungated, both wrong), and a view-only gate would have **introduced** the divergence on a platform that did not have one. iOS already has it, since its views gate while its engine does not. This PR removes the divergence on both platforms instead of spreading it.

## User-visible effect, and it is real

For a user with fewer than four valid resting-HR nights, an all-implausible history, or a baseline stale beyond 14 nights, the RHR term now drops and Charge renormalises onto the remaining terms. **The number moves, for existing users, on both platforms.**

No stored value is rewritten, so history will hold a mix of old-rule and new-rule days, the same situation #1987 tracks for #1982. **This needs a release note.** Since `usable` is provisional-or-trusted, a real personal baseline that has gone stale is dropped as well, which is the reading of "usable" the rest of the codebase uses.

## Tests

Eight mirrored per platform, 1:1 by name. Three are controls proving the gate is not a blanket off: a usable baseline still contributes to the score, still produces its row, and still produces its trace term and baseline line. One pins the invariant directly, that passing an unusable baseline is indistinguishable from passing none, row for row.

Verified non-vacuous rather than assumed: with the gates reverted, **4 of the 6 original tests go red and every control stays green**. The pre-existing `RecoveryScorerTraceTest` passes unchanged at 10/10, so the trace's other invariants are intact.

Full Android suite: 668 classes, 5,648 tests, 0 failures. `doc_comment_lint.py` clean. Swift is CI-verified as always; I checked the Swift API assumptions by hand first, which caught that `ChargeDriver.label` is a `String` there while the Kotlin twin uses a `ChargeDriverLabel` enum.
