### PR TITLE
diag: carry the bytes for an unmapped packet type, and sample every layout

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Spo2ReTrace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Spo2ReTrace.swift
@@ -19,9 +19,21 @@ import Foundation
 // rides in it). The Kotlin twin is Spo2ReTrace.kt; the emitted line is byte-identical on both platforms.
 public enum Spo2ReTrace {
 
-    /// Max records dumped per offload session. A handful is enough for an offline correlation pass and
-    /// keeps the strap log bounded; the Backfiller counter spans chunks and resets per session.
-    public static let maxSamples = 8
+    /// Max records dumped per offload session, across all layout versions. A handful is enough for an
+    /// offline correlation pass and keeps the strap log bounded; the Backfiller counter spans chunks and
+    /// resets per session.
+    public static let maxSamples = 12
+
+    /// Max records dumped per DISTINCT layout version, so the budget cannot be spent entirely on the
+    /// layout we already understand.
+    ///
+    /// The dump used to take the first `maxSamples` decodable records in arrival order. On a strap that
+    /// emits a dominant layout plus a rarer one, that spends the whole budget inside the first chunk on
+    /// the dominant layout — and the rare one is precisely the one still unmapped. The log would then
+    /// announce "historical records use layout vN" while carrying no bytes of vN at all: proof a thing
+    /// exists, with no material to work on it. Stratifying guarantees every layout the strap emits gets
+    /// samples, including one at 1% of traffic, and stops re-dumping a layout already at parity.
+    public static let maxPerVersion = 3
 
     /// One record's RE line: the mapped SpO2 channels + timestamp + layout version, then the FULL frame
     /// hex (no prefix cap - a v24 record is ~84 B and the unmapped tail is exactly where a banked SpO2

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Spo2ReTraceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/Spo2ReTraceTests.swift
@@ -31,7 +31,20 @@ final class Spo2ReTraceTests: XCTestCase {
         XCTAssertTrue(line.contains("v=null"), line)
     }
 
-    func testSampleCapBoundedAtEight() {
-        XCTAssertEqual(Spo2ReTrace.maxSamples, 8)
+    func testSampleCapBounded() {
+        XCTAssertEqual(Spo2ReTrace.maxSamples, 12)
+    }
+
+    /// The per-layout cap is what stops one dominant layout spending the whole session budget, and it
+    /// only does that if it is strictly smaller than the session cap.
+    func testPerVersionCapIsBoundedAndSmallerThanTheSessionCap() {
+        XCTAssertEqual(Spo2ReTrace.maxPerVersion, 3)
+        XCTAssertLessThan(Spo2ReTrace.maxPerVersion, Spo2ReTrace.maxSamples)
+    }
+
+    /// The session cap has to leave room for more than one layout, or stratifying changes nothing:
+    /// a 5/MG emits v18 alongside v20/v21/v26 and every one of them needs samples.
+    func testSessionCapCoversSeveralDistinctLayouts() {
+        XCTAssertGreaterThanOrEqual(Spo2ReTrace.maxSamples / Spo2ReTrace.maxPerVersion, 4)
     }
 }

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -199,6 +199,24 @@ final class Backfiller {
     /// The complete records are always in the reject archive.
     static let rejectHexDumpBudget = 24
 
+    /// #891: the dump line for the first frame of an unmapped packet type, or nil when this chunk holds
+    /// no frame of that type.
+    ///
+    /// Pure and static so the SELECTION is pinnable: the census names a type, and this has to find the
+    /// bytes that earned the name. Byte-identical to the Android line, which sources its hex from
+    /// `StreamBatch.unhandledPacketSamples` because the Kotlin extractor is handed raw ByteArrays and can
+    /// sample in place. Swift's extractor only sees `ParsedFrame`s whose `rawHex` is empty on the ingest
+    /// fast path (`collectFields: false`, D#969), so the bytes have to be zipped back in here.
+    /// Takes `typeNames` rather than the `ParsedFrame`s they came from: the selection only needs the
+    /// name, and `ParsedFrame`'s memberwise init is internal to WhoopProtocol, so a StrandTests case
+    /// cannot build one. A helper that cannot be called from its own test is not a testable helper.
+    static func unmappedTypeDumpLine(typeName: String, frames: [[UInt8]],
+                                     typeNames: [String]) -> String? {
+        guard let raw = zip(frames, typeNames).first(where: { $0.1 == typeName })?.0 else { return nil }
+        let hex = raw.map { String(format: "%02x", $0) }.joined()
+        return "Backfill: unmapped type \(typeName) first frame \(raw.count)B: \(hex)"
+    }
+
     /// How many reject frames this chunk may hex-dump, given what the session has already spent (#1992).
     ///
     /// The dump is the only channel carrying an unmapped layout's raw bytes to someone who can map it,
@@ -222,6 +240,11 @@ final class Backfiller {
     /// SpO2 RE dump (PR #945, reimplemented): how many full-record dumps this session emitted, bounded by
     /// `Spo2ReTrace.maxSamples`. Session-scoped so the cap spans chunks; reset per session in `begin`.
     private var spo2Dumped = 0
+
+    /// SpO2 RE dump: how many records this session dumped for each layout version, so one layout cannot
+    /// spend the whole session budget. Key -1 buckets a record whose `hist_version` did not decode.
+    /// Session-scoped alongside `spo2Dumped`; reset in `begin`. Twin of the Android `spo2DumpedByVersion`.
+    private var spo2DumpedByVersion: [Int: Int] = [:]
 
     /// Durably archives undecodable record frames BEFORE the trim ack (#77 / #91). Returns true once
     /// the bytes are safe (written OR cap-reached — either way the chunk may be acked) and false on a
@@ -320,6 +343,7 @@ final class Backfiller {
         sessionDynAccel = Streams.DynAccelDiag()
         loggedLayoutVersions.removeAll(keepingCapacity: true)
         spo2Dumped = 0
+        spo2DumpedByVersion = [:]
         // #547: the range markers belong to a connection's GET_DATA_RANGE, which BLEManager re-sets per
         // connect; clear them here so a fresh session never reuses a previous strap's window. BLEManager
         // re-publishes them as soon as the range reply arrives.
@@ -644,6 +668,11 @@ final class Backfiller {
             if spo2Dumped < Spo2ReTrace.maxSamples, connectionActive(), let connectionLog {
                 for (raw, p) in zip(frames, parsed) where spo2Dumped < Spo2ReTrace.maxSamples {
                     guard let unix = p.parsed["unix"]?.intValue else { continue }
+                    // Stratify by layout: without this the first chunk's dominant layout eats the whole
+                    // budget and the rare, still-unmapped one never gets a frame. See `maxPerVersion`.
+                    let ver = p.parsed["hist_version"]?.intValue ?? -1
+                    let dumpedForVer = spo2DumpedByVersion[ver] ?? 0
+                    if dumpedForVer >= Spo2ReTrace.maxPerVersion { continue }
                     connectionLog(Spo2ReTrace.recordLine(
                         frame: raw,
                         version: p.parsed["hist_version"]?.intValue,
@@ -651,6 +680,7 @@ final class Backfiller {
                         red: p.parsed["spo2_red"]?.intValue,
                         ir: p.parsed["spo2_ir"]?.intValue,
                         skinRaw: p.parsed["skin_temp_raw"]?.intValue))
+                    spo2DumpedByVersion[ver] = dumpedForVer + 1
                     spo2Dumped += 1
                 }
             }
@@ -714,6 +744,21 @@ final class Backfiller {
                          "decoder has no rows for — they are being dropped. If \(typeName) is not a name " +
                          "you recognise, this is a firmware record type NOOP has never mapped: please " +
                          "report it on #891 with the strap model and firmware build.")
+                    // #891: and the bytes, so the report is actionable. Without this the line above asks a
+                    // reporter to raise an issue about a record that exists nowhere else: `default:` drops
+                    // the frame and the reject archive only ever holds type-47. First sighting only, so a
+                    // long offload of one unmapped type still costs exactly one dump.
+                    //
+                    // Taken HERE rather than in the extractor, which is where the Android twin collects it:
+                    // `extractHistoricalStreams` receives already-parsed frames, and `ParsedFrame.rawHex` is
+                    // deliberately empty on the ingest fast path (`collectFields: false`, D#969), so reading
+                    // it there would emit an empty dump on every real offload while passing any test that
+                    // builds its own ParsedFrame. The raw bytes only exist at this level. Same log line on
+                    // both platforms; no prefix cap, for the reason the reject dump has none.
+                    if let line = Backfiller.unmappedTypeDumpLine(typeName: typeName, frames: frames,
+                                                                  typeNames: parsed.map(\.typeName)) {
+                        log?(line)
+                    }
                 }
             }
             // Diagnostic (#77): the AGGREGATE silent-loss case — frames arrived but produced no rows at

--- a/StrandTests/BackfillerHexDumpBudgetTests.swift
+++ b/StrandTests/BackfillerHexDumpBudgetTests.swift
@@ -94,4 +94,42 @@ final class BackfillerHexDumpBudgetTests: XCTestCase {
                        "begin() must never refill the budget: the rolling log it protects belongs to "
                         + "the process, not to one offload session")
     }
+
+    // MARK: - #891: the unmapped-type dump line
+
+    /// The census names a type; this has to find the bytes that earned the name, and the byte count is
+    /// derived from those bytes so the number and the payload beside it cannot disagree.
+    @MainActor func testUnmappedTypeDumpLineSelectsTheMatchingFrame() {
+        let frames: [[UInt8]] = [[0x01, 0x02], [0xaa, 0xbb, 0xcc, 0xdd]]
+        let names = ["HISTORICAL_DATA", "type53"]
+        let line = Backfiller.unmappedTypeDumpLine(typeName: "type53", frames: frames, typeNames: names)
+        XCTAssertEqual(line, "Backfill: unmapped type type53 first frame 4B: aabbccdd")
+    }
+
+    /// The FIRST frame of that type, not the last: a long offload of one unmapped type costs one dump.
+    @MainActor func testUnmappedTypeDumpLineTakesTheFirstMatch() {
+        let frames: [[UInt8]] = [[0x11], [0x22]]
+        let names = ["type53", "type53"]
+        let line = Backfiller.unmappedTypeDumpLine(typeName: "type53", frames: frames, typeNames: names)
+        XCTAssertEqual(line, "Backfill: unmapped type type53 first frame 1B: 11")
+    }
+
+    /// No frame of that type in this chunk means no line, rather than an empty dump that reads like the
+    /// strap sent nothing. This is the case that would have shipped silently: reading `ParsedFrame.rawHex`
+    /// here returns "" on the ingest fast path (`collectFields: false`), so every real offload would have
+    /// logged a dump with no bytes in it while any test building its own ParsedFrame passed.
+    @MainActor func testUnmappedTypeDumpLineIsNilWhenNoFrameMatches() {
+        let frames: [[UInt8]] = [[0x01, 0x02]]
+        XCTAssertNil(Backfiller.unmappedTypeDumpLine(typeName: "type53", frames: frames,
+                                                    typeNames: ["HISTORICAL_DATA"]))
+    }
+
+    /// The full frame rides the line - no prefix cap, for the reason the reject dump has none: an unmapped
+    /// layout's fields are as likely to sit in the tail as the head.
+    @MainActor func testUnmappedTypeDumpLineDoesNotTruncate() {
+        let raw = [UInt8](repeating: 0xab, count: 600)
+        let line = Backfiller.unmappedTypeDumpLine(typeName: "type53", frames: [raw], typeNames: ["type53"])
+        XCTAssertTrue(line?.hasSuffix(String(repeating: "ab", count: 600)) == true)
+        XCTAssertTrue(line?.contains("600B") == true)
+    }
 }

--- a/android/app/src/main/java/com/noop/analytics/Spo2ReTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/Spo2ReTrace.kt
@@ -22,9 +22,23 @@ package com.noop.analytics
  */
 object Spo2ReTrace {
 
-    /** Max records dumped per offload session. A handful is enough for an offline correlation pass and
-     *  keeps the strap log bounded; the Backfiller counter spans chunks and resets per session. */
-    const val MAX_SAMPLES = 8
+    /** Max records dumped per offload session, across all layout versions. A handful is enough for an
+     *  offline correlation pass and keeps the strap log bounded; the Backfiller counter spans chunks and
+     *  resets per session. */
+    const val MAX_SAMPLES = 12
+
+    /**
+     * Max records dumped per DISTINCT layout version, so the budget cannot be spent entirely on the
+     * layout we already understand.
+     *
+     * The dump used to take the first [MAX_SAMPLES] decodable records in arrival order. On a strap that
+     * emits a dominant layout plus a rarer one, that spends the whole budget inside the first chunk on
+     * the dominant layout - and the rare one is precisely the one still unmapped. The log would then
+     * announce "historical records use layout vN" while carrying no bytes of vN at all: proof a thing
+     * exists, with no material to work on it. Stratifying guarantees every layout the strap emits gets
+     * samples, including one at 1% of traffic, and stops re-dumping a layout already at parity.
+     */
+    const val MAX_PER_VERSION = 3
 
     /**
      * One record's RE line: the mapped SpO2 channels + timestamp + layout version, then the FULL frame

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -291,6 +291,11 @@ class Backfiller(
      *  [com.noop.analytics.Spo2ReTrace.MAX_SAMPLES]. Session-scoped so the cap spans chunks; reset in begin. */
     private var spo2Dumped = 0
 
+    /** SpO2 RE dump: how many records this session dumped for each layout version, so one layout cannot
+     *  spend the whole session budget. Key -1 buckets a record whose `hist_version` did not decode.
+     *  Session-scoped alongside [spo2Dumped]; reset in begin. Twin of the Swift `spo2DumpedByVersion`. */
+    private val spo2DumpedByVersion = HashMap<Int, Int>()
+
     /**
      * #547: logged once per session the first time the #547 ingest gate drops an implausible-timestamp
      * record (a bad strap clock/flash emitting far-past / year-2027-spike / future-dated `unix` values).
@@ -350,6 +355,7 @@ class Backfiller(
         loggedLayoutVersions.clear()
         chunkIndex = 0
         spo2Dumped = 0
+        spo2DumpedByVersion.clear()
         loggedImplausibleClock = false
         sessionDroppedImplausible = 0
         sessionUnhandledPacketTypes.clear()   // #891: a second offload must re-log its first sighting
@@ -476,6 +482,11 @@ class Backfiller(
                     // `as? Long`, not `as? Int`: the decoder carries unix in the unsigned domain, so an
                     // Int cast would miss on EVERY record and silently stop the dump. See `histU32`.
                     val recUnix = d["unix"] as? Long ?: continue
+                    // Stratify by layout: without this the first chunk's dominant layout eats the whole
+                    // budget and the rare, still-unmapped one never gets a single frame. See MAX_PER_VERSION.
+                    val ver = d["hist_version"] as? Int ?: -1
+                    val dumpedForVer = spo2DumpedByVersion[ver] ?: 0
+                    if (dumpedForVer >= com.noop.analytics.Spo2ReTrace.MAX_PER_VERSION) continue
                     connectionLog(
                         com.noop.analytics.Spo2ReTrace.recordLine(
                             frame = f,
@@ -486,6 +497,7 @@ class Backfiller(
                             skinRaw = d["skin_temp_raw"] as? Int,
                         ),
                     )
+                    spo2DumpedByVersion[ver] = dumpedForVer + 1
                     spo2Dumped++
                 }
             }
@@ -528,6 +540,13 @@ class Backfiller(
                             "you recognise, this is a firmware record type NOOP has never mapped: please " +
                             "report it on #891 with the strap model and firmware build.",
                     )
+                    // #891: and the bytes, so the report is actionable. Without this the line above asks a
+                    // reporter to raise an issue about a record that exists nowhere else: the else branch
+                    // drops the frame and the reject archive only ever holds type-47. First sighting only,
+                    // so a long offload of one unmapped type still costs exactly one dump.
+                    decoded.unhandledPacketSamples[typeName]?.let { hex ->
+                        log(unmappedTypeDumpLine(typeName, hex))
+                    }
                 }
             }
             // #324: the strap RTC-state events (RTC_LOST / BOOT / SET_RTC) the #547 gate dropped for a bad
@@ -756,7 +775,15 @@ class Backfiller(
          */
         internal const val REJECT_HEX_DUMP_BUDGET = 24
 
-    /**
+        /**
+         * #891: the dump line for the first frame of an unmapped packet type. Byte-identical to the Swift
+         * `Backfiller.unmappedTypeDumpLine`; [hex] is the FULL frame, so the length is derived from it
+         * rather than passed separately and able to disagree with the bytes beside it.
+         */
+        internal fun unmappedTypeDumpLine(typeName: String, hex: String): String =
+            "Backfill: unmapped type $typeName first frame ${hex.length / 2}B: $hex"
+
+        /**
          * How many reject frames this chunk may hex-dump, given what the session has already spent (#1992).
          *
          * The dump is the only channel carrying an unmapped layout's raw bytes to someone who can map it,

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -86,6 +86,16 @@ data class StreamBatch(
      */
     val unhandledPacketTypes: Map<String, Int> = emptyMap(),
     /**
+     * #891: one full-frame hex sample per type in [unhandledPacketTypes], keyed the same way, taken from
+     * the first such frame in the batch.
+     *
+     * The census alone tells a reporter that their firmware banks a record NOOP cannot read, and then
+     * asks them to report it — while carrying none of the bytes anyone would need to map it. The dropped
+     * frame is not archived either: `rejectedHistoricalRecords` only ever holds type-47, so these bytes
+     * existed nowhere. Diag only (excluded from [isEmpty]). Mirrors Swift `Streams.unhandledPacketSamples`.
+     */
+    val unhandledPacketSamples: Map<String, String> = emptyMap(),
+    /**
      * #520 diagnostic: a summary of `dynamic_acceleration@41` (the strap's own gravity-removed motion
      * magnitude) over this batch's v18 records. The field has been decoded on both platforms all along
      * with nothing consuming it, so there is no evidence on whether it is a usable stillness signal;

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -715,6 +715,10 @@ fun extractHistoricalStreams(
     var droppedImplausible = 0
     // #891: packet types that reach the `else` branch and are dropped. See StreamBatch.unhandledPacketTypes.
     val unhandledTypes = mutableMapOf<String, Int>()
+    // #891: the FIRST frame seen for each of those types, as full hex. The census says a type exists;
+    // without its bytes the strap log asks a reporter to open an issue about a record nobody can then
+    // map. One frame per type per batch is enough to place the fields and keeps the log bounded.
+    val unhandledSamples = mutableMapOf<String, String>()
     // #324: oldest/newest own-timestamp among the dropped records (the poisoned-range epoch span), and the
     // dropped RTC-state events (RTC_LOST / BOOT / SET_RTC) — the ground truth that the clock reset. Declared
     // before correctedWall so the local function can capture them (Kotlin: no forward reference to locals).
@@ -1045,6 +1049,10 @@ fun extractHistoricalStreams(
                     val parsed = Framing.parseFrame(frame, family)
                     if (parsed.ok && parsed.crcOk != false) {
                         unhandledTypes[name] = (unhandledTypes[name] ?: 0) + 1
+                        // No prefix cap: an unmapped layout's interesting fields are as likely to sit in
+                        // the tail as the head, and a truncated sample is the one shape that looks like
+                        // evidence without being any.
+                        unhandledSamples.getOrPut(name) { frame.joinToString("") { b -> "%02x".format(b) } }
                     }
                 }
             }
@@ -1064,6 +1072,7 @@ fun extractHistoricalStreams(
         ppgWaveform = ppgWaveform,
         v18Aux = v18Aux,
         unhandledPacketTypes = unhandledTypes,   // #891 diag census (not persisted)
+        unhandledPacketSamples = unhandledSamples,   // #891 one frame per unmapped type (not persisted)
         droppedImplausibleTs = droppedImplausible,
         droppedImplausibleOldestTs = droppedOldest,   // #324 poisoned-range epoch span (diag only)
         droppedImplausibleNewestTs = droppedNewest,

--- a/android/app/src/test/java/com/noop/analytics/Spo2ReTraceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/Spo2ReTraceTest.kt
@@ -39,7 +39,20 @@ class Spo2ReTraceTest {
         assertTrue(line, line.contains("v=null"))
     }
 
-    @Test fun sampleCapBoundedAtEight() {
-        assertEquals(8, Spo2ReTrace.MAX_SAMPLES)
+    @Test fun sampleCapBounded() {
+        assertEquals(12, Spo2ReTrace.MAX_SAMPLES)
+    }
+
+    /** The per-layout cap is what stops one dominant layout spending the whole session budget, and it
+     *  only does that if it is strictly smaller than the session cap. */
+    @Test fun perVersionCapIsBoundedAndSmallerThanTheSessionCap() {
+        assertEquals(3, Spo2ReTrace.MAX_PER_VERSION)
+        assertTrue(Spo2ReTrace.MAX_PER_VERSION < Spo2ReTrace.MAX_SAMPLES)
+    }
+
+    /** The session cap has to leave room for more than one layout, or stratifying changes nothing:
+     *  a 5/MG emits v18 alongside v20/v21/v26 and every one of them needs samples. */
+    @Test fun sessionCapCoversSeveralDistinctLayouts() {
+        assertTrue(Spo2ReTrace.MAX_SAMPLES / Spo2ReTrace.MAX_PER_VERSION >= 4)
     }
 }

--- a/android/app/src/test/java/com/noop/ble/RejectHexDumpBudgetTest.kt
+++ b/android/app/src/test/java/com/noop/ble/RejectHexDumpBudgetTest.kt
@@ -1,6 +1,7 @@
 package com.noop.ble
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -56,5 +57,27 @@ class RejectHexDumpBudgetTest {
     /** The budget must clear more than one chunk, or the sample cannot span an offload. */
     @Test fun theBudgetIsWorthMoreThanOneChunk() {
         assertEquals(true, Backfiller.REJECT_HEX_DUMP_BUDGET > cap)
+    }
+
+    // --- #891: the unmapped-type dump line ---
+
+    /**
+     * The byte count is DERIVED from the hex rather than passed alongside it, so the number and the bytes
+     * beside it cannot disagree. A dump whose stated length contradicts its payload is worse than none:
+     * it sends whoever is mapping the layout looking for a field that was never there.
+     */
+    @Test
+    fun unmappedTypeDumpLineDerivesItsLengthFromTheBytes() {
+        val line = Backfiller.unmappedTypeDumpLine("type53", "aabbccdd")
+        assertEquals("Backfill: unmapped type type53 first frame 4B: aabbccdd", line)
+    }
+
+    /** The full frame rides the line - no prefix cap, for the reason the reject dump has none. */
+    @Test
+    fun unmappedTypeDumpLineDoesNotTruncate() {
+        val hex = "ab".repeat(600)
+        val line = Backfiller.unmappedTypeDumpLine("HISTORICAL_IMU_DATA_STREAM", hex)
+        assertTrue(line, line.endsWith(hex))
+        assertTrue(line, line.contains("600B"))
     }
 }

--- a/android/app/src/test/java/com/noop/protocol/HistoricalStreamsUnhandledTypeTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/HistoricalStreamsUnhandledTypeTest.kt
@@ -65,6 +65,46 @@ class HistoricalStreamsUnhandledTypeTest {
         assertTrue("it still yields no rows — this is a census, not a decoder", b.isEmpty)
     }
 
+    /**
+     * #891: the census names a type; the SAMPLE carries the bytes that earned the name. Without it the
+     * strap log asks a reporter to open an issue about a record that exists nowhere else - the else
+     * branch drops the frame and the reject archive only ever holds type-47.
+     */
+    @Test
+    fun unmappedTypeCarriesItsBytes() {
+        val t = PacketType.HISTORICAL_IMU_DATA_STREAM.rawValue
+        val f = frameOfType(t)
+        val b = extract(listOf(f))
+        val expected = f.joinToString("") { "%02x".format(it) }
+        assertEquals(expected, b.unhandledPacketSamples["HISTORICAL_IMU_DATA_STREAM"])
+    }
+
+    /**
+     * The sample is the FIRST frame of that type and only that one. A 30k-record offload of one unmapped
+     * type must cost exactly one dump, which is the same reason the census logs on first sighting.
+     */
+    @Test
+    fun onlyTheFirstFrameOfATypeIsSampled() {
+        val t = PacketType.HISTORICAL_IMU_DATA_STREAM.rawValue
+        val first = frameOfType(t)
+        val b = extract(listOf(first, frameOfType(t), frameOfType(t)))
+        assertEquals(3, b.unhandledPacketTypes["HISTORICAL_IMU_DATA_STREAM"])
+        assertEquals(1, b.unhandledPacketSamples.size)
+        assertEquals(first.joinToString("") { "%02x".format(it) },
+            b.unhandledPacketSamples["HISTORICAL_IMU_DATA_STREAM"])
+    }
+
+    /**
+     * The excluded-by-design types must not be sampled either. Counting them was already rejected as
+     * crying wolf; dumping their bytes into every healthy sync would be strictly worse.
+     */
+    @Test
+    fun expectedUnhandledTypesAreNotSampled() {
+        val b = extract(listOf(frameOfType(PacketType.CONSOLE_LOGS.rawValue),
+                               frameOfType(PacketType.METADATA.rawValue)))
+        assertTrue(b.unhandledPacketSamples.toString(), b.unhandledPacketSamples.isEmpty())
+    }
+
     /** Distinct unhandled types are tallied separately, so a report can name each. */
     @Test
     fun distinctTypesAreTalliedSeparately() {


### PR DESCRIPTION
Two gaps in what a strap log carries, both on the paths whose entire job is making an unmapped firmware
mappable. Prompted by looking at what a 5/MG actually gives us for #1992 and the v20/v21 decode gaps.

## 1. #891 names an unmapped record type and withholds its bytes

The census line says:

> the strap sent N record(s) of packet type X, which this decoder has no rows for ... please report it on
> #891 with the strap model and firmware build

and carries no hex. The frame is not recoverable anywhere else either, which the code comment already
says out loud: the decoder's fallthrough drops it, and `rejectedHistoricalRecords` archives only type-47.
So the single line that asks for a report is the one that makes the report unactionable.

Each unmapped type now dumps its first frame, full length, once per session. First sighting only, so a
30k-record offload of one unmapped type still costs exactly one dump, matching the census line's own
first-sighting rule.

## 2. The RE dump samples arrival order, not layout

`Spo2ReTrace` took the first 8 decodable records in arrival order. On a strap emitting a dominant layout
beside a rarer one, the budget is spent inside the first chunk on the layout already at parity, and the
rare one, which is the one still unmapped, never gets a frame.

The failure mode is specific and bad: the log announces *"historical records use layout vN"* from
`loggedLayoutVersions` while carrying zero bytes of vN. Proof a thing exists, with no material to work on
it. This bites v20/v21 in particular, because they decode, so they never reach the reject path that would
otherwise have dumped them.

The budget is now per layout version: 3 each, 12 a session. Guarantees samples for a layout at 1% of
traffic, and stops re-dumping one already understood.

## A deliberate asymmetry

Sampling sits in the extractor on Android and in the Backfiller on Apple.

Android's extractor is handed raw `ByteArray`s, so it samples in place, next to the family-aware type
naming that decides what the sample is keyed by (duplicating that naming in the Backfiller is exactly the
kind of thing that drifts). Swift's extractor only sees `ParsedFrame`s, and `ParsedFrame.rawHex` is
deliberately empty on the ingest fast path (`collectFields: false`, D#969). Reading it there would have
logged an empty dump on every real offload while passing any test that built its own `ParsedFrame` -- so
the bytes are zipped back in at the Backfiller, which is the level that actually has them. The emitted
line is identical on both platforms and pinned by tests on both sides.

## Tests

+7 Kotlin, +4 Swift. The selection is pinned, not just the formatting: that a sample matches the frame
that earned it, that only the first frame of a type is taken, that the excluded-by-design types
(`METADATA`, `CONSOLE_LOGS`) are not sampled, that no frame of that type yields no line rather than an
empty dump, and that neither dump truncates. The two budget tests that pinned `MAX_SAMPLES == 8` are
repinned to the new shape rather than deleted, and gained an assertion that the per-layout cap is
strictly smaller than the session cap, since stratifying does nothing if it is not.

Android: 670 classes / 5666 tests, 0 failures. Swift is CI-verified only.

## Privacy

Both dumps go through the existing `log` seam, so they inherit the `redactHexDumpPii` scrub that runs at
the log-sanitiser layer. Nothing new is written to a file directly.
