### PR TITLE
diag: census what a re-score carries, not just how many nights it visited

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -191,6 +191,33 @@ object IntelligenceEngine {
      *  consumed by pass 2's universal dayOwner emit. */
     private data class OwnerRead(val owner: String, val hrRows: Int)
 
+    /**
+     * #2013: the census beside `re-score: done`, saying what the pass is carrying rather than how many
+     * nights it visited.
+     *
+     * A day that is scored but comes back with a null metric vanishes from that metric's detail screen
+     * without a word, and the reported case looked identical to a day that was never scored at all. The
+     * split between "the pass never produced it" and "the pass produced it and it was lost downstream" is
+     * the first question in that investigation and the log could not answer it.
+     *
+     * This counts what the pass PRODUCED, taken from its own DayResult rather than from a stored row, so
+     * it answers one half of the split. If a metric matches the night count and days are still absent
+     * from the screen, the loss is downstream of here and wants its own line at the write. That is the
+     * useful outcome either way: it says which half to look in, which is what #2013 lacked.
+     *
+     * Pure so the wording is pinned without running a pass. Names the day SPAN too, since a window that
+     * quietly shrank is the other way days go missing.
+     */
+    internal fun reScoreCensusLine(scored: List<Computed>): String {
+        if (scored.isEmpty()) return "re-score census: 0 night(s), nothing to carry"
+        val days = scored.map { it.day }.sorted()
+        return "re-score census: ${scored.size} night(s) ${days.first()}..${days.last()} " +
+            "charge=${scored.count { it.recovery != null }} effort=${scored.count { it.strain != null }} " +
+            "sleep=${scored.count { it.sleepMin != null }} hrv=${scored.count { it.hrv != null }} " +
+            "rhr=${scored.count { it.rhr != null }} (a metric short of the night count is one the pass " +
+            "produced nothing for)"
+    }
+
     /** Summary of one scored day (for logging / a future on-device intelligence screen). */
     data class Computed(
         val day: String,
@@ -455,6 +482,11 @@ object IntelligenceEngine {
                 spo2CandidateDisplay, effortMethod, dayCycleMode).first
         }
         diag("re-score: done — scored ${scored.size} night(s) in ${(System.nanoTime() - reScoreStart) / 1_000_000} ms (#1005)")
+        // #2013: what the pass actually CARRIES, beside how many nights it touched. "scored N nights" is
+        // silent about a day that was scored and came back empty, which is exactly the shape reported: the
+        // detail screen omitted days the log showed being scored, and nothing in between said which half
+        // lost them. A census of the results makes that answerable from one shared log.
+        diag(reScoreCensusLine(scored))
         scored
     }
 

--- a/android/app/src/test/java/com/noop/analytics/ReScoreCensusTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ReScoreCensusTest.kt
@@ -1,0 +1,55 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #2013: "scored N nights" cannot distinguish a day the pass never produced from a day it produced and
+ * something downstream lost. The reported case looked exactly like the second and could have been the
+ * first, and no line in a shared log separated them.
+ */
+class ReScoreCensusTest {
+
+    private fun day(d: String, strain: Double?) =
+        IntelligenceEngine.Computed(day = d, recovery = 50.0, strain = strain, sleepMin = 400.0, hrv = 40.0, rhr = 55)
+
+    /**
+     * The case that motivated this: every night scored, but Effort short of the night count. That says
+     * the pass produced nothing for those days, so the loss is upstream of persistence.
+     */
+    @Test
+    fun `a metric short of the night count is visible`() {
+        val line = IntelligenceEngine.reScoreCensusLine(
+            listOf(day("2026-08-29", 9.9), day("2026-08-30", null), day("2026-08-31", null)),
+        )
+        assertTrue(line, line.contains("3 night(s)"))
+        assertTrue(line, line.contains("effort=1"))
+        assertTrue(line, line.contains("charge=3"))
+    }
+
+    /** The span is named, because a window that quietly shrank is the other way days go missing. */
+    @Test
+    fun `the census names the day span`() {
+        val line = IntelligenceEngine.reScoreCensusLine(
+            listOf(day("2026-09-09", 1.0), day("2026-08-26", 2.0), day("2026-09-01", 3.0)),
+        )
+        assertTrue(line, line.contains("2026-08-26..2026-09-09"))
+    }
+
+    /** A pass that produced everything reads as complete, so a healthy log is not noisy to scan. */
+    @Test
+    fun `a complete pass reports every metric at the night count`() {
+        val line = IntelligenceEngine.reScoreCensusLine(listOf(day("2026-09-01", 1.0), day("2026-09-02", 2.0)))
+        listOf("charge=2", "effort=2", "sleep=2", "hrv=2", "rhr=2").forEach {
+            assertTrue(line, line.contains(it))
+        }
+    }
+
+    /** An empty pass says so rather than printing an empty span. */
+    @Test
+    fun `an empty pass is stated, not rendered as a blank range`() {
+        val line = IntelligenceEngine.reScoreCensusLine(emptyList())
+        assertTrue(line, line.contains("0 night(s)"))
+        assertTrue(line, !line.contains(".."))
+    }
+}


### PR DESCRIPTION
diag: census what a re-score CARRIES, not just how many nights it visited

Filed as #2013: days the re-score computed did not reach the daily rows, and the
detail screen omitted them entirely while showing stale values for others. Working
out where they were lost took reading a 500KB log line by line, because nothing
said what the pass produced.

The done line reports a night COUNT. A day scored with a null metric vanishes from
that metric's detail screen without a word, and looks identical in the log to a day
that was never scored. That is the first question in this investigation and no
shared log could answer it.

The census names the span and counts each metric against the night count, so a
metric short of it is one the pass produced nothing for. That splits "never
produced" from "produced and lost downstream" in one line, which is the split that
took an evening to establish by hand.

The day SPAN is there because a window that quietly shrank is the other way days go
missing, and that is equally invisible in a count.

Example of what it would have said for the reported case, where every night scored but Effort came back
short:

```
re-score census: 21 night(s) 2026-08-19..2026-09-09 charge=21 effort=16 sleep=21 hrv=20 rhr=21 (a metric short of the night count is one the pass produced nothing for)
```

## Tests

+4. The motivating case is pinned directly: a metric short of the night count is visible. Plus the span,
a complete pass reading as complete so a healthy log stays easy to scan, and an empty pass saying so
rather than printing a blank range.

677 classes / 5724 tests, 0 failures. Diagnostic only, no behaviour change. Android-only for now; the
Swift twin is worth adding once this has proved itself on a real log.