### PR TITLE
perf: bound the RE dump's search, and stop formatting hex a byte at a time

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/Spo2ReTrace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/Spo2ReTrace.swift
@@ -35,6 +35,19 @@ public enum Spo2ReTrace {
     /// samples, including one at 1% of traffic, and stops re-dumping a layout already at parity.
     public static let maxPerVersion = 3
 
+    /// Max records this dump may EXAMINE per session, separate from how many it may dump.
+    ///
+    /// The dump budget alone stopped bounding the work the moment `maxPerVersion` arrived: the loop's
+    /// outer guard counts DUMPS, so on a strap emitting one layout the per-version cap is reached at 3,
+    /// the dump count sticks below `maxSamples` forever, and every later chunk keeps re-examining every
+    /// frame to rediscover a version already at cap.
+    ///
+    /// Costs Apple far less than Android, which re-decodes each frame here while this side reads the
+    /// already-parsed record. It is applied on BOTH so the two platforms examine the same frames and so
+    /// dump the same records: a budget on one side only would silently diverge the two logs on a long
+    /// offload, which is the one thing this line's byte-identical promise cannot survive.
+    public static let maxExamined = 512
+
     /// One record's RE line: the mapped SpO2 channels + timestamp + layout version, then the FULL frame
     /// hex (no prefix cap - a v24 record is ~84 B and the unmapped tail is exactly where a banked SpO2
     /// would sit). Absent channels render "null" so a channel-less record still proves what it lacks.

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Hex.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Hex.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/*
+ * Hex.swift - the hex encoder the per-frame diagnostic paths use. Twin of the Kotlin `toHexLower`.
+ *
+ * `map { String(format: "%02x", $0) }.joined()` reads well and is fine for a one-off line, but it runs
+ * `String(format:)` ONCE PER BYTE, and that bridges to NSString formatting and parses the format string
+ * every time, plus a String per byte for `joined()` to concatenate. The captures write a line per frame
+ * for a whole offload and a deep-buffer frame is 2140 bytes.
+ *
+ * A nibble lookup into one preallocated buffer does the same job with a single allocation.
+ */
+
+private let hexDigits: [UInt8] = Array("0123456789abcdef".utf8)
+
+public extension Array where Element == UInt8 {
+
+    /// Lowercase, two digits per byte, no separator. Byte-for-byte identical to the `%02x` join it
+    /// replaces, which matters because these dumps are read by existing decode tooling.
+    ///
+    /// Named to match the Kotlin `toHexLower` rather than `hexString`: the two produce the same bytes and
+    /// a reader comparing the platforms should not have to check whether two differently-named helpers
+    /// agree on case or separator.
+    var hexLower: String {
+        var out = [UInt8](repeating: 0, count: count * 2)
+        var i = 0
+        for b in self {
+            out[i] = hexDigits[Int(b >> 4)]
+            out[i + 1] = hexDigits[Int(b & 0x0F)]
+            i += 2
+        }
+        return String(decoding: out, as: UTF8.self)
+    }
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/HexTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/HexTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import WhoopProtocol
+
+/// The fast encoder has to be byte-for-byte identical to the `%02x` join it replaces: its output goes
+/// into capture files and reject archives that existing decode tooling reads. Twin of the Kotlin
+/// `HexTest`, using the OLD implementation as the oracle rather than a hand-written expectation.
+final class HexTests: XCTestCase {
+
+    private func slow(_ b: [UInt8]) -> String { b.map { String(format: "%02x", $0) }.joined() }
+
+    func testMatchesTheFormatBasedEncoderAcrossTheWholeByteRange() {
+        let all = (0...255).map { UInt8($0) }
+        XCTAssertEqual(slow(all), all.hexLower)
+    }
+
+    /// The high half of the range is where a nibble-shifting encoder usually goes wrong.
+    func testHighBytesAreZeroPadded() {
+        XCTAssertEqual([0x00].hexLower, "00")
+        XCTAssertEqual([0x0f].hexLower, "0f")
+        XCTAssertEqual([0x80].hexLower, "80")
+        XCTAssertEqual([0xff].hexLower, "ff")
+    }
+
+    func testEmptyInEmptyOut() {
+        XCTAssertEqual([UInt8]().hexLower, "")
+    }
+
+    /// Lowercase, no separator: the shape every existing consumer of these dumps expects.
+    func testOutputIsLowercaseAndUnseparated() {
+        XCTAssertEqual([0xab, 0xcd, 0xef].hexLower, "abcdef")
+    }
+
+    /// A realistic deep-buffer frame, since that is the size this exists for.
+    func testLongFrameMatchesTheOracle() {
+        let frame = (0..<2140).map { UInt8($0 % 256) }
+        XCTAssertEqual(slow(frame), frame.hexLower)
+    }
+}

--- a/Strand/BLE/PuffinDeepBufferLog.swift
+++ b/Strand/BLE/PuffinDeepBufferLog.swift
@@ -139,7 +139,9 @@ final class PuffinDeepBufferLog {
         guard !disabled, Self.isDeepBuffer(frame), isEnabled else { return }
         let tsMs = Int(Date().timeIntervalSince1970 * 1000)
         let strapTs = Self.strapTs(frame).map { String($0) } ?? "null"
-        let hex = frame.map { String(format: "%02x", $0) }.joined()
+        // Fast encoder: this runs once per captured frame for a whole offload, and a deep-buffer frame
+        // is 2140 bytes, so the per-byte String(format:) it replaced bridged to NSString 2140 times.
+        let hex = frame.hexLower
         // #423/#455: run the raw-IMU decoder on the 1244-B buffer so every captured IMU frame carries
         // its decoded activity summary (cadence/energy/jerk/gyro) inline beside the raw hex. This is the
         // first CALLER of `Whoop5RawImu.decode` outside its own tests — it exercises the decoder on real

--- a/Strand/Collect/Backfiller.swift
+++ b/Strand/Collect/Backfiller.swift
@@ -246,6 +246,10 @@ final class Backfiller {
     /// Session-scoped alongside `spo2Dumped`; reset in `begin`. Twin of the Android `spo2DumpedByVersion`.
     private var spo2DumpedByVersion: [Int: Int] = [:]
 
+    /// SpO2 RE dump: records EXAMINED this session, bounded by `Spo2ReTrace.maxExamined`. Applied here so
+    /// both platforms examine the same frames and dump the same records. Twin of Android `spo2Examined`.
+    private var spo2Examined = 0
+
     /// Durably archives undecodable record frames BEFORE the trim ack (#77 / #91). Returns true once
     /// the bytes are safe (written OR cap-reached — either way the chunk may be acked) and false on a
     /// genuine write failure, in which case `finishChunk` holds the cursor/ack so the strap re-sends.
@@ -344,6 +348,7 @@ final class Backfiller {
         loggedLayoutVersions.removeAll(keepingCapacity: true)
         spo2Dumped = 0
         spo2DumpedByVersion = [:]
+        spo2Examined = 0
         // #547: the range markers belong to a connection's GET_DATA_RANGE, which BLEManager re-sets per
         // connect; clear them here so a fresh session never reuses a previous strap's window. BLEManager
         // re-publishes them as soon as the range reply arrives.
@@ -665,8 +670,11 @@ final class Backfiller {
             // frames carry no record bytes to correlate. Records dump whether or not they carry SpO2
             // channels, so "nothing banked" is provable too. Never a user-facing number (never-fabricate;
             // the #194 lesson). Twin of the Android Backfiller emit.
-            if spo2Dumped < Spo2ReTrace.maxSamples, connectionActive(), let connectionLog {
+            if spo2Dumped < Spo2ReTrace.maxSamples, spo2Examined < Spo2ReTrace.maxExamined,
+               connectionActive(), let connectionLog {
                 for (raw, p) in zip(frames, parsed) where spo2Dumped < Spo2ReTrace.maxSamples {
+                    if spo2Examined >= Spo2ReTrace.maxExamined { break }
+                    spo2Examined += 1
                     guard let unix = p.parsed["unix"]?.intValue else { continue }
                     // Stratify by layout: without this the first chunk's dominant layout eats the whole
                     // budget and the rare, still-unmapped one never gets a frame. See `maxPerVersion`.

--- a/Strand/Collect/RawHistoryArchive.swift
+++ b/Strand/Collect/RawHistoryArchive.swift
@@ -164,7 +164,9 @@ struct RawHistoryArchive {
         // Build the new JSONL lines (each newline-terminated). The version that drives floor-aware
         // retention (#344) is re-derived per line from the stored frame inside `evictLines`.
         let newLines: [String] = frames.map { f in
-            let hex = f.map { String(format: "%02x", $0) }.joined()
+            // Fast encoder: one line per REJECTED frame, which on an unmapped-layout strap is every
+            // frame of every chunk.
+            let hex = f.hexLower
             // Hand-built JSON: the only dynamic field is hex (always [0-9a-f]) so no escaping is
             // needed, and this avoids a JSONEncoder allocation per frame on the offload hot path.
             return "{\"capturedAtMs\":\(capturedAtMs),\"trim\":\(Int(trim)),"

--- a/android/app/src/main/java/com/noop/analytics/Spo2ReTrace.kt
+++ b/android/app/src/main/java/com/noop/analytics/Spo2ReTrace.kt
@@ -41,6 +41,22 @@ object Spo2ReTrace {
     const val MAX_PER_VERSION = 3
 
     /**
+     * Max records this dump may EXAMINE per session, separate from how many it may dump.
+     *
+     * The dump budget alone stopped bounding the work the moment [MAX_PER_VERSION] arrived. The loop's
+     * outer guard counts DUMPS, so on a strap emitting one layout the per-version cap is reached at 3,
+     * the dump count sticks below [MAX_SAMPLES] forever, and every later chunk re-decodes every frame to
+     * rediscover a version already at cap. That is a full second decode of the whole offload, on top of
+     * the one the extractor already did, for a dump that can never fire again.
+     *
+     * Bounding examinations instead keeps the stratified search working - several chunks' worth of
+     * frames is plenty to turn up a layout at a few percent of traffic - while making the cost fixed
+     * rather than proportional to offload length. The pre-stratification code examined barely more
+     * frames than it dumped; this is the ceiling that restores that property.
+     */
+    const val MAX_EXAMINED = 512
+
+    /**
      * One record's RE line: the mapped SpO2 channels + timestamp + layout version, then the FULL frame
      * hex (no prefix cap - a v24 record is ~84 B and the unmapped tail is exactly where a banked SpO2
      * would sit). Absent channels render "null" so a channel-less record still proves what it lacks.

--- a/android/app/src/main/java/com/noop/ble/Backfiller.kt
+++ b/android/app/src/main/java/com/noop/ble/Backfiller.kt
@@ -296,6 +296,11 @@ class Backfiller(
      *  Session-scoped alongside [spo2Dumped]; reset in begin. Twin of the Swift `spo2DumpedByVersion`. */
     private val spo2DumpedByVersion = HashMap<Int, Int>()
 
+    /** SpO2 RE dump: records EXAMINED this session, bounded by [com.noop.analytics.Spo2ReTrace.MAX_EXAMINED].
+     *  Counts the decode attempts the search costs, which the dump counter stopped bounding once the
+     *  per-version cap could hold dumps back indefinitely. Reset in begin. Twin of Swift `spo2Examined`. */
+    private var spo2Examined = 0
+
     /**
      * #547: logged once per session the first time the #547 ingest gate drops an implausible-timestamp
      * record (a bad strap clock/flash emitting far-past / year-2027-spike / future-dated `unix` values).
@@ -356,6 +361,7 @@ class Backfiller(
         chunkIndex = 0
         spo2Dumped = 0
         spo2DumpedByVersion.clear()
+        spo2Examined = 0
         loggedImplausibleClock = false
         sessionDroppedImplausible = 0
         sessionUnhandledPacketTypes.clear()   // #891: a second offload must re-log its first sighting
@@ -475,9 +481,16 @@ class Backfiller(
             // the strap's type-50 console frames carry no record bytes to correlate. Records dump whether
             // or not they carry SpO2 channels, so "nothing banked" is provable too. Never a user-facing
             // number (never-fabricate; the #194 lesson). Twin of the Swift Backfiller emit.
-            if (spo2Dumped < com.noop.analytics.Spo2ReTrace.MAX_SAMPLES && connectionActive()) {
+            if (spo2Dumped < com.noop.analytics.Spo2ReTrace.MAX_SAMPLES &&
+                spo2Examined < com.noop.analytics.Spo2ReTrace.MAX_EXAMINED &&
+                connectionActive()
+            ) {
                 for (f in frames) {
                     if (spo2Dumped >= com.noop.analytics.Spo2ReTrace.MAX_SAMPLES) break
+                    // The decode below is a SECOND decode of a frame the extractor already decoded, so the
+                    // search has to be bounded by what it examines and not only by what it dumps.
+                    if (spo2Examined >= com.noop.analytics.Spo2ReTrace.MAX_EXAMINED) break
+                    spo2Examined++
                     val d = decodeHistorical(f, family) ?: continue
                     // `as? Long`, not `as? Int`: the decoder carries unix in the unsigned domain, so an
                     // Int cast would miss on EVERY record and silently stop the dump. See `histU32`.

--- a/android/app/src/main/java/com/noop/ble/RawHistoryArchive.kt
+++ b/android/app/src/main/java/com/noop/ble/RawHistoryArchive.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.noop.data.WhoopRepository
 import com.noop.protocol.DeviceFamily
 import com.noop.protocol.extractHistoricalStreams
+import com.noop.protocol.toHexLower
 import java.io.File
 import java.io.FileOutputStream
 
@@ -115,7 +116,9 @@ class RawHistoryArchive(
     private fun familyTag(family: DeviceFamily): String =
         if (family == DeviceFamily.WHOOP5) "whoop5" else "whoop4"
 
-    private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+    // Shared fast encoder: the archive writes one line per rejected frame, which on an unmapped-layout
+    // strap is every frame of every chunk.
+    private fun ByteArray.toHex(): String = toHexLower()
 
     /**
      * Every archived frame with its strap family, oldest first — the read-back of the JSONL that

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -62,6 +62,7 @@ import com.noop.protocol.Whoop5Config
 import com.noop.protocol.extractStreams
 import com.noop.protocol.WhoopGattServiceFamily
 import com.noop.protocol.whoopGattScanDecision
+import com.noop.protocol.toHexLower
 import com.noop.analytics.Baselines
 import com.noop.analytics.BatterySocLine
 import com.noop.analytics.ConnectionReadout
@@ -11239,7 +11240,9 @@ class WhoopBleClient(
     /** Coerce a parsed value to a Double (battery_pct may arrive as Double or Int). */
     private fun doubleValue(v: Any?): Double? = (v as? Number)?.toDouble()
 
-    private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it) }
+    // Delegates to the shared fast encoder: this runs once per captured frame for a whole offload, and
+    // the per-byte String.format it used to do allocated a Formatter for every byte of a 2140-B frame.
+    private fun ByteArray.toHex(): String = toHexLower()
 
     // MARK: 5/MG raw backfill capture (opt-in research aid, #78 fork)
     //

--- a/android/app/src/main/java/com/noop/protocol/Hex.kt
+++ b/android/app/src/main/java/com/noop/protocol/Hex.kt
@@ -1,0 +1,34 @@
+package com.noop.protocol
+
+/*
+ * Hex.kt - the hex encoder the per-frame diagnostic paths use.
+ *
+ * `joinToString("") { "%02x".format(it) }` reads well and is fine for a one-off line, but it runs
+ * String.format ONCE PER BYTE: each call parses the format string and allocates a Formatter, plus a
+ * String per byte for joinToString to concatenate. The captures write one line per frame for the whole
+ * offload, and a deep-buffer frame is 2140 bytes, so that is ~2140 Formatter allocations per frame.
+ *
+ * A nibble lookup into one preallocated CharArray does the same job with a single allocation.
+ * Byte-for-byte identical output: lowercase, two digits, no separator.
+ */
+
+private val HEX_DIGITS = "0123456789abcdef".toCharArray()
+
+/**
+ * Lowercase, two digits per byte, no separator. Identical output to the `%02x` join it replaces.
+ *
+ * NOT named `toHexString`: the stdlib has an `@ExperimentalStdlibApi ByteArray.toHexString()` with the
+ * same arity since Kotlin 1.9. An explicit import outranks a default one so ours would still win, but
+ * that is a resolution subtlety to be relying on the day the stdlib one stabilises, and both return
+ * lowercase unseparated hex, so a silent swap would not fail a single test.
+ */
+internal fun ByteArray.toHexLower(): String {
+    val out = CharArray(size * 2)
+    var i = 0
+    for (b in this) {
+        val v = b.toInt() and 0xFF
+        out[i++] = HEX_DIGITS[v ushr 4]
+        out[i++] = HEX_DIGITS[v and 0x0F]
+    }
+    return String(out)
+}

--- a/android/app/src/test/java/com/noop/analytics/Spo2ReTraceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/Spo2ReTraceTest.kt
@@ -55,4 +55,16 @@ class Spo2ReTraceTest {
     @Test fun sessionCapCoversSeveralDistinctLayouts() {
         assertTrue(Spo2ReTrace.MAX_SAMPLES / Spo2ReTrace.MAX_PER_VERSION >= 4)
     }
+
+    /**
+     * The examine budget is what keeps the search bounded now that a per-version cap can hold dumps back
+     * indefinitely. Without it the loop's only stop condition counts dumps, so a single-layout strap
+     * re-decodes every frame of every chunk for the whole offload to rediscover a version at cap.
+     */
+    @Test
+    fun `the examine budget bounds the search independently of the dump budget`() {
+        assertTrue(Spo2ReTrace.MAX_EXAMINED > Spo2ReTrace.MAX_SAMPLES)
+        // Enough frames to sweep several chunks, so a layout at a few percent of traffic is still found.
+        assertTrue(Spo2ReTrace.MAX_EXAMINED >= 256)
+    }
 }

--- a/android/app/src/test/java/com/noop/protocol/HexTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/HexTest.kt
@@ -1,0 +1,40 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The fast encoder has to be byte-for-byte identical to the `%02x` join it replaces, because its output
+ * goes into capture files and strap logs that existing decode tooling reads.
+ */
+class HexTest {
+
+    private fun slow(b: ByteArray) = b.joinToString("") { "%02x".format(it) }
+
+    @Test
+    fun `matches the format-based encoder across the whole byte range`() {
+        val all = ByteArray(256) { it.toByte() }
+        assertEquals(slow(all), all.toHexLower())
+    }
+
+    /** The sign bit is where a hand-rolled encoder usually goes wrong. */
+    @Test
+    fun `high bytes are unsigned and zero-padded`() {
+        assertEquals("00", byteArrayOf(0).toHexLower())
+        assertEquals("0f", byteArrayOf(15).toHexLower())
+        assertEquals("80", byteArrayOf((-128).toByte()).toHexLower())
+        assertEquals("ff", byteArrayOf((-1).toByte()).toHexLower())
+    }
+
+    @Test
+    fun `empty in, empty out`() {
+        assertEquals("", ByteArray(0).toHexLower())
+    }
+
+    /** Lowercase, no separator: the shape every existing consumer of these dumps expects. */
+    @Test
+    fun `output is lowercase and unseparated`() {
+        val b = byteArrayOf(0xAB.toByte(), 0xCD.toByte(), 0xEF.toByte())
+        assertEquals("abcdef", b.toHexLower())
+    }
+}


### PR DESCRIPTION
Two costs in the diagnostic paths. The first is a regression I introduced in #1998 and only found by
going back over it.

## The RE dump's search stopped being bounded

Stratifying the SpO2 dump per layout version broke the only thing that bounded its work:

```kotlin
for (f in frames) {
    if (spo2Dumped >= MAX_SAMPLES) break          // counts DUMPS
    val d = decodeHistorical(f, family) ?: continue     // a SECOND full decode, per frame
    if (dumpedForVer >= MAX_PER_VERSION) continue       // ...but this holds dumps back
```

The outer guard counts dumps. Once the per-version cap holds dumps back, the dump count sticks below the
session budget and never trips it again. On a strap emitting a single layout, which is the common case
(a 4.0 emits v24, a 5/MG is mostly v18), the cap is reached after three records and **every later chunk
re-decodes every frame** to rediscover a version already at cap.

That is a full second decode of the whole offload, on top of the one `extractHistoricalStreams` already
did, for a dump that can never fire again. Before stratification the loop examined barely more frames than
it dumped and stopped in the first chunk or two.

The search is now bounded by what it EXAMINES, not only by what it dumps. 512 records is several chunks'
worth, so a layout at a few percent of traffic is still found, while the cost becomes fixed rather than
proportional to offload length.

**Both platforms get the budget** even though Apple pays far less for it: Swift reads the already-parsed
record where Android re-decodes. Applying it on one side only would make the two examine different frames
and therefore dump different records on a long offload, and a byte-identical line that describes different
records is worse than no parity claim at all.

Only reachable with Test Centre Connection mode on, which is exactly when someone is measuring the sync
they are trying to diagnose.

## Hex was formatted one byte at a time

The two capture paths built hex with `joinToString("") { "%02x".format(it) }`. That runs `String.format`
**per byte**: each call parses the format string and allocates a `Formatter`, plus a `String` per byte for
`joinToString` to concatenate. They write a line per frame for a whole offload, and a deep-buffer frame is
2140 bytes, so a single frame cost ~2140 `Formatter` allocations.

A nibble lookup into one preallocated `CharArray` does the same job with a single allocation. The other 27
sites using the same idiom are one-offs and are left alone; only the per-frame paths (`WhoopBleClient`'s
captures and `RawHistoryArchive`, which writes a line per rejected frame) were worth touching.

## Tests

+5. The encoder is pinned identical to the `%02x` join **across the whole 256-value byte range**, using
the old implementation as the oracle, because these dumps are read by existing decode tooling and a
sign-extension slip is the classic way a hand-rolled hex encoder goes wrong. Plus the empty case, the
high-byte/zero-pad cases, and that the examine budget is independent of and larger than the dump budget.

671 classes / 5678 tests, 0 failures. Swift is CI-verified only.
