### PR TITLE
diag: name the BLE integers the strap log printed bare

### DIFF
--- a/android/app/src/main/java/com/noop/ble/BleStatusLabels.kt
+++ b/android/app/src/main/java/com/noop/ble/BleStatusLabels.kt
@@ -1,0 +1,62 @@
+package com.noop.ble
+
+/*
+ * BleStatusLabels.kt - names for the BLE integers the strap log used to print bare.
+ *
+ * The strap log is the only evidence a remote report carries, and a bare number in it is evidence
+ * nobody can read. `gattStatusLabel` already established the discipline for GATT operation statuses:
+ * name the codes that answer a question, leave everything else as a bare number rather than guessing,
+ * because a confidently wrong name in a failure line is worse than no name at all. These extend the
+ * same treatment to the two other integer spaces the log emits.
+ *
+ * Deliberately three separate functions rather than one: a scan error, a GATT operation status and a
+ * disconnect reason are DIFFERENT number spaces that happen to share the Int type. Forcing them
+ * through one table is exactly how a code acquires a name from the wrong space.
+ *
+ * Pure formatters: no IO, no state, no PII (these are protocol integers), unit-tested without a radio.
+ * Android-only. CoreBluetooth reports scan and disconnect problems as central-manager state changes and
+ * NSErrors, not as status integers; the Apple side tokenises those via `BLEManager.bleErrorToken`.
+ */
+
+/**
+ * A `ScanCallback.SCAN_FAILED_*` code, named.
+ *
+ * Worth naming even though a scan failure is rare, because one of these codes is both common and
+ * entirely self-inflicted: Android permits an app 5 scan starts per 30 seconds and answers the sixth
+ * with [SCAN_FAILED_SCANNING_TOO_FREQUENTLY], after which scanning simply stops working for the rest of
+ * the window. That is the leading cause of "it will not find my strap", it is fixable once seen, and
+ * the log reported it as the character "6".
+ */
+internal fun scanFailureLabel(code: Int): String = when (code) {
+    1 -> "ALREADY_STARTED(1)"
+    2 -> "APPLICATION_REGISTRATION_FAILED(2) - the BLE stack rejected our scanner; a Bluetooth restart usually clears it"
+    3 -> "INTERNAL_ERROR(3)"
+    4 -> "FEATURE_UNSUPPORTED(4) - this device's radio cannot do the scan we asked for"
+    5 -> "OUT_OF_HARDWARE_RESOURCES(5) - too many scanners open across all apps"
+    SCAN_FAILED_SCANNING_TOO_FREQUENTLY ->
+        "SCANNING_TOO_FREQUENTLY(6) - Android throttles an app to 5 scan starts per 30s and this one was refused; scanning stays dead until the window rolls"
+    else -> "$code"
+}
+
+/** The throttle code, named because callers reason about it and not just log it. */
+internal const val SCAN_FAILED_SCANNING_TOO_FREQUENTLY = 6
+
+/**
+ * A DISCONNECT status, named.
+ *
+ * A different space from [gattStatusLabel]'s: these arrive as HCI disconnect reasons surfaced through
+ * the same `status` Int, so 8 here means "link supervision timeout" and not the GATT code 8. That
+ * overlap is the whole reason this is separate rather than another branch of one shared table.
+ *
+ * Only the reasons that are unambiguous and long-established are named. 133 stays described as the
+ * catch-all it is rather than being given a specific cause it does not have.
+ */
+internal fun disconnectStatusLabel(status: Int): String = when (status) {
+    0 -> "status=0 (clean)"
+    8 -> "status=8 (link supervision timeout - the strap went out of range or stopped responding)"
+    19 -> "status=19 (the STRAP terminated the connection)"
+    22 -> "status=22 (this phone terminated the connection)"
+    62 -> "status=62 (connection failed to establish)"
+    133 -> "status=133 (GATT_ERROR, Android's catch-all - no specific cause reported)"
+    else -> "status=$status"
+}

