### PR TITLE
fix: let a tap on a liquid vessel reach the action its parent is wired to

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -1033,7 +1033,10 @@ struct LiquidTodayView: View {
     private func cardLinkBody(title: String, sub: String, value: String,
                               tint: Color, frac: Double?) -> some View {
         HStack(spacing: 12) {
-                LiquidVessel(value: frac, tint: tint, animated: false).frame(width: 30, height: 30)
+                // tapPassesThrough: the vessel's splash gesture would otherwise swallow the enclosing
+                // Button's tap, leaving a dead 30pt disc on the leading edge of a tappable card row.
+                LiquidVessel(value: frac, tint: tint, animated: false, tapPassesThrough: true)
+                    .frame(width: 30, height: 30)
                 VStack(alignment: .leading, spacing: 1) {
                     Text(title.uppercased()).font(StrandFont.overlineScaled(11)).tracking(1.0)
                         .foregroundStyle(StrandPalette.textPrimary)
@@ -1198,7 +1201,9 @@ struct LiquidTodayView: View {
     private func vitalRowBody(_ label: String, _ value: String, _ tint: Color, _ frac: Double?,
                               linked: Bool) -> some View {
         HStack(spacing: 12) {
-            LiquidVessel(value: frac, tint: tint, animated: false).frame(width: 26, height: 26)
+            // Same as cardLinkBody: without this the disc eats the row's NavigationLink tap.
+            LiquidVessel(value: frac, tint: tint, animated: false, tapPassesThrough: true)
+                .frame(width: 26, height: 26)
             Text(label).font(StrandFont.subhead).foregroundStyle(StrandPalette.textSecondary)
             Spacer()
             Text(value).font(StrandFont.number(15)).foregroundStyle(StrandPalette.textPrimary)

--- a/Strand/Screens/CoupledView.swift
+++ b/Strand/Screens/CoupledView.swift
@@ -408,8 +408,11 @@ struct CoupledView: View {
                         // Left: the SLEEP PERFORMANCE % as the liquid vessel (Rest world), with the score
                         // counting up over the fluid. Empty vessel when there's no scored performance.
                         ZStack {
+                            // heroCard opts its vessel out of hit testing so the Button owns the tap;
+                            // this ring keeps its splash instead and lets the NavigationLink run alongside.
                             LiquidVessel(value: sleepPerformance.map { max(0, min(1, $0 / 100)) },
-                                         tint: StrandPalette.restColor, animated: false)
+                                         tint: StrandPalette.restColor, animated: false,
+                                         tapPassesThrough: true)
                                 .frame(width: 88, height: 88)
                             if let p = sleepPerformance {
                                 CountUpText(value: p,

--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -827,9 +827,11 @@ private struct FitnessAgeSection: View {
                 HStack(alignment: .center, spacing: NoopMetrics.space5) {
                     // The signature liquid gauge anchors the hero: a vessel tinted to the Charge world,
                     // filled by how young the fitness age reads (younger = fuller), with the age counting
-                    // up over it. Same HeroScoreCell idiom as Today; taps fall through to the trend button.
+                    // up over it. Same HeroScoreCell idiom as Today. tapPassesThrough is what actually makes
+                    // taps reach the trend Button: a plain splash gesture on the vessel swallows them.
                     ZStack {
-                        LiquidVessel(value: fitnessAgeFraction(age), tint: StrandPalette.chargeColor, animated: true)
+                        LiquidVessel(value: fitnessAgeFraction(age), tint: StrandPalette.chargeColor,
+                                     animated: true, tapPassesThrough: true)
                             .frame(width: 96, height: 96)
                         CountUpNumber(value: Double(shown), font: StrandFont.rounded(30))
                             .foregroundStyle(.white)

--- a/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoupledScreen.kt
@@ -344,6 +344,8 @@ private fun HeroCard(
                         modifier = Modifier
                             .size(232.dp)
                             .alpha(if (isCarrying) 0.8f else 1f),
+                        // Without this the whole 232dp ring, which is most of the card, is a dead zone.
+                        onTap = onTap,
                     )
                     HeroCentre(recovery = recovery, readinessLevel = readinessLevel)
                 }
@@ -582,6 +584,7 @@ private fun SleepCard(
                     tint = Palette.restColor,
                     animated = sleepPerformance != null,
                     modifier = Modifier.size(96.dp),
+                    onTap = onOpenSleep,
                 )
                 if (sleepPerformance != null) {
                     CountUpText(

--- a/android/app/src/main/java/com/noop/ui/LiquidPrimitives.kt
+++ b/android/app/src/main/java/com/noop/ui/LiquidPrimitives.kt
@@ -76,6 +76,13 @@ fun LiquidVessel(
     tint: Color,
     animated: Boolean = true,
     modifier: Modifier = Modifier,
+    // #1995: run alongside the splash when the vessel is the tap target for something.
+    //
+    // The vessel owns a `clickable` for its splash, and in Compose a child's clickable CONSUMES the
+    // event, so a clickable parent never sees it. That silently broke the hero Charge ring: the column
+    // wrapped the vessel in a clickable Box and the tap never arrived. Passing the action IN, rather
+    // than wrapping the vessel, is what makes the ring both splash and act.
+    onTap: (() -> Unit)? = null,
 ) {
     val renderStill = rememberPoseStill()
 
@@ -114,6 +121,7 @@ fun LiquidVessel(
                     interactionSource = remember { MutableInteractionSource() },
                 ) {
                     sim.splash(12)
+                    onTap?.invoke()
                     // A LIGHT tap impact, matching iOS `.sensoryFeedback(.impact(weight: .light))`. Compose's
                     // HapticFeedbackType on this BOM only offers LongPress (heavy) / TextHandleMove, so route a
                     // light KEYBOARD_TAP through the platform view — the closest available light-impact tick.

--- a/android/app/src/main/java/com/noop/ui/LiquidPrimitives.kt
+++ b/android/app/src/main/java/com/noop/ui/LiquidPrimitives.kt
@@ -76,12 +76,18 @@ fun LiquidVessel(
     tint: Color,
     animated: Boolean = true,
     modifier: Modifier = Modifier,
-    // #1995: run alongside the splash when the vessel is the tap target for something.
+    // Runs when the vessel itself is tapped. ANY caller that wraps a vessel in a clickable parent has to
+    // hand that same action down here as well.
     //
-    // The vessel owns a `clickable` for its splash, and in Compose a child's clickable CONSUMES the
-    // event, so a clickable parent never sees it. That silently broke the hero Charge ring: the column
-    // wrapped the vessel in a clickable Box and the tap never arrived. Passing the action IN, rather
-    // than wrapping the vessel, is what makes the ring both splash and act.
+    // On the animated render the vessel owns a `clickable` for its splash, and in Compose a child's
+    // clickable CONSUMES the event, so the clickable parent never sees a touch that lands on the vessel.
+    // The hero rings and the Coupled cards were wrapped rather than wired, so their taps went nowhere.
+    // Passing the action IN, instead of wrapping, is what lets one tap both splash and act.
+    //
+    // `onTap` SUPPLEMENTS a clickable parent, it does not replace one. The still render (reduce-motion,
+    // power-save, quiet motion, or `animated = false`) attaches no clickable at all, so there a tap
+    // reaches the parent by itself. That is why the rings kept working for anyone with reduced motion,
+    // and why this went unnoticed for so long.
     onTap: (() -> Unit)? = null,
 ) {
     val renderStill = rememberPoseStill()
@@ -121,11 +127,12 @@ fun LiquidVessel(
                     interactionSource = remember { MutableInteractionSource() },
                 ) {
                     sim.splash(12)
-                    onTap?.invoke()
                     // A LIGHT tap impact, matching iOS `.sensoryFeedback(.impact(weight: .light))`. Compose's
                     // HapticFeedbackType on this BOM only offers LongPress (heavy) / TextHandleMove, so route a
                     // light KEYBOARD_TAP through the platform view — the closest available light-impact tick.
                     view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                    // Last: the splash and the tick are local feedback, and the action may navigate away.
+                    onTap?.invoke()
                 },
         ) {
             sim.step(now = seconds, tilt = LiquidMotion.shared.tilt, target = value ?: 0.0)
@@ -134,6 +141,9 @@ fun LiquidVessel(
     } else {
         // One-shot, cached render — posed at the fill line, no clock, no motion acquire.
         val posed = remember(value) { LiquidSim.posed(value ?: 0.0) }
+        // Deliberately NO clickable here: this branch has no splash to swallow with, so a tap falls
+        // straight through to whatever clickable parent the caller wrapped it in, which is the behaviour
+        // every caller already wants. Adding one would only take the parent's press animation away.
         Canvas(modifier = modifier.aspectRatio(1f)) {
             with(LiquidRender) { vessel(size = size, sim = posed, now = 0.0, tint = tint) }
         }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2649,6 +2649,8 @@ private fun ScoreHeroRow(
             ) {
                 // CHARGE, recovery 0–100, as a liquid VESSEL with the value counting up over it. Honest
                 // empty / calibrating overlay; badges its recovery winner.
+                val effortRingTap = onOpenMetric?.let { open -> { open(HERO_EFFORT_METRIC_KEY) } }
+                val restRingTap = onOpenMetric?.let { open -> { open(HERO_REST_METRIC_KEY) } }
                 HeroRingColumn(
                     modifier = Modifier.width(col),
                     domain = DomainTheme.Charge,
@@ -2671,6 +2673,7 @@ private fun ScoreHeroRow(
                                 diameter = ring,
                                 animated = animated,
                                 showsValue = true,
+                                onTap = onChargeTap,
                             )
                         } else {
                             HeroScoreVessel(
@@ -2680,6 +2683,7 @@ private fun ScoreHeroRow(
                                 diameter = ring,
                                 animated = animated,
                                 showsValue = recovery != null,
+                                onTap = onChargeTap,
                             )
                             // Empty vessel + calibrating / no-data overlay (the carried case is above).
                             if (recovery == null) RingEmptyOverlay(recoveryCalibration, diameter = ring)
@@ -2693,7 +2697,11 @@ private fun ScoreHeroRow(
                     modifier = Modifier.width(col),
                     domain = DomainTheme.Effort,
                     onInfo = { onScoreInfo(ScoreSection.EFFORT) },
-                    onRingTap = onOpenMetric?.let { open -> { open(HERO_EFFORT_METRIC_KEY) } },
+                    onRingTap = effortRingTap,
+                    ringTapLabel = uiString(
+                        R.string.today_action_open_detail,
+                        uiString(R.string.today_metric_effort),
+                    ),
                 ) {
                     Box(contentAlignment = Alignment.Center) {
                         HeroScoreVessel(
@@ -2704,6 +2712,7 @@ private fun ScoreHeroRow(
                             animated = animated,
                             showsValue = strain != null,
                             format = { if (effortScale == EffortScale.WHOOP) String.format(Locale.getDefault(), "%.1f", it) else it.toInt().toString() },
+                            onTap = effortRingTap,
                         )
                         if (strain == null) RingNoData(diameter = ring)
                     }
@@ -2715,7 +2724,11 @@ private fun ScoreHeroRow(
                         modifier = Modifier.width(col),
                         domain = DomainTheme.Rest,
                         onInfo = { onScoreInfo(ScoreSection.REST) },
-                        onRingTap = onOpenMetric?.let { open -> { open(HERO_REST_METRIC_KEY) } },
+                        onRingTap = restRingTap,
+                        ringTapLabel = uiString(
+                            R.string.today_action_open_detail,
+                            uiString(R.string.today_metric_rest),
+                        ),
                     ) {
                         Box(contentAlignment = Alignment.Center) {
                             HeroScoreVessel(
@@ -2725,6 +2738,7 @@ private fun ScoreHeroRow(
                                 diameter = ring,
                                 animated = animated,
                                 showsValue = restScore != null && !restPendingSync,
+                                onTap = restRingTap,
                             )
                             // #1164: when today's Rest is provisional (strap has banked records not yet
                             // offloaded), show "Pending sync" instead of a number that will change once the
@@ -2777,9 +2791,17 @@ private fun HeroRingColumn(
     domain: DomainTheme,
     onInfo: () -> Unit,
     modifier: Modifier = Modifier,
-    // A1: when non-null (Charge), the ring is tappable and opens the breakdown sheet. The chevron cue is
-    // overlaid by the caller INSIDE the ring box so it adds no stacked height (#762 self-sizing parity).
+    // A1: when non-null the ring is tappable , Charge opens the breakdown sheet, Effort and Rest open
+    // their metric detail (#1995). The chevron cue is overlaid by the caller INSIDE the ring box so it
+    // adds no stacked height (#762 self-sizing parity).
+    //
+    // This wires the tap for the ring's SURROUND and for TalkBack (which activates the semantics node
+    // directly). A touch that lands on the vessel itself never reaches here , see the onTap the callers
+    // hand to HeroScoreVessel.
     onRingTap: (() -> Unit)? = null,
+    // Charge's ring opens a breakdown, so "see what shaped" is honest there. Effort and Rest open a
+    // trend detail instead, so they override it rather than announce a breakdown they do not show.
+    ringTapLabel: String? = null,
     ring: @Composable () -> Unit,
 ) {
     val domainLabel = uiString(
@@ -2806,7 +2828,8 @@ private fun HeroRingColumn(
                     .clickable(
                         interactionSource = ringInteraction,
                         indication = null,
-                        onClickLabel = uiString(R.string.today_action_see_what_shaped, domainLabel),
+                        onClickLabel = ringTapLabel
+                            ?: uiString(R.string.today_action_see_what_shaped, domainLabel),
                         onClick = onRingTap,
                     ),
             ) { ring() }
@@ -2882,6 +2905,9 @@ private fun HeroScoreVessel(
     animated: Boolean = true,
     showsValue: Boolean = true,
     format: (Double) -> String = { it.roundToInt().toString() },
+    // #1995: forwarded to LiquidVessel so the ring can act on a tap as well as splash. Wrapping the
+    // vessel in a clickable parent does NOT work: its own clickable consumes the event first.
+    onTap: (() -> Unit)? = null,
 ) {
     Box(modifier = modifier.size(diameter), contentAlignment = Alignment.Center) {
         LiquidVessel(
@@ -2889,6 +2915,7 @@ private fun HeroScoreVessel(
             tint = tint,
             animated = animated,
             modifier = Modifier.size(diameter),
+            onTap = onTap,
         )
         if (showsValue) {
             // Count-up number over the vessel — white, tabular, a soft shadow for legibility, hit-transparent

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2791,12 +2791,12 @@ private fun HeroRingColumn(
     domain: DomainTheme,
     onInfo: () -> Unit,
     modifier: Modifier = Modifier,
-    // A1: when non-null the ring is tappable , Charge opens the breakdown sheet, Effort and Rest open
+    // A1: when non-null the ring is tappable. Charge opens the breakdown sheet; Effort and Rest open
     // their metric detail (#1995). The chevron cue is overlaid by the caller INSIDE the ring box so it
     // adds no stacked height (#762 self-sizing parity).
     //
     // This wires the tap for the ring's SURROUND and for TalkBack (which activates the semantics node
-    // directly). A touch that lands on the vessel itself never reaches here , see the onTap the callers
+    // directly). A touch that lands on the vessel itself never reaches here: see the onTap the callers
     // hand to HeroScoreVessel.
     onRingTap: (() -> Unit)? = null,
     // Charge's ring opens a breakdown, so "see what shaped" is honest there. Effort and Rest open a

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2312,6 +2312,7 @@
     <string name="today_action_how_charge">So wird Energie berechnet</string>
     <string name="today_action_reset_hr_zoom">Herzfrequenz-Zoom zurücksetzen</string>
     <string name="today_action_see_what_shaped">Einflüsse auf %1$s anzeigen</string>
+    <string name="today_action_open_detail">%1$s-Details öffnen</string>
     <string name="today_action_show_sources">Synchronisierte NOOP-Quellen anzeigen</string>
     <string name="today_action_show_workout">Workout-Details anzeigen</string>
     <string name="today_contributors">Einflussfaktoren</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2299,6 +2299,7 @@
     <string name="today_action_how_charge">Cómo se calcula la carga</string>
     <string name="today_action_reset_hr_zoom">Restablecer zoom de frecuencia cardíaca</string>
     <string name="today_action_see_what_shaped">Ver qué influyó en %1$s</string>
+    <string name="today_action_open_detail">Abrir el detalle de %1$s</string>
     <string name="today_action_show_sources">Mostrar las fuentes sincronizadas con NOOP</string>
     <string name="today_action_show_workout">Mostrar los detalles del entrenamiento</string>
     <string name="today_contributors">Factores</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2298,6 +2298,7 @@
     <string name="today_action_how_charge">Comment l’énergie est calculée</string>
     <string name="today_action_reset_hr_zoom">Réinitialiser le zoom de fréquence cardiaque</string>
     <string name="today_action_see_what_shaped">Voir ce qui a influencé %1$s</string>
+    <string name="today_action_open_detail">Ouvrir le détail %1$s</string>
     <string name="today_action_show_sources">Afficher les sources synchronisées avec NOOP</string>
     <string name="today_action_show_workout">Afficher les détails de la séance</string>
     <string name="today_contributors">Facteurs</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2291,6 +2291,7 @@
     <string name="today_action_how_charge">Jak obliczana jest energia</string>
     <string name="today_action_reset_hr_zoom">Zresetuj powiększenie tętna</string>
     <string name="today_action_see_what_shaped">Zobacz, co wpłynęło na %1$s</string>
+    <string name="today_action_open_detail">Otwórz szczegóły: %1$s</string>
     <string name="today_action_show_sources">Pokaż źródła synchronizowane z NOOP</string>
     <string name="today_action_show_workout">Pokaż szczegóły treningu</string>
     <string name="today_contributors">Czynniki</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2291,6 +2291,7 @@
     <string name="today_action_how_charge">Como a energia é calculada</string>
     <string name="today_action_reset_hr_zoom">Repor zoom da frequência cardíaca</string>
     <string name="today_action_see_what_shaped">Ver o que influenciou %1$s</string>
+    <string name="today_action_open_detail">Abrir o detalhe de %1$s</string>
     <string name="today_action_show_sources">Mostrar as fontes sincronizadas com o NOOP</string>
     <string name="today_action_show_workout">Mostrar os detalhes do treino</string>
     <string name="today_contributors">Contributos</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -2242,6 +2242,7 @@
     <string name="today_action_how_charge">Как рассчитывается Заряд</string>
     <string name="today_action_reset_hr_zoom">Сбросить масштаб пульса</string>
     <string name="today_action_see_what_shaped">Посмотреть, что сформировало ваш показатель %1$s</string>
+    <string name="today_action_open_detail">Открыть подробности: %1$s</string>
     <string name="today_action_show_sources">Показать, откуда синхронизируется NOOP</string>
     <string name="today_action_show_workout">Показать детали тренировки</string>
     <string name="today_contributors">Участники</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2222,6 +2222,7 @@
     <string name="today_action_how_charge">了解能量的计算方式</string>
     <string name="today_action_reset_hr_zoom">重置心率缩放</string>
     <string name="today_action_see_what_shaped">查看影响 %1$s 的因素</string>
+    <string name="today_action_open_detail">打开%1$s详情</string>
     <string name="today_action_show_sources">查看 NOOP 同步的数据源</string>
     <string name="today_action_show_workout">查看锻炼详情</string>
     <string name="today_contributors">影响因素</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2417,6 +2417,7 @@
     <string name="today_action_how_charge">How Charge is calculated</string>
     <string name="today_action_reset_hr_zoom">Reset the heart rate zoom</string>
     <string name="today_action_see_what_shaped">See what shaped your %1$s</string>
+    <string name="today_action_open_detail">Open your %1$s detail</string>
     <string name="today_action_show_sources">Show what NOOP is synced from</string>
     <string name="today_action_show_workout">Show workout detail</string>
     <string name="today_contributors">Contributors</string>


### PR DESCRIPTION
Reported on the 11.1.1 testing build: tapping any of the three hero rings on Today does nothing.

## Root cause

`LiquidVessel` puts a `clickable` on its own `Canvas` to drive the splash. In Compose a child's
`clickable` **consumes** the pointer event, so the clickable `Box` that `HeroRingColumn` wraps around the
ring never receives a touch that lands on the ring itself.

Charge's ring tap has been inert on Android for as long as it has existed, and the Effort and Rest rings
from #1995 were wired the same way and inherited it. The ring splashed on touch, which is exactly why it
looked like it was working.

Only the **animated** render attaches that clickable. The still render (reduce-motion, power-save, quiet
motion, or `animated = false`) attaches none, so the parent's tap works there. That is why the rings kept
working for some people, and a large part of why this went unnoticed.

## The fix

Pass the action **into** the vessel (`LiquidVessel(onTap:)`, forwarded through `HeroScoreVessel`) instead
of wrapping it, so a single tap both splashes and acts. `HeroRingColumn` keeps its own `clickable`: it
covers the ring's surround, and TalkBack activates that semantics node directly rather than by
synthesising a touch, so the accessible path was never broken and stays intact.

## The same defect elsewhere

Sweeping every `LiquidVessel` call site on both platforms found five more instances.

**Android, live:** `CoupledScreen.HeroCard` (232dp Charge vessel) and `SleepCard` (96dp sleep vessel) each
sit inside a clickable card, so most of each card was a dead zone whenever the value was present. Both now
hand their action down.

**Android, deliberately untouched:** `HeroVitalRow` and `DashboardCardRow` build their vessels with
`animated = false`, so they take the still render and their taps already reach the row.

**iOS:** there is no such branch. `LiquidSplashTap` is applied unconditionally, so `animated: false` is no
protection and the two equivalent Today rows **are** affected, along with `CoupledView.sleepCard`'s ring
and `HealthView`'s Fitness Age hero, whose comment claimed taps fell through to its `Button` when they did
not. All four take `tapPassesThrough`, the `simultaneousGesture` route added in #1995, so the splash and
the parent's tap both run.

## Accessibility label

#1995 left Effort and Rest announcing *"See what shaped your Effort"* for a ring that opens a trend detail
rather than a breakdown. They now announce *"Open your Effort detail"* (`today_action_open_detail`, added
to English and all seven translated locales). Charge does open a breakdown sheet, so it keeps the original
wording.

## Verification

- `compileFullDebugKotlin` clean
- full JVM suite green: 670 classes / 5659 tests, 0 failures
- `lintVitalFullRelease` clean (the new string is in every locale, no `ExtraTranslation`)
- `Tools/i18n_audit.py --ci` clean
- Swift is CI-verified only

No automated pin is possible for this one. The repo has no Compose UI test harness (`createComposeRule`
appears nowhere under `app/src/test` or `app/src/androidTest`), so gesture consumption is not reachable
from the JVM suite, which is a fair part of why this shipped broken.

On-device check needed: the three Today rings (Charge opens its breakdown, Effort and Rest open their
metric detail), the Coupled Charge and Sleep cards, and on iOS the Today vitals and dashboard rows, the
Coupled sleep ring, and the Fitness Age hero.
