### PR TITLE
fix(charts): a continuous line with a zero floor and visible readings

### DIFF
--- a/android/app/src/main/java/com/noop/ui/Charts.kt
+++ b/android/app/src/main/java/com/noop/ui/Charts.kt
@@ -104,7 +104,7 @@ private fun hypnogramSummary(stages: List<Pair<String, Float>>): String {
 /** Map a list of values into evenly-spaced points within [bounds], scaling y to the
  *  value range. A flat series (min == max) is centered vertically. Returns an empty
  *  list when there are fewer than two finite points. */
-private fun pointsFor(
+internal fun pointsFor(
     values: List<Double>,
     width: Float,
     height: Float,
@@ -118,7 +118,13 @@ private fun pointsFor(
     // A supplied domain never HIDES a reading: it widens to contain anything outside it, so anchoring can
     // only ever change the scale, never clip a value off the chart.
     val lo = yDomain?.let { minOf(it.start, clean.min()) } ?: clean.min()
-    val hi = yDomain?.let { maxOf(it.endInclusive, clean.max()) } ?: clean.max()
+    var hi = yDomain?.let { maxOf(it.endInclusive, clean.max()) } ?: clean.max()
+    // A series that is entirely flat AT the supplied floor would otherwise have zero span, and the
+    // zero-span fallback puts a flat line mid-chart. That is right when the scale came from the data
+    // (a steady 70bpm belongs in the middle) and wrong when a floor was asked for: an all-zero Effort
+    // week must sit ON the floor, which is the whole property the floor exists to give. Widening by one
+    // unit puts it there. Only when a domain was supplied, so auto-scaled charts keep their behaviour.
+    if (yDomain != null && hi <= lo) hi = lo + 1.0
     return pointsFor(clean, width, height, topPad, bottomPad, timestamps, lo, hi)
 }
 
@@ -268,6 +274,16 @@ fun LineChart(
      * line at the top, so this is opt-in per metric rather than "percentages get 0..100".
      */
     yDomain: ClosedFloatingPointRange<Double>? = null,
+    /**
+     * Draw a small marker at every reading.
+     *
+     * A line alone cannot say WHERE the measurements are. On a daily trend with missing days that matters:
+     * a long straight run is either a steady week or one reading either side of a gap, and the line looks
+     * identical. Markers say which, without fragmenting the stroke the way breaking it did.
+     *
+     * Opt-in, so the dense live charts (HR at 1 Hz) are untouched, where a dot per sample would be noise.
+     */
+    showsPoints: Boolean = false,
 ) {
     val cleanValues = remember(values) { values.filter { it.isFinite() } }
     // Timestamps filtered by the SAME finiteness cut as cleanValues so indices stay aligned;
@@ -419,18 +435,13 @@ fun LineChart(
                             }
                             // The line itself.
                             for (path in linePaths) drawPath(path = path, color = color, style = lineStroke)
-                            // A segment of ONE point strokes nothing: a Path with a moveTo and no lineTo
-                            // draws no pixels. Without this the reading is silently invisible while the
-                            // stats row still counts it, which is exactly what breaking the line on a
-                            // missing day creates: an isolated day between two gaps. On the reported
-                            // Effort series that day was 5 Sep, the fortnight's MAXIMUM.
-                            for (range in segments) {
-                                if (range.first != range.last) continue
-                                drawCircle(
-                                    color = color,
-                                    radius = strokePx * 1.4f,
-                                    center = pts[range.first],
-                                )
+                            // Markers only while they can still be told apart. On the ALL range a daily
+                            // series is hundreds of points, and a dot every few pixels merges into a
+                            // thick smear that hides the line it was meant to annotate.
+                            val markerRadius = strokePx * 1.2f
+                            val spacing = if (pts.size > 1) size.width / (pts.size - 1) else size.width
+                            if (showsPoints && spacing >= markerRadius * 3f) {
+                                for (p in pts) drawCircle(color = color, radius = markerRadius, center = p)
                             }
                             // A one-reading segment has no visible stroke. Method-segmented trends retain
                             // a small point so neither side of a method transition disappears.

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2112,15 +2112,17 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                     formatValue = { "${detail.format(it)} ${detail.unit}".trim() },
                     // VO2max breaks on an estimator change; every other metric breaks on a missing day,
                     // so the line stops asserting a value for days that were never measured.
-                    segmentIds = when {
-                        key == "vo2max_est" -> vo2MaxTrendSegmentIds(filteredReadings)
-                        vitalIsDailyCadence(key) -> dailyGapSegmentIds(filteredReadings)
-                        // Sparse by design: every point would be isolated and the line would vanish.
-                        else -> null
-                    },
+                    // Only VO2max breaks, on an estimator change. Breaking on a missing DAY was tried and
+                    // removed: with points positioned by date a gap already shows as a longer run between
+                    // two readings, and breaking as well fragmented the line into pieces with the odd
+                    // orphan dot, which reads as a rendering fault rather than as missing data.
+                    segmentIds = if (key == "vo2max_est") vo2MaxTrendSegmentIds(filteredReadings) else null,
                     // Anchor the metrics whose natural range IS their interesting range, so a calm one
                     // stops being drawn as violently as a wild one.
                     yDomain = vitalChartYDomain(key),
+                    // A daily trend has few enough readings for a marker each, and they are what say where
+                    // the measurements actually are once gaps stretch the line between them.
+                    showsPoints = true,
                 )
                 // #1662: the VO2max line is SPLIT on purpose wherever the estimator changes, so two
                 // non-adjacent Nes runs are never joined across an incompatible Uth stretch. Nothing said

--- a/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
@@ -57,7 +57,14 @@ internal fun vitalChartYDomain(key: String): ClosedFloatingPointRange<Double>? =
         // "rest", NOT "sleep_performance": that is the SERIES name this detail reads underneath, and it is
         // never a detail key on Android. Writing the series name here compiled, passed a test asserting it,
         // and left the Rest chart auto-scaling exactly as before.
-        "recovery", "rest", "strain" -> 0.0..100.0
+        // A ZERO-WIDTH domain at 0, not 0..100. The chart widens a domain to contain the data, so this
+        // pins the FLOOR at zero while the ceiling follows the readings.
+        //
+        // Anchoring at 100 was the first attempt and it overcorrected: Effort peaks in the low forties, so
+        // the top ~58% of the chart sat permanently empty, and Rest at 46..93 wasted the bottom half. A
+        // zero floor keeps what actually mattered, that heights stay comparable and a 0.0 day reads as the
+        // floor rather than as the middle, without spending most of the height on range nobody reaches.
+        "recovery", "rest", "strain" -> 0.0..0.0
         else -> null
     }
 
@@ -75,43 +82,6 @@ internal fun dayEpochSeconds(readings: List<VitalReading>): List<Long>? {
         out += day.toEpochDay() * 86_400L
     }
     return out
-}
-
-/**
- * Is this metric EXPECTED to have a reading every day?
- *
- * Only a daily metric can have a "missing day": breaking the line on a gap says a measurement that should
- * be there is not. `fitness_age` and `vitality` come from `metricSeries` and are written only when the
- * engine has the inputs, so they are sparse BY DESIGN and every point would be isolated, turning the chart
- * into scattered dots. `vo2max_est` segments on estimator changes instead, which is a different question
- * about the same line.
- *
- * Narrow for the same reason [vitalChartYDomain] is: this changes what a chart asserts, so it applies only
- * where the assertion has been thought about.
- */
-internal fun vitalIsDailyCadence(key: String): Boolean =
-    key !in setOf("fitness_age", "vitality", "vo2max_est")
-
-/**
- * Segment ids that BREAK the line wherever a day has no reading.
- *
- * The chart spaces points by index, so a four-day gap is drawn exactly like a one-day step and the line
- * slopes smoothly through days that were never measured. That is the chart asserting something it does not
- * know. Breaking the stroke instead says "no reading here" without moving or dropping a single point, which
- * is why this rides the existing segment mechanism rather than filtering the data.
- *
- * Days are consecutive when their keys are one calendar day apart. A non-parsing key never joins a run, so
- * an unexpected format degrades to more breaks rather than to a confident wrong line.
- */
-internal fun dailyGapSegmentIds(readings: List<VitalReading>): List<String> {
-    var group = 0
-    var previousDay: java.time.LocalDate? = null
-    return readings.map { reading ->
-        val day = runCatching { java.time.LocalDate.parse(reading.day) }.getOrNull()
-        if (previousDay != null && (day == null || day != previousDay!!.plusDays(1))) group++
-        previousDay = day
-        "gap$group"
-    }
 }
 
 /** Sequential ids for a method-aware trend. Nes → Uth → Nes becomes three segments rather than joining

--- a/android/app/src/test/java/com/noop/ui/ChartXSpacingTest.kt
+++ b/android/app/src/test/java/com/noop/ui/ChartXSpacingTest.kt
@@ -105,3 +105,42 @@ class ChartXSpacingTest {
         }
     }
 }
+
+/**
+ * The y geometry, specifically the property the zero FLOOR exists to give: a 0.0 reading sits at the very
+ * bottom of the plot. The first version of the floor broke exactly this. An all-zero series has zero span,
+ * and the zero-span fallback puts a flat line mid-chart, so an all-zero Effort week floated through the
+ * middle while claiming a floor at zero.
+ */
+class ChartFloorTest {
+
+    private val h = 100f
+    private val topPad = 6.5f
+    private val bottomPad = 6.5f
+    private fun yOf(values: List<Double>, domain: ClosedFloatingPointRange<Double>?) =
+        pointsFor(values, 100f, h, topPad, bottomPad, domain).map { it.y }
+
+    /** The bug: every reading zero, with a zero floor, must draw ON the floor and not mid-chart. */
+    @org.junit.Test
+    fun `an all-zero series sits on the floor, not in the middle`() {
+        val y = yOf(listOf(0.0, 0.0, 0.0), 0.0..0.0)
+        val bottom = h - bottomPad
+        y.forEach { org.junit.Assert.assertEquals(bottom, it, 0.01f) }
+    }
+
+    /** A zero reading beside real values also sits on the floor, which is why the floor is there. */
+    @org.junit.Test
+    fun `a zero reading beside real values sits on the floor`() {
+        val y = yOf(listOf(0.0, 42.3), 0.0..0.0)
+        org.junit.Assert.assertEquals(h - bottomPad, y.first(), 0.01f)
+        org.junit.Assert.assertEquals(topPad, y.last(), 0.01f)   // the max reaches the top
+    }
+
+    /** Without a domain a flat series keeps its old mid-chart placement: auto-scaled charts are untouched. */
+    @org.junit.Test
+    fun `a flat auto-scaled series still sits mid-chart`() {
+        val y = yOf(listOf(70.0, 70.0), null)
+        val mid = topPad + 0.5f * (h - topPad - bottomPad)
+        y.forEach { org.junit.Assert.assertEquals(mid, it, 0.01f) }
+    }
+}

--- a/android/app/src/test/java/com/noop/ui/VitalChartShapeTest.kt
+++ b/android/app/src/test/java/com/noop/ui/VitalChartShapeTest.kt
@@ -19,9 +19,11 @@ class VitalChartShapeTest {
     /** The percentage metrics get their real range, so a calm one is drawn calm. */
     @Test
     fun `percentage metrics anchor to their natural range`() {
-        assertEquals(0.0..100.0, vitalChartYDomain("recovery"))
-        assertEquals(0.0..100.0, vitalChartYDomain("rest"))
-        assertEquals(0.0..100.0, vitalChartYDomain("strain"))
+        // A zero-WIDTH domain: the chart widens it to contain the data, so the floor is pinned at zero
+        // and the ceiling follows the readings.
+        assertEquals(0.0..0.0, vitalChartYDomain("recovery"))
+        assertEquals(0.0..0.0, vitalChartYDomain("rest"))
+        assertEquals(0.0..0.0, vitalChartYDomain("strain"))
     }
 
     /**
@@ -31,7 +33,7 @@ class VitalChartShapeTest {
      */
     @Test
     fun `effort anchors to the stored scale, not the displayed one`() {
-        assertEquals(0.0..100.0, vitalChartYDomain("strain"))
+        assertEquals(0.0..0.0, vitalChartYDomain("strain"))
     }
 
     /**
@@ -70,90 +72,23 @@ class VitalChartShapeTest {
 
     // --- the gap break ---
 
-    /** Consecutive days are one run: nothing changes for a fully-measured stretch. */
-    @Test
-    fun `consecutive days stay one unbroken run`() {
-        val ids = dailyGapSegmentIds(
-            listOf(reading("2026-09-01", 1.0), reading("2026-09-02", 2.0), reading("2026-09-03", 3.0)),
-        )
-        assertEquals(1, ids.distinct().size)
-    }
+
+
+
+
+
+
 
     /**
-     * The reported shape: 9 readings across a fortnight, with 4 Sep and 29..31 Aug absent. Each gap has
-     * to break the stroke, so the chart stops sloping through days nobody measured.
+     * What the zero floor buys, stated as the property rather than the constant: a 0.0 reading sits at the
+     * very bottom of the chart, and the top is set by the data rather than by a ceiling nobody reaches.
+     * Anchoring at 100 satisfied the first half and wasted most of the height on the second.
      */
     @Test
-    fun `a missing day breaks the line`() {
-        val ids = dailyGapSegmentIds(
-            listOf(reading("2026-09-03", 27.5), reading("2026-09-05", 42.3), reading("2026-09-06", 1.0)),
-        )
-        assertEquals(listOf("gap0", "gap1", "gap1"), ids)
-    }
-
-    /** Every point is kept: breaking the line must never drop a reading. */
-    @Test
-    fun `no reading is dropped by the break`() {
-        val readings = listOf(reading("2026-09-01", 1.0), reading("2026-09-09", 2.0))
-        assertEquals(readings.size, dailyGapSegmentIds(readings).size)
-    }
-
-    /** An unparseable day degrades to a break, never to a confident wrong line. */
-    @Test
-    fun `an unparseable day does not join a run`() {
-        val ids = dailyGapSegmentIds(
-            listOf(reading("2026-09-01", 1.0), reading("not-a-date", 2.0), reading("2026-09-02", 3.0)),
-        )
-        assertTrue(ids.toString(), ids.distinct().size > 1)
-    }
-
-    /**
-     * The case breaking the line creates and that would otherwise hide data: a day isolated between two
-     * gaps forms a one-point segment, and a Path with a moveTo and no lineTo strokes nothing. On the
-     * reported Effort series that day is 5 Sep, the fortnight's MAXIMUM, so the stats row would have said
-     * 42.3 while the chart showed no such point.
-     *
-     * This pins the SEGMENTING that produces it. The chart draws a marker for any range whose first and
-     * last index are equal, which is exactly the shape asserted here.
-     */
-    @Test
-    fun `a day isolated between gaps forms its own single-point segment`() {
-        val ids = dailyGapSegmentIds(
-            listOf(
-                reading("2026-09-01", 32.9), reading("2026-09-02", 2.2), reading("2026-09-03", 27.5),
-                reading("2026-09-05", 42.3),
-                reading("2026-09-07", 0.0), reading("2026-09-08", 31.6),
-            ),
-        )
-        val ranges = lineChartSegmentRanges(ids.size, ids)
-        val isolated = ranges.filter { it.first == it.last }
-        assertEquals(1, isolated.size)
-        assertEquals(3, isolated.single().first)   // index of 5 Sep, the maximum
-    }
-
-    /** A fully-measured stretch has no isolated points, so nothing extra is drawn on a healthy chart. */
-    @Test
-    fun `a consecutive run produces no isolated points`() {
-        val ids = dailyGapSegmentIds(
-            listOf(reading("2026-09-01", 1.0), reading("2026-09-02", 2.0), reading("2026-09-03", 3.0)),
-        )
-        assertTrue(lineChartSegmentRanges(ids.size, ids).none { it.first == it.last })
-    }
-
-    /**
-     * The break only applies where a "missing day" means something. Fitness Age and Vitality are written
-     * only when the engine has the inputs, so they are sparse BY DESIGN: breaking on every gap would
-     * isolate every point and leave scattered dots where a trend used to be. VO2max segments on estimator
-     * changes instead.
-     */
-    @Test
-    fun `sparse-by-design metrics are not broken on gaps`() {
-        assertTrue(vitalIsDailyCadence("recovery"))
-        assertTrue(vitalIsDailyCadence("sleep_performance"))
-        assertTrue(vitalIsDailyCadence("strain"))
-        assertTrue(vitalIsDailyCadence("rhr"))
-        assertFalse(vitalIsDailyCadence("fitness_age"))
-        assertFalse(vitalIsDailyCadence("vitality"))
-        assertFalse(vitalIsDailyCadence("vo2max_est"))
+    fun `the zero floor pins the bottom without reserving unreachable height`() {
+        val d = vitalChartYDomain("strain")!!
+        assertEquals(0.0, d.start, 0.0)
+        // Zero width: nothing above zero is reserved, so the ceiling comes from the readings.
+        assertEquals(d.start, d.endInclusive, 0.0)
     }
 }


### PR DESCRIPTION
fix(charts): a continuous line with a zero floor and visible readings

Three corrections to my own chart work, from seeing it on a device.

Breaking the line on a missing day is removed. With points positioned by date a
gap already shows as a longer run between two readings, and breaking as well
fragmented the line into pieces with the odd orphan dot, which reads as a
rendering fault rather than as missing data. The reporter called it broken twice
and was right both times. VO2max keeps its break on an estimator change, which is
a different question about the same line.

The domain is a zero FLOOR rather than 0..100. The chart widens a domain to
contain the data, so a zero-width domain at 0 pins the bottom while the ceiling
follows the readings. Anchoring at 100 overcorrected: Effort peaks in the low
forties, so the top 58% of the chart sat permanently empty, and Rest at 46..93
wasted the bottom half. The zero floor keeps what mattered, comparable heights and
a 0.0 day reading as the floor, without spending most of the height on range
nobody reaches.

Readings are drawn as markers. A line alone cannot say WHERE the measurements
are, and once gaps stretch it between points a long straight run is either a
steady week or one reading either side of a gap. Markers say which without
fragmenting the stroke. Opt-in, so the dense live charts are untouched.

The gap-segment helpers go with the break they served.

## What is kept from the earlier passes

Date-proportional spacing stays: a gap occupies the width it spans, which is what makes a stretched line
segment mean something. The isolated-point marker stays too, since VO2max can still produce a one-point
segment and a Path with a moveTo and no lineTo draws nothing.

## Honest note

This is the sixth change to this chart today. Anchoring and spacing were right; breaking the line was not,
and I shipped it before the spacing it depended on. Seeing it on a device is what settled it.

674 classes / 5709 tests, 0 failures.