--- a/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
+++ b/android/app/src/main/java/com/noop/ble/BondStateTrace.kt
@@ -26,7 +26,7 @@ internal const val NO_BOND_REASON = -1
 /**
  * A `BluetoothDevice.UNBOND_REASON_*` value, named.
  *
- * Deliberately mirrors [gattWriteStatusLabel]: name the codes that answer the question and leave
+ * Deliberately mirrors [gattStatusLabel]: name the codes that answer the question and leave
  * anything else as a bare number. A confidently wrong name in the line whose whole job is explaining a
  * pairing failure is worse than no name, and this broadcast's vendor stacks do emit values AOSP does
  * not define.

--- a/android/app/src/main/java/com/noop/ble/ClientHelloOutcome.kt
+++ b/android/app/src/main/java/com/noop/ble/ClientHelloOutcome.kt
@@ -60,10 +60,15 @@ internal fun clientHelloOutcomeLine(
  * bond" (the pair [BondRefusalGiveUp] already keys on), and 133 is the catch-all Android returns for a
  * link that went away underneath the operation.
  *
+ * Named for GATT statuses generally, not just writes: the same integers arrive from service discovery,
+ * a CCCD write and a characteristic read, and they mean the same thing in each. A DISCONNECT status is
+ * NOT this space (see [disconnectStatusLabel]) - 8 there is an HCI link-supervision timeout, not a GATT
+ * code, and running one through the other's table is how a number acquires a name from the wrong space.
+ *
  * Android-only by design: CoreBluetooth reports `didWriteValueFor` with an `Error`, not a status code,
  * which is why the outcome line takes its status pre-rendered.
  */
