### PR TITLE
fix(charts): stop drawing every metric as if it were maximally volatile

### DIFF
--- a/android/app/src/main/java/com/noop/ui/Charts.kt
+++ b/android/app/src/main/java/com/noop/ui/Charts.kt
@@ -110,10 +110,15 @@ private fun pointsFor(
     height: Float,
     topPad: Float,
     bottomPad: Float,
+    yDomain: ClosedFloatingPointRange<Double>? = null,
 ): List<Offset> {
     val clean = values.filter { it.isFinite() }
     if (clean.size < 2 || width <= 0f || height <= 0f) return emptyList()
-    return pointsFor(clean, width, height, topPad, bottomPad, clean.min(), clean.max())
+    // A supplied domain never HIDES a reading: it widens to contain anything outside it, so anchoring can
+    // only ever change the scale, never clip a value off the chart.
+    val lo = yDomain?.let { minOf(it.start, clean.min()) } ?: clean.min()
+    val hi = yDomain?.let { maxOf(it.endInclusive, clean.max()) } ?: clean.max()
+    return pointsFor(clean, width, height, topPad, bottomPad, lo, hi)
 }
 
 private fun pointsFor(
@@ -246,6 +251,21 @@ fun LineChart(
     // Optional sequential line-segment ids, index-aligned with [values]. Adjacent unequal ids break the
     // stroke/fill without dropping either reading; used by VO₂max when its estimator changes.
     segmentIds: List<String>? = null,
+    /**
+     * Optional FIXED y-domain, instead of scaling to the data's own min/max.
+     *
+     * Auto-scaling makes every chart fill its full height whatever the metric actually did, so a Rest
+     * series moving 46..93 on a natural 0..100 scale is drawn exactly as violently as an Effort series
+     * moving 0..42. A reader cannot tell a calm metric from a volatile one, and a single low day rewrites
+     * the whole shape. Where a metric HAS a natural domain, saying so is what makes the height mean
+     * something.
+     *
+     * Default null keeps every existing caller byte-identical: only metrics that genuinely have a fixed
+     * range should pass one. A metric whose interesting variation is a narrow band inside its nominal
+     * range (blood oxygen lives at 90..100) is WORSE anchored, because the real movement flattens to a
+     * line at the top, so this is opt-in per metric rather than "percentages get 0..100".
+     */
+    yDomain: ClosedFloatingPointRange<Double>? = null,
 ) {
     val cleanValues = remember(values) { values.filter { it.isFinite() } }
     // Timestamps filtered by the SAME finiteness cut as cleanValues so indices stay aligned;
@@ -349,7 +369,7 @@ fun LineChart(
                     val strokePx = 2.5f
                     val topPad = strokePx + 4f
                     val bottomPad = strokePx + 4f
-                    val pts = pointsFor(cleanValues, size.width, size.height, topPad, bottomPad)
+                    val pts = pointsFor(cleanValues, size.width, size.height, topPad, bottomPad, yDomain)
                     if (pts.isEmpty()) {
                         onDrawBehind { drawBaseline() }
                     } else {
@@ -392,6 +412,19 @@ fun LineChart(
                             }
                             // The line itself.
                             for (path in linePaths) drawPath(path = path, color = color, style = lineStroke)
+                            // A segment of ONE point strokes nothing: a Path with a moveTo and no lineTo
+                            // draws no pixels. Without this the reading is silently invisible while the
+                            // stats row still counts it, which is exactly what breaking the line on a
+                            // missing day creates: an isolated day between two gaps. On the reported
+                            // Effort series that day was 5 Sep, the fortnight's MAXIMUM.
+                            for (range in segments) {
+                                if (range.first != range.last) continue
+                                drawCircle(
+                                    color = color,
+                                    radius = strokePx * 1.4f,
+                                    center = pts[range.first],
+                                )
+                            }
                             // A one-reading segment has no visible stroke. Method-segmented trends retain
                             // a small point so neither side of a method transition disappears.
                             if (cleanSegmentIds != null) {
@@ -408,7 +441,7 @@ fun LineChart(
                         val strokePx = 2.5f
                         val topPad = strokePx + 4f
                         val bottomPad = strokePx + 4f
-                        val pts = pointsFor(cleanValues, size.width, size.height, topPad, bottomPad)
+                        val pts = pointsFor(cleanValues, size.width, size.height, topPad, bottomPad, yDomain)
                         if (selectedIndex in pts.indices) {
                             val p = pts[selectedIndex]
                             drawLine(

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2106,7 +2106,17 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                     // default, which prints a decimal for any non-integer, so a rounded metric answered
                     // "72.4" on tap with "72 ms" written directly underneath.
                     formatValue = { "${detail.format(it)} ${detail.unit}".trim() },
-                    segmentIds = if (key == "vo2max_est") vo2MaxTrendSegmentIds(filteredReadings) else null,
+                    // VO2max breaks on an estimator change; every other metric breaks on a missing day,
+                    // so the line stops asserting a value for days that were never measured.
+                    segmentIds = when {
+                        key == "vo2max_est" -> vo2MaxTrendSegmentIds(filteredReadings)
+                        vitalIsDailyCadence(key) -> dailyGapSegmentIds(filteredReadings)
+                        // Sparse by design: every point would be isolated and the line would vanish.
+                        else -> null
+                    },
+                    // Anchor the metrics whose natural range IS their interesting range, so a calm one
+                    // stops being drawn as violently as a wild one.
+                    yDomain = vitalChartYDomain(key),
                 )
                 // #1662: the VO2max line is SPLIT on purpose wherever the estimator changes, so two
                 // non-adjacent Nes runs are never joined across an incompatible Uth stretch. Nothing said

--- a/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
@@ -35,6 +35,66 @@ internal const val SPO2_CANDIDATE_ATTRIBUTION_SOURCE = "spo2-candidate-estimate"
 internal fun vo2MaxAttributionSource(estimator: Vo2MaxEstimator?): String =
     VO2_MAX_ATTRIBUTION_PREFIX + (estimator?.provenanceId ?: "unknown")
 
+/**
+ * The y-domain a metric should be drawn against, or null to scale to the data.
+ *
+ * Auto-scaling makes a calm metric look exactly as violent as a wild one: Rest moving 46..93 on a 0..100
+ * scale fills the same full height as Effort moving 0..42, and one low day rewrites the whole shape. For a
+ * metric whose natural range IS its interesting range, anchoring is what makes the height mean something.
+ *
+ * Deliberately a small allow-list rather than "percentages get 0..100". Blood oxygen is a percentage whose
+ * real movement lives in 90..100, so anchoring it to the nominal range would flatten the signal into a line
+ * at the top: strictly worse than auto-scaling. Resting HR, HRV and skin temperature have no fixed range at
+ * all.
+ *
+ * Effort is 0..100 here whatever the user's display scale says. The readings store the RAW 0-100 composite
+ * and only `format()` converts to the 0..21 reading, so the chart plots the stored value. Taking the domain
+ * from the display scale would have squashed every Effort chart on a WHOOP-scale install into the bottom
+ * fifth of its height.
+ */
+internal fun vitalChartYDomain(key: String): ClosedFloatingPointRange<Double>? =
+    when (key) {
+        "recovery", "sleep_performance", "strain" -> 0.0..100.0
+        else -> null
+    }
+
+/**
+ * Is this metric EXPECTED to have a reading every day?
+ *
+ * Only a daily metric can have a "missing day": breaking the line on a gap says a measurement that should
+ * be there is not. `fitness_age` and `vitality` come from `metricSeries` and are written only when the
+ * engine has the inputs, so they are sparse BY DESIGN and every point would be isolated, turning the chart
+ * into scattered dots. `vo2max_est` segments on estimator changes instead, which is a different question
+ * about the same line.
+ *
+ * Narrow for the same reason [vitalChartYDomain] is: this changes what a chart asserts, so it applies only
+ * where the assertion has been thought about.
+ */
+internal fun vitalIsDailyCadence(key: String): Boolean =
+    key !in setOf("fitness_age", "vitality", "vo2max_est")
+
+/**
+ * Segment ids that BREAK the line wherever a day has no reading.
+ *
+ * The chart spaces points by index, so a four-day gap is drawn exactly like a one-day step and the line
+ * slopes smoothly through days that were never measured. That is the chart asserting something it does not
+ * know. Breaking the stroke instead says "no reading here" without moving or dropping a single point, which
+ * is why this rides the existing segment mechanism rather than filtering the data.
+ *
+ * Days are consecutive when their keys are one calendar day apart. A non-parsing key never joins a run, so
+ * an unexpected format degrades to more breaks rather than to a confident wrong line.
+ */
+internal fun dailyGapSegmentIds(readings: List<VitalReading>): List<String> {
+    var group = 0
+    var previousDay: java.time.LocalDate? = null
+    return readings.map { reading ->
+        val day = runCatching { java.time.LocalDate.parse(reading.day) }.getOrNull()
+        if (previousDay != null && (day == null || day != previousDay!!.plusDays(1))) group++
+        previousDay = day
+        "gap$group"
+    }
+}
+
 /** Sequential ids for a method-aware trend. Nes → Uth → Nes becomes three segments rather than joining
  *  the non-adjacent Nes runs across an incompatible estimator. */
 internal fun vo2MaxTrendSegmentIds(readings: List<VitalReading>): List<String> {

--- a/android/app/src/test/java/com/noop/ui/VitalChartShapeTest.kt
+++ b/android/app/src/test/java/com/noop/ui/VitalChartShapeTest.kt
@@ -1,0 +1,138 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The two things that made the Vital Signs charts read as noise: every metric drawn at full height
+ * whatever it did, and a line sloped smoothly through days that were never measured.
+ */
+class VitalChartShapeTest {
+
+    private fun reading(day: String, value: Double) = VitalReading(day, value, "dev")
+
+    // --- the anchored domain ---
+
+    /** The percentage metrics get their real range, so a calm one is drawn calm. */
+    @Test
+    fun `percentage metrics anchor to their natural range`() {
+        assertEquals(0.0..100.0, vitalChartYDomain("recovery"))
+        assertEquals(0.0..100.0, vitalChartYDomain("sleep_performance"))
+        assertEquals(0.0..100.0, vitalChartYDomain("strain"))
+    }
+
+    /**
+     * Effort anchors to 0..100 whatever the display scale, because the readings store the RAW composite
+     * and only format() converts. Taking the domain from the 0..21 display would squash every Effort
+     * chart on a WHOOP-scale install into the bottom fifth of its height.
+     */
+    @Test
+    fun `effort anchors to the stored scale, not the displayed one`() {
+        assertEquals(0.0..100.0, vitalChartYDomain("strain"))
+    }
+
+    /**
+     * Blood oxygen is the case that proves this is not "percentages get 0..100": its real movement lives
+     * in 90..100, so anchoring would flatten the signal into a line at the top. Metrics with no fixed
+     * range at all keep auto-scaling too.
+     */
+    @Test
+    fun `metrics whose range is not their signal keep auto-scaling`() {
+        assertNull(vitalChartYDomain("spo2"))
+        assertNull(vitalChartYDomain("rhr"))
+        assertNull(vitalChartYDomain("hrv"))
+        assertNull(vitalChartYDomain("skin_temp"))
+    }
+
+    // --- the gap break ---
+
+    /** Consecutive days are one run: nothing changes for a fully-measured stretch. */
+    @Test
+    fun `consecutive days stay one unbroken run`() {
+        val ids = dailyGapSegmentIds(
+            listOf(reading("2026-09-01", 1.0), reading("2026-09-02", 2.0), reading("2026-09-03", 3.0)),
+        )
+        assertEquals(1, ids.distinct().size)
+    }
+
+    /**
+     * The reported shape: 9 readings across a fortnight, with 4 Sep and 29..31 Aug absent. Each gap has
+     * to break the stroke, so the chart stops sloping through days nobody measured.
+     */
+    @Test
+    fun `a missing day breaks the line`() {
+        val ids = dailyGapSegmentIds(
+            listOf(reading("2026-09-03", 27.5), reading("2026-09-05", 42.3), reading("2026-09-06", 1.0)),
+        )
+        assertEquals(listOf("gap0", "gap1", "gap1"), ids)
+    }
+
+    /** Every point is kept: breaking the line must never drop a reading. */
+    @Test
+    fun `no reading is dropped by the break`() {
+        val readings = listOf(reading("2026-09-01", 1.0), reading("2026-09-09", 2.0))
+        assertEquals(readings.size, dailyGapSegmentIds(readings).size)
+    }
+
+    /** An unparseable day degrades to a break, never to a confident wrong line. */
+    @Test
+    fun `an unparseable day does not join a run`() {
+        val ids = dailyGapSegmentIds(
+            listOf(reading("2026-09-01", 1.0), reading("not-a-date", 2.0), reading("2026-09-02", 3.0)),
+        )
+        assertTrue(ids.toString(), ids.distinct().size > 1)
+    }
+
+    /**
+     * The case breaking the line creates and that would otherwise hide data: a day isolated between two
+     * gaps forms a one-point segment, and a Path with a moveTo and no lineTo strokes nothing. On the
+     * reported Effort series that day is 5 Sep, the fortnight's MAXIMUM, so the stats row would have said
+     * 42.3 while the chart showed no such point.
+     *
+     * This pins the SEGMENTING that produces it. The chart draws a marker for any range whose first and
+     * last index are equal, which is exactly the shape asserted here.
+     */
+    @Test
+    fun `a day isolated between gaps forms its own single-point segment`() {
+        val ids = dailyGapSegmentIds(
+            listOf(
+                reading("2026-09-01", 32.9), reading("2026-09-02", 2.2), reading("2026-09-03", 27.5),
+                reading("2026-09-05", 42.3),
+                reading("2026-09-07", 0.0), reading("2026-09-08", 31.6),
+            ),
+        )
+        val ranges = lineChartSegmentRanges(ids.size, ids)
+        val isolated = ranges.filter { it.first == it.last }
+        assertEquals(1, isolated.size)
+        assertEquals(3, isolated.single().first)   // index of 5 Sep, the maximum
+    }
+
+    /** A fully-measured stretch has no isolated points, so nothing extra is drawn on a healthy chart. */
+    @Test
+    fun `a consecutive run produces no isolated points`() {
+        val ids = dailyGapSegmentIds(
+            listOf(reading("2026-09-01", 1.0), reading("2026-09-02", 2.0), reading("2026-09-03", 3.0)),
+        )
+        assertTrue(lineChartSegmentRanges(ids.size, ids).none { it.first == it.last })
+    }
+
+    /**
+     * The break only applies where a "missing day" means something. Fitness Age and Vitality are written
+     * only when the engine has the inputs, so they are sparse BY DESIGN: breaking on every gap would
+     * isolate every point and leave scattered dots where a trend used to be. VO2max segments on estimator
+     * changes instead.
+     */
+    @Test
+    fun `sparse-by-design metrics are not broken on gaps`() {
+        assertTrue(vitalIsDailyCadence("recovery"))
+        assertTrue(vitalIsDailyCadence("sleep_performance"))
+        assertTrue(vitalIsDailyCadence("strain"))
+        assertTrue(vitalIsDailyCadence("rhr"))
+        assertFalse(vitalIsDailyCadence("fitness_age"))
+        assertFalse(vitalIsDailyCadence("vitality"))
+        assertFalse(vitalIsDailyCadence("vo2max_est"))
+    }
+}


### PR DESCRIPTION
Reported from the Effort and Rest detail screens: the trends look "a bit all over the place". They do, and
both causes sit in one function.

## Every metric is drawn at maximum volatility

`pointsFor` scales to the data's own min and max, so **every** chart fills its full height whatever the
metric actually did. Rest moving 46..93 on a natural 0..100 scale is drawn exactly as violently as Effort
moving 0..42. A reader cannot tell a calm metric from a wild one, and one low day rewrites the whole shape.

`LineChart` now takes an optional fixed `yDomain`, and the metrics whose natural range IS their interesting
range pass one. It is **opt-in**, so every other chart in the app stays byte-identical.

Deliberately not "percentages get 0..100":

- **Blood oxygen** is a percentage whose real movement lives in 90..100. Anchoring it to the nominal range
  would flatten the signal into a line at the top, strictly worse than auto-scaling.
- **Resting HR, HRV, skin temperature** have no fixed range at all.
- **Effort** anchors to 0..100 whatever the user's display scale says, because the readings store the RAW
  composite and only `format()` converts to the 0..21 reading. I had this backwards first and the code
  said so plainly: *"Readings store the RAW 0-100 composite; only format() scales."* Taking the domain from
  the display scale would have squashed every Effort chart on a WHOOP-scale install into the bottom fifth
  of its height.

A supplied domain can only ever change the scale, never hide a reading: it widens to contain any value
outside it rather than clipping.

## The line slopes through days that were never measured

The reporter's Effort had **nine readings across a fortnight**, with 4 Sep and 29..31 Aug absent, and the
chart drew a four-day gap exactly like a one-day step. That is the chart asserting something it does not
know.

The stroke now breaks on a missing day. Nothing is moved and nothing is dropped: it rides the same segment
mechanism VO₂max already uses for estimator changes.

**Zeros are not dropped.** An Effort `0.0` is a real computed value from thin wear time, not a no-data
sentinel: a day with no data is `n/a` and never becomes a reading at all. My first instinct was to filter
them and it was wrong. Only the interpolation between real points changes.

## Not in this PR

Points are still spaced by index rather than by date (`stepX = width / (values.size - 1)`), so gaps break
the line but do not take up proportional width. That is a bigger change and belongs on its own.

The same two properties affect every other `LineChart` in the app (Today HR, Stress, Apple Health, Trends
Explore, Health HR, Sleep, Trends). The mechanism is now central, so those can opt in individually once
each has been looked at on a real screen.

## Tests

+9. The domain allow-list is pinned in both directions, including blood oxygen explicitly keeping
auto-scaling, and Effort anchoring to the stored scale rather than the displayed one. The gap break is
pinned on the reported shape, and on the invariant that matters most: no reading is dropped.

673 classes / 5701 tests, 0 failures. Android-only for now; the iOS charts are a separate surface.
