### PR TITLE
recovery: close the doc and comment gaps left by the resting-HR gate

### DIFF
--- a/Strand/Screens/ChargeBreakdownWiring.swift
+++ b/Strand/Screens/ChargeBreakdownWiring.swift
@@ -1,0 +1,52 @@
+import Foundation
+import StrandAnalytics
+import WhoopStore
+
+// MARK: - Charge breakdown wiring (pure, testable)
+//
+// The fold-and-score wiring behind the "What shaped it" sheet, lifted out of the two views that had
+// byte-identical private copies of it (TodayView.chargeBreakdown / CoupledView.chargeBreakdown). They
+// differed only in which row they display and where their sleep-performance number comes from, both of
+// which are inputs, so one function serves both.
+//
+// Extracted so it can be TESTED. Living inside a `View` struct as a private method meant the only way to
+// exercise it was to render the view, so the iOS side of this path had no test at all while the Android
+// twin did. Kotlin twin: `TodayScoring.recoveryChargeDrivers`.
+//
+// Pure: no SwiftUI state, no I/O, no store access. Nothing here invents a number. The drivers come from
+// `RecoveryScorer.chargeDrivers` and the tier is SURFACED from `ScoreConfidence.charge` against the same
+// folded HRV baseline the drivers scored with, so the header and the rows agree by construction.
+enum ChargeBreakdownWiring {
+
+    /// The ordered Charge driver rows for `row` plus its confidence tier, folded from the visible `days`
+    /// history, or nil when the night cannot honestly score (missing HRV or resting HR, or an HRV
+    /// baseline that is not yet usable) so the sheet hides rather than showing fabricated rows.
+    ///
+    /// `sleepPerfPercent` is the Rest composite on a 0-100 scale, divided by 100 here to match
+    /// `AnalyticsEngine`'s `sleepPerf` form, so the Sleep row scores against the headline's own input.
+    ///
+    /// The resting-HR and respiration baselines are passed only when usable. `RecoveryScorer` and
+    /// `chargeDrivers` both apply that gate themselves since #1990, so these are belt-and-braces rather
+    /// than load-bearing; they are kept because they say the intent at the call site, which is where a
+    /// reader looks first.
+    static func breakdown(days: [DailyMetric],
+                          row: DailyMetric,
+                          sleepPerfPercent: Double?) -> (drivers: [ChargeDriver], confidence: ScoreConfidence)? {
+        guard let hrv = row.avgHrv, let rhr = row.restingHr else { return nil }
+        // PERF: one pass per series. The two private copies this replaces each re-folded the full history
+        // per body evaluation of the open sheet; the guard above still runs before any fold.
+        let hrvBase = Baselines.foldHistory(days.map(\.avgHrv), cfg: Baselines.hrvCfg)
+        guard hrvBase.usable else { return nil }
+        let rhrBase = Baselines.foldHistory(days.map { $0.restingHr.map(Double.init) },
+                                            cfg: Baselines.restingHRCfg)
+        let respBase = Baselines.foldHistory(days.map(\.respRateBpm), cfg: Baselines.respCfg)
+        let drivers = RecoveryScorer.chargeDrivers(
+            hrv: hrv, rhr: Double(rhr), resp: row.respRateBpm,
+            hrvBaseline: hrvBase,
+            rhrBaseline: rhrBase.usable ? rhrBase : nil,
+            respBaseline: respBase.usable ? respBase : nil,
+            sleepPerf: sleepPerfPercent.map { $0 / 100.0 },
+            skinTempDev: row.skinTempDevC)
+        return (drivers, ScoreConfidence.charge(recovery: row.recovery, hrvBaseline: hrvBase))
+    }
+}

