### PR TITLE
fix: a connection the phone is holding is not a strap refusing to pair

### DIFF
--- a/android/app/src/main/java/com/noop/ble/BondRefusalGiveUp.kt
+++ b/android/app/src/main/java/com/noop/ble/BondRefusalGiveUp.kt
@@ -143,6 +143,74 @@ class BondRefusalGiveUp(
                 "please share your strap log."
 
         /**
+         * #1997: which reconnect guide the never-bonded pause should show.
+         *
+         * Pure so the SELECTION is pinned and not just the two texts. Testing a predicate and a string
+         * separately proves neither is wired to the other, and an inline `if` in a BLE callback cannot be
+         * reached from a JVM test at all. Same shape as the other decisions in this file.
+         */
+        fun reconnectGuideFor(heldLink: Boolean): String =
+            if (heldLink) heldLinkGuide() else stalePairingGuide()
+
+        /**
+         * The long-standing guide: a stale pairing, or the official app holding the strap. Correct advice
+         * when the strap really is refusing, and the default whenever there is no evidence of a held link.
+         */
+        fun stalePairingGuide(): String =
+            """
+            Your strap connects but never finishes pairing with NOOP, so it drops and retries in a loop. This is almost always a stale Bluetooth pairing, usually after a WHOOP firmware update, or the official WHOOP app holding the strap. NOOP works fine once it's re-paired:
+
+            1. Quit the official WHOOP app (or turn off Bluetooth on that phone).
+            2. Open Settings → Bluetooth, find your WHOOP, and Forget / Unpair it.
+            3. Tap the band repeatedly until its LEDs flash blue (pairing mode).
+            4. Come back here and tap Connect.
+            """.trimIndent()
+
+        /**
+         * #1997: the reconnect GUIDE for a held link, replacing the re-pair steps for this state only.
+         *
+         * The re-pair guide's four steps are the right advice when a stale pairing is the cause. They are
+         * actively harmful here: nothing was exchanged for the strap to refuse, so forgetting the pairing
+         * and re-pairing changes nothing, and the reporter was doing it several times a day.
+         *
+         * Auto-reconnect still pauses, which is what stops both batteries draining on a retry loop. Only
+         * the explanation and the actions change.
+         */
+        fun heldLinkGuide(): String =
+            """
+            Your phone is still holding a Bluetooth connection to your strap, and your strap is not
+            answering on it: the connection size negotiation is refused and no data arrives. Re-pairing
+            will not change this, so it is not worth doing.
+
+            1. If the official WHOOP app is running, quit it. A strap talks to one phone at a time.
+            2. Otherwise turn Bluetooth off and back on, which releases the held connection.
+            3. Come back here and tap Connect.
+            """.trimIndent()
+
+        /**
+         * #1997: the paused hint for a link the OS was already HOLDING, rather than a strap refusing.
+         *
+         * [pausedHintHandshakeUnanswered] deliberately declines to name a cause, and that is right for an
+         * unanswered handshake: several things produce it and "close the WHOOP app" would be a guess
+         * dressed as instruction. This branch exists because there IS evidence. The MTU exchange was
+         * refused, which happens when it already took place on a connection the phone still holds, and not
+         * one frame arrived on the link. Naming what was observed is then reporting, not guessing.
+         *
+         * It still does not assert WHICH owner holds the link, because NOOP cannot see that. It names the
+         * two candidates and the actions that belong to the user. Crucially it does NOT send them to
+         * re-pair: nothing was exchanged for the strap to refuse, so re-pairing cannot change this state,
+         * and the reporter had been doing exactly that on a loop.
+         *
+         * Pure; no em-dash.
+         */
+        fun pausedHintLinkHeld(): String =
+            "NOOP stopped retrying because the phone's Bluetooth is still holding a connection to your " +
+                "strap that the strap is not answering on: the connection size negotiation is refused and " +
+                "no data arrives. Re-pairing will not change this, so it is not worth doing. If the " +
+                "official WHOOP app is running, quit it. Otherwise turn Bluetooth off and on again, which " +
+                "releases the held connection. Then tap Connect."
+
+        /**
          * #750: a short OPAQUE token for the epitaph, derived from the strap's device id.
          *
          * DIVERGENCE FROM SWIFT (deliberate, PII): on iOS the source is a CoreBluetooth-local UUID

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -1045,6 +1045,23 @@ class WhoopBleClient(
         ): Boolean = wasConnected && !didBond && !intentionalDisconnect && !staleDirectBond &&
             status != GATT_CONN_TERMINATE_LOCAL_HOST && !alreadyPausedForBondLoop && !helloSuppressed
 
+        /**
+         * #1997: was this link one the strap never spoke on, on a connection the OS was already holding?
+         *
+         * The MTU exchange is refused (non-zero status, so the link sits at the 23-byte default) and not a
+         * single frame arrived. On the reporting device every re-attach looked exactly like this while the
+         * one link that negotiated 247 carried traffic, so this is the shape of attaching to a stale
+         * connection rather than of a strap declining to pair.
+         *
+         * This selects the GUIDE, and deliberately does NOT gate the pause. Excluding these links from
+         * [shouldCountNeverBondedSelfDrop] was the first shape of this fix and it was wrong: CLIENT_HELLO
+         * is 5/MG only, so on the reporter's WHOOP 4.0 nothing else would have bounded the loop, and the
+         * connect-drop-retry cycle would have run forever draining both batteries. That is the exact
+         * failure #982 exists to prevent. The pause is right; only the explanation was wrong.
+         */
+        internal fun heldLinkWithoutTraffic(mtuStatus: Int, inboundFrames: Int): Boolean =
+            mtuStatus != 0 && inboundFrames == 0
+
         /** Pure guard for a delayed service-discovery kick. The operation belongs only to the exact
          *  connection that scheduled it, and a temporarily-missing GATT wrapper must not consume the
          *  once-only claim. Kept pure because local JVM tests cannot instantiate BluetoothGatt. */
@@ -6495,6 +6512,12 @@ class WhoopBleClient(
                 it.copy(pairingHint = when {
                     suppress -> BondRefusalGiveUp.helloSuppressedHint()
                     authRefusal -> BondRefusalGiveUp.pausedHint()
+                    // #1997: BEFORE the unanswered-handshake hint, because this is the more specific
+                    // observation. A refused MTU exchange with no inbound traffic says the link is held
+                    // and the strap is not on it, which the generic hint cannot say and which changes
+                    // what the user should do: not re-pair.
+                    heldLinkWithoutTraffic(lastMtuStatus, inboundFrames) ->
+                        BondRefusalGiveUp.pausedHintLinkHeld()
                     else -> BondRefusalGiveUp.pausedHintHandshakeUnanswered()
                 })
             }
@@ -6551,6 +6574,21 @@ class WhoopBleClient(
      *  the duplicate could re-enter discovery and leave every later CCCD write BUSY. Keep the dedup for
      *  stable telemetry and to avoid repeating any future callback-side work. */
     private var lastMtuValue = -1
+
+    /**
+     * #1997: the status the last MTU exchange reported, and the reason a refused one matters.
+     *
+     * A re-attach to a link the OS still holds answers the MTU request with a non-zero status and leaves
+     * the link at the 23-byte default. On the reporter's log every such link then carried ZERO inbound
+     * frames, while the one link that negotiated 247 carried traffic. So a refused exchange is a cheap,
+     * early tell that this link is not one the strap is actually talking on.
+     *
+     * Plain `var`, like [lastMtuValue] and `lastMtuAtMs` beside it, which are written in the same callback
+     * and read on the same paths. Marking only this one `@Volatile` would advertise a thread-safety
+     * property it cannot deliver: it is read in a single expression with `inboundFrames`, also a plain
+     * var, so the pair would be no more coherent than before while looking as though it had been made so.
+     */
+    private var lastMtuStatus = 0
     private var lastMtuAtMs = 0L
 
     /** #1066 follow-up: wall-clock of the `requestMtu` attempt, so `onMtuChanged` can log how long the MTU
@@ -6798,6 +6836,7 @@ class WhoopBleClient(
             }
             lastMtuValue = mtu
             lastMtuAtMs = now
+            lastMtuStatus = status
             // Whatever the strap granted (≤ requested). Telemetry only: Android can emit this callback
             // for the connection itself as well as requestMtu, without saying which. Starting discovery
             // here can overlap the still-running MTU operation and wedge service discovery.
@@ -6805,7 +6844,16 @@ class WhoopBleClient(
             // capture reveals how much headroom that 1.5s has before discovery. -1 when no request preceded
             // this callback (a bare connection-event MTU).
             val settledMs = if (mtuRequestedAtMs > 0L) now - mtuRequestedAtMs else -1L
-            log("MTU negotiated: $mtu (status=$status)" +
+            // #1997: a refused exchange has to READ as refused. "MTU negotiated: 23 (status=4)" looks like
+            // a result, and a triager has to already know that 23 is the default the link falls back to.
+            val mtuOutcome = if (status == BluetoothGatt.GATT_SUCCESS) {
+                // Unchanged on the healthy path: this line appears in every connection log and dropping
+                // its status would be a change nobody asked for. Only the refusal renders differently.
+                "MTU negotiated: $mtu (status=$status)"
+            } else {
+                "MTU exchange REFUSED (${gattStatusLabel(status)}) — link stays at the $mtu-byte default"
+            }
+            log(mtuOutcome +
                 if (settledMs >= 0L) " — settled ${settledMs}ms after request (fixed wait ${MTU_DISCOVERY_SETTLE_MS}ms)" else "")
         }
 
@@ -10857,16 +10905,14 @@ class WhoopBleClient(
                 // #1539: park the connect in the same breath as the pause, so this can end while backgrounded.
                 standingConnectWhilePausedIfDue(justTripped = true)
             if (_state.value.reconnectGuide == null) {
-                _state.update { it.copy(
-                    reconnectGuide = """
-                    Your strap connects but never finishes pairing with NOOP, so it drops and retries in a loop. This is almost always a stale Bluetooth pairing, usually after a WHOOP firmware update, or the official WHOOP app holding the strap. NOOP works fine once it's re-paired:
-
-                    1. Quit the official WHOOP app (or turn off Bluetooth on that phone).
-                    2. Open Settings → Bluetooth, find your WHOOP, and Forget / Unpair it.
-                    3. Tap the band repeatedly until its LEDs flash blue (pairing mode).
-                    4. Come back here and tap Connect.
-                    """.trimIndent()
-                ) }
+                // #1997: the pause is right either way, it stops both batteries draining on a loop. What
+                // was wrong is blaming the strap. When the MTU exchange was refused and nothing arrived,
+                // the phone is holding a connection the strap is not on, and re-pairing cannot change
+                // that: the reporter had been doing it several times a day on this guide's advice.
+                val guide = BondRefusalGiveUp.reconnectGuideFor(
+                    heldLinkWithoutTraffic(lastMtuStatus, inboundFrames),
+                )
+                _state.update { it.copy(reconnectGuide = guide) }
             }
         }
 
@@ -11158,6 +11204,7 @@ class WhoopBleClient(
         // Clear the onMtuChanged dedup (#50) so the first MTU callback of the NEXT connection — even to
         // the same strap with the same granted mtu — is never mistaken for a duplicate of the last one.
         lastMtuValue = -1
+        lastMtuStatus = 0
         lastMtuAtMs = 0L
         mtuRequestedAtMs = 0L   // #1066: don't measure settle time across a connection boundary
         // The strap forgets the realtime-HR toggle across a disconnect; the post-bond branch re-arms it

--- a/android/app/src/test/java/com/noop/ble/BondRefusalGiveUpTest.kt
+++ b/android/app/src/test/java/com/noop/ble/BondRefusalGiveUpTest.kt
@@ -2,6 +2,7 @@ package com.noop.ble
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -100,5 +101,86 @@ class BondRefusalGiveUpTest {
         assertEquals(5, g.giveUpThreshold)
         repeat(4) { assertFalse(g.recordRefusal()) }
         assertTrue(g.recordRefusal())
+    }
+
+    // --- #1997: the held-link hint ---
+
+    /**
+     * The whole point of this branch: it must NOT send the user to re-pair. The reporter was re-pairing
+     * and rebooting on a loop because the generic guide told them to, for a state where nothing was
+     * exchanged for the strap to refuse.
+     */
+    @Test
+    fun `the held-link hint does not tell the user to re-pair`() {
+        val h = BondRefusalGiveUp.pausedHintLinkHeld().lowercase()
+        // It DOES say the word, to rule the action out. What it must not do is instruct it: no Forget,
+        // no Unpair, no numbered steps. Asserting the word is absent was wrong and this test caught it.
+        assertTrue(h, h.contains("re-pairing will not change this"))
+        assertFalse(h, h.contains("forget"))
+        assertFalse(h, h.contains("unpair"))
+        assertFalse(h, h.contains("1."))
+    }
+
+    /**
+     * It names both candidate owners and the action for each, without asserting WHICH holds the link,
+     * because NOOP cannot see that. Naming the observation is reporting; naming the owner would be a
+     * guess, which is the standard `pausedHintHandshakeUnanswered` already sets.
+     */
+    @Test
+    fun `the held-link hint offers both actions without claiming which owner holds it`() {
+        val h = BondRefusalGiveUp.pausedHintLinkHeld().lowercase()
+        assertTrue(h, h.contains("whoop app"))
+        assertTrue(h, h.contains("bluetooth off and on"))
+        assertFalse(h, h.contains("is holding it"))
+    }
+
+    /** Distinct from the generic hint, or the more specific observation would be invisible. */
+    @Test
+    fun `the held-link hint is not the unanswered-handshake hint`() {
+        assertNotEquals(
+            BondRefusalGiveUp.pausedHintHandshakeUnanswered(),
+            BondRefusalGiveUp.pausedHintLinkHeld(),
+        )
+    }
+
+    /**
+     * The guide is what the user actually sees, and it is where the harm was: the re-pair steps sent the
+     * reporter to forget and re-pair several times a day for a state re-pairing cannot change.
+     */
+    @Test
+    fun `the held-link guide replaces the re-pair steps rather than repeating them`() {
+        // Collapse the wrapping: the assertion is about what the guide SAYS, and a phrase that happens to
+        // straddle a line break is still said. Matching the raw string pinned the wrapping instead.
+        val g = BondRefusalGiveUp.heldLinkGuide().lowercase().replace(Regex("\\s+"), " ")
+        assertTrue(g, g.contains("re-pairing will not change this"))
+        assertFalse(g, g.contains("forget"))
+        assertFalse(g, g.contains("unpair"))
+        assertFalse(g, g.contains("flash blue"))
+        // and it still gives them something to do
+        assertTrue(g, g.contains("quit it"))
+        assertTrue(g, g.contains("bluetooth off and back on"))
+    }
+
+    /**
+     * The SELECTION, not just the two texts. Pinning a predicate and a string separately proves neither
+     * is wired to the other, which is how a fix ends up unreachable in the case it was written for.
+     */
+    @Test
+    fun `a held link selects the held-link guide, and anything else keeps the stale-pairing one`() {
+        assertEquals(BondRefusalGiveUp.heldLinkGuide(), BondRefusalGiveUp.reconnectGuideFor(heldLink = true))
+        assertEquals(BondRefusalGiveUp.stalePairingGuide(), BondRefusalGiveUp.reconnectGuideFor(heldLink = false))
+    }
+
+    /**
+     * The default path is unchanged copy. This guide was moved out of the BLE callback to make the
+     * selection testable, and a move must not edit what the user reads: an arrow was silently turned into
+     * a ">" during the extraction and this is what would have caught it.
+     */
+    @Test
+    fun `the stale-pairing guide still says exactly what it said`() {
+        val g = BondRefusalGiveUp.stalePairingGuide()
+        assertTrue(g, g.contains("Open Settings → Bluetooth, find your WHOOP, and Forget / Unpair it."))
+        assertTrue(g, g.contains("Tap the band repeatedly until its LEDs flash blue (pairing mode)."))
+        assertTrue(g, g.startsWith("Your strap connects but never finishes pairing with NOOP"))
     }
 }

--- a/android/app/src/test/java/com/noop/ble/NeverBondedSelfDropGiveUpTest.kt
+++ b/android/app/src/test/java/com/noop/ble/NeverBondedSelfDropGiveUpTest.kt
@@ -179,4 +179,40 @@ class NeverBondedSelfDropGiveUpTest {
             )
         )
     }