-internal fun gattWriteStatusLabel(status: Int?): String = when (status) {
+internal fun gattStatusLabel(status: Int?): String = when (status) {
     null -> "status=n/a"
     0 -> "status=GATT_SUCCESS(0)"
     3 -> "status=GATT_WRITE_NOT_PERMITTED(3)"

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -5238,7 +5238,7 @@ class WhoopBleClient(
         // set, the unbonded offload probe would stand aside for its full budget waiting on a chain that
         // had already died, in exactly the case the probe most wants a clear queue for.
         disChainInFlight = false
-        log(disReadFailureLine(uuid.toString(), gattWriteStatusLabel(status)))
+        log(disReadFailureLine(uuid.toString(), gattStatusLabel(status)))
         // Report it, but do NOT latch it when WE put a pairing in flight on this link. The latch is
         // persisted per device and permanent, and a read issued into a link that is mid-encryption
         // negotiation can fail for reasons that have nothing to do with the strap's policy. Latching that
@@ -5423,7 +5423,7 @@ class WhoopBleClient(
     private fun noteUnbondedProbeRefused(uuid: java.util.UUID, status: Int) {
         unbondedProbeSubscribing = false
         unbondedProbeAwaitingReply = false
-        log(puffinSubscribeRefusedLine(uuid.toString(), gattWriteStatusLabel(status)))
+        log(puffinSubscribeRefusedLine(uuid.toString(), gattStatusLabel(status)))
         if (explicitBondRequestedThisLink) {
             log("Unbonded offload probe: not latching that refusal — a pairing was requested on this link," +
                 " so the failure is not attributable to the strap (#1635)")
@@ -5999,7 +5999,7 @@ class WhoopBleClient(
 
         override fun onScanFailed(errorCode: Int) {
             scanning = false
-            log("Scan failed: $errorCode")
+            log("Scan failed: ${scanFailureLabel(errorCode)}")
         }
     }
 
@@ -6381,7 +6381,7 @@ class WhoopBleClient(
         val pinned = preferredAddress ?: return                 // single-WHOOP: nothing to re-adopt
         if (failedAddress == null || !failedAddress.equals(pinned, ignoreCase = true)) return
         pinnedBondRefusals++
-        log("Multi-WHOOP: pinned strap $pinned refused the encrypted bond (status=$status, refusal $pinnedBondRefusals/$PIN_BOND_REFUSAL_LIMIT)")
+        log("Multi-WHOOP: pinned strap $pinned refused the encrypted bond (${gattStatusLabel(status)}, refusal $pinnedBondRefusals/$PIN_BOND_REFUSAL_LIMIT)")
         val working = lastBondedAddress
         if (pinnedBondRefusals >= PIN_BOND_REFUSAL_LIMIT && working != null && !working.equals(pinned, ignoreCase = true)) {
             readoptWorkingStrap(working = working, awayFrom = pinned)
@@ -6826,7 +6826,7 @@ class WhoopBleClient(
         @SuppressLint("MissingPermission")
         override fun onServicesDiscovered(g: BluetoothGatt, status: Int) {
             if (status != BluetoothGatt.GATT_SUCCESS) {
-                log("Service discovery failed: $status")
+                log("Service discovery failed: ${gattStatusLabel(status)}")
                 return
             }
             // Port of didDiscoverServices → didDiscoverCharacteristicsFor, collapsed: Android
@@ -6984,7 +6984,7 @@ class WhoopBleClient(
         ) {
             // Port of didWriteValueFor: a CONFIRMED-write completion (no error) == bonding succeeded.
             if (status != BluetoothGatt.GATT_SUCCESS) {
-                log("Confirmed write failed: status=$status")
+                log("Confirmed write failed: ${gattStatusLabel(status)}")
                 // #1635: a FAILED completion is still a completion, and it carries two obligations.
                 //
                 // Report it: before this, a failed callback produced no line at all and then a false
@@ -7003,7 +7003,7 @@ class WhoopBleClient(
                         isHelloChar = failedHelloChar,
                         charUuid = characteristic.uuid.toString(),
                         elapsedMs = System.currentTimeMillis() - clientHelloWriteAtMs,
-                        status = gattWriteStatusLabel(status),
+                        status = gattStatusLabel(status),
                     ))
                 }
                 if (failedHelloChar) clientHelloWriteAtMs = 0L
@@ -7047,7 +7047,7 @@ class WhoopBleClient(
                         isHelloChar = isHelloChar,
                         charUuid = characteristic.uuid.toString(),
                         elapsedMs = System.currentTimeMillis() - clientHelloWriteAtMs,
-                        status = gattWriteStatusLabel(status),
+                        status = gattStatusLabel(status),
                     ))
                     // Consume the window ONLY for the hello's own completion. A foreign completion that
                     // cleared it would make a genuine ack arriving afterwards look unsolicited, costing a
@@ -7061,7 +7061,7 @@ class WhoopBleClient(
                     // Declining must not be silent — see [clientHelloDeclinedLine].
                     log(clientHelloDeclinedLine(
                         charUuid = characteristic.uuid.toString(),
-                        status = gattWriteStatusLabel(status),
+                        status = gattStatusLabel(status),
                     ))
                 }
                 // Only the hello's OWN completion is evidence of a bond. Declining here withholds the
@@ -7183,7 +7183,7 @@ class WhoopBleClient(
             status: Int,
         ) {
             if (status != BluetoothGatt.GATT_SUCCESS) {
-                log("Notify enable failed for ${descriptor.characteristic?.uuid}: status=$status")
+                log("Notify enable failed for ${descriptor.characteristic?.uuid}: ${gattStatusLabel(status)}")
                 // #1635: on the puffin notify chars during the unbonded probe, this IS the result — the
                 // generic line above cannot say so, because it is written for a transient stack failure
                 // and this is a verdict about whether the offload needs an encrypted link at all.
@@ -10972,7 +10972,7 @@ class WhoopBleClient(
             // #747: the bond keeps being refused, so auto-reconnect is paused: we stop hammering a strap that
             // can't bond (the epitaph + paused hint were already surfaced when the give-up tripped). The user
             // re-arms it by tapping Connect (clearPairingHintForUserConnect). We do NOT schedule a reconnect.
-            log("Disconnected (status=$status); auto-reconnect paused (strap keeps refusing to pair; tap Connect once it's free)")
+            log("Disconnected ${disconnectStatusLabel(status)}; auto-reconnect paused (strap keeps refusing to pair; tap Connect once it's free)")
             // #1539: a connect attempt CONSUMES the parked request, so re-park it — floored, so a reachable
             // strap that keeps refusing gets one attempt per window instead of a connect/refuse spin.
             standingConnectWhilePausedIfDue()
@@ -11026,7 +11026,7 @@ class WhoopBleClient(
                     staleBondRemoved = true
                     log(staleBondRemovalLine(staleDirectFailures, removeOsBond(staleDevice)))
                 }
-                log("Disconnected (status=$status) before the bonded fast-path reached a session — stale OS bond (attempt $staleDirectFailures); falling back to a scan")
+                log("Disconnected ${disconnectStatusLabel(status)} before the bonded fast-path reached a session — stale OS bond (attempt $staleDirectFailures); falling back to a scan")
                 lastDevice = null
                 // Two consecutive wiped-bond failures = the strap really reset its pairing (firmware
                 // update / official WHOOP app re-bond), not a one-off transient drop. Surface the same
@@ -11075,12 +11075,12 @@ class WhoopBleClient(
                 // count — keep it DIRECT; only a genuinely-out-of-range band escalates to PASSIVE for power.
                 val aclHeld = isStrapAclHeld(dev.address)
                 val passiveReconnect = passiveReconnectDecision(failedReconnectAttempts, aclHeld)
-                log("Disconnected (status=$status); reconnecting ${if (passiveReconnect) "passively" else "directly"} in ${directDelay / 1000}s (attempt $failedReconnectAttempts$heldSuffix${if (aclHeld) ", ACL-held" else ""})")
+                log("Disconnected ${disconnectStatusLabel(status)}; reconnecting ${if (passiveReconnect) "passively" else "directly"} in ${directDelay / 1000}s (attempt $failedReconnectAttempts$heldSuffix${if (aclHeld) ", ACL-held" else ""})")
                 // #1030 (ryanbr): cancellable backoff timer (see scheduleReconnect).
                 scheduleReconnect(directDelay) { connectToDevice(dev, autoConnect = passiveReconnect) }
             } else {
                 val rescanDelay = nextReconnectDelayMs()
-                log("Disconnected (status=$status); rescanning in ${rescanDelay / 1000}s (attempt $failedReconnectAttempts$heldSuffix)")
+                log("Disconnected ${disconnectStatusLabel(status)}; rescanning in ${rescanDelay / 1000}s (attempt $failedReconnectAttempts$heldSuffix)")
                 // #1030 (ryanbr): cancellable backoff timer (see scheduleReconnect).
                 scheduleReconnect(rescanDelay) { connectFromSystem(selectedModel) }
             }

--- a/android/app/src/test/java/com/noop/ble/BleStatusLabelsTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BleStatusLabelsTest.kt
@@ -1,0 +1,102 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * A bare integer in a strap log is evidence nobody can read, and the log is the only evidence a remote
+ * report carries. These pin the naming and, more importantly, pin that the three integer spaces stay
+ * SEPARATE.
+ */
+class BleStatusLabelsTest {
+
+    // --- scan failures ---
+
+    /**
+     * The code worth all of this: Android allows 5 scan starts per 30s and refuses the sixth, after
+     * which scanning is dead until the window rolls. It is the leading cause of "it will not find my
+     * strap", it is self-inflicted and fixable, and the log used to report it as "6".
+     */
+    @Test
+    fun `the scan throttle explains itself`() {
+        val l = scanFailureLabel(SCAN_FAILED_SCANNING_TOO_FREQUENTLY)
+        assertTrue(l, l.contains("SCANNING_TOO_FREQUENTLY(6)"))
+        assertTrue(l, l.contains("5 scan starts per 30s"))
+    }
+
+    @Test
+    fun `the other defined scan codes are named`() {
+        assertTrue(scanFailureLabel(1).startsWith("ALREADY_STARTED(1)"))
+        assertTrue(scanFailureLabel(2).startsWith("APPLICATION_REGISTRATION_FAILED(2)"))
+        assertTrue(scanFailureLabel(3).startsWith("INTERNAL_ERROR(3)"))
+        assertTrue(scanFailureLabel(4).startsWith("FEATURE_UNSUPPORTED(4)"))
+        assertTrue(scanFailureLabel(5).startsWith("OUT_OF_HARDWARE_RESOURCES(5)"))
+    }
+
+    /** An undefined code prints as itself. A wrong name in a failure line is worse than no name. */
+    @Test
+    fun `an unknown scan code is not given an invented name`() {
+        assertEquals("7", scanFailureLabel(7))
+        assertEquals("0", scanFailureLabel(0))
+    }
+
+    // --- disconnect reasons ---
+
+    @Test
+    fun `the disconnect reasons that matter are named`() {
+        assertTrue(disconnectStatusLabel(8).contains("out of range"))
+        assertTrue(disconnectStatusLabel(19).contains("STRAP terminated"))
+        assertTrue(disconnectStatusLabel(22).contains("phone terminated"))
+        assertTrue(disconnectStatusLabel(62).contains("failed to establish"))
+    }
+
+    /** 133 keeps its honesty: it is Android's catch-all, so it is not given a cause it does not have. */
+    @Test
+    fun `the catch-all is described as a catch-all`() {
+        val l = disconnectStatusLabel(133)
+        assertTrue(l, l.contains("catch-all"))
+        assertTrue(l, l.contains("no specific cause"))
+    }
+
+    @Test
+    fun `an unknown disconnect status keeps the old bare rendering`() {
+        assertEquals("status=41", disconnectStatusLabel(41))
+    }
+
+    // --- and the spaces stay apart ---
+
+    /**
+     * THE point of three functions instead of one. 8 is a link-supervision timeout as a DISCONNECT
+     * reason and something else entirely as a GATT operation status, so a shared table would hand one
+     * of them a name from the wrong space. This fails the moment someone merges them.
+     */
+    @Test
+    fun `the same integer means different things in the two spaces`() {
+        assertNotEquals(disconnectStatusLabel(8), gattStatusLabel(8))
+        assertTrue(disconnectStatusLabel(8).contains("link supervision"))
+        assertEquals("status=8", gattStatusLabel(8))
+    }
+
+    /**
+     * The flip side of the test above, and the reason it is not enough on its own. 133 is Android's
+     * catch-all in BOTH spaces and genuinely means the same thing, so the labellers AGREE about it.
+     * Separate tables was a decision about which codes differ, not a claim that every code does, and
+     * pinning only the disagreement would leave the boundary half-documented.
+     */
+    @Test
+    fun `the catch-all means the same thing in both spaces`() {
+        assertTrue(disconnectStatusLabel(133).contains("GATT_ERROR"))
+        assertTrue(gattStatusLabel(133).contains("GATT_ERROR"))
+        assertTrue(disconnectStatusLabel(0).contains("clean"))
+        assertTrue(gattStatusLabel(0).contains("GATT_SUCCESS"))
+    }
+
+    /** A GATT status the write path already named keeps that name wherever it is now used. */
+    @Test
+    fun `gatt statuses keep their names on the paths that reuse the labeller`() {
+        assertEquals("status=GATT_INSUFFICIENT_AUTHENTICATION(5)", gattStatusLabel(5))
+        assertEquals("status=GATT_INSUFFICIENT_ENCRYPTION(15)", gattStatusLabel(15))
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/BondStateTraceTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BondStateTraceTest.kt
@@ -240,7 +240,7 @@ class BondStateTraceTest {
 
     /**
      * An undefined value prints as itself rather than as a guess - the same discipline
-     * `gattWriteStatusLabel` applies to GATT codes, and vendor stacks do emit values AOSP does not define.
+     * `gattStatusLabel` applies to GATT codes, and vendor stacks do emit values AOSP does not define.
      */
     @Test
     fun `an unknown reason is not given an invented name`() {

--- a/android/app/src/test/java/com/noop/ble/ClientHelloOutcomeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/ClientHelloOutcomeTest.kt
@@ -63,9 +63,9 @@ class ClientHelloOutcomeTest {
         // The bug this guards: writeStatusLabel maps BluetoothStatusCodes (writeCharacteristic's return
         // value), a DIFFERENT enumeration that collides on small integers. Rendering a callback status
         // through it names the wrong error confidently.
-        assertEquals("status=GATT_INSUFFICIENT_AUTHENTICATION(5)", gattWriteStatusLabel(5))
-        assertEquals("status=GATT_INSUFFICIENT_ENCRYPTION(15)", gattWriteStatusLabel(15))
-        assertEquals("status=GATT_SUCCESS(0)", gattWriteStatusLabel(0))
+        assertEquals("status=GATT_INSUFFICIENT_AUTHENTICATION(5)", gattStatusLabel(5))
+        assertEquals("status=GATT_INSUFFICIENT_ENCRYPTION(15)", gattStatusLabel(15))
+        assertEquals("status=GATT_SUCCESS(0)", gattStatusLabel(0))
     }
 
     @Test
@@ -75,14 +75,14 @@ class ClientHelloOutcomeTest {
         for (code in listOf(1, 2, 3)) {
             assertTrue(
                 "code $code should not share a label across the two domains",
-                gattWriteStatusLabel(code) != WhoopBleClient.writeStatusLabel(code),
+                gattStatusLabel(code) != WhoopBleClient.writeStatusLabel(code),
             )
         }
     }
 
     @Test
     fun `an unknown code is a bare number rather than a guess`() {
-        assertEquals("status=99", gattWriteStatusLabel(99))
-        assertEquals("status=n/a", gattWriteStatusLabel(null))
+        assertEquals("status=99", gattStatusLabel(99))
+        assertEquals("status=n/a", gattStatusLabel(null))
     }
 }


### PR DESCRIPTION
A bare number in a strap log is evidence nobody can read, and that log is the only evidence a remote
report carries. `gattStatusLabel` already established the discipline for GATT statuses, and was then
applied to only some of the paths that emit one. Thirteen sites in `WhoopBleClient` still printed raw
integers.

## The one that matters most

`onScanFailed` logged the raw code:

```kotlin
log("Scan failed: $errorCode")
```

One of those codes is both common and entirely self-inflicted. Android permits an app **5 scan starts per
30 seconds** and refuses the sixth with `SCAN_FAILED_SCANNING_TOO_FREQUENTLY`, after which scanning is
simply dead until the window rolls. That is the leading cause of "it will not find my strap", it is
fixable the moment somebody sees it, and the log reported it as the character `6`. There was no naming for
these codes anywhere in the tree.

## GATT statuses, on the rest of the paths that have one

Service discovery, CCCD writes, the confirmed write and the pinned-strap refusal now use the labeller,
renamed `gattWriteStatusLabel` to `gattStatusLabel`: the same integers arrive from discovery and reads and
mean the same thing there, so the old name was describing one caller rather than the space.

A failed CCCD write is worth calling out. It means notifications silently never arrive, which presents as
a connected strap that sends nothing.

## Disconnects get their own labeller, deliberately

Disconnect statuses are a **different number space** that happens to share the `Int` type: they carry HCI
reasons through the same `status`, so `8` there is a link-supervision timeout and NOT the GATT code 8.
Running one space through the other's table is precisely how a number acquires a name from the wrong
space, which is the failure `ClientHelloOutcome` already warns about. A test pins that the two labellers
disagree about `8`, so a later attempt to merge the tables fails loudly instead of quietly mislabelling.

Only long-established reasons are named. `133` stays described as Android's catch-all rather than being
handed a specific cause it does not carry.

## Deliberately left bare

MTU and PHY keep their raw `status`. Those lines already report the negotiated value, which is the
actionable content, and labelling `status=0` would add noise to every healthy connect.

## Tests

+8. The throttle code explains itself, every other defined scan code is named, unknown codes in both
spaces keep their bare rendering, `133` stays honest about being a catch-all, and the two spaces are
pinned as disagreeing about `8`.

671 classes / 5667 tests, 0 failures. Android-only: CoreBluetooth reports scan and disconnect problems as
central-manager state changes and NSErrors rather than status integers, and the Apple side tokenises those
via `BLEManager.bleErrorToken`. No user-facing copy; strap-log lines are diagnostic and unlocalised.
