### PR TITLE
today: tap a hero ring to open its metric detail

### DIFF
--- a/Strand/Liquid/LiquidPrimitives.swift
+++ b/Strand/Liquid/LiquidPrimitives.swift
@@ -211,6 +211,25 @@ enum LiquidRender {
 
 // MARK: - Views
 
+/// Applies the splash tap either as a normal tap (consuming it) or as a simultaneous gesture (sharing
+/// it with whatever wraps the view).
+///
+/// A plain `onTapGesture` inside a `NavigationLink` swallows the tap, so the link never pushes. That is
+/// why the hero rings could splash but not navigate. `simultaneousGesture` lets both run, which is the
+/// behaviour a tappable gauge wants; standalone vessels keep the consuming tap so nothing else changes.
+private struct LiquidSplashTap: ViewModifier {
+    let passesThrough: Bool
+    let action: () -> Void
+
+    func body(content: Content) -> some View {
+        if passesThrough {
+            content.simultaneousGesture(TapGesture().onEnded { action() })
+        } else {
+            content.onTapGesture { action() }
+        }
+    }
+}
+
 /// A circular liquid gauge. `value` is 0...1 (nil = empty/no-data). Tap → splash.
 ///
 /// `animated: false` renders a single static frame (no TimelineView, no CoreMotion) — the small
@@ -220,16 +239,24 @@ struct LiquidVessel: View {
     let value: Double?
     let tint: Color
     var animated: Bool = true
+    /// When the vessel sits inside a NavigationLink or Button, the splash tap must not CONSUME the
+    /// tap or the wrapping control never fires. Opt in and the splash runs as a simultaneous gesture
+    /// instead, so both happen: the liquid still splashes and the link still pushes. Default false
+    /// keeps every standalone vessel byte-identical (#1995).
+    var tapPassesThrough: Bool = false
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ObservedObject private var motion = NoopMotionState.shared
     @State private var sim: LiquidSim
     @State private var splashes = 0
 
-    init(value: Double?, tint: Color, animated: Bool = true) {
+    // The custom init exists to seed `_sim` from `value`, which also means the memberwise init is NOT
+    // synthesised: any new stored property has to be threaded through here or callers cannot pass it.
+    init(value: Double?, tint: Color, animated: Bool = true, tapPassesThrough: Bool = false) {
         self.value = value
         self.tint = tint
         self.animated = animated
+        self.tapPassesThrough = tapPassesThrough
         _sim = State(initialValue: LiquidSim(target: value ?? 0))
     }
 
@@ -250,7 +277,7 @@ struct LiquidVessel: View {
         }
         .aspectRatio(1, contentMode: .fit)
         .contentShape(Circle())
-        .onTapGesture { sim.splash(12); splashes &+= 1 }
+        .modifier(LiquidSplashTap(passesThrough: tapPassesThrough) { sim.splash(12); splashes &+= 1 })
         .liquidTapHaptic(trigger: splashes)   // light tap feedback (guarded so the primitives compile on macOS 13)
         .onAppear { LiquidMotion.shared.acquire() }
         .onDisappear { LiquidMotion.shared.release() }
@@ -425,6 +452,8 @@ struct LiquidScoreGauge: View {
     var captionText: String? = nil
     var numberColor: Color = StrandPalette.textPrimary
     var captionColor: Color = StrandPalette.textTertiary
+    /// Forwarded to `LiquidVessel` so a gauge inside a link still splashes AND still navigates (#1995).
+    var tapPassesThrough: Bool = false
 
     @State private var shown: Double = 0
 
@@ -434,7 +463,8 @@ struct LiquidScoreGauge: View {
 
     var body: some View {
         ZStack {
-            LiquidVessel(value: frac, tint: tint, animated: animated)
+            LiquidVessel(value: frac, tint: tint, animated: animated,
+                         tapPassesThrough: tapPassesThrough)
                 .frame(width: diameter, height: diameter)
             VStack(spacing: captionText == nil ? 0 : 1) {
                 Group {

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -659,7 +659,8 @@ struct LiquidTodayView: View {
             // Activity (`Repository.widgetAnchor`) and Android. Effort deliberately does NOT carry — it is
             // today's own accumulation, so yesterday's number would be a false statement, not a stale one.
             HeroScoreCell(label: String(localized: "Charge"), score: chargeDisplay.pct, tint: StrandPalette.chargeColor,
-                          animated: dataLoaded, onGuide: { guideSection = .charge })
+                          animated: dataLoaded, onGuide: { guideSection = .charge },
+                          detailRoute: .metric("recovery"))
             // #45: the hero Effort must honour the user's Effort scale like every other Effort read-out.
             // Show the value on the chosen scale (0–100 or WHOOP 0–21) with the matching vessel max, and
             // one decimal on the compressed 0–21 axis to match the app-wide `effortDisplay` convention
@@ -669,9 +670,11 @@ struct LiquidTodayView: View {
                           tint: StrandPalette.effortColor, animated: dataLoaded,
                           onGuide: { guideSection = .effort },
                           maxValue: effortScale == .whoop ? 21 : 100,
-                          decimals: effortScale == .whoop ? 1 : 0)
+                          decimals: effortScale == .whoop ? 1 : 0,
+                          detailRoute: .metric("strain"))
             HeroScoreCell(label: String(localized: "Rest"), score: restScore, tint: StrandPalette.restColor,
-                          animated: dataLoaded, onGuide: { guideSection = .rest })
+                          animated: dataLoaded, onGuide: { guideSection = .rest },
+                          detailRoute: .metric("sleep_performance"))
                 .overlay(alignment: .top) {
                     if let sourceLabel = heroSourceLabel {
                         SourceBadge("\(sourceLabel)", tint: StrandPalette.textSecondary)
@@ -2055,17 +2058,52 @@ private struct HeroScoreCell: View {
     // Decimal places for the displayed number. 0 keeps the whole-number scores; the WHOOP 0–21 Effort
     // scale passes 1 to match the app-wide one-decimal `effortDisplay` convention (#45).
     var decimals: Int = 0
+    /// Where the GAUGE taps through to, or nil to keep the ring inert (#1995).
+    ///
+    /// Same `TabRoute.metric(key)` the Recovery Vitals rows use, so a ring and the Key-Metrics tile for
+    /// the same score land on the identical dossier rather than diverging. The LABEL keeps its own job:
+    /// it opens the scoring guide, which is this screen's only route to that explainer.
+    var detailRoute: TabRoute? = nil
+
+    /// The gauge, linked when there is somewhere to go.
+    ///
+    /// Built here rather than inline so the linked and plain forms stay in one place and the body reads
+    /// as three stacked elements rather than a branch.
+    @ViewBuilder
+    private var gaugeView: some View {
+        let gauge = LiquidScoreGauge(
+            score: score,
+            tint: tint,
+            diameter: Self.vesselDiameter,
+            animated: animated,
+            maxValue: maxValue,
+            decimals: decimals,
+            tapPassesThrough: detailRoute != nil
+        )
+        if let detailRoute {
+            NavigationLink(value: detailRoute) { gauge }
+                .buttonStyle(LiquidPressStyle())
+                // The ring is what shows the NUMBER, so its spoken label carries the number too. Without
+                // this a VoiceOver user hears only the metric name on the element displaying the value,
+                // while the label below it reads the score, which is backwards.
+                .accessibilityLabel(Text("\(label), \(spokenScore)"))
+                .accessibilityHint(Text("Opens the trend and readings"))
+        } else {
+            gauge
+        }
+    }
+
+    /// The score as VoiceOver should say it, matching the label row's own phrasing.
+    private var spokenScore: String {
+        guard let score else { return String(localized: "no data yet") }
+        return decimals > 0
+            ? String(format: "%.\(decimals)f", locale: AppLanguage.activeLocale, score)
+            : String(Int(score.rounded()))
+    }
 
     var body: some View {
         VStack(spacing: 7) {
-            LiquidScoreGauge(
-                score: score,
-                tint: tint,
-                diameter: Self.vesselDiameter,
-                animated: animated,
-                maxValue: maxValue,
-                decimals: decimals
-            )
+            gaugeView
             Button(action: onGuide) {
                 HStack(spacing: 3) {
                     // #74: one line, shrink-to-fit rather than wrap under large Dynamic Type (mirrors the
@@ -2079,7 +2117,7 @@ private struct HeroScoreCell: View {
                 .foregroundStyle(StrandPalette.textSecondary)
             }
             .buttonStyle(.plain)
-            .accessibilityLabel(Text("\(label), \(score.map { decimals > 0 ? String(format: "%.\(decimals)f", locale: AppLanguage.activeLocale, $0) : String(Int($0.rounded())) } ?? String(localized: "no data yet")). See how it is scored."))
+            .accessibilityLabel(Text("\(label), \(spokenScore). See how it is scored."))
         }
         .frame(maxWidth: .infinity)
     }

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -210232,6 +210232,17 @@
         "ru": {"stringUnit": {"state": "translated", "value": "Пересчитывает абсолютные °C для ночей, до которых не доходит окно в 21 ночь, тем же алгоритмом, что и обычный расчёт. Только заполняет: измеренное значение никогда не перезаписывается. Результат смотрите в журнале ремешка."}},
         "zh-Hans": {"stringUnit": {"state": "translated", "value": "用与评分流程相同的漏斗，为 21 晚窗口未覆盖的夜晚重新推导绝对温度（°C）。仅填充：绝不覆盖已测量的值。结果见腕带日志。"}},
         "zh-Hant": {"stringUnit": {"state": "translated", "value": "以與評分流程相同的漏斗，為 21 晚視窗未涵蓋的夜晚重新推導絕對溫度（°C）。僅填充：絕不覆寫已測量的值。結果見腕帶日誌。"}}
+    } },
+    "Opens the trend and readings": { "localizations": {
+        "de": {"stringUnit": {"state": "translated", "value": "Öffnet den Trend und die Messwerte"}},
+        "es": {"stringUnit": {"state": "translated", "value": "Abre la tendencia y las lecturas"}},
+        "fr": {"stringUnit": {"state": "translated", "value": "Ouvre la tendance et les relevés"}},
+        "it": {"stringUnit": {"state": "translated", "value": "Apre l'andamento e le letture"}},
+        "pl": {"stringUnit": {"state": "translated", "value": "Otwiera trend i odczyty"}},
+        "pt-PT": {"stringUnit": {"state": "translated", "value": "Abre a tendência e as leituras"}},
+        "ru": {"stringUnit": {"state": "translated", "value": "Открывает тренд и показания"}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "打开趋势和读数"}},
+        "zh-Hant": {"stringUnit": {"state": "translated", "value": "開啟趨勢與讀數"}}
     } }
   },
   "version": "1.0"

--- a/StrandTests/HeroRingDetailRouteTests.swift
+++ b/StrandTests/HeroRingDetailRouteTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import Strand
+
+/// #1995: the three hero rings tap through to their metric dossier, so the ring and the Key-Metrics tile
+/// for the same score reach the identical screen.
+///
+/// `TabRoute.metric(key)` resolves through `MetricCatalog.all` and, when a key does not match, falls back
+/// to the Health screen rather than failing. That fallback is the reason these assertions exist: rename a
+/// catalog key and the ring would keep working, keep animating, and quietly land on the wrong screen. No
+/// crash, no log, nothing to notice. Pinning the three keys here turns that into a build failure.
+///
+/// The Key-Metrics tiles below the rings pass these same three keys, so this also guards the pair from
+/// drifting apart.
+final class HeroRingDetailRouteTests: XCTestCase {
+
+    /// Charge, Effort and Rest, in the order the hero row renders them.
+    private let heroKeys = ["recovery", "strain", "sleep_performance"]
+
+    func testEveryHeroRingKeyResolvesToACatalogMetric() {
+        for key in heroKeys {
+            XCTAssertNotNil(MetricCatalog.all.first(where: { $0.key == key }),
+                            "hero ring key '\(key)' is not in MetricCatalog, so its ring would silently "
+                             + "fall back to the Health screen instead of the metric")
+        }
+    }
+
+    /// Each key must name exactly one metric: two entries and the ring's destination depends on ordering.
+    func testEveryHeroRingKeyIsUnambiguous() {
+        for key in heroKeys {
+            XCTAssertEqual(MetricCatalog.all.filter { $0.key == key }.count, 1,
+                           "hero ring key '\(key)' must match exactly one catalog entry")
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.DirectionsRun
 import androidx.compose.material.icons.automirrored.filled.DirectionsWalk
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.ShowChart
 import androidx.compose.material.icons.filled.Accessibility
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Air
@@ -1515,6 +1516,7 @@ fun TodayScreen(
                                         historyPendingSync = live.historyPendingSync,
                                         isTodaySelected = selectedDayOffset == 0,
                                     ),
+                                    onOpenMetric = onOpenMetric,
                                 )
                             }
                             // Honest "why is Effort 0?" caption — only when today's Effort is a real
@@ -1802,6 +1804,10 @@ fun TodayScreen(
                 onHowCalculated = {
                     showChargeBreakdown = false
                     openGuide(ScoreSection.CHARGE)
+                },
+                onOpenTrend = {
+                    showChargeBreakdown = false
+                    onOpenMetric(HERO_CHARGE_METRIC_KEY)
                 },
             )
         }
@@ -2553,6 +2559,16 @@ private fun LiquidWordmark() {
     }
 }
 
+/// Vital-detail keys the hero rings open (#1995).
+///
+/// These are the keys `VitalDetailScreen`'s `when` accepts, NOT the metricSeries keys. Rest is the
+/// difference that bites: its detail key is "rest" while the series underneath it is
+/// "sleep_performance", which is what iOS routes on. An unknown key falls through that `when` to a null
+/// model and renders an empty screen, so the pairing is pinned by `HeroRingMetricKeyTest`.
+internal const val HERO_CHARGE_METRIC_KEY = "recovery"
+internal const val HERO_EFFORT_METRIC_KEY = "strain"
+internal const val HERO_REST_METRIC_KEY = "rest"
+
 // MARK: - Score hero row, three Charge / Effort / Rest score vessels
 //
 // The liquid Today hero: three equal daily-score vessels in Charge / Effort / Rest order, with a tappable
@@ -2575,6 +2591,11 @@ private fun ScoreHeroRow(
     // #1164: pending-sync state for today's Rest (strap has banked records not yet offloaded). When true
     // the Rest vessel shows "Pending sync" instead of a provisional number that will change.
     restPendingSync: Boolean = false,
+    // #1995: tapping the Effort or Rest ring opens that score's own vital detail, the same trend the
+    // metric cards below already push, so the ring and its card can never lead to different screens.
+    // Charge keeps `onChargeTap` (its breakdown sheet), which is richer than a trend and has no twin on
+    // the iOS liquid Today. Defaulted to a no-op so the ring stays inert where a host does not bind it.
+    onOpenMetric: ((String) -> Unit)? = null,
 ) {
     val recovery = day?.recovery
     // Prefer the live in-progress Effort for today, but never BELOW the day's already-earned strain
@@ -2672,6 +2693,7 @@ private fun ScoreHeroRow(
                     modifier = Modifier.width(col),
                     domain = DomainTheme.Effort,
                     onInfo = { onScoreInfo(ScoreSection.EFFORT) },
+                    onRingTap = onOpenMetric?.let { open -> { open(HERO_EFFORT_METRIC_KEY) } },
                 ) {
                     Box(contentAlignment = Alignment.Center) {
                         HeroScoreVessel(
@@ -2693,6 +2715,7 @@ private fun ScoreHeroRow(
                         modifier = Modifier.width(col),
                         domain = DomainTheme.Rest,
                         onInfo = { onScoreInfo(ScoreSection.REST) },
+                        onRingTap = onOpenMetric?.let { open -> { open(HERO_REST_METRIC_KEY) } },
                     ) {
                         Box(contentAlignment = Alignment.Center) {
                             HeroScoreVessel(
@@ -4636,6 +4659,15 @@ internal fun ChargeBreakdownSheet(
     showReadiness: Boolean,
     onClose: () -> Unit,
     onHowCalculated: () -> Unit,
+    // #1995: the Charge ring opens THIS sheet rather than the trend, because the sheet's other entry
+    // (the Synthesis card) sits in a section the user can hide, so routing the ring away could orphan it.
+    // The trend is therefore reachable from inside, which keeps every hero ring leading to its own
+    // score's detail while Charge's stays the richer one.
+    //
+    // Null renders NO row, which is why CoupledScreen passes nothing: that screen has no metric
+    // navigation at all, so a link there would be a dead one. A host that cannot go somewhere should
+    // not offer to.
+    onOpenTrend: (() -> Unit)? = null,
 ) {
     Surface(modifier = Modifier.fillMaxSize(), color = Palette.surfaceBase) {
         Column(modifier = Modifier.fillMaxSize()) {
@@ -4670,6 +4702,49 @@ internal fun ChargeBreakdownSheet(
                 // S4: the SEPARATE Readiness block now lives here behind the Charge-ring tap (today-only,
                 // matching the old inline gate). A one-word read (Push / Maintain / Rest) stays on the hero.
                 if (showReadiness) ReadinessSection(days, carriedDay = carriedDay)
+                onOpenTrend?.let { openTrend ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(14.dp))
+                            .clickable(
+                                onClickLabel = uiString(R.string.l10n_today_screen_see_the_charge_trend_9dcbcff7),
+                                onClick = openTrend,
+                            )
+                            .background(Palette.surfaceInset)
+                            .padding(14.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ShowChart,
+                            contentDescription = null,
+                            tint = DomainTheme.Charge.color,
+                            modifier = Modifier.size(14.dp),
+                        )
+                        Column(
+                            modifier = Modifier.weight(1f),
+                            verticalArrangement = Arrangement.spacedBy(1.dp),
+                        ) {
+                            Text(
+                                uiString(R.string.l10n_today_screen_see_the_charge_trend_9dcbcff7),
+                                style = NoopType.subhead,
+                                color = Palette.textPrimary,
+                            )
+                            Text(
+                                uiString(R.string.l10n_today_screen_every_day_s_score_over_time_a00ea7c7),
+                                style = NoopType.caption,
+                                color = Palette.textTertiary,
+                            )
+                        }
+                        Icon(
+                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = null,
+                            tint = Palette.textTertiary,
+                            modifier = Modifier.size(12.dp),
+                        )
+                    }
+                }
                 // Everything above is what shaped YOUR Charge today; this opens the general METHOD behind the
                 // score, so the two are clearly separated, not conflated. Opens the scoring guide at the
                 // Charge section, the same target the per-ring ⓘ buttons use. Mirrors the iOS chargeBreakdown

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2755,4 +2755,6 @@
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Aktualisiert %1$s</string>
     <string name="widget_hr_name">NOOP Herzfrequenz</string>
     <string name="widget_hr_description">Live-Herzfrequenz mit den letzten drei Stunden als Verlauf.</string>
+    <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Ladungs-Trend ansehen</string>
+    <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Jeder Tageswert im Zeitverlauf.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2742,4 +2742,6 @@
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Actualizado %1$s</string>
     <string name="widget_hr_name">NOOP Frecuencia cardíaca</string>
     <string name="widget_hr_description">Frecuencia cardíaca en directo con las últimas tres horas como gráfico.</string>
+    <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Ver la tendencia de Carga</string>
+    <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">La puntuación de cada día, a lo largo del tiempo.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2741,4 +2741,6 @@
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Mis à jour %1$s</string>
     <string name="widget_hr_name">NOOP Fréquence cardiaque</string>
     <string name="widget_hr_description">Fréquence cardiaque en direct avec les trois dernières heures en courbe.</string>
+    <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Voir la tendance de la charge</string>
+    <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Le score de chaque jour, dans la durée.</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2746,4 +2746,6 @@
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Zaktualizowano %1$s</string>
     <string name="widget_hr_name">NOOP Tętno</string>
     <string name="widget_hr_description">Tętno na żywo z ostatnimi trzema godzinami jako wykres.</string>
+    <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Zobacz trend Energii</string>
+    <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Wynik każdego dnia w czasie.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2734,4 +2734,6 @@
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Atualizado %1$s</string>
     <string name="widget_hr_name">NOOP Frequência cardíaca</string>
     <string name="widget_hr_description">Frequência cardíaca em direto com as últimas três horas em gráfico.</string>
+    <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Ver a tendência da Carga</string>
+    <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">A pontuação de cada dia, ao longo do tempo.</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -2625,4 +2625,6 @@
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Обновлено %1$s</string>
     <string name="widget_hr_name">NOOP Пульс</string>
     <string name="widget_hr_description">Пульс в реальном времени и график за последние три часа.</string>
+    <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Посмотреть динамику Заряда</string>
+    <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Оценка за каждый день во времени.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2655,4 +2655,6 @@
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">更新于 %1$s</string>
     <string name="widget_hr_name">NOOP 心率</string>
     <string name="widget_hr_description">实时心率，并显示最近三小时的曲线。</string>
+    <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">查看充能趋势</string>
+    <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">每天的分数，随时间变化。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2771,4 +2771,6 @@
     <string name="units_kilometres">Kilometres</string>
     <string name="units_miles">Miles</string>
     <string name="units_follow_body">Follow body</string>
+    <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">See the Charge trend</string>
+    <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Every day\'s score, over time.</string>
 </resources>

--- a/android/app/src/test/java/com/noop/ui/HeroRingMetricKeyTest.kt
+++ b/android/app/src/test/java/com/noop/ui/HeroRingMetricKeyTest.kt
@@ -1,0 +1,58 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #1995: the Effort and Rest hero rings open their own vital detail, so the ring and the metric card
+ * below it can never lead to different screens.
+ *
+ * The keys are pinned because `VitalDetailScreen` resolves them through a `when` that ends in
+ * `else -> null`. An unrecognised key does not crash and does not log: it renders an empty detail. So a
+ * rename would leave the ring tappable, animating, and landing on a blank screen with nothing to notice.
+ *
+ * Rest is the one that bites. Its DETAIL key is "rest" while the series underneath it is
+ * "sleep_performance", which is what the iOS side routes on. Using the iOS key here would compile, run,
+ * and silently show nothing.
+ *
+ * LIMIT, stated rather than implied: [supportedDetailKeys] below is a MIRROR of the `when` in
+ * VitalDetailScreen, maintained by hand. It catches a change to the hero constants, which is the likely
+ * edit, but it cannot catch someone renaming a branch of that `when`. Making it real would mean driving
+ * the screen's own resolution from a shared set, which is a bigger change than this one.
+ */
+class HeroRingMetricKeyTest {
+
+    /** The keys `VitalDetailScreen`'s `when` accepts, as of this test. */
+    private val supportedDetailKeys = setOf(
+        "recovery", "strain", "resp", "spo2", "rhr", "hrv", "skin", "rest",
+        "fitness_age", "vitality", "vo2max_est", "steps_est", "active_kcal",
+    )
+
+    @Test fun chargeOpensTheRecoveryDetail() {
+        assertEquals("recovery", HERO_CHARGE_METRIC_KEY)
+        assertTrue("the Charge trend link's key must be one VitalDetailScreen resolves",
+            HERO_CHARGE_METRIC_KEY in supportedDetailKeys)
+    }
+
+    @Test fun effortRingOpensTheEffortDetail() {
+        assertEquals("strain", HERO_EFFORT_METRIC_KEY)
+        assertTrue("the Effort ring's key must be one VitalDetailScreen resolves",
+            HERO_EFFORT_METRIC_KEY in supportedDetailKeys)
+    }
+
+    @Test fun restRingOpensTheRestDetail() {
+        assertEquals("rest", HERO_REST_METRIC_KEY)
+        assertTrue("the Rest ring's key must be one VitalDetailScreen resolves",
+            HERO_REST_METRIC_KEY in supportedDetailKeys)
+    }
+
+    /**
+     * The trap, stated as an assertion: "sleep_performance" is the SERIES key, not a detail key. Routing
+     * the Rest ring there would render an empty screen.
+     */
+    @Test fun theRestSeriesKeyIsNotADetailKey() {
+        assertTrue("sleep_performance is a metricSeries key; the detail resolves 'rest' instead",
+            "sleep_performance" !in supportedDetailKeys)
+    }
+}


### PR DESCRIPTION
A user asked for the hero rings on the liquid Today screen to open detail, so the Key Metrics tiles below are not the only way to reach a score's own data.

## What they did before

`HeroScoreCell` gave the ring a splash animation and nothing else. The label plus its chevron opened `ScoringGuideView`. So the card explained **how** Charge, Effort and Rest are calculated but offered no route to **what they actually are**, and the obvious target, the ring, did nothing but ripple.

Worth noting for anyone reading the earlier triage: this is `LiquidTodayView`, not `TodayView`. The classic screen's Charge ring does open a breakdown sheet; this one's does not, and never did. Same app, different Today.

## What changed

The gauge taps through to `TabRoute.metric(key)`, the same value-based route the **Recovery Vitals rows** already use, landing on the same `MetricDetailView` the Key-Metrics tile for that score pushes:

| ring | key | destination |
|---|---|---|
| Charge | `recovery` | its metric dossier |
| Effort | `strain` | its metric dossier |
| Rest | `sleep_performance` | its metric dossier |

Those are the exact keys the tiles beneath already pass, so a ring and the tile under it cannot lead to different screens.

**The label keeps its own job.** It still opens the scoring guide, which is this screen's only route to that explainer. The change adds a destination rather than replacing one.

## The splash survives, and that took a change

A plain `onTapGesture` inside a `NavigationLink` **consumes** the tap, so the link never fires. That is precisely why a gauge that splashes could not also navigate. `LiquidVessel` gains an opt-in `tapPassesThrough` which runs the splash as a `simultaneousGesture` instead, so both happen: the liquid still splashes and the link still pushes.

It defaults to `false`, so every other vessel in the app is byte-identical. Only the three hero rings opt in.

## Tests

Two, pinning the keys against `MetricCatalog`. This is not ceremony: `TabRoute.metric` falls back to the **Health screen** when a key does not resolve, and its own comment calls that fallback theoretical. Rename a catalog key and the ring would keep working, keep animating, and quietly land on the wrong screen with no crash and nothing in a log. These turn that into a build failure, and they also guard the ring/tile pair from drifting apart.

## Scope

## Android

The Effort and Rest rings get the same treatment, opening their own vital detail through the `onOpenMetric` callback the metric cards below already use, so a ring and its card cannot lead to different screens there either.

**The Rest key is not the same on the two platforms, and that is deliberate.** iOS routes on `sleep_performance`; Android's `VitalDetailScreen` resolves `rest`, and reads the `sleep_performance` series underneath it. Those are two namespaces: series keys and detail keys. Using the iOS key on Android would compile, run, and render an **empty screen**, because that `when` ends in `else -> null`, so there is no crash and nothing in a log. Both are named constants now, pinned by a test that also asserts `sleep_performance` is *not* a detail key, which is the mistake a future reader is most likely to make.

**Android's Charge ring still opens its breakdown sheet, and the sheet now offers the trend from inside.**

Routing the ring straight to the trend is the obvious way to make three identical-looking rings behave alike, and it is wrong. That sheet's only other entry is the Synthesis card, and `SYNTHESIS` is a `TodaySection` the user can hide, so anyone who has hidden it would lose the breakdown entirely. A "See the Charge trend" row beside the existing "How Charge is calculated" resolves the inconsistency without losing anything.

So on both platforms every hero ring now leads to that score's own detail. Charge's is simply the richer one on Android, with the trend one tap further in.

Android suite: 670 classes, 5,659 tests, 0 failures. `i18n_audit.py --ci --platform android` reports no new gaps.

Two new Android strings, added across all seven locales with keys generated by the repository's own algorithm, which I verified rather than assumed: `sha1("How Charge is calculated")[:8]` really is `142d5e8e`. Each locale uses its own established term for Charge (Ladung, Carga, charge, Energia, Carga, Заряд, 充能). Android says "Ladung" in German where iOS says "Energie"; that divergence pre-dates this and is left alone rather than quietly changed.

## Accessibility and localisation

The ring's spoken label carries the **score**, not just the metric name. The ring is the element showing the number, so a VoiceOver user hearing only "Charge" on it, while the label beneath reads the value, would have it backwards.

That needs one new hint string. I claimed in an earlier draft of this description that there were no new strings, which was wrong: `"Opens the trend and readings"` is new. It is appended to the catalogue with all nine non-English locales, text-spliced rather than round-tripped, so the diff is 11 lines rather than a reformat of a 6 MB file. `i18n_audit.py --ci` reports no new gaps.

Swift rests on CI as always.