--- a/Strand/Screens/CoupledView.swift
+++ b/Strand/Screens/CoupledView.swift
@@ -531,21 +531,8 @@ struct CoupledView: View {
     /// sheet's inline confidence fold re-folded the full `repo.days` history four times per body eval of
     /// the open sheet; one call now folds each series exactly once, guards before any fold.
     private func chargeBreakdown() -> (drivers: [ChargeDriver], confidence: ScoreConfidence)? {
-        guard let row = breakdownRow, let hrv = row.avgHrv, let rhr = row.restingHr else { return nil }
-        let hrvBase = Baselines.foldHistory(repo.days.map(\.avgHrv), cfg: Baselines.hrvCfg)
-        guard hrvBase.usable else { return nil }
-        let rhrBase = Baselines.foldHistory(repo.days.map { $0.restingHr.map(Double.init) },
-                                            cfg: Baselines.restingHRCfg)
-        let respBase = Baselines.foldHistory(repo.days.map(\.respRateBpm), cfg: Baselines.respCfg)
-        // Rest-quality term = the same sleep performance the sleep row shows, ÷100 (AnalyticsEngine's form).
-        let sleepPerf = sleepPerformance.map { $0 / 100.0 }
-        let drivers = RecoveryScorer.chargeDrivers(
-            hrv: hrv, rhr: Double(rhr), resp: row.respRateBpm,
-            hrvBaseline: hrvBase,
-            rhrBaseline: rhrBase.usable ? rhrBase : nil,
-            respBaseline: respBase.usable ? respBase : nil,
-            sleepPerf: sleepPerf, skinTempDev: row.skinTempDevC)
-        return (drivers, ScoreConfidence.charge(recovery: row.recovery, hrvBaseline: hrvBase))
+        guard let row = breakdownRow else { return nil }
+        return ChargeBreakdownWiring.breakdown(days: repo.days, row: row, sleepPerfPercent: sleepPerformance)
     }
 
     @ViewBuilder

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -798,26 +798,8 @@ struct TodayView: View {
     /// fold while actually recomputing it. One call folds each series exactly once (three passes), and the
     /// sheet reads drivers + confidence out of a single sheet-local `let`.
     private func chargeBreakdown() -> (drivers: [ChargeDriver], confidence: ScoreConfidence)? {
-        guard let row = chargeBreakdownRow,
-              let hrv = row.avgHrv, let rhr = row.restingHr else { return nil }
-        let hrvBase = Baselines.foldHistory(repo.days.map(\.avgHrv), cfg: Baselines.hrvCfg)
-        guard hrvBase.usable else { return nil }
-        let rhrBase = Baselines.foldHistory(repo.days.map { $0.restingHr.map(Double.init) },
-                                            cfg: Baselines.restingHRCfg)
-        let respBase = Baselines.foldHistory(repo.days.map(\.respRateBpm), cfg: Baselines.respCfg)
-        // Rest-quality term = the Rest composite ÷100, matching AnalyticsEngine's `sleepPerf`. `restScore`
-        // is the same merged sleep_performance value the Rest ring reads, so the term stays consistent.
-        let sleepPerf = restScore.map { $0 / 100.0 }
-        let drivers = RecoveryScorer.chargeDrivers(
-            hrv: hrv, rhr: Double(rhr), resp: row.respRateBpm,
-            hrvBaseline: hrvBase,
-            rhrBaseline: rhrBase.usable ? rhrBase : nil,
-            respBaseline: respBase.usable ? respBase : nil,
-            sleepPerf: sleepPerf, skinTempDev: row.skinTempDevC)
-        // Confidence tier SURFACED (never recomputed) from the existing `ScoreConfidence.charge` against
-        // the SAME folded HRV baseline the drivers scored with, so the dot + tier tag in the sheet header
-        // agree with the breakdown by construction.
-        return (drivers, ScoreConfidence.charge(recovery: row.recovery, hrvBaseline: hrvBase))
+        guard let row = chargeBreakdownRow else { return nil }
+        return ChargeBreakdownWiring.breakdown(days: repo.days, row: row, sleepPerfPercent: restScore)
     }
 
     /// The night's relative skin-temp marker for the displayed row (A5), or nil. Surfaced verbatim from

--- a/StrandTests/ChargeBreakdownWiringTests.swift
+++ b/StrandTests/ChargeBreakdownWiringTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+import StrandAnalytics
+import WhoopStore
+@testable import Strand
+
+/// Swift twin of the Android `RecoveryDriversUiTest` wiring cases.
+///
+/// This suite could not exist before: the derivation lived as a private method inside `TodayView` (and a
+/// byte-identical copy inside `CoupledView`), reachable only by rendering the view, so the iOS end of the
+/// "What shaped it" path had no test at all while Android's did. `ChargeBreakdownWiring.breakdown` is that
+/// derivation lifted out unchanged.
+///
+/// Case mapping against the Kotlin suite, stated so the gap is legible rather than implied:
+///   * `rhrRowIsAbsentWhenTheRestingHrBaselineIsNotUsable` - twinned below.
+///   * `coldStartHistoryProducesNoRows` - twinned below.
+///   * `scoredDayProducesDriverRows` - twinned below, and it carries the confidence assertion too, since
+///     this API returns the tier in the same tuple where Kotlin has a separate `chargeConfidenceTier`.
+///   * `nullDayProducesNoRows` - deliberately NOT twinned. This API takes a non-optional row, so the
+///     nil-row guard stays in the view where it belongs; there is nothing here to assert.
+final class ChargeBreakdownWiringTests: XCTestCase {
+
+    private func day(_ d: String, hrv: Double? = 55, rhr: Int? = 55, recovery: Double? = nil) -> DailyMetric {
+        DailyMetric(day: d, totalSleepMin: 450, efficiency: 0.9, deepMin: nil, remMin: nil, lightMin: nil,
+                    disturbances: nil, restingHr: rhr, avgHrv: hrv, recovery: recovery, strain: nil,
+                    exerciseCount: nil)
+    }
+
+    /// A history with no banked resting HR folds to `foldHistory`'s synthetic midpoint (about 75 bpm),
+    /// which is nobody's resting HR, so the row must be absent. The HRV row still stands, since that
+    /// baseline is real. The display day itself carries a reading, so this pins the BASELINE being
+    /// unusable rather than the reading being missing.
+    ///
+    /// The gate is not in this file: `RecoveryScorer.chargeDrivers` applies it (#1990). This pins the end
+    /// of the path, the surface a user actually sees.
+    func testRhrRowIsAbsentWhenTheRestingHrBaselineIsNotUsable() {
+        let history = (1...6).map { day(String(format: "2026-01-%02d", $0), rhr: nil) }
+        let today = day("2026-01-07", rhr: 55)
+        let out = ChargeBreakdownWiring.breakdown(days: history + [today], row: today, sleepPerfPercent: 85)
+        let labels = (out?.drivers ?? []).map(\.label)
+        XCTAssertTrue(labels.contains("Heart rate variability"),
+                      "the HRV baseline is real, so its row must still be there: \(labels)")
+        XCTAssertFalse(labels.contains("Resting heart rate"),
+                       "no usable resting-HR baseline, so no RHR row: \(labels)")
+    }
+
+    /// Two nights only: the HRV baseline is not usable yet, so there are no honest drivers and the sheet
+    /// hides rather than showing fabricated rows.
+    func testColdStartHistoryProducesNoBreakdown() {
+        let days = [day("2026-01-01"), day("2026-01-02")]
+        XCTAssertNil(ChargeBreakdownWiring.breakdown(days: days, row: days[1], sleepPerfPercent: 85))
+    }
+
+    /// The usable-baseline half of the pair: a real history banks both baselines, so both rows appear and
+    /// the surfaced tier is past calibrating.
+    func testAScoredDayProducesDriverRowsAndATier() {
+        let past = (1...10).map { day(String(format: "2026-01-%02d", $0), hrv: 50 + Double($0 % 3)) }
+        let today = day("2026-01-20", hrv: 62, rhr: 51, recovery: 64)
+        let out = ChargeBreakdownWiring.breakdown(days: past + [today], row: today, sleepPerfPercent: 85)
+        XCTAssertNotNil(out)
+        let labels = (out?.drivers ?? []).map(\.label)
+        XCTAssertTrue(labels.contains("Heart rate variability"), "\(labels)")
+        XCTAssertTrue(labels.contains("Resting heart rate"), "\(labels)")
+        XCTAssertNotEqual(out?.confidence, .calibrating)
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt
+++ b/android/app/src/main/java/com/noop/analytics/RecoveryScorer.kt
@@ -293,7 +293,8 @@ object RecoveryScorer {
      * @param resp tonight's respiration (raw or calibrated — z is scale-invariant);
      *   null drops the term.
      * @param hrvBaseline HRV baseline (required for a score).
-     * @param rhrBaseline resting-HR baseline; null drops the RHR term.
+     * @param rhrBaseline resting-HR baseline; null drops the RHR term. On the BaselineState overload an
+     *   UNUSABLE baseline (#1988) is treated as null, so a synthetic cold-start midpoint never scores.
      * @param respBaseline respiration baseline; null drops the resp term.
      * @param sleepPerf sleep-performance proxy (Rest composite 0..1, or efficiency
      *   0..1 for legacy callers); null drops the term.

--- a/android/app/src/main/java/com/noop/ui/TodayScoring.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScoring.kt
@@ -69,6 +69,9 @@ internal fun recoveryChargeDrivers(
     val ordered = days.sortedBy { it.day }
     val hrvBase = Baselines.foldHistory(ordered.map { it.avgHrv }, Baselines.hrvCfg)
     if (!hrvBase.usable) return emptyList()
+    // Passed on ungated, unlike respBase below, and that is deliberate since #1988: chargeDrivers
+    // gates this one itself, for its score AND for the row it builds from the baseline directly.
+    // Gating again here would be harmless but would suggest the callee does not, which it does.
     val rhrBase = Baselines.foldHistory(ordered.map { it.restingHr?.toDouble() }, Baselines.restingHRCfg)
     val respBase = Baselines.foldHistory(ordered.map { it.respRateBpm }, Baselines.respCfg).takeIf { it.usable }
 

--- a/android/app/src/test/java/com/noop/ui/RecoveryDriversUiTest.kt
+++ b/android/app/src/test/java/com/noop/ui/RecoveryDriversUiTest.kt
@@ -4,6 +4,7 @@ import com.noop.analytics.ScoreConfidence
 import com.noop.analytics.ChargeDriverLabel
 import com.noop.data.DailyMetric
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -66,5 +67,32 @@ class RecoveryDriversUiTest {
 
     @Test fun nullDayProducesNoRows() {
         assertTrue(recoveryChargeDrivers(scoredHistory(), null).isEmpty())
+    }
+
+    // ---- #1988: the RHR row needs a USABLE resting-HR baseline ----------------------------------
+
+    /**
+     * A history with no banked resting HR folds to `foldHistory`'s synthetic midpoint (about 75 bpm),
+     * which is nobody's resting HR. Scoring the RHR row against it moves a bar on a baseline the user
+     * has never had, so the row must be absent. The HRV row still stands, since that baseline is real.
+     *
+     * The display day itself carries a reading, so this is specifically the BASELINE being unusable,
+     * not the reading being missing.
+     *
+     * The gate is NOT in this file: `recoveryChargeDrivers` passes its fold on ungated and
+     * `RecoveryDrivers.chargeDrivers` applies it (#1990). This pins the end of that path, the surface a
+     * user actually sees, which nothing else covers. `scoredDayProducesDriverRows` above is the usable
+     * -baseline half of the pair: it asserts the row IS present on a history that banks resting HR, so
+     * the two together show the gate is not a blanket off. Deliberately not restated here.
+     */
+    @Test fun rhrRowIsAbsentWhenTheRestingHrBaselineIsNotUsable() {
+        val history = (1..6).map { day("2026-01-0$it", rhr = null) }
+        val today = day("2026-01-07", rhr = 55)
+        val drivers = recoveryChargeDrivers(history + today, today)
+        val labels = drivers.map { it.label }
+        assertTrue("the HRV baseline is real, so its row must still be there",
+            labels.contains(ChargeDriverLabel.HEART_RATE_VARIABILITY))
+        assertFalse("no usable resting-HR baseline, so no RHR row: got $labels",
+            labels.contains(ChargeDriverLabel.RESTING_HEART_RATE))
     }
 }


### PR DESCRIPTION
Four follow-ups to #1990. No behaviour change.

## 1. A doc-parity gap that #1990 introduced

`RecoveryScorer.kt`'s `@param rhrBaseline` still read "null drops the RHR term", while the Swift twin was updated to name the unusable rule. So the same parameter was documented two different ways in the two languages, which is precisely the drift the parity contract exists to remove. My gap, from #1990. Now matched.

## 2. TodayScoring reads like an oversight, and is not

It folds an rhr baseline and passes it **ungated**, directly above a resp baseline that **is** gated with `takeIf { it.usable }`. Before #1990 that asymmetry was the defect. It is safe now only because `chargeDrivers` gates internally, for its score and for the row it builds from the baseline directly.

Left alone, the next reader either adds a redundant gate or concludes #1988 was half done. The reason is now written where the asymmetry is, rather than three files away.

## 3. An end-to-end pin at the UI boundary

**One** case from the superseded #1989, restored into the UI wiring suite: the RHR row is absent when the baseline is unusable.

**It passes without any production change**, because #1990 already gates the callee. Stating that plainly: it is a regression pin at the surface a user actually sees, not evidence of a fix. It is worth having because every other test of this behaviour sits at the analytics layer, and nothing pinned the wiring that carries it to the screen. If someone later simplifies `TodayScoring` or the gate inside `chargeDrivers`, this is the test that goes red. Its doc names `chargeDrivers` as the holder of the gate, so a reader is not sent hunting through this file for it.

The **usable-baseline control** that PR also carried is deliberately not brought over. `scoredDayProducesDriverRows`, directly above, uses the identical fixture and already asserts the RHR row is present, so the control added no coverage at all. I caught this re-reviewing my own branch, and it is the same thing I asked a contributor to remove from #1982 earlier today, so it would have been poor form to ship it. The remaining test points at that existing assertion instead of restating it.

## On #1988

Verified as addressed by #1990, and not in the way I originally proposed. The gate went into the callee, so the Android UI path is covered without `TodayScoring` changing at all. I confirmed it by running these two tests against unmodified `main` before writing this branch: 6 of 6 green.

## 4. The parity gap that made the test one-sided

The Android test above had no iOS twin, and could not have one. The same derivation lived as a **private method inside `TodayView`**, with a byte-identical copy inside `CoupledView`, reachable only by rendering the view. So `grep chargeDrivers StrandTests/` returned nothing across 17 Today suites: the iOS end of this path was untested, while Android's equivalent had been extracted into a callable `recoveryChargeDrivers` and tested for some time.

Both copies are now one `ChargeBreakdownWiring.breakdown`, lifted out unchanged. They differed only in which row they display and where their sleep-performance number comes from, both of which are inputs, so a single function serves both. That removes a real duplication (a change to one was never going to be applied to the other by anything but memory) and makes the twin possible.

`StrandTests/ChargeBreakdownWiringTests.swift` is that twin. Its header maps the cases against the Kotlin suite explicitly, including the one that deliberately has **no** counterpart: this API takes a non-optional row, so the nil-row guard stays in the view and there is nothing to assert. Naming that beats leaving a silent 5-versus-3 count difference for someone to rediscover.

## Verification

Full Android suite: 668 classes, 5,649 tests, 0 failures, unaffected by this change. `doc_comment_lint.py` clean. The Swift half rests on CI, as always here; I checked the API details by hand first (`ScoreConfidence` is `Equatable`, `ChargeDriver.label` is a `String` on Swift where Kotlin uses an enum, `DailyMetric`'s initialiser, and that the new file needs no `project.yml` edit because the app target globs `Strand/`).
