### PR TITLE
fix(today): make the Arrange affordance read as a control

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1301,10 +1301,24 @@ fun TodayScreen(
             Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                 LiquidWordmark()
                 // One consistent customization affordance for section order and visibility.
+                //
+                // #2008: reported as "not visible". It was not hidden, it was unreadable as a control:
+                // #486 folded it out of its own pinned row onto the wordmark row, and it kept the
+                // TERTIARY text colour, so the one affordance for rearranging Today sat at the dimmest
+                // tier in the palette beside a decorative 50%-opacity wordmark. Nothing said "button".
+                //
+                // The compact row #486 wanted is kept. What changes is that it now reads as a control:
+                // secondary text on a frosted pill, which is the idiom the rest of Today uses for a
+                // tappable surface. iOS has never had this problem, its twin is a proper header button
+                // (`nativeLiquidGlassHeaderButton`) at a fixed control size.
                 TextButton(
                     onClick = { showLayoutEditor = true },
-                    colors = ButtonDefaults.textButtonColors(contentColor = Palette.textTertiary),
-                    modifier = Modifier.align(Alignment.CenterEnd),
+                    colors = ButtonDefaults.textButtonColors(contentColor = Palette.textSecondary),
+                    contentPadding = PaddingValues(horizontal = Metrics.space10, vertical = Metrics.space4),
+                    modifier = Modifier
+                        .align(Alignment.CenterEnd)
+                        .clip(RoundedCornerShape(50))
+                        .frostedCardSurface(cornerRadius = 999.dp),
                 ) {
                     Icon(
                         Icons.Filled.Tune,


### PR DESCRIPTION
fix(today): make the Arrange affordance read as a control

Reported in #2008 by @adamstefanik as the rearranging button not being visible.
It was never hidden and never gated. It was unreadable AS a control.

#486 folded it out of its own pinned full-width row onto the wordmark row, which
was the right call for vertical space, but it kept the TERTIARY text colour. So
the single affordance for rearranging Today sat at the dimmest tier in the palette
next to a decorative 50%-opacity wordmark, with nothing about it saying "button".

The compact row #486 wanted is kept. What changes is that it now looks tappable:
secondary text on a frosted pill, the idiom the rest of Today already uses for a
tappable surface.

iOS has never had this problem. Its twin is a proper header button at a fixed
control size, so this closes a divergence rather than opening one.

## Scope

Only the confirmed half of #2008. The reporter also says a live HR window on Today became a 5-minute
average; there is no live-HR element on Today at all on Android, and the 24-hour HR trend that is there has
used 5-minute bucket means since 1.43, so neither is a recent change. Their platform is not stated and the
two Today surfaces have diverged, so that half is a question rather than a fix.

Their timing does not match this either: #486 landed 2026-07-16, well before 11.0.0 on 2026-09-02. So the
discoverability problem is real and worth fixing on its own merits, but it may not be what changed for them.

No behaviour change, no new strings, no test: this is contrast and shape on one control.