+
+    // --- #1997: a held link still bounds the loop, and only the explanation changes ---
+
+    /**
+     * The shape from the report: the MTU exchange is refused, so the link sits at the 23-byte default, and
+     * not one frame arrives. Both halves are required. A refused exchange on a link that still carried
+     * traffic is a different story, and a silent link that negotiated its MTU fine is the #1809 shape,
+     * which this must not claim.
+     */
+    @Test
+    fun `a held link is a refused MTU exchange AND no traffic`() {
+        assertTrue(WhoopBleClient.heldLinkWithoutTraffic(mtuStatus = 4, inboundFrames = 0))
+        assertFalse(WhoopBleClient.heldLinkWithoutTraffic(mtuStatus = 4, inboundFrames = 6))
+        assertFalse(WhoopBleClient.heldLinkWithoutTraffic(mtuStatus = 0, inboundFrames = 0))
+        assertFalse(WhoopBleClient.heldLinkWithoutTraffic(mtuStatus = 0, inboundFrames = 6))
+    }
+
+    /**
+     * The correction that matters: a held link STILL counts toward the give-up.
+     *
+     * The first version of this fix excluded it, on the reasoning that nothing was exchanged for the strap
+     * to refuse. That was wrong in a way only reachable by asking what else would stop the loop:
+     * CLIENT_HELLO is 5/MG only, so on the reporter's WHOOP 4.0 the other give-up never fires, and
+     * excluding these links would leave the connect-drop-retry cycle unbounded, draining both batteries.
+     * That is exactly what #982 exists to prevent. The pause is correct; only the guide was wrong.
+     */
+    @Test
+    fun `a held link still counts, so the retry loop stays bounded`() {
+        assertTrue(
+            WhoopBleClient.shouldCountNeverBondedSelfDrop(
+                wasConnected = true, didBond = false, intentionalDisconnect = false,
+                staleDirectBond = false, status = 0, alreadyPausedForBondLoop = false,
+                helloSuppressed = false,
+            ),
+        )
+    }
 }


