### PR TITLE
ble: point the unmapped-layout report line at the right issue

### DIFF
--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -638,7 +638,7 @@ final class Backfiller {
                       p.parsed["ppg_waveform"] == nil,
                       !loggedUnmappedVersions.contains(v) else { continue }
                 loggedUnmappedVersions.insert(v)
-                log?("Historical records use firmware layout v\(v), which NOOP doesn't decode yet — no motion data, so sleep can't be computed from the strap. Please report this (issue #30).")
+                log?("Historical records use firmware layout v\(v), which NOOP doesn't decode yet: those records carry no heart rate or motion, so any night made only of them can't be staged from the strap. A strap emitting a mix of layouts still stages the nights it can. Please report this (issue #1992).")
             }
             let decoded = d.decoded
             // #520: accumulate the motion-magnitude diagnostic across the session; logged once at the


### PR DESCRIPTION
One line. When NOOP meets a historical record whose firmware layout it has no field map for, the strap log says:

> Historical records use firmware layout v20, which NOOP doesn't decode yet ... Please report this (issue #30).

In this repository the number 30 belongs to a pull request about reading Workouts across the my-whoop union, merged long ago. So every user who followed that pointer landed somewhere with nothing to do with what they were looking at. It now names #1992, which actually tracks the undecodable layout.

This is not academic. A 5/MG reporter hit this exact line, followed it, and the layout has stayed unmapped long enough to cost measurable BLE radio time on every connection: records that never become rows leave the offload frontier permanently short of the strap's reported newest, so the auto-continue keeps finding backlog and re-kicking to its cap.

## The same sentence also overstated the problem

Re-reviewing this, the wording was wrong in a second way. It said sleep "can't be computed from the strap", flatly, when the line fires once per unmapped layout VERSION on a strap that may be emitting several.

The reporter who hit it had **25 of 50 frames decoding fine**, so sleep was partly computing while the log told them it could not. Their report was titled "zero progress" and concluded staging was broken. This line plausibly helped them get there.

It now says nights made only of those records cannot be staged, and that a strap emitting a mix of layouts still stages the nights it can. That is a slightly larger edit than the number, on the same sentence, and I would rather say so than slip it in: revert that half if you disagree.

Also drops an em-dash, since this is user-facing copy.

## Deliberately not touched

Several code comments cite the same number as provenance for the v25 layout work (`HistoricalStreams.kt`, and the reject-archive comments in both Backfillers). Those are non-user-facing, and retracing what each one originally referred to is a separate job from making the line users are *told to follow* point somewhere real. Left alone rather than churned on a guess.

## Worth knowing, and not addressed here

**Android has no equivalent line at all.** Its `Backfiller` logs `historical records use layout v<n>` with no explanation and no request to report. So an Android user with an unmapped layout is never told it is a problem, never asked for the capture that would map it, and has no reason to file anything.

That is a plausible reason these reports only ever arrive from iOS, and it means fixing the pointer only helps half the users. I have left it out because adding user-facing diagnostic copy to Android is a larger change than correcting a number, and it deserves its own review rather than riding along. Say the word and I will do it as a follow-up.

## Verification

`doc_comment_lint.py` clean. Swift-only, one string literal, no behaviour change; CI covers the compile.
