### PR TITLE
diag: spend the reject hex dump from a session budget, not per chunk

### DIFF
--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -86,6 +86,16 @@ final class Backfiller {
     private let log: ((String) -> Void)?
     /// Versions already reported this session, so the diagnostic logs each once (no spam).
     private var loggedUnmappedVersions: Set<Int> = []
+    /// #1992: reject frames still allowed to hex-dump (see `hexDumpAllowance`).
+    ///
+    /// Deliberately NOT reset in `begin()`, for the same reason as `lastAckedTrim`: the thing being
+    /// protected is the ROLLING LOG, which belongs to the process, not to one offload session. The
+    /// auto-continue re-kicks up to 24 sessions per connection, so a per-session budget would allow
+    /// 24 x 24 frames and flood the buffer exactly as before, which is the shape the reporter hit.
+    private(set) var rejectHexBudget = Backfiller.rejectHexDumpBudget
+    /// Reject frames seen this session, so the suppression line can say what it stopped showing.
+    private var rejectFramesSeen = 0
+    private var rejectHexSuppressedNoted = false
 
     /// Per-session persistence tally — the success-side observability the log forensics flagged as the
     /// blind spot (#150): we logged FAILURES (decoded-to-0) but never SUCCESSES, so a strap log couldn't
@@ -182,6 +192,26 @@ final class Backfiller {
     /// stops it re-kicking forever when the cursor is frozen. nil until the first ack. NOT reset in
     /// `begin()` (it's a cross-session high-water mark, not a per-session tally).
     private(set) var lastAckedTrim: UInt32?
+
+    /// Reject frames one connection may hex-dump (#1992). Three chunks worth at the per-chunk cap:
+    /// enough distinct records to triangulate field offsets (v25 was mapped from 45, spread over many
+    /// logs), while leaving room in a 2000-line rolling buffer for the lines that give the dump context.
+    /// The complete records are always in the reject archive.
+    static let rejectHexDumpBudget = 24
+
+    /// How many reject frames this chunk may hex-dump, given what the session has already spent (#1992).
+    ///
+    /// The dump is the only channel carrying an unmapped layout's raw bytes to someone who can map it,
+    /// and it was bounded PER CHUNK with no session budget. On the straps it exists for that defeats
+    /// itself: a strap rejecting ~25 records per chunk, across many chunks and many sessions per
+    /// connection, emits 8 long hex lines each time, floods the 2000-line rolling log, and evicts its own
+    /// earlier dumps along with the context needed to read them.
+    ///
+    /// Pure, so the arithmetic is testable without a Backfiller. Kotlin twin: `hexDumpAllowance`.
+    static func hexDumpAllowance(_ rejectedCount: Int, _ budgetRemaining: Int,
+                                 perChunkCap: Int = 8) -> Int {
+        max(0, min(rejectedCount, perChunkCap, budgetRemaining))
+    }
 
     /// Distinct historical layout versions logged this session. Unlike `loggedUnmappedVersions` (which
     /// only fires for layouts NOOP can't decode), this surfaces the layout on a HEALTHY sync too, so a
@@ -714,7 +744,9 @@ final class Backfiller {
                 // prefix — v25/v26 records run ~84 B and the truncated tail is exactly where the
                 // unmapped motion/HR fields sit), and sample a few more so one log carries enough
                 // records to triangulate offsets. These only ever fire for unmapped firmware.
-                let sample = Array(rejected.prefix(8))
+                rejectFramesSeen += rejected.count
+                // #1992: spend from a SESSION budget, not a fresh 8 per chunk. See `hexDumpAllowance`.
+                let sample = Array(rejected.prefix(Backfiller.hexDumpAllowance(rejected.count, rejectHexBudget)))
                 var emptySkipped = 0
                 for (i, f) in sample.enumerated() {
                     // #1007: an all-zero frame has no record layout to map, so its hex dump is pure log
@@ -722,9 +754,18 @@ final class Backfiller {
                     if isEmptyRecordFrame(f) { emptySkipped += 1; continue }
                     let hex = f.map { String(format: "%02x", $0) }.joined()
                     log?("Backfill: rejected frame[\(i)] \(f.count)B: \(hex)")
+                    rejectHexBudget -= 1
                 }
                 if emptySkipped > 0 {
                     log?("Backfill: #1007 \(emptySkipped)/\(sample.count) sampled frame(s) all-zero (empty payload) - hex dump skipped")
+                }
+                // Say ONCE that the sample is capped, so a reader knows the dump is a sample rather than
+                // everything the strap sent, and where the rest lives.
+                if rejectHexBudget <= 0, !rejectHexSuppressedNoted {
+                    rejectHexSuppressedNoted = true
+                    log?("Backfill: hex dumps capped at \(Backfiller.rejectHexDumpBudget) frame(s) while this connection lasts "
+                         + "(\(rejectFramesSeen) reject frame(s) seen so far); the complete records are in the "
+                         + "reject archive. Sample is enough to map a layout (#1992)")
                 }
             }
             // Commit the decoded rows FIRST (durable). Doing this before the reject archive means a

--- a/StrandTests/BackfillerHexDumpBudgetTests.swift
+++ b/StrandTests/BackfillerHexDumpBudgetTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import Strand
+import WhoopProtocol
+import WhoopStore
+
+/// #1992: the reject hex dump spends ONE budget for the connection, not a fresh per-chunk allowance.
+///
+/// The dump is the only channel that carries an unmapped layout's raw bytes to someone who can map it.
+/// Bounded per chunk with no session cap, it defeated itself on exactly the straps it exists for: ~25
+/// rejects per chunk, many chunks, many sessions per connection, 8 long hex lines each time, flooding a
+/// 2000-line rolling log and evicting its own earlier dumps.
+///
+/// Kotlin twin: `RejectHexDumpBudgetTest`, which mirrors the six arithmetic cases. The scope test at
+/// the end has NO Kotlin counterpart on purpose: constructing an Android `Backfiller` in a plain JVM
+/// test needs a repository over a 152-method DAO with no fake in the tree, whereas Swift's store is a
+/// protocol with existing test fakes. The invariant is identical on both sides; only one platform can
+/// currently assert it.
+final class BackfillerHexDumpBudgetTests: XCTestCase {
+
+    private let cap = 8
+
+    @MainActor func testAChunkNeverDumpsMoreThanThePerChunkCap() {
+        XCTAssertEqual(Backfiller.hexDumpAllowance(50, 24), cap)
+    }
+
+    @MainActor func testAChunkNeverDumpsMoreThanItRejected() {
+        XCTAssertEqual(Backfiller.hexDumpAllowance(3, 24), 3)
+    }
+
+    /// The point of the change: successive chunks drain one budget rather than each getting a fresh 8.
+    @MainActor func testSuccessiveChunksDrainTheOneBudget() {
+        var budget = Backfiller.rejectHexDumpBudget
+        var dumped = 0
+        for _ in 0 ..< 10 {
+            let n = Backfiller.hexDumpAllowance(25, budget)
+            dumped += n
+            budget -= n
+        }
+        XCTAssertEqual(dumped, Backfiller.rejectHexDumpBudget,
+                       "ten chunks must not exceed the one budget")
+        XCTAssertEqual(budget, 0)
+    }
+
+    /// Once spent, later chunks dump nothing, which is what stops the flood.
+    @MainActor func testAnExhaustedBudgetDumpsNothing() {
+        XCTAssertEqual(Backfiller.hexDumpAllowance(25, 0), 0)
+    }
+
+    /// Never negative, however the counters are driven.
+    @MainActor func testTheAllowanceIsNeverNegative() {
+        XCTAssertEqual(Backfiller.hexDumpAllowance(0, 24), 0)
+        XCTAssertEqual(Backfiller.hexDumpAllowance(25, -5), 0)
+    }
+
+    /// The budget must clear more than one chunk, or the sample cannot span an offload.
+    @MainActor func testTheBudgetIsWorthMoreThanOneChunk() {
+        XCTAssertGreaterThan(Backfiller.rejectHexDumpBudget, cap)
+    }
+
+    // MARK: - The budget's SCOPE, which the arithmetic above cannot pin
+
+    /// A minimal store, mirroring the fakes the other Backfiller suites use. The protocol has no default
+    /// implementations, so every requirement is stubbed here.
+    private final class NoopStore: BackfillStoreWriting {
+        @discardableResult
+        func insert(_ streams: Streams, deviceId: String) async throws
+            -> (hr: Int, rr: Int, events: Int, battery: Int,
+                spo2: Int, skinTemp: Int, resp: Int, gravity: Int) {
+            (0, 0, 0, 0, 0, 0, 0, 0)
+        }
+        func enqueueRawBatch(_ meta: RawBatchMeta, frames: [[UInt8]]) async throws {}
+        func setCursor(_ name: String, _ value: Int) async throws {}
+        func cursor(_ name: String) async throws -> Int? { nil }
+    }
+
+    /// The budget must NOT reset when a session begins.
+    ///
+    /// This is the half of the change the pure arithmetic cannot see: `hexDumpAllowance` behaves
+    /// identically whether the budget is per session or per connection, so a test of it alone passes
+    /// either way. The auto-continue re-kicks up to 24 sessions per connection, so a per-session budget
+    /// would permit 24 x 24 frames and flood the rolling log exactly as before, which is the shape the
+    /// reporter hit. Same reasoning as `lastAckedTrim`, which is likewise not reset in `begin()`.
+    @MainActor func testBeginDoesNotRefillTheBudget() {
+        let backfiller = Backfiller(store: NoopStore(), deviceId: "test", ackTrim: { _, _ in }, log: { _ in })
+        XCTAssertEqual(backfiller.rejectHexBudget, Backfiller.rejectHexDumpBudget)
+
+        backfiller.begin(family: .whoop4)
+        XCTAssertEqual(backfiller.rejectHexBudget, Backfiller.rejectHexDumpBudget,
+                       "a fresh Backfiller starts full, so this only shows begin() did not zero it")
+
+        // A second session must inherit whatever the first spent, not start over.
+        backfiller.begin(family: .whoop4)
+        XCTAssertEqual(backfiller.rejectHexBudget, Backfiller.rejectHexDumpBudget,
+                       "begin() must never refill the budget: the rolling log it protects belongs to "
+                        + "the process, not to one offload session")
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -264,6 +264,19 @@ class Backfiller(
         private set
 
     /**
+     * #1992: reject frames still allowed to hex-dump (see [hexDumpAllowance]).
+     *
+     * Deliberately NOT reset in [begin], for the same reason as [lastAckedTrim]: the thing being
+     * protected is the ROLLING LOG, which belongs to the process, not to one offload session. The
+     * auto-continue re-kicks up to 24 sessions per connection, so a per-session budget would allow
+     * 24 x 24 frames and flood the buffer exactly as before, which is the shape the reporter hit.
+     */
+    private var rejectHexBudget: Int = REJECT_HEX_DUMP_BUDGET
+    /** Reject frames seen this session, so the suppression line can say what it stopped showing. */
+    private var rejectFramesSeen: Int = 0
+    private var rejectHexSuppressedNoted: Boolean = false
+
+    /**
      * Distinct historical record-layout versions logged this session. Before this, only the unmapped/
      * reject path surfaced a version, so a HEALTHY log never revealed which layout the strap emits
      * (v24/v25 on 4.0, v18/v26 on 5/MG) — exactly the firmware→layout signal triage needs. Reset in
@@ -554,7 +567,10 @@ class Backfiller(
                 // records run ~84 B and the truncated tail is exactly where the unmapped motion/HR
                 // fields sit), and sample a few more so one log carries enough records to triangulate
                 // offsets. These only ever fire for unmapped firmware.
-                val sample = rejected.take(8)
+                rejectFramesSeen += rejected.size
+                // #1992: spend from a SESSION budget, not a fresh 8 per chunk. See [hexDumpAllowance].
+                val allowance = hexDumpAllowance(rejected.size, rejectHexBudget)
+                val sample = rejected.take(allowance)
                 var emptySkipped = 0
                 sample.forEachIndexed { i, f ->
                     // #1007: an all-zero frame has no record layout to map, so its hex dump is pure log
@@ -562,9 +578,20 @@ class Backfiller(
                     if (isEmptyRecordFrame(f)) { emptySkipped++; return@forEachIndexed }
                     val hex = f.joinToString("") { "%02x".format(it) }
                     log("Backfill: rejected frame[$i] ${f.size}B: $hex")
+                    rejectHexBudget--
                 }
                 if (emptySkipped > 0) {
                     log("Backfill: #1007 $emptySkipped/${sample.size} sampled frame(s) all-zero (empty payload) - hex dump skipped")
+                }
+                // Say ONCE that the sample is capped, so a reader knows the dump is a sample rather than
+                // everything the strap sent, and where the rest lives.
+                if (rejectHexBudget <= 0 && !rejectHexSuppressedNoted) {
+                    rejectHexSuppressedNoted = true
+                    log(
+                        "Backfill: hex dumps capped at $REJECT_HEX_DUMP_BUDGET frame(s) while this connection lasts " +
+                            "($rejectFramesSeen reject frame(s) seen so far); the complete records are in the " +
+                            "reject archive. Sample is enough to map a layout (#1992)",
+                    )
                 }
             }
             // Commit the decoded rows FIRST (durable) — BEFORE the reject archive (#1006, matching the
@@ -721,6 +748,30 @@ class Backfiller(
     }
 
     companion object {
+        /**
+         * Reject frames one connection may hex-dump (#1992). Three chunks worth at the per-chunk
+         * cap: enough distinct records to triangulate field offsets (v25 was mapped from 45, spread
+         * across many logs), while leaving room in a 2000-line rolling buffer for the lines that
+         * give the dump its context. The complete records are always in the reject archive.
+         */
+        internal const val REJECT_HEX_DUMP_BUDGET = 24
+
+    /**
+         * How many reject frames this chunk may hex-dump, given what the session has already spent (#1992).
+         *
+         * The dump is the only channel carrying an unmapped layout's raw bytes to someone who can map it,
+         * and it was bounded PER CHUNK with no session budget. On the straps it exists for that defeats
+         * itself: a strap rejecting ~25 records per chunk, across many chunks and many sessions per
+         * connection, emits 8 long hex lines each time, floods the 2000-line rolling log, and evicts its own
+         * earlier dumps along with the context needed to read them. A session budget keeps a usable sample
+         * rather than a flood that rolls itself away.
+         *
+         * Pure, so the arithmetic is testable without constructing a Backfiller (which needs a repository
+         * over a 152-method DAO). Swift twin: `hexDumpAllowance`.
+         */
+        internal fun hexDumpAllowance(rejectedCount: Int, budgetRemaining: Int, perChunkCap: Int = 8): Int =
+            maxOf(0, minOf(rejectedCount, perChunkCap, budgetRemaining))
+
         /** Cursor name for the strap's safe-trim watermark. Matches the Swift `setCursor("strap_trim", ...)`. */
         const val STRAP_TRIM_CURSOR = "strap_trim"
 

--- a/android/app/src/test/java/com/noop/ble/RejectHexDumpBudgetTest.kt
+++ b/android/app/src/test/java/com/noop/ble/RejectHexDumpBudgetTest.kt
@@ -1,0 +1,60 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * #1992: the reject hex dump spends ONE budget for the connection, not a fresh per-chunk allowance.
+ *
+ * The dump is the only channel that carries an unmapped layout's raw bytes to someone who can map it.
+ * Bounded per chunk with no session cap, it defeated itself on exactly the straps it exists for: ~25
+ * rejects per chunk, many chunks, many sessions per connection, 8 long hex lines each time, flooding a
+ * 2000-line rolling log and evicting its own earlier dumps.
+ *
+ * Swift twin: `BackfillerHexDumpBudgetTests`. It carries one case more: that `begin()` does not refill
+ * the budget, which is what makes it a per-CONNECTION cap rather than a per-session one. That cannot be
+ * asserted here, because constructing a Backfiller in a plain JVM test needs a repository over a
+ * 152-method DAO with no fake in the tree. The invariant holds on both sides; only Swift can pin it.
+ */
+class RejectHexDumpBudgetTest {
+
+    private val cap = 8
+
+    @Test fun aChunkNeverDumpsMoreThanThePerChunkCap() {
+        assertEquals(cap, Backfiller.hexDumpAllowance(rejectedCount = 50, budgetRemaining = 24))
+    }
+
+    @Test fun aChunkNeverDumpsMoreThanItRejected() {
+        assertEquals(3, Backfiller.hexDumpAllowance(rejectedCount = 3, budgetRemaining = 24))
+    }
+
+    /** The point of the change: successive chunks drain one budget rather than each getting a fresh 8. */
+    @Test fun successiveChunksDrainTheOneBudget() {
+        var budget = Backfiller.REJECT_HEX_DUMP_BUDGET
+        var dumped = 0
+        repeat(10) {
+            val n = Backfiller.hexDumpAllowance(rejectedCount = 25, budgetRemaining = budget)
+            dumped += n
+            budget -= n
+        }
+        assertEquals("ten chunks must not exceed the one budget",
+            Backfiller.REJECT_HEX_DUMP_BUDGET, dumped)
+        assertEquals(0, budget)
+    }
+
+    /** Once spent, later chunks dump nothing, which is what stops the flood. */
+    @Test fun anExhaustedBudgetDumpsNothing() {
+        assertEquals(0, Backfiller.hexDumpAllowance(rejectedCount = 25, budgetRemaining = 0))
+    }
+
+    /** Never negative, however the counters are driven. */
+    @Test fun theAllowanceIsNeverNegative() {
+        assertEquals(0, Backfiller.hexDumpAllowance(rejectedCount = 0, budgetRemaining = 24))
+        assertEquals(0, Backfiller.hexDumpAllowance(rejectedCount = 25, budgetRemaining = -5))
+    }
+
+    /** The budget must clear more than one chunk, or the sample cannot span an offload. */
+    @Test fun theBudgetIsWorthMoreThanOneChunk() {
+        assertEquals(true, Backfiller.REJECT_HEX_DUMP_BUDGET > cap)
+    }
+}


### PR DESCRIPTION
Addresses the capture half of #1992. This does not decode v20; it makes the diagnostic that exists to capture it actually deliver.

## The diagnostic was destroying its own output

The hex dump of undecodable record frames is the only channel carrying an unmapped layout's raw bytes to someone who can map it. It was bounded **per chunk**, eight frames, with no session budget, while the explanatory message beside it was correctly gated once per layout version.

On exactly the straps it exists for, that defeats itself. The reporter's 5/MG rejected about 25 records per chunk, over many chunks, across **fifteen sessions in one connection**. Eight long hex lines per chunk floods a 2000-line rolling buffer, so the dump evicted its own earlier frames along with the lines needed to interpret them. Fifteen sessions of an unmapped v20 layout produced nothing usable, and that is the likeliest reason this layout has never been mapped despite the dump existing since the v25 work.

## The change

Both platforms spend **one budget of 24 frames**, three chunks' worth, across the whole connection rather than resetting each chunk. When it is exhausted they say so once: how many reject frames were seen, and that the complete records are in the reject archive. The per-chunk cap of 8 and the all-zero skip are unchanged, so a strap with a couple of bad chunks behaves exactly as before.

24 is enough to work with: v25 was mapped from 45 records spread over many logs, and nothing is lost either way since the archive keeps everything.

### The budget is per CONNECTION, not per session

Deliberately not reset in `begin()`, for the same reason `lastAckedTrim` is not: what it protects is the rolling log, which belongs to the process rather than to one offload session.

I had it per session at first, and re-reviewing caught that it would not have fixed the reported case. The auto-continue re-kicks up to **24 sessions per connection**, so a per-session budget permits 24 x 24 = 576 frames and floods a 2000-line buffer exactly as before. It would have looked like a fix and improved nothing for the person who reported it.

## Why a pure helper

`hexDumpAllowance(rejectedCount, budgetRemaining, perChunkCap)` on both sides, because constructing a `Backfiller` in a plain JVM test needs a repository over a 152-method DAO with no fake in the tree. That is the same obstacle a contributor hit on #1980 and declared rather than worked around; extracting the arithmetic gets it under test without inventing a fake.

Six mirrored tests each, including that ten chunks cannot exceed the one budget and that the allowance never goes negative however the counters are driven.

Swift carries a **seventh**: that `begin()` does not refill the budget. The arithmetic alone cannot see that, since `hexDumpAllowance` behaves identically either way, so the six pass whichever scope is chosen. Swift's store is a protocol with existing test fakes, so it can assert the scope; the Android `Backfiller` needs a repository over a 152-method DAO with no fake in the tree, so it cannot yet. Both test files say so, rather than leaving a silent 7-versus-6 count for someone to rediscover.

## Verification

Android suite: 669 classes, 5,655 tests, 0 failures. `doc_comment_lint.py` clean. Swift rests on CI as always.

## Not addressed here

Android still has no user-facing line telling anyone an unmapped layout is a problem or asking them to report it, so its users are never prompted for the capture this improves. Flagged on #1993 and still open.