### PR DESCRIPTION
Reported in #1997 by @semoi: a WHOOP 4.0 reconnects, the strap sends nothing, and after four cycles NOOP
pauses auto-reconnect and shows the re-pair guide. They had been re-pairing and rebooting several times a
day on that advice.

## What the log actually shows

| link | MTU | inbound |
|---|---|---|
| gen=1 | `247 (status=0)` | 6 frames / 26 bytes |
| gen=2 | `23 (status=4)` | **0 frames** |
| gen=3 | `23 (status=4)` | **0 frames** |

Every re-attach is answered with a refused MTU exchange and sits at the 23-byte default, and on exactly
those links nothing arrives. The first bounce reports `ACL-held`, so the phone's stack still holds the
connection. NOOP re-attaches to a connection the strap is not on. No part of that is a strap declining to
pair.

NOOP cannot clear that connection, and this does not try to: `gatt.close()` is already called on teardown
and before each new connect, so NOOP is not the one holding it, and Android gives an app no way to drop a
connection it does not own.

## Three changes

**1. The pause stays, and the guide changes.** The first version of this fix excluded these links from the
never-bonded give-up, reasoning that nothing was exchanged for the strap to refuse. That was wrong, and
only visible by asking what else would stop the loop: `CLIENT_HELLO` is 5/MG only, so on this reporter's
WHOOP 4.0 the other give-up never fires, and excluding them would leave the connect-drop-retry cycle
unbounded and draining both batteries. That is exactly the failure #982 exists to prevent. The pause is
correct. Only the explanation was wrong, so the guide swaps and the counting does not.

