### PR TITLE
fix(charts): anchor the Rest chart, which the wrong key left untouched

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
@@ -54,7 +54,10 @@ internal fun vo2MaxAttributionSource(estimator: Vo2MaxEstimator?): String =
  */
 internal fun vitalChartYDomain(key: String): ClosedFloatingPointRange<Double>? =
     when (key) {
-        "recovery", "sleep_performance", "strain" -> 0.0..100.0
+        // "rest", NOT "sleep_performance": that is the SERIES name this detail reads underneath, and it is
+        // never a detail key on Android. Writing the series name here compiled, passed a test asserting it,
+        // and left the Rest chart auto-scaling exactly as before.
+        "recovery", "rest", "strain" -> 0.0..100.0
         else -> null
     }
 

--- a/android/app/src/test/java/com/noop/ui/VitalChartShapeTest.kt
+++ b/android/app/src/test/java/com/noop/ui/VitalChartShapeTest.kt
@@ -20,7 +20,7 @@ class VitalChartShapeTest {
     @Test
     fun `percentage metrics anchor to their natural range`() {
         assertEquals(0.0..100.0, vitalChartYDomain("recovery"))
-        assertEquals(0.0..100.0, vitalChartYDomain("sleep_performance"))
+        assertEquals(0.0..100.0, vitalChartYDomain("rest"))
         assertEquals(0.0..100.0, vitalChartYDomain("strain"))
     }
 
@@ -32,6 +32,27 @@ class VitalChartShapeTest {
     @Test
     fun `effort anchors to the stored scale, not the displayed one`() {
         assertEquals(0.0..100.0, vitalChartYDomain("strain"))
+    }
+
+    /**
+     * Every key in the allow-list has to be one the screen ACTUALLY receives. The first version anchored
+     * "sleep_performance", which is the series this detail reads underneath and never a detail key here,
+     * so Rest kept auto-scaling while a test asserting that key passed. Pinning against the real key list
+     * is what makes the allow-list checkable rather than plausible.
+     *
+     * `realKeys` is a HAND-MAINTAINED mirror of the `when` in `buildVitalDetail`/`buildSeriesVitalDetail`;
+     * a unit test cannot enumerate a `when`. It catches an anchored key that no screen sends, which is the
+     * bug that shipped. It does NOT catch a newly added metric, so a new key belongs here too.
+     */
+    @Test
+    fun `every anchored key is a real detail key`() {
+        val realKeys = setOf(
+            "recovery", "strain", "resp", "spo2", "rhr", "hrv", "skin", "rest",
+            "fitness_age", "vitality", "vo2max_est", "steps_est",
+        )
+        val anchored = realKeys.filter { vitalChartYDomain(it) != null }
+        assertEquals(setOf("recovery", "rest", "strain"), anchored.toSet())
+        assertNull(vitalChartYDomain("sleep_performance"))   // the series name, not a detail key
     }
 
     /**


### PR DESCRIPTION
fix(charts): anchor the Rest chart, which the wrong key left untouched

#2004 anchored "recovery", "sleep_performance" and "strain". On Android the Rest
detail key is "rest": sleep_performance is the SERIES this detail reads underneath
and is never a detail key here. So Rest kept auto-scaling and looked exactly as it
did before, which is what the reporter saw on the build.

The test asserted vitalChartYDomain("sleep_performance") and passed, because the
function happily answers for a key nothing ever passes. A green test for a key
that does not exist is what made this feel verified.

The allow-list is now pinned against the REAL key list the screen dispatches on,
so an anchored key that no screen sends fails the test rather than passing it.

The Effort and Charge charts were correct in #2004; only Rest was missed, and only because
`sleep_performance` is the series name rather than the detail key on this platform.

673 classes / 5705 tests, 0 failures.