### PR TITLE
feat(today): draw the daily scores as bars, not as a line

### DIFF
--- a/android/app/src/main/java/com/noop/ui/Charts.kt
+++ b/android/app/src/main/java/com/noop/ui/Charts.kt
@@ -638,6 +638,14 @@ fun BarChart(
     formatValue: ((Double) -> String)? = null,
 ) {
     val cleanValues = remember(values) { values.map { if (it.isFinite() && it > 0.0) it else 0.0 } }
+    // The cleaned list flattens a non-finite value to 0.0 so it draws nothing, which is right for the
+    // GEOMETRY and wrong for the read-out: a caller passing NaN for "no reading that day" would have its
+    // empty slots answer "0.0" on tap, asserting a measurement that does not exist.
+    //
+    // The raw list decides only WHETHER a slot can be labelled, never what the label says. Cleaning also
+    // flattens NEGATIVES to zero, and at least one caller (sleep debt) may pass them, so reading the raw
+    // value for the number itself would quietly change what those charts report on tap.
+
     // cleanValues ZEROES (never drops) non-finite bars, so indices stay aligned with [values] and the
     // labels only need a size match — null when absent/mismatched so selection falls back to value-only.
     val cleanSelectionLabels = remember(values, selectionLabels) {
@@ -738,10 +746,15 @@ fun BarChart(
                                 cap = StrokeCap.Round,
                             )
                         }
-                        if (selectionEnabled && selectedIndex in clean.indices) {
+                        val selectedRaw = values.getOrNull(selectedIndex)
+                        if (selectionEnabled && selectedIndex in clean.indices &&
+                            selectedRaw != null && selectedRaw.isFinite()
+                        ) {
                             drawContext.canvas.nativeCanvas.apply {
                                 drawText(
                                     lineChartSelectionLabel(
+                                        // The CLEANED value, exactly as before, so no existing caller's
+                                        // label changes. The raw value only decides WHETHER to label.
                                         value = clean[selectedIndex],
                                         formatValue = formatValue,
                                         pointLabel = cleanSelectionLabels?.getOrNull(selectedIndex),

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2086,6 +2086,29 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                         color = Palette.textTertiary,
                     )
                 }
+                // #2008 follow-up: the daily SCORES are drawn as bars. A line asserts continuity between
+                // readings, and on a series swinging ~20 points a day that climb-and-dive through values
+                // which never existed is most of what reads as noise. One slot per DAY positions the bars
+                // by date and turns a missing day into an empty slot. Levels (resting HR, HRV, skin temp)
+                // stay lines: those really do vary continuously between measurements.
+                // Remembered like `dayLabels` beside it: densifying rebuilds a slot per day and formats a
+                // label for each, and on the ALL range that is hundreds of both. Recomputing them every
+                // recomposition is the cost this screen already avoids for the line path's derived lists.
+                val bars = remember(filteredReadings, key) {
+                    if (vitalChartIsBars(key)) densifyByDay(filteredReadings) else null
+                }
+                val barValues = remember(bars) { bars?.map { it.second } }
+                val barLabels = remember(bars) { bars?.map { shortDayLabel(it.first) } }
+                if (barValues != null && barLabels != null) {
+                    BarChart(
+                        values = barValues,
+                        modifier = Modifier.height(Metrics.chartHeight),
+                        color = detail.color,
+                        selectionEnabled = true,
+                        selectionLabels = barLabels,
+                        formatValue = { "${detail.format(it)} ${detail.unit}".trim() },
+                    )
+                } else {
                 LineChart(
                     values = values,
                     modifier = Modifier.height(Metrics.chartHeight),
@@ -2124,6 +2147,7 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                     // the measurements actually are once gaps stretch the line between them.
                     showsPoints = true,
                 )
+                }
                 // #1662: the VO2max line is SPLIT on purpose wherever the estimator changes, so two
                 // non-adjacent Nes runs are never joined across an incompatible Uth stretch. Nothing said
                 // so, and a silent gap in a trend is indistinguishable from a rendering fault - it was

--- a/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
@@ -84,6 +84,51 @@ internal fun dayEpochSeconds(readings: List<VitalReading>): List<Long>? {
     return out
 }
 
+/**
+ * Which metrics are drawn as BARS rather than as a line.
+ *
+ * A line asserts continuity between points: it says the value travelled from one reading to the next. For
+ * a daily score that is false, and it is most of what makes a spiky series look chaotic. The reported
+ * Effort swings 19.8 points a day on a 0..42 range, so a line spends the whole chart climbing and diving
+ * through values that never existed.
+ *
+ * Bars claim nothing between slots. A zero day is a short bar beside a tall one instead of a plunge, and a
+ * day with no reading is simply an empty slot.
+ *
+ * Only the daily SCORES. Resting HR, HRV, skin temperature, respiratory rate and blood oxygen are levels
+ * that genuinely do vary continuously between measurements, so a line is the honest shape for them, and
+ * Fitness Age and Vitality are too sparse to fill a bar chart.
+ */
+internal fun vitalChartIsBars(key: String): Boolean = key in setOf("recovery", "rest", "strain")
+
+/**
+ * One slot per DAY across the window, rather than one per reading.
+ *
+ * Bars are laid out evenly across their slots, so giving every day a slot is what positions them by date:
+ * a missing day becomes an empty slot of the right width, with no separate spacing machinery. Days with no
+ * reading carry NaN, which the bar chart already treats as nothing to draw.
+ *
+ * Returns null when a day key fails to parse, so the caller falls back to the per-reading form rather than
+ * silently dropping readings into the wrong slots.
+ */
+internal fun densifyByDay(readings: List<VitalReading>): List<Pair<String, Double>>? {
+    if (readings.isEmpty()) return emptyList()
+    val byDay = LinkedHashMap<java.time.LocalDate, Double>()
+    for (r in readings) {
+        val day = runCatching { java.time.LocalDate.parse(r.day) }.getOrNull() ?: return null
+        byDay[day] = r.value
+    }
+    val first = byDay.keys.min()
+    val last = byDay.keys.max()
+    val out = ArrayList<Pair<String, Double>>()
+    var day = first
+    while (!day.isAfter(last)) {
+        out += day.toString() to (byDay[day] ?: Double.NaN)
+        day = day.plusDays(1)
+    }
+    return out
+}
+
 /** Sequential ids for a method-aware trend. Nes → Uth → Nes becomes three segments rather than joining
  *  the non-adjacent Nes runs across an incompatible estimator. */
 internal fun vo2MaxTrendSegmentIds(readings: List<VitalReading>): List<String> {

--- a/android/app/src/test/java/com/noop/ui/VitalBarChartTest.kt
+++ b/android/app/src/test/java/com/noop/ui/VitalBarChartTest.kt
@@ -1,0 +1,100 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Daily SCORES are drawn as bars. A line asserts continuity between readings, and on a series swinging
+ * about twenty points a day that climb-and-dive through values which never existed is most of what reads
+ * as noise. Bars claim nothing between slots.
+ */
+class VitalBarChartTest {
+
+    private fun reading(day: String, value: Double) = VitalReading(day, value, "dev")
+
+    @Test
+    fun `the daily scores are bars`() {
+        assertTrue(vitalChartIsBars("strain"))
+        assertTrue(vitalChartIsBars("rest"))
+        assertTrue(vitalChartIsBars("recovery"))
+    }
+
+    /**
+     * Levels stay lines. Resting HR, HRV, skin temperature, respiratory rate and blood oxygen genuinely do
+     * vary continuously between measurements, so a connecting line is the honest shape for them; drawing
+     * them as bars would be the mirror of the mistake this corrects.
+     */
+    @Test
+    fun `levels and sparse series stay lines`() {
+        listOf("rhr", "hrv", "skin", "resp", "spo2", "fitness_age", "vitality", "vo2max_est")
+            .forEach { assertFalse(it, vitalChartIsBars(it)) }
+    }
+
+    // --- one slot per day ---
+
+    /**
+     * The property that positions bars by date without any spacing machinery: every day in the window gets
+     * a slot, so a missing day is an empty slot of the right width rather than a bar shuffled left.
+     */
+    @Test
+    fun `every day in the window gets a slot`() {
+        val d = densifyByDay(
+            listOf(reading("2026-09-01", 32.9), reading("2026-09-03", 27.5), reading("2026-09-05", 42.3)),
+        )!!
+        assertEquals(5, d.size)
+        assertEquals(listOf("2026-09-01", "2026-09-02", "2026-09-03", "2026-09-04", "2026-09-05"), d.map { it.first })
+    }
+
+    /** A day with no reading carries NaN, which the bar chart already treats as nothing to draw. */
+    @Test
+    fun `a missing day is not a zero`() {
+        val d = densifyByDay(listOf(reading("2026-09-01", 32.9), reading("2026-09-03", 27.5)))!!
+        assertTrue(d[1].second.isNaN())
+        // and a REAL zero stays a real zero, distinct from the missing day beside it
+        val withZero = densifyByDay(listOf(reading("2026-09-01", 0.0), reading("2026-09-03", 27.5)))!!
+        assertEquals(0.0, withZero[0].second, 0.0)
+        assertTrue(withZero[1].second.isNaN())
+    }
+
+    /** Consecutive readings densify to themselves: a fully-measured stretch gains nothing and loses none. */
+    @Test
+    fun `a complete stretch is unchanged`() {
+        val r = listOf(reading("2026-09-01", 1.0), reading("2026-09-02", 2.0), reading("2026-09-03", 3.0))
+        assertEquals(r.map { it.day to it.value }, densifyByDay(r))
+    }
+
+    /** An unparseable day refuses, so the caller falls back rather than dropping readings into wrong slots. */
+    @Test
+    fun `an unparseable day refuses rather than mis-slotting`() {
+        assertNull(densifyByDay(listOf(reading("2026-09-01", 1.0), reading("nope", 2.0))))
+    }
+
+    @Test
+    fun `an empty series densifies to nothing`() {
+        assertEquals(emptyList<Pair<String, Double>>(), densifyByDay(emptyList()))
+    }
+
+    /**
+     * The read-out must not invent a measurement. BarChart flattens a non-finite value to 0.0 so it draws
+     * nothing, which is right for the geometry and wrong for the label: an empty slot would otherwise
+     * answer "0.0 %" on tap for a day that was never measured. That is the same class as a chart drawing
+     * one day and labelling another, and it only became reachable once missing days got their own slots.
+     *
+     * Pinned through the formatter the chart uses, since the drawing itself is not reachable from a JVM
+     * test: a finite value labels, and the caller now gates the non-finite case before it gets here.
+     */
+    @Test
+    fun `a densified gap carries no value to report`() {
+        val d = densifyByDay(listOf(reading("2026-09-01", 32.9), reading("2026-09-03", 27.5)))!!
+        val gap = d[1].second
+        assertTrue(gap.isNaN())
+        // The label is only rendered for a finite value, so the gap contributes none.
+        assertFalse(gap.isFinite())
+        // and the readings either side still do
+        assertTrue(d[0].second.isFinite())
+        assertTrue(d[2].second.isFinite())
+    }
+}


### PR DESCRIPTION
feat(today): draw the daily scores as bars, not as a line

The Effort trend still read as noise after anchoring, spacing and a continuous
line, and the chart type was the reason. A line asserts continuity between
readings: it says the value travelled from one to the next. For a daily score that
is false, and on the reported series it is most of what looks chaotic. That Effort
swings 19.8 points a day on a 0..42 range, so the line spends the whole chart
climbing to and diving from values that never existed.

Bars claim nothing between slots. A zero day is a short bar beside a tall one
rather than a plunge and a climb.

One slot per DAY rather than per reading, which positions the bars by date with no
spacing machinery at all: a day with no reading is an empty slot of the right
width. It carries NaN, which BarChart already treats as nothing to draw, and a
real zero stays a real zero.

Only the daily SCORES: Effort, Rest and Charge. Resting HR, HRV, skin temperature,
respiratory rate and blood oxygen are LEVELS that do vary continuously between
measurements, so a line is the honest shape for them, and drawing them as bars
would be the mirror of the mistake this corrects. Fitness Age and Vitality are too
sparse to fill a bar chart.

BarChart is the existing primitive, already used by the Sleep metric cards and
Trends. Nothing new was built.

## Why this rather than more line tweaks

Anchoring, date spacing and removing the breaks each helped, and none of them addressed the cause. The
reporter said "up and down" of the same series three times, and they were right every time: the line was
drawing travel that never happened. Changing the primitive is the fix; restyling the line was not.

Worth noting the earlier passes were not wasted, they were just aimed at the wrong thing. Date spacing in
particular is subsumed here, since one slot per day IS date positioning for a bar chart.

## Tests

+7. The allow-list is pinned in both directions, including that levels stay lines. The densifier is pinned
on the property that matters: every day in the window gets a slot, a missing day is NaN rather than a zero,
a real zero survives as a zero beside it, a complete stretch is unchanged, and an unparseable day refuses
rather than shuffling readings into the wrong slots.

676 classes / 5719 tests, 0 failures. Android-only; the iOS detail chart is Swift Charts and separate.