**2. The guide and hint say the connection is held, rather than blaming the strap**, and say re-pairing
will not change it, replacing the four re-pair steps for this state only. It still does not assert WHICH owner holds the link, because NOOP cannot see that: it names
both candidates and the action for each.

That restraint is the standard the neighbouring `pausedHintHandshakeUnanswered` already sets, which says
naming a cause is *"a guess dressed as instruction"* for an unanswered handshake. This branch meets that
bar rather than bending it: a refused MTU exchange with zero traffic is a positive observation that
something holds the link, not an inference from silence.

**3. The MTU line reads as the failure it is.** `MTU negotiated: 23 (status=4)` looks like a result and
requires the reader to know 23 is the fallback. This also revisits the call made in #2000 to leave MTU
status bare; on this log it is the single most diagnostic line.

## Tests

+6. The predicate needs BOTH halves, so a refused exchange that still carried frames and a silent link
that negotiated fine are both left alone, the latter being the #1809 shape. A held link is pinned as
STILL counting toward the give-up, which is the correction above and the thing that keeps the loop
bounded. The guide is pinned as replacing the re-pair steps rather than repeating them, and as still
giving the user something to do.

One of these tests caught a real mistake while being written: it asserted the hint never contains the word
"re-pair", but the hint deliberately contains it in order to rule the action out. The assertion now pins
what was meant, which is that it never *instructs* one.

672 classes / 5693 tests, 0 failures.

Android-only: the refused MTU re-exchange is how this state presents on Android, and CoreBluetooth
negotiates MTU itself with no equivalent status to read.

**Still open with the reporter:** whether the official WHOOP app is installed, which would confirm the
owner of the held connection. The fix does not depend on the answer, since it describes what was observed
rather than asserting a cause.
