### PR TITLE
diag: say WHY a bond ended, and make the refusal readable in any locale

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -5627,11 +5627,33 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
     /// locale-dependent free-text string. We emit the `CBError`/`CBATTError` raw enum value (an Int), so
     /// the token is locale-independent and carries no free text. A nil error reads "unknown"; an error
     /// from neither CoreBluetooth domain reads "code?" (no localizedDescription, which could carry text).
-    private func connErrorToken(_ error: Error?) -> String {
+    private func connErrorToken(_ error: Error?) -> String { BLEManager.bleErrorToken(error) }
+
+    /// The stable token itself. `nonisolated static` for the same reason `isInsufficientAuthError` is:
+    /// so a unit test pins it without a CoreBluetooth seam.
+    nonisolated static func bleErrorToken(_ error: Error?) -> String {
         guard let error else { return "unknown" }
         if let cb = error as? CBError { return "cbError\(cb.code.rawValue)" }
         if let att = error as? CBATTError { return "cbAttError\(att.code.rawValue)" }
         return "code?"
+    }
+
+    /// The same token as a log SUFFIX, for the ordinary strap log rather than Connection test mode.
+    ///
+    /// Foundation LOCALIZES CoreBluetooth error strings, so a failure line built from
+    /// `localizedDescription` alone is unmatchable in a shared log from a non-English phone. That is not
+    /// hypothetical here: `isInsufficientAuthError` documents the same property silently defeating the
+    /// old `localizedDescription.contains("encryption")` classification for the entire localized user
+    /// base (#78 hole-1), which Android was immune to because it matches GATT status ints 5/15. The
+    /// classification was made code-first then; the LOGGING still says only what the phone's locale says.
+    ///
+    /// ADDITIVE, never a replacement: the description stays for readability and for the CoreBluetooth
+    /// paths that surface plain NSErrors outside both domains (those read `code?`). The tokens line up
+    /// with the Android side by construction, since ATT insufficient-authentication and
+    /// insufficient-encryption are the same 5 and 15 that `gattWriteStatusLabel` names.
+    nonisolated static func bleErrorSuffix(_ error: Error?) -> String {
+        guard error != nil else { return "" }
+        return " [\(bleErrorToken(error))]"
     }
 
     /// Feed one 5/MG bond refusal into the #747 give-up and act on the trip (#1635).
@@ -5919,7 +5941,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
             // #747: the bond keeps being refused, so auto-reconnect is paused: we stop hammering a strap that
             // can't bond (the epitaph + paused hint were already surfaced when the give-up tripped). The user
             // re-arms it by tapping Connect. We do NOT schedule a rescan here.
-            log("Disconnected\(error.map { ": \($0.localizedDescription)" } ?? ""); auto-reconnect paused (strap keeps refusing to pair; tap Connect once it's free)")
+            log("Disconnected\(error.map { ": \($0.localizedDescription)" } ?? "")\(BLEManager.bleErrorSuffix(error)); auto-reconnect paused (strap keeps refusing to pair; tap Connect once it's free)")
             // #1539: a connect attempt CONSUMES the parked request, so re-park it — floored, so a reachable
             // strap that keeps refusing gets one attempt per window instead of a connect/refuse spin.
             standingConnectWhilePausedIfDue()
@@ -5928,7 +5950,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
                 state.append(log: "reconnect paused=bondLoop (strap refusing bond)", domain: .connection)
             }
         } else if !intentionalDisconnect {
-            log("Disconnected\(error.map { " — \($0.localizedDescription)" } ?? "")")
+            log("Disconnected\(error.map { " — \($0.localizedDescription)" } ?? "")\(BLEManager.bleErrorSuffix(error))")
             // Connection test mode: count + describe the involuntary reconnect churn, and mark the link
             // down for the uptime readout. Gated zero-cost (the .connection bool is read before any string
             // is built). Diagnostic only - the rescan above is unchanged. The count increments only on an
@@ -5963,7 +5985,7 @@ extension BLEManager: @preconcurrency CBCentralManagerDelegate {
                                didFailToConnect peripheral: CBPeripheral,
                                error: Error?) {
         cancelPendingConnectProbe()   // #730: it FAILED rather than pending — this log is the answer
-        log("Failed to connect\(error.map { " — \($0.localizedDescription)" } ?? "")")
+        log("Failed to connect\(error.map { " — \($0.localizedDescription)" } ?? "")\(BLEManager.bleErrorSuffix(error))")
         // The strap wiped its bond (a firmware update, or the official WHOOP app re-bonding it). macOS keeps
         // re-presenting the now-stale pairing key, so every reconnect loops on this same error with no
         // recovery and no user guidance. Surface an actionable re-pair guide instead of failing silently —
@@ -6295,7 +6317,7 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                            didWriteValueFor characteristic: CBCharacteristic,
                            error: Error?) {
         if let error = error {
-            log("Confirmed write failed: \(error.localizedDescription)")
+            log("Confirmed write failed: \(error.localizedDescription)\(BLEManager.bleErrorSuffix(error))")
             // #1635: a failed write owes no ack. Leaving the window open would let the NEXT completion on
             // fd4b0002 — DISABLE_ALARM and every other puffin command share it — satisfy both halves of
             // the bond gate below and declare a bond the strap never granted, which is the whole bug.

--- a/StrandTests/BondErrorTokenTests.swift
+++ b/StrandTests/BondErrorTokenTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+import CoreBluetooth
+@testable import Strand
+
+/// #1635 / #78 hole-1: a BLE failure line has to carry something a reader in ANY locale can match.
+///
+/// Foundation localizes CoreBluetooth error strings. `isInsufficientAuthError` already documents what
+/// that costs: the old `localizedDescription.contains("encryption")` classification silently never
+/// matched on a non-English device, for the entire localized user base. The classification was made
+/// code-first then; the LOGGING still said only what the phone's locale said, so a shared strap log from
+/// a French phone carried a refusal nobody triaging could match.
+///
+/// Android was always immune because it matches GATT status ints, which is why this exists: the tokens
+/// line up with `gattWriteStatusLabel`'s 5 and 15 by construction.
+final class BondErrorTokenTests: XCTestCase {
+
+    /// The two codes that mean "the strap refused the encrypted bond" are exactly Android's 5 and 15.
+    /// Pinned as numbers, because the whole point is that the two platforms' logs can be read the same way.
+    func testRefusalCodesMatchTheAndroidGattStatuses() {
+        XCTAssertEqual(CBATTError.Code.insufficientAuthentication.rawValue, 5)
+        XCTAssertEqual(CBATTError.Code.insufficientEncryption.rawValue, 15)
+        XCTAssertEqual(BLEManager.bleErrorToken(CBATTError(.insufficientAuthentication)), "cbAttError5")
+        XCTAssertEqual(BLEManager.bleErrorToken(CBATTError(.insufficientEncryption)), "cbAttError15")
+    }
+
+    /// The suffix is additive and bracketed, so it can be spotted in a line whose other half is localized.
+    func testSuffixIsBracketedAndAppendable() {
+        XCTAssertEqual(BLEManager.bleErrorSuffix(CBATTError(.insufficientAuthentication)), " [cbAttError5]")
+    }
+
+    /// No error means no suffix: a clean disconnect line is unchanged, so this adds nothing to the
+    /// overwhelmingly common healthy path.
+    func testNoErrorAddsNothing() {
+        XCTAssertEqual(BLEManager.bleErrorSuffix(nil), "")
+    }
+
+    /// An error from neither CoreBluetooth domain reads `code?` rather than leaking free text. Some
+    /// CoreBluetooth paths do surface plain NSErrors, which is why the description is kept alongside
+    /// rather than replaced.
+    func testForeignErrorDomainCarriesNoFreeText() {
+        let foreign = NSError(domain: "com.example.other", code: 42,
+                              userInfo: [NSLocalizedDescriptionKey: "some localized text"])
+        XCTAssertEqual(BLEManager.bleErrorSuffix(foreign), " [code?]")
+        XCTAssertFalse(BLEManager.bleErrorSuffix(foreign).contains("localized"))
+    }
+
+    /// The CBError domain is tokenised too, so a connect failure is as matchable as a write failure.
+    func testConnectionDomainErrorsAreTokenised() {
+        XCTAssertEqual(BLEManager.bleErrorToken(CBError(.connectionTimeout)),
+                       "cbError\(CBError.Code.connectionTimeout.rawValue)")
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
+++ b/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
@@ -11,6 +11,44 @@ internal fun bondStateName(state: Int): String = when (state) {
 }
 
 /**
+ * The `ACTION_BOND_STATE_CHANGED` extra carrying WHY a bond ended, and the values it takes.
+ *
+ * Both the extra and the `UNBOND_REASON_*` constants are `@hide` in AOSP, so they are mirrored here as
+ * literals rather than referenced. That is the same trade the GATT status constants in `WhoopBleClient`
+ * already make; the values have been stable across every release that ships this broadcast, and a
+ * hidden-API reference would not compile.
+ */
+internal const val EXTRA_BOND_REASON = "android.bluetooth.device.extra.REASON"
+
+/** What `getIntExtra` returns when the OS supplied no reason. Not a code the broadcast ever sends. */
+internal const val NO_BOND_REASON = -1
+
+/**
+ * A `BluetoothDevice.UNBOND_REASON_*` value, named.
+ *
+ * Deliberately mirrors [gattWriteStatusLabel]: name the codes that answer the question and leave
+ * anything else as a bare number. A confidently wrong name in the line whose whole job is explaining a
+ * pairing failure is worse than no name, and this broadcast's vendor stacks do emit values AOSP does
+ * not define.
+ *
+ * The distinction this exists to preserve: AUTH_FAILED ("the strap refused authentication") and
+ * AUTH_TIMEOUT ("nobody answered") and REMOTE_DEVICE_DOWN ("the link went away") are three different
+ * findings for #1635, and a trace that only says "pairing did NOT complete" cannot tell them apart.
+ */
+internal fun bondFailureReasonLabel(reason: Int): String = when (reason) {
+    1 -> "reason=AUTH_FAILED(1)"
+    2 -> "reason=AUTH_REJECTED(2)"
+    3 -> "reason=AUTH_CANCELED(3)"
+    4 -> "reason=REMOTE_DEVICE_DOWN(4)"
+    5 -> "reason=DISCOVERY_IN_PROGRESS(5)"
+    6 -> "reason=AUTH_TIMEOUT(6)"
+    7 -> "reason=REPEATED_ATTEMPTS(7)"
+    8 -> "reason=REMOTE_AUTH_CANCELED(8)"
+    9 -> "reason=REMOVED(9)"
+    else -> "reason=$reason"
+}
+
+/**
  * One line per OS bond-state transition, with how long after the CLIENT_HELLO write it happened.
  *
  * NOOP has never observed `ACTION_BOND_STATE_CHANGED`, so the OS pairing flow has been invisible. That
@@ -31,6 +69,15 @@ internal fun bondStateName(state: Int): String = when (state) {
  * (another app, another device) then carries no elapsed time rather than a misleading one measured from
  * a write it has nothing to do with.
  *
+ * [reason] is the OS's own `UNBOND_REASON_*` for a bond that ENDED, and is the difference between
+ * "the strap refused authentication" and "nobody answered in time" - two findings this line previously
+ * rendered identically as "pairing did NOT complete".
+ *
+ * Appended ONLY to a failed transition that actually carries one. A successful pairing has no reason to
+ * give, the broadcast leaves the extra absent on transitions INTO bonding, and a stack that supplies
+ * nothing gets the wording it had before rather than a "reason=n/a" that says less than silence. The
+ * existing failure line is therefore unchanged whenever there is no new information to add.
+ *
  * Pure so the wording is unit-tested without a radio. Android-only: CoreBluetooth performs pairing
  * opaquely and exposes no equivalent transition, so there is nothing to twin.
  */
@@ -40,12 +87,21 @@ internal fun bondStateTraceLine(
     address: String?,
     sinceMs: Long?,
     sinceLabel: String = "CLIENT_HELLO",
+    reason: Int? = null,
 ): String {
     val who = address?.takeIf { it.isNotBlank() } ?: "unknown"
     val since = sinceMs?.let { " ${it}ms after $sinceLabel" } ?: ""
+    // A bond ends two ways, and BOTH carry a reason. Scoping this to the failed-pairing transition would
+    // have left the other one, a bond that EXISTED and then went away, as a bare state change with no
+    // explanation - which is where REMOVED and REMOTE_DEVICE_DOWN actually show up.
+    val why = reason?.takeIf { it != NO_BOND_REASON }?.let { ", " + bondFailureReasonLabel(it) } ?: ""
     val note = when {
         previous == BluetoothDevice.BOND_BONDING && current == BluetoothDevice.BOND_NONE ->
-            " — pairing did NOT complete"
+            " — pairing did NOT complete$why"
+        // "ended" rather than "was removed": the transition says the bond is gone, the reason code says
+        // why, and naming a cause here would be the line concluding rather than observing.
+        previous == BluetoothDevice.BOND_BONDED && current == BluetoothDevice.BOND_NONE ->
+            " — the bond ended$why"
         current == BluetoothDevice.BOND_BONDED -> " — paired"
         else -> ""
     }

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -2805,7 +2805,7 @@ class WhoopBleClient(
 
     /** #1635: record an OS bond-state transition in the strap log. The OS pairing flow has never been
      *  observed, which is what leaves the 5/MG bond failure undecided - see [bondStateTraceLine]. */
-    fun onBondStateChanged(previous: Int, current: Int, address: String?) {
+    fun onBondStateChanged(previous: Int, current: Int, address: String?, reason: Int? = null) {
         // Time against whichever request is actually outstanding. The hello takes precedence when both
         // are, but the explicit-pairing experiment deliberately sends no hello, so without the second
         // marker every transition it causes would print untimed — and how long a pairing took is most of
@@ -2817,7 +2817,7 @@ class WhoopBleClient(
         val label = if (helloMs != null) "CLIENT_HELLO" else "the pairing request"
         if (!shouldTraceBondState(address, lastDeviceAddress, since != null)) return
         sawBondTransitionThisLink = true
-        log(bondStateTraceLine(previous, current, address, since, label))
+        log(bondStateTraceLine(previous, current, address, since, label, reason))
     }
 
     @Volatile private var familyEstablished = false

--- a/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
@@ -236,7 +236,11 @@ class WhoopConnectionService : Service() {
                 }
             val cur = intent.getIntExtra(BluetoothDevice.EXTRA_BOND_STATE, BluetoothDevice.ERROR)
             val prev = intent.getIntExtra(BluetoothDevice.EXTRA_PREVIOUS_BOND_STATE, BluetoothDevice.ERROR)
-            runCatching { ble.onBondStateChanged(prev, cur, dev?.address) }
+            // WHY a bond ended, which the transition alone cannot say: refused, timed out and link-lost
+            // all render as BOND_BONDING -> BOND_NONE. [NO_BOND_REASON] when the OS supplied nothing.
+            // [EXTRA_BOND_REASON] documents why the extra's name is a literal rather than a reference.
+            val reason = intent.getIntExtra(EXTRA_BOND_REASON, NO_BOND_REASON)
+            runCatching { ble.onBondStateChanged(prev, cur, dev?.address, reason) }
         }
     }
 

--- a/android/app/src/test/java/com/noop/ble/BondStateTraceTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BondStateTraceTest.kt
@@ -3,6 +3,7 @@ package com.noop.ble
 import android.bluetooth.BluetoothDevice
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -154,5 +155,96 @@ class BondStateTraceTest {
         val line = bondStatePollLine(android.bluetooth.BluetoothDevice.BOND_BONDING, sawTransitionLine = true)
         assertFalse(line.contains("missed it"))
         assertTrue(bondStatePollLine(android.bluetooth.BluetoothDevice.BOND_BONDED, true).contains("paired"))
+    }
+
+    // --- #1635: WHY a bond ended, not just that it did ---
+
+    /**
+     * The reason rides the failure line. "Refused authentication" and "nobody answered" and "the link
+     * went away" are three different findings, and the transition alone renders all three identically.
+     */
+    @Test
+    fun `a failed pairing names the OS reason when there is one`() {
+        assertEquals(
+            "bond state: BOND_BONDING -> BOND_NONE device=FD:D4:F7:24:53:4A 3158ms after CLIENT_HELLO" +
+                " — pairing did NOT complete, reason=AUTH_FAILED(1)",
+            bondStateTraceLine(BluetoothDevice.BOND_BONDING, BluetoothDevice.BOND_NONE,
+                "FD:D4:F7:24:53:4A", 3158, reason = 1),
+        )
+    }
+
+    /**
+     * The OTHER way a bond ends: one that EXISTED and then went away. Scoping the reason to the failed
+     * pairing would have left this as a bare state change with no explanation, and it is exactly where
+     * REMOVED and REMOTE_DEVICE_DOWN show up.
+     */
+    @Test
+    fun `a bond that existed and then ended is explained too`() {
+        assertEquals(
+            "bond state: BOND_BONDED -> BOND_NONE device=AA:BB — the bond ended, reason=REMOTE_DEVICE_DOWN(4)",
+            bondStateTraceLine(BluetoothDevice.BOND_BONDED, BluetoothDevice.BOND_NONE,
+                "AA:BB", null, reason = 4),
+        )
+    }
+
+    /** It says the bond ended, not that it was "removed": the code supplies the cause, the line does not. */
+    @Test
+    fun `a bond ending without a reason still says the bond ended`() {
+        val line = bondStateTraceLine(BluetoothDevice.BOND_BONDED, BluetoothDevice.BOND_NONE,
+            "AA:BB", null, reason = NO_BOND_REASON)
+        assertTrue(line, line.endsWith("— the bond ended"))
+        assertFalse(line, line.contains("reason="))
+    }
+
+    /**
+     * A stack that supplies nothing gets the wording it had before. `getIntExtra` returns -1 when the
+     * extra is absent, and "reason=n/a" would say less than silence while changing every failure line
+     * anyone has ever pattern-matched on.
+     */
+    @Test
+    fun `an absent reason leaves the failure line exactly as it was`() {
+        val was = "bond state: BOND_BONDING -> BOND_NONE device=AA:BB 10ms after CLIENT_HELLO" +
+            " — pairing did NOT complete"
+        assertEquals(was, bondStateTraceLine(BluetoothDevice.BOND_BONDING, BluetoothDevice.BOND_NONE,
+            "AA:BB", 10, reason = null))
+        assertEquals(was, bondStateTraceLine(BluetoothDevice.BOND_BONDING, BluetoothDevice.BOND_NONE,
+            "AA:BB", 10, reason = NO_BOND_REASON))
+    }
+
+    /** A successful pairing has no reason to give, so one is never appended even if the OS sent a value. */
+    @Test
+    fun `a successful pairing never carries a reason`() {
+        val line = bondStateTraceLine(BluetoothDevice.BOND_BONDING, BluetoothDevice.BOND_BONDED,
+            "AA:BB", 900, reason = 1)
+        assertTrue(line, line.endsWith("— paired"))
+        assertFalse(line, line.contains("reason="))
+    }
+
+    /**
+     * Every code AOSP defines is named. Pinned as a set so adding one cannot silently leave a hole, and
+     * so the two that matter most for #1635 - refused vs timed out - are provably distinguishable.
+     */
+    @Test
+    fun `the defined unbond reasons are all named`() {
+        assertEquals("reason=AUTH_FAILED(1)", bondFailureReasonLabel(1))
+        assertEquals("reason=AUTH_REJECTED(2)", bondFailureReasonLabel(2))
+        assertEquals("reason=AUTH_CANCELED(3)", bondFailureReasonLabel(3))
+        assertEquals("reason=REMOTE_DEVICE_DOWN(4)", bondFailureReasonLabel(4))
+        assertEquals("reason=DISCOVERY_IN_PROGRESS(5)", bondFailureReasonLabel(5))
+        assertEquals("reason=AUTH_TIMEOUT(6)", bondFailureReasonLabel(6))
+        assertEquals("reason=REPEATED_ATTEMPTS(7)", bondFailureReasonLabel(7))
+        assertEquals("reason=REMOTE_AUTH_CANCELED(8)", bondFailureReasonLabel(8))
+        assertEquals("reason=REMOVED(9)", bondFailureReasonLabel(9))
+        assertNotEquals(bondFailureReasonLabel(1), bondFailureReasonLabel(6))
+    }
+
+    /**
+     * An undefined value prints as itself rather than as a guess - the same discipline
+     * `gattWriteStatusLabel` applies to GATT codes, and vendor stacks do emit values AOSP does not define.
+     */
+    @Test
+    fun `an unknown reason is not given an invented name`() {
+        assertEquals("reason=42", bondFailureReasonLabel(42))
+        assertEquals("reason=0", bondFailureReasonLabel(0))
     }
 }


### PR DESCRIPTION
`ACTION_BOND_STATE_CHANGED` carries a reason code for a bond that ended. The receiver read
`EXTRA_BOND_STATE` and `EXTRA_PREVIOUS_BOND_STATE` and dropped it, so every failure rendered identically:

> bond state: BOND_BONDING -> BOND_NONE device=FD:XX:XX:XX:XX:4A 3158ms after CLIENT_HELLO, pairing did NOT complete

A strap that **refused** authentication, one that never answered in time, and a link that went away
underneath the pairing all produce that same line. For #1635, where the open question is precisely why the
strap will not pair, that is the most informative field Android offers, and it was the one field not
captured.

## What changes

The reason now rides the failure line:

> ... pairing did NOT complete, reason=AUTH_FAILED(1)

Named the way `gattWriteStatusLabel` already names GATT codes: the nine values AOSP defines get names,
anything else prints as itself rather than as a guess. That file's own reasoning applies unchanged here:
a confidently wrong name in the line whose whole job is explaining a pairing failure is worse than no name,
and vendor stacks do emit values AOSP does not define.

## Both ways a bond ends

A bond ends two ways and both carry a reason. The first draft covered only the failed pairing, which left
the other case, a bond that EXISTED and then went away, as a bare state change with no explanation. That
is the case where `REMOVED(9)` and `REMOTE_DEVICE_DOWN(4)` actually appear, so it now reads:

> bond state: BOND_BONDED -> BOND_NONE device=AA:BB, the bond ended, reason=REMOTE_DEVICE_DOWN(4)

It says the bond *ended*, not that it was "removed": the transition says the bond is gone and the code
says why, so naming a cause in the prose would be the line concluding rather than observing, which is the
stance the rest of the file takes.

## Deliberately additive

The reason is appended only to a failure that actually carries one. A successful pairing has none to give,
the extra is absent on transitions *into* bonding, and a stack that supplies nothing gets the wording it
had before rather than a `reason=n/a` that says less than silence.

The pre-existing test pinning the exact failure string is **untouched and still passes**. That is the
check that this adds information without changing any line that had none to add. The first draft appended
`reason=n/a` unconditionally, which contradicted its own doc comment and would have altered every failure
line anyone has pattern-matched on.

## Hidden API

Both `EXTRA_REASON` and the `UNBOND_REASON_*` values are `@hide` in AOSP, so they are mirrored as literals
rather than referenced, the same trade the `GATT_INSUFFICIENT_AUTHENTICATION` / `_ENCRYPTION` constants in
`WhoopBleClient` already make. A hidden-API reference would not compile.

## The bond reason is Android-only, but the gap was not

CoreBluetooth performs pairing opaquely and never surfaces an SMP outcome. Checked rather than assumed:
the Apple side's `emitConnectionBondState` fires only on success, derived from NOOP's own CLIENT_HELLO ack,
so there is no failure transition to twin. `BondStateTrace` already documents this asymmetry.

Apple had the same CLASS of gap, though, and that half is here too.

Foundation LOCALIZES CoreBluetooth error strings, so a failure line built from `localizedDescription`
alone cannot be matched in a log shared from a non-English phone. That is not hypothetical:
`isInsufficientAuthError` documents the same property silently defeating the old
`localizedDescription.contains("encryption")` classification for the entire localized user base
(#78 hole-1), while Android was immune because it matches GATT status ints. The classification was made
code-first then. The **logging** still said only what the phone's locale said, including on the
CLIENT_HELLO write failure, which is the single most important line for #1635.

`BLEManager` already builds a stable, locale-independent token for Connection test mode, and its own doc
says it exists "for parity with Android's integer GATT status". It now rides the four failure lines on the
bond path as a bracketed suffix **beside** the description, never replacing it, since some CoreBluetooth
paths surface plain NSErrors outside both domains (those read `code?`, carrying no free text).

The two sides line up by construction: ATT insufficient-authentication and insufficient-encryption are the
same 5 and 15 that `gattWriteStatusLabel` names, which a test pins as numbers.

## Tests

+7, pinning the selection and not just the wording: that a reason is named when present, that an absent
reason (`null` and the -1 that `getIntExtra` returns) leaves the line byte-identical to before, that a
successful pairing never carries one even if a value arrives, that all nine defined codes are named and
that AUTH_FAILED and AUTH_TIMEOUT are provably distinguishable, and that an undefined value is not given
an invented name. Plus both shapes of a bond that existed and then ended, with and without a reason.

Apple: +5 in a new `BondErrorTokenTests`, pinning that the refusal codes equal Android's 5 and 15, that
the suffix is bracketed and additive, that no error adds nothing so healthy lines are untouched, that a
foreign error domain leaks no free text, and that CBError is tokenised too. Swift is CI-verified only.

Android: 670 classes / 5666 tests, 0 failures. No new user-facing copy; log lines are diagnostic and unlocalised.
Reason codes are integers, and the line's MAC is masked by the existing `redactStrapLogPii` rule.
