### PR TITLE
Re-fold a day's motion only when that day's gravity moved

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalysisPhaseTally.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/AnalysisPhaseTally.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Where an `analyzeRecent` pass spends the time AFTER its per-day loop.
+///
+/// #1538 added a cost line, but it brackets the day loop and is emitted the moment that loop returns. Every
+/// phase after it — the baseline folds, pass 2, the persist, the weekly metrics, the steps calibration, the
+/// sleep writes and heals, the workout rescore — was outside the tally, so a pass whose time went somewhere
+/// after the loop reported a small `prep`/`score` and no explanation for the rest. The steps calibration
+/// alone re-folded sixty days of gravity per pass under that blind spot.
+///
+/// This is the same idea at the other end of the pass: stamp each phase as it completes and print them in
+/// order, so the dominant phase names itself instead of being inferred from what the day-loop line does not
+/// account for.
+public enum AnalysisPhaseTally {
+    /// Render ordered `(name, seconds)` phases as one line, each in milliseconds.
+    ///
+    /// Phases print in the order given, which is execution order — reading the line top to bottom is reading
+    /// the pass front to back. The total is included because the phases deliberately do NOT have to sum to
+    /// the pass: anything not bracketed shows up as the difference, which is itself the signal that a phase
+    /// is still unmeasured.
+    ///
+    /// `scope` names WHAT was bracketed, and it is a parameter rather than a constant because the two
+    /// platforms can afford to measure different amounts: Android's `analyzeRecentOnCpu` sits under a
+    /// JaCoCo method-size ratchet that leaves no room for the marks, so it brackets only its persist
+    /// helper. A line that said `postLoop` while timing part of the post-loop would misreport its own
+    /// total, which is the one thing a cost line must not do. Byte-identical to the Kotlin
+    /// `AnalysisPhaseTally.logLine`.
+    public static func logLine(scope: String, _ phases: [(name: String, seconds: Double)]) -> String {
+        let parts = phases.map { "\($0.name)=\(millis($0.seconds))ms" }
+        let total = phases.reduce(0.0) { $0 + $1.seconds }
+        return "analyzeRecent \(scope) total=\(millis(total))ms "
+            + (parts.isEmpty ? "(no phases)" : parts.joined(separator: " "))
+    }
+
+    /// Seconds to whole milliseconds, floored at zero.
+    ///
+    /// The clamp is the parity contract, not defensive habit. These are `Date()` differences, and a wall
+    /// clock that steps backwards mid-pass (an NTP correction is enough) yields a negative interval — the
+    /// one input where Swift's round-half-away-from-zero and Kotlin's round-half-up disagree, at exactly
+    /// -0.5 ms. Clamping first makes both sides provably identical instead of identical only while the
+    /// clock behaves. A phase cannot take less than no time, so nothing true is lost.
+    private static func millis(_ seconds: Double) -> Int {
+        guard seconds.isFinite, seconds > 0 else { return 0 }
+        return Int((seconds * 1000).rounded())
+    }
+}

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsMotionCache.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StepsMotionCache.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Per-day reuse identity for the steps-calibration motion fold in `IntelligenceEngine.analyzeRecent`.
+///
+/// The drain this closes: the calibration fits one coefficient from sixty days of strap motion, and it
+/// re-folded all sixty on EVERY pass. Each day meant a `gravitySamples` read capped at 200,000 rows, so a
+/// worn library paid millions of materialised rows per pass to re-derive numbers that had not moved. The
+/// phase does not scale with the days being re-scored — it always reads the same sixty — so a two-day pass
+/// could cost more than a twenty-one-day one, which is what made it hard to see in a cost line keyed on the
+/// day loop.
+///
+/// `StepsEstimateEngine.dayMotionIntensity` is a pure fold over one day's gravity stream. Nothing else
+/// reaches it: no profile field, no baseline, no toggle, no other stream. So unlike `AnalyzeRecentDayCache`
+/// there is no pass-config signature to invalidate against — the value changes exactly when that one day's
+/// gravity changes, and the key below is the whole story.
+///
+/// Like the day-scan cache this is in-memory and per-process. It never persists, never crosses the
+/// `.noopbak` boundary, and a relaunch pays the full fold once. That is deliberate: the cost being closed is
+/// the repeat within a process, where an offload storm fires passes back to back.
+public enum StepsMotionCache {
+    /// The per-day reuse key. Reuse a cached motion volume iff this string is unchanged.
+    ///
+    /// - `owner`: the resolved owning device the fold was measured against. A day whose owner flips between
+    ///   straps must re-fold, and the fingerprint below is device-scoped, so this makes that explicit rather
+    ///   than relying on two devices never producing an identical count and newest timestamp for one window.
+    /// - `gravityCount` / `gravityMaxTs`: the day window's gravity witness. Any gravity row added or removed
+    ///   moves one of the two. Deliberately NOT the wider `dayStreamFingerprint`: that also counts HR, R-R,
+    ///   respiration, SpO2, steps, skin temp and sleep state, so an ordinary HR offload would invalidate a
+    ///   motion volume that cannot have changed by it.
+    public static func cacheKey(owner: String, gravityCount: Int, gravityMaxTs: Int) -> String {
+        "\(owner)|\(gravityCount)|\(gravityMaxTs)"
+    }
+
+    /// The pass's one-line reuse readout, beside the phase cost line.
+    ///
+    /// `reused` and `folded` sum to the days scanned, so the ratio is readable without a second line. A pass
+    /// reporting `folded=60` every time means the key is moving when it should not, which is the failure
+    /// this cache can have and the reason the number is reported at all rather than assumed.
+    public static func logLine(reused: Int, folded: Int, size: Int) -> String {
+        "analyzeRecent stepsMotion reused=\(reused)/\(reused + folded) size=\(size)"
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalysisPhaseTallyTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/AnalysisPhaseTallyTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// The post-loop phase line. Mirrored by the Kotlin `AnalysisPhaseTallyTest` against the SAME literals:
+/// the two platforms name their own phases (the passes genuinely differ after the day loop), but the
+/// rendering — order, rounding, the total, the empty case — is one contract.
+final class AnalysisPhaseTallyTests: XCTestCase {
+
+    func testPhasesRenderInOrderWithATotal() {
+        let line = AnalysisPhaseTally.logLine(scope: "postLoop", [
+            (name: "baselines", seconds: 0.012),
+            (name: "score2", seconds: 1.1),
+            (name: "steps", seconds: 28.93),
+        ])
+        XCTAssertEqual(line, "analyzeRecent postLoop total=30042ms baselines=12ms score2=1100ms steps=28930ms")
+    }
+
+    /// The phases are printed in the order GIVEN, never sorted by cost. Execution order is the point: the
+    /// line is read front to back as the pass runs, and a sort would hide where in the pass the time sits.
+    func testOrderIsExecutionOrderNotCost() {
+        let line = AnalysisPhaseTally.logLine(scope: "postLoop", [
+            (name: "steps", seconds: 28.93),
+            (name: "baselines", seconds: 0.012),
+        ])
+        XCTAssertEqual(line, "analyzeRecent postLoop total=28942ms steps=28930ms baselines=12ms")
+    }
+
+    /// A backwards wall-clock step (an NTP correction mid-pass is enough) yields a negative interval.
+    /// It floors at zero rather than printing a negative duration — and, more to the point, that is the
+    /// one input where Swift's round-half-away-from-zero and Kotlin's round-half-up would disagree.
+    func testNegativeAndNonFinitePhasesFloorAtZero() {
+        XCTAssertEqual(AnalysisPhaseTally.logLine(scope: "postLoop", [(name: "skew", seconds: -0.0005)]),
+                       "analyzeRecent postLoop total=0ms skew=0ms")
+        XCTAssertEqual(AnalysisPhaseTally.logLine(scope: "postLoop", [(name: "nan", seconds: Double.nan)]),
+                       "analyzeRecent postLoop total=0ms nan=0ms")
+    }
+
+    /// The total is the sum of what was MEASURED, not of the pass. A phase nobody bracketed shows up as
+    /// the gap between this number and `re-score: done`, which is how the next blind spot gets found.
+    func testTotalIsTheSumOfMeasuredPhasesOnly() {
+        XCTAssertEqual(AnalysisPhaseTally.logLine(scope: "postLoop", [(name: "a", seconds: 0.5), (name: "b", seconds: 0.25)]),
+                       "analyzeRecent postLoop total=750ms a=500ms b=250ms")
+    }
+
+    /// The scope is the caller's, not a constant. Android brackets only its persist helper (the JaCoCo
+    /// method-size ratchet leaves no room in `analyzeRecentOnCpu`), so its line must not claim a `postLoop`
+    /// total it never measured. Same phases, different scope, different line.
+    func testScopeNamesWhatWasActuallyBracketed() {
+        let phases: [(name: String, seconds: Double)] = [(name: "weekly", seconds: 0.07),
+                                                         (name: "steps", seconds: 28.93)]
+        XCTAssertEqual(AnalysisPhaseTally.logLine(scope: "persistSteps", phases),
+                       "analyzeRecent persistSteps total=29000ms weekly=70ms steps=28930ms")
+        XCTAssertEqual(AnalysisPhaseTally.logLine(scope: "postLoop", phases),
+                       "analyzeRecent postLoop total=29000ms weekly=70ms steps=28930ms")
+    }
+
+    func testNoPhasesSaysSoRatherThanPrintingNothing() {
+        XCTAssertEqual(AnalysisPhaseTally.logLine(scope: "postLoop", []), "analyzeRecent postLoop total=0ms (no phases)")
+    }
+}

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsMotionCacheTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StepsMotionCacheTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// The steps-calibration motion cache's key and readout. Mirrored by the Kotlin
+/// `StepsMotionCacheTest`, which pins the SAME literals — the key is a cross-platform contract only in
+/// the sense that both sides must invalidate on the same facts, and pinning the rendered strings is how
+/// a one-sided change to either rule is caught.
+final class StepsMotionCacheTests: XCTestCase {
+
+    func testKeyIsStableForUnchangedInputs() {
+        let a = StepsMotionCache.cacheKey(owner: "my-whoop", gravityCount: 8640, gravityMaxTs: 1_757_000_000)
+        let b = StepsMotionCache.cacheKey(owner: "my-whoop", gravityCount: 8640, gravityMaxTs: 1_757_000_000)
+        XCTAssertEqual(a, b)
+        XCTAssertEqual(a, "my-whoop|8640|1757000000")
+    }
+
+    /// The three facts that MUST invalidate a fold, one at a time. A row added moves the count; a row
+    /// replacing another at a newer timestamp moves the max; a day changing hands moves the owner.
+    func testEveryInputInvalidates() {
+        let base = StepsMotionCache.cacheKey(owner: "my-whoop", gravityCount: 8640, gravityMaxTs: 1_757_000_000)
+        XCTAssertNotEqual(base, StepsMotionCache.cacheKey(owner: "my-whoop", gravityCount: 8641,
+                                                          gravityMaxTs: 1_757_000_000))
+        XCTAssertNotEqual(base, StepsMotionCache.cacheKey(owner: "my-whoop", gravityCount: 8640,
+                                                          gravityMaxTs: 1_757_000_001))
+        XCTAssertNotEqual(base, StepsMotionCache.cacheKey(owner: "whoop-5mg", gravityCount: 8640,
+                                                          gravityMaxTs: 1_757_000_000))
+    }
+
+    /// An empty day is a real, cacheable answer — the key for it is well-formed and distinct from a day
+    /// that has rows. Caching it is what stops an unworn gap re-reading its whole stream every pass.
+    func testEmptyDayHasItsOwnKey() {
+        let empty = StepsMotionCache.cacheKey(owner: "my-whoop", gravityCount: 0, gravityMaxTs: 0)
+        XCTAssertEqual(empty, "my-whoop|0|0")
+        XCTAssertNotEqual(empty, StepsMotionCache.cacheKey(owner: "my-whoop", gravityCount: 1,
+                                                           gravityMaxTs: 0))
+    }
+
+    /// The owner is the FIRST field, so two devices cannot collide by arranging their counts: the
+    /// separator makes `a|1|2` and `a|1|2` the only way to match.
+    func testOwnerBoundaryCannotBeForgedByCounts() {
+        XCTAssertNotEqual(StepsMotionCache.cacheKey(owner: "a", gravityCount: 1, gravityMaxTs: 2),
+                          StepsMotionCache.cacheKey(owner: "a|1", gravityCount: 2, gravityMaxTs: 0))
+    }
+
+    func testLogLineReportsTheRatioAndSize() {
+        XCTAssertEqual(StepsMotionCache.logLine(reused: 58, folded: 2, size: 60),
+                       "analyzeRecent stepsMotion reused=58/60 size=60")
+        // A cold process: everything folded, nothing reused. This is the line a FIRST pass prints, and
+        // seeing it on every pass is the symptom that the key is moving when it should not.
+        XCTAssertEqual(StepsMotionCache.logLine(reused: 0, folded: 60, size: 60),
+                       "analyzeRecent stepsMotion reused=0/60 size=60")
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -97,6 +97,26 @@ extension WhoopStore {
         }
     }
 
+    /// Per-day GRAVITY fingerprint: `(count, maxTs)` over one device's `gravitySample` rows in a window.
+    ///
+    /// The witness the steps-calibration motion cache reuses a day's fold against. `dayStreamFingerprint`
+    /// already computes this pair, but it computes it alongside eight other streams, so a new HR row would
+    /// invalidate a motion volume that cannot have changed. `StepsEstimateEngine.dayMotionIntensity` is a
+    /// pure fold over one day's gravity stream and nothing else, so its cache key must move when that
+    /// stream moves and at no other time. Same COUNT/COALESCE(MAX) shape and the same `(deviceId, ts)`
+    /// index as `hrFingerprint(deviceId:from:to:)` above, and never a row fetch.
+    public func gravityFingerprint(deviceId: String, from: Int, to: Int) async throws -> (count: Int, maxTs: Int) {
+        try syncRead { db in
+            guard let row = try Row.fetchOne(db, sql: """
+                SELECT COUNT(*) AS c, COALESCE(MAX(ts), 0) AS m FROM gravitySample
+                WHERE deviceId = ? AND ts >= ? AND ts <= ?
+                """, arguments: [deviceId, from, to]) else { return (0, 0) }
+            let c: Int = row["c"]
+            let m: Int = row["m"]
+            return (c, m)
+        }
+    }
+
     /// Cross-device raw-HR fingerprint: `(count, maxTs)` over EVERY `hrSample` row, no `deviceId` filter.
     /// The `analyzeRecent` re-score gate (#1392) only needs to answer "did the raw stream change AT ALL",
     /// so it must see HR that lands under ANY id — an Oura ring, an Apple Watch, or a WHOOP re-added under a

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/GravityWitnessTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/GravityWitnessTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+import WhoopProtocol
+@testable import WhoopStore
+
+/// The contract the steps-calibration motion cache rests on.
+///
+/// `StepsEstimateEngine.dayMotionIntensity` sums the distance between CONSECUTIVE gravity samples, so it
+/// depends on the set of x/y/z values in a day AND on their order. The cache re-folds a day only when
+/// `gravityFingerprint` moves, which is sound only while a day's gravity cannot change underneath an
+/// unchanged `(count, maxTs)`. These pin the parts of that a test can reach; the rest is structural (the
+/// reads are `ORDER BY ts ASC`, and nothing anywhere rewrites a `ts` or a vector in place).
+final class GravityWitnessTests: XCTestCase {
+
+    private func store() async throws -> WhoopStore {
+        let s = try await WhoopStore.inMemory()
+        try await s.upsertDevice(id: "dev1", mac: nil, name: nil)
+        try await s.upsertDevice(id: "other", mac: nil, name: nil)
+        return s
+    }
+
+    private func grav(_ ts: Int, _ v: Double) -> GravitySample {
+        GravitySample(ts: ts, x: v, y: v, z: v, dynAccel: nil)
+    }
+
+    /// The load-bearing one. Re-offloading a second that is already banked is absorbed by
+    /// `ON CONFLICT(deviceId, ts) DO NOTHING`: the stored vector is the FIRST one, not the newest. That is
+    /// what makes an unchanged witness mean an unchanged fold. Were this ever flipped to a REPLACE, the
+    /// values under a day would change while its count and newest timestamp held still, and the cache would
+    /// serve a motion volume for data it no longer describes — silently, with no failing read.
+    func testReinsertingAnExistingSecondChangesNeitherTheWitnessNorTheValues() async throws {
+        let s = try await store()
+        _ = try await s.insert(Streams(gravity: [grav(100, 1), grav(200, 2)]), deviceId: "dev1")
+        let before = try await s.gravityFingerprint(deviceId: "dev1", from: 0, to: 1000)
+
+        _ = try await s.insert(Streams(gravity: [grav(100, 99), grav(200, 99)]), deviceId: "dev1")
+        let after = try await s.gravityFingerprint(deviceId: "dev1", from: 0, to: 1000)
+        XCTAssertEqual(before.count, after.count)
+        XCTAssertEqual(before.maxTs, after.maxTs)
+
+        let rows = try await s.gravitySamples(deviceId: "dev1", from: 0, to: 1000, limit: 100)
+        XCTAssertEqual(rows.map { $0.x }, [1, 2], "conflict-ignore must keep the first vector, not the newest")
+    }
+
+    /// A new second moves both halves, so the day re-folds. Both are asserted: a witness that moved only
+    /// its count would miss an append that replaced nothing, and one that moved only its newest timestamp
+    /// would miss a backfilled second older than the day's last.
+    func testAnAppendMovesTheWitnessAndABackfillMovesTheCount() async throws {
+        let s = try await store()
+        _ = try await s.insert(Streams(gravity: [grav(200, 1)]), deviceId: "dev1")
+        let one = try await s.gravityFingerprint(deviceId: "dev1", from: 0, to: 1000)
+        XCTAssertEqual(one.count, 1)
+        XCTAssertEqual(one.maxTs, 200)
+
+        _ = try await s.insert(Streams(gravity: [grav(300, 1)]), deviceId: "dev1")
+        let appended = try await s.gravityFingerprint(deviceId: "dev1", from: 0, to: 1000)
+        XCTAssertEqual(appended.count, 2)
+        XCTAssertEqual(appended.maxTs, 300)
+
+        // A second that lands BEFORE the day's newest: the timestamp holds, the count is the only witness
+        // that moves. An offload does not commit its channels in order, so this is the ordinary case.
+        _ = try await s.insert(Streams(gravity: [grav(100, 1)]), deviceId: "dev1")
+        let backfilled = try await s.gravityFingerprint(deviceId: "dev1", from: 0, to: 1000)
+        XCTAssertEqual(backfilled.count, 3)
+        XCTAssertEqual(backfilled.maxTs, 300, "a backfill leaves the newest timestamp alone")
+    }
+
+    /// Scoped to one device and one window, because the cache key pairs the witness with a resolved owner
+    /// and a day. Another strap's gravity, or the same strap's gravity on another day, must not move it.
+    func testTheWitnessIsScopedToOneDeviceAndOneWindow() async throws {
+        let s = try await store()
+        _ = try await s.insert(Streams(gravity: [grav(100, 1), grav(200, 1)]), deviceId: "dev1")
+        let base = try await s.gravityFingerprint(deviceId: "dev1", from: 0, to: 250)
+
+        _ = try await s.insert(Streams(gravity: [grav(150, 1)]), deviceId: "other")
+        _ = try await s.insert(Streams(gravity: [grav(900, 1)]), deviceId: "dev1")
+        let after = try await s.gravityFingerprint(deviceId: "dev1", from: 0, to: 250)
+        XCTAssertEqual(base.count, after.count)
+        XCTAssertEqual(base.maxTs, after.maxTs)
+    }
+
+    /// An empty window is a real answer, not a missing one: `(0, 0)`. The cache stores zero folds under it
+    /// so an unworn gap stops re-reading its whole stream to rediscover that it is empty.
+    func testAnEmptyWindowReportsZeroRatherThanFailing() async throws {
+        let s = try await store()
+        let fp = try await s.gravityFingerprint(deviceId: "dev1", from: 0, to: 1000)
+        XCTAssertEqual(fp.count, 0)
+        XCTAssertEqual(fp.maxTs, 0)
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -64,6 +64,10 @@ final class IntelligenceEngine: ObservableObject {
     /// never crosses `.noopbak`. The engine is a single long-lived instance (AppModel), so this survives the
     /// storm's back-to-back passes the drain is made of. See `AnalyzeRecentDayCache` (StrandAnalytics).
     private var dayScanCache: [String: (key: String, scan: DayScan)] = [:]
+    /// Per-day steps-calibration motion folds, `[day: (key, motion)]`, keyed by `StepsMotionCache.cacheKey`.
+    /// In-memory and per-process exactly like `dayScanCache`; see `StepsMotionCache` for why this one needs
+    /// no config signature. Pruned to the calibration window each pass so it cannot grow without bound.
+    private var stepsMotionCache: [String: (key: String, motion: Double)] = [:]
     /// The scoring-config signature the `dayScanCache` entries were produced under (profile / baselines1 /
     /// tz / sleep need+consistency / habitual midsleep / stager toggles). Those feed `analyzeDay` but are
     /// pass-global, not in the per-day key, so when the current pass's signature differs every cached scan is
@@ -1614,6 +1618,19 @@ final class IntelligenceEngine: ObservableObject {
         // #1005: write the loop's updated reuse cache back to the (main-actor) stored property. The pass ran
         // to completion above (`.value` awaited), so there is no concurrent access.
         dayScanCache = updatedDayScanCache
+        // #1538: the pass after the day loop was never measured. The cost line above brackets the loop and
+        // is emitted the moment it returns, so a pass whose time went somewhere later reported a small
+        // prep/score and no account of the rest — which is where the steps calibration was re-folding sixty
+        // days of gravity every pass, unseen. Stamp each phase as it completes; `AnalysisPhaseTally` renders
+        // them in execution order beside `re-score: done`. `Date()` matches the clock the loop's own tally
+        // uses, and the formatter floors a backwards clock step at zero.
+        var postLoopPhases: [(name: String, seconds: Double)] = []
+        var postLoopMark = Date()
+        func markPostLoopPhase(_ name: String) {
+            let now = Date()
+            postLoopPhases.append((name: name, seconds: now.timeIntervalSince(postLoopMark)))
+            postLoopMark = now
+        }
 
         // #714: replay each skipped day's diagnostic now that we're back on the main actor (diagnosticSink
         // is MainActor-bound). Always-on , not gated behind a test mode, mirroring the Kotlin `diag` sink.
@@ -1683,6 +1700,7 @@ final class IntelligenceEngine: ObservableObject {
                                  detectionFunnel: res.detectionFunnel))
         }
 
+        markPostLoopPhase("dayReplay")
         // ── Seed the baseline from the UNION of imported nightly history + the values just computed.
         // THIS is the BLE-only recovery fix: the "-noop" nightly avgHrv/restingHr finally feed the
         // baseline so a strap-only user crosses Baselines.minNightsSeed and recovery lights up.
@@ -1796,6 +1814,7 @@ final class IntelligenceEngine: ObservableObject {
         realWorkouts += (try? await store.workouts(deviceId: "apple-health", from: windowStart,
                                                     to: now, limit: 100_000)) ?? []
 
+        markPostLoopPhase("baselines")
         // ── Pass 2: re-score ONLY recovery against the now-seeded baseline (cheap, baseline-dependent);
         // every other field was computed once in pass 1. Recovery stays nil until the HRV baseline is
         // usable (≥ minNightsSeed valid nights) , honest cold-start, via RecoveryScorer's usable gate.
@@ -2103,6 +2122,7 @@ final class IntelligenceEngine: ObservableObject {
             }
         }
 
+        markPostLoopPhase("score2")
         // ── Apple-Watch recovery fold (M1 "Watch as a device") ──────────────────────────────────────
         // A watch-only user has apple-health DAILY aggregates (SDNN HRV + resting HR) but no raw stream, so
         // the raw-HR scoring loop above never touched their days and the import left `recovery: nil`. Fill
@@ -2132,6 +2152,7 @@ final class IntelligenceEngine: ObservableObject {
             _ = try? await store.upsertDailyMetrics(appleRecoveryRows, deviceId: Repository.appleHealthSource)
         }
 
+        markPostLoopPhase("watchFold")
         // #277 migration: the loop now keys days by the LOCAL calendar day. A prior run (before this
         // fix) wrote the SAME period under UTC-day keys, so without a cleanup an off-by-one UTC row and
         // the new local row would coexist as duplicate days. We reconcile the COMPUTED ("-noop") daily
@@ -2258,6 +2279,7 @@ final class IntelligenceEngine: ObservableObject {
                 _ = try? await store.deleteDailyMetrics(deviceId: computedId, from: stale.day, to: stale.day)
             }
         }
+        markPostLoopPhase("persist")
         // ── Fitness Age (Phase 2) , weekly, keyed to the week's Saturday ────────────────────────────
         // Roll the last 7 computed days into the Nes/HUNT inputs and upsert a weekly Fitness Age (+ an
         // optional VO₂max when a waist is set) under the same "-noop" source. Idempotent on the Saturday
@@ -2315,6 +2337,7 @@ final class IntelligenceEngine: ObservableObject {
             ], deviceId: computedId)
         }
 
+        markPostLoopPhase("weekly")
         // ── Steps ESTIMATE (WHOOP 4.0) , DAILY, keyed to each strap-only day ────────────────────────
         // A WHOOP 4.0 sends no step count over BLE, so for days the phone DIDN'T also count steps we
         // estimate them: calibrate the strap's daily MOTION VOLUME against the phone's real step count
@@ -2334,21 +2357,26 @@ final class IntelligenceEngine: ObservableObject {
             nowLocalMidnight - (stepsCalDays - 1) * 86_400, offsetSec: tzOffset)
         // ── FIX 2 (main-actor jank): hoist the 60-day steps-calibration STORE READS off the main actor ──
         // Same residual stall FIX 1 fixed, smaller scale: this class is `@MainActor`, so each `await store.…`
-        // below resumes its continuation ON the main actor , the apple-health read + 60 per-day
+        // below resumes its continuation ON the main actor , the apple-health read + the per-day
         // owner-resolve/gravity reads add 60+ read-resumes of main-actor contention every analyzeRecent.
         // The reads touch NO `@Published`/`profile`/`registry`-isolated state , only the captured immutable
-        // inputs (calOldest/newestDay/nowLocalMidnight/tzOffset/regDevices/regActiveId), the `WhoopStore`
-        // actor, the nonisolated `registry`, the nonisolated-static `resolveDayOwner`, and the pure static
-        // `StepsEstimateEngine.dayMotionIntensity`. So we hoist the whole gather into ONE
-        // `Task.detached(priority:.utility)` whose continuations resume OFF the main actor, returning two
-        // plain `[String: Double]` value types (fully Sendable , even cleaner than FIX 1's [DayScan]). The
-        // pure `StepsEstimateEngine.calibrate/estimate/status` fit + the `profile.*` assignments stay on the
-        // main actor below, consuming those dictionaries. Same per-day inputs (same window, same owner
+        // inputs (calOldest/newestDay/nowLocalMidnight/tzOffset/regDevices/regActiveId/the incoming motion
+        // cache), the `WhoopStore` actor, the nonisolated `registry`, the nonisolated-static
+        // `resolveDayOwner`, and the pure static `StepsEstimateEngine.dayMotionIntensity`. So we hoist the
+        // whole gather into ONE `Task.detached(priority:.utility)` whose continuations resume OFF the main
+        // actor, returning plain value types only: two `[String: Double]`, the updated
+        // `[String: (key: String, motion: Double)]` motion cache, and its log line. All fully Sendable ,
+        // tuples of Sendable elements, the same shape the day loop already returns its `dayScanCache` in.
+        // The pure `StepsEstimateEngine.calibrate/estimate/status` fit + the `profile.*` assignments stay on
+        // the main actor below, consuming those dictionaries. Same per-day inputs (same window, same owner
         // resolution, same `m > 0` / `steps > 0` filters), same outputs , only the executor the reads resume
-        // on changes. Bind `deviceId` (a MainActor instance `let`) to a local Sendable `String` so the
-        // @Sendable detached closure captures the VALUE, never `self`, exactly as FIX 1's `ownerFallbackId`.
+        // on changes, and — since the motion cache — which days need their gravity read at all. Bind
+        // `deviceId` (a MainActor instance `let`) to a local Sendable `String` so the @Sendable detached
+        // closure captures the VALUE, never `self`, exactly as FIX 1's `ownerFallbackId`.
         let stepsFallbackId = deviceId
-        let (refStepsByDay, motionByDay): ([String: Double], [String: Double]) =
+        let inStepsMotionCache = stepsMotionCache
+        let (refStepsByDay, motionByDay, updatedStepsMotionCache, stepsMotionLogLine):
+            ([String: Double], [String: Double], [String: (key: String, motion: Double)], String) =
             await Task.detached(priority: .utility) {
             // Phone reference steps per day, from the apple-health daily rows (steps > 0 only).
             // #693: read `appleDaily`, NOT `dailyMetrics`. Apple-Health import writes the phone step count into
@@ -2361,21 +2389,57 @@ final class IntelligenceEngine: ObservableObject {
             for r in appleRows { if let s = r.steps, s > 0 { refSteps[r.day] = Double(s) } }
             // Per-day motion volume over the calibration window, read from the owner-resolved strap streams.
             // (Owner resolution mirrors the scoring loop; one device installs resolve to `deviceId`.)
+            //
+            // Each day is re-folded only when its own gravity witness moved. The fold is pure over that one
+            // stream, so an unchanged witness means an unchanged volume — see `StepsMotionCache`. The
+            // fingerprint is a COUNT/MAX aggregate over the same `(deviceId, ts)` index the read walks, so a
+            // hit replaces a read capped at 200,000 rows with one that returns a single row.
             var motion: [String: Double] = [:]
+            var motionCacheLocal = inStepsMotionCache
+            var motionReused = 0
+            var motionFolded = 0
+            var motionWindow: Set<String> = []
             for off in 0..<stepsCalDays {
                 let dayMid = Self.midnightLocal(nowLocalMidnight - off * 86_400, offsetSec: tzOffset)
                 let dayEnd = dayMid + 86_400 - 1
                 let dayKey = AnalyticsEngine.dayString(dayMid, offsetSec: tzOffset)
+                motionWindow.insert(dayKey)
                 let owner = await Self.resolveDayOwner(day: dayKey, from: dayMid, to: dayEnd, store: store,
                                                        devices: regDevices, activeId: regActiveId,
                                                        registry: registry, fallbackDeviceId: stepsFallbackId)
-                let grav = (try? await store.gravitySamples(deviceId: owner, from: dayMid, to: dayEnd,
-                                                            limit: 200_000)) ?? []
-                let m = StepsEstimateEngine.dayMotionIntensity(grav)
+                // A witness that could not be READ is not a witness. `(0, 0)` would be indistinguishable
+                // from a genuinely empty day, so a failed aggregate could serve a stale zero for a day that
+                // has since gained gravity. On a nil fingerprint the cache is bypassed in both directions:
+                // fold fresh, and store nothing under a key that does not describe anything.
+                let fp = try? await store.gravityFingerprint(deviceId: owner, from: dayMid, to: dayEnd)
+                let key = fp.map { StepsMotionCache.cacheKey(owner: owner, gravityCount: $0.count,
+                                                             gravityMaxTs: $0.maxTs) }
+                let m: Double
+                if let key, let cached = motionCacheLocal[dayKey], cached.key == key {
+                    m = cached.motion
+                    motionReused += 1
+                } else {
+                    let grav = (try? await store.gravitySamples(deviceId: owner, from: dayMid, to: dayEnd,
+                                                                limit: 200_000)) ?? []
+                    m = StepsEstimateEngine.dayMotionIntensity(grav)
+                    motionFolded += 1
+                    // A ZERO fold is cached too. Storing only the days that moved would leave every unworn
+                    // gap re-reading its whole stream on every pass to rediscover that it is empty, which is
+                    // most of the window on exactly the sparse libraries this is worst for.
+                    if let key { motionCacheLocal[dayKey] = (key: key, motion: m) }
+                }
+                // Unchanged: only a positive volume becomes a calibration/estimation input. The cache holds
+                // the fold, this holds the filter, so `motionByDay` is byte-identical to the old loop's — and
+                // `#1816`'s stepsHasBankedMotion, which reads its emptiness, is untouched.
                 if m > 0 { motion[dayKey] = m }
             }
-            return (refSteps, motion)
+            motionCacheLocal = motionCacheLocal.filter { motionWindow.contains($0.key) }
+            let motionLog = StepsMotionCache.logLine(reused: motionReused, folded: motionFolded,
+                                                     size: motionCacheLocal.count)
+            return (refSteps, motion, motionCacheLocal, motionLog)
         }.value
+        stepsMotionCache = updatedStepsMotionCache
+        diagnosticSink?(stepsMotionLogLine, nil)
         // #1816: persist whether the strap has banked ANY motion in the calibration scan window, so the
         // Today tile can distinguish "Need N more phone-step days" (motion exists, phone half missing)
         // from "No motion synced yet" (the motion half is the blocker, and no number of phone-step days
@@ -2440,6 +2504,7 @@ final class IntelligenceEngine: ObservableObject {
             }
         }
 
+        markPostLoopPhase("steps")
         // Drop any freshly-detected session that overlaps a night the user has already hand-corrected.
         // A detected onset can drift second-to-second as more raw data arrives, so without this the
         // re-detected night would upsert as a SECOND row beside the edited one (different startTs ⇒ no
@@ -2487,6 +2552,7 @@ final class IntelligenceEngine: ObservableObject {
         for (start, states) in sleepStateByStart {
             _ = try? await store.persistSessionSleepState(deviceId: computedId, sessionStart: start, states: states)
         }
+        markPostLoopPhase("sleepWrite")
         // ── Overlap-aware banked-sleep heal (#899) ────────────────────────────────────────────────────
         // An unstable strap clock re-banks the SAME night under a shifted timebase, so successive passes
         // detect it at shifted bounds and the upsert above lands a SECOND row beside the stale one (the
@@ -2566,6 +2632,7 @@ final class IntelligenceEngine: ObservableObject {
             _ = try? await store.upsertWorkouts(rows, deviceId: devId)
         }
 
+        markPostLoopPhase("sleepHeal")
         // #137: a manually-started workout is scored from sparse live HR at save time , near-zero
         // calories/strain on a 5/MG. Now that offloaded HR may cover the window, re-score the
         // under-sampled ones from that denser data.
@@ -2591,10 +2658,13 @@ final class IntelligenceEngine: ObservableObject {
         // Sleep tab stops showing the removed duplicates right away.
         if !dailies.isEmpty || !healDropped.isEmpty { await repo.refresh() }
 
+        markPostLoopPhase("workouts")
         // #836/#sleep-sync: record the complete raw-analysis fingerprint this run scored against, so a later
         // NON-forced tick can short-circuit while it's unchanged. Written ONLY at the end of a completed run (never on an
         // early guard-return), so an interrupted/failed run can't advance the watermark past unscored data.
         if !wmKey.isEmpty { UserDefaults.standard.set(wmKey, forKey: Self.analyzeWatermarkKey) }
+        markPostLoopPhase("tail")
+        diagnosticSink?(AnalysisPhaseTally.logLine(scope: "postLoop", postLoopPhases), nil)
         // #1538: clear the started-mark and bank how long a COMPLETED pass costs on this install. The
         // measurement is what lets `RescoreBackgroundPolicy` tell an install that finishes comfortably in a
         // background wake from one that never could, instead of guessing from a constant — the cost varies

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -2419,14 +2419,19 @@ final class IntelligenceEngine: ObservableObject {
                     m = cached.motion
                     motionReused += 1
                 } else {
-                    let grav = (try? await store.gravitySamples(deviceId: owner, from: dayMid, to: dayEnd,
-                                                                limit: 200_000)) ?? []
-                    m = StepsEstimateEngine.dayMotionIntensity(grav)
+                    // nil is a FAILED read; `[]` is a day that genuinely banked nothing. The old code
+                    // collapsed both to zero, which cost one pass. Caching would make it cost every pass
+                    // until that day's gravity happened to change — a transient store error turned into a
+                    // stale zero feeding the step estimate for the life of the process.
+                    let gravRead = try? await store.gravitySamples(deviceId: owner, from: dayMid, to: dayEnd,
+                                                                   limit: 200_000)
+                    m = StepsEstimateEngine.dayMotionIntensity(gravRead ?? [])
                     motionFolded += 1
-                    // A ZERO fold is cached too. Storing only the days that moved would leave every unworn
-                    // gap re-reading its whole stream on every pass to rediscover that it is empty, which is
-                    // most of the window on exactly the sparse libraries this is worst for.
-                    if let key { motionCacheLocal[dayKey] = (key: key, motion: m) }
+                    // A ZERO fold from a read that SUCCEEDED is cached. Storing only the days that moved
+                    // would leave every unworn gap re-reading its whole stream on every pass to rediscover
+                    // that it is empty, which is most of the window on the sparse libraries this is worst
+                    // for. A zero that only means "we could not look" is not cached.
+                    if let key, gravRead != nil { motionCacheLocal[dayKey] = (key: key, motion: m) }
                 }
                 // Unchanged: only a positive volume becomes a calibration/estimation input. The cache holds
                 // the fold, this holds the filter, so `motionByDay` is byte-identical to the old loop's — and

--- a/android/app/src/main/java/com/noop/analytics/AnalysisPhaseTally.kt
+++ b/android/app/src/main/java/com/noop/analytics/AnalysisPhaseTally.kt
@@ -1,0 +1,78 @@
+package com.noop.analytics
+
+import kotlin.math.roundToLong
+
+/**
+ * Where an `analyzeRecent` pass spends the time AFTER its per-day loop. Kotlin twin of the Swift
+ * `AnalysisPhaseTally`.
+ *
+ * #1538 added a cost line, but it brackets the day loop and is emitted the moment that loop returns. Every
+ * phase after it — the baseline folds, pass 2, the persist, the weekly metrics, the steps calibration, the
+ * sleep writes and heals, the workout rescore — was outside the tally, so a pass whose time went somewhere
+ * after the loop reported a small `prep`/`score` and no explanation for the rest. The steps calibration
+ * alone re-folded sixty days of gravity per pass under that blind spot.
+ *
+ * This is the same idea at the other end of the pass: stamp each phase as it completes and print them in
+ * order, so the dominant phase names itself instead of being inferred from what the day-loop line does not
+ * account for.
+ */
+object AnalysisPhaseTally {
+    /**
+     * Render ordered `(name, seconds)` phases as one line, each in milliseconds.
+     *
+     * Phases print in the order given, which is execution order — reading the line top to bottom is reading
+     * the pass front to back. The total is included because the phases deliberately do NOT have to sum to
+     * the pass: anything not bracketed shows up as the difference, which is itself the signal that a phase
+     * is still unmeasured.
+     *
+     * [scope] names WHAT was bracketed, and it is a parameter rather than a constant because the two
+     * platforms can afford to measure different amounts — see the class note. A line that said `postLoop`
+     * while timing only part of the post-loop would misreport its own total, which is the one thing a cost
+     * line must not do. Byte-identical to the Swift `AnalysisPhaseTally.logLine`.
+     */
+    fun logLine(scope: String, phases: List<Pair<String, Double>>): String {
+        val parts = phases.map { "${it.first}=${millis(it.second)}ms" }
+        val total = phases.sumOf { it.second }
+        return "analyzeRecent $scope total=${millis(total)}ms " +
+            if (parts.isEmpty()) "(no phases)" else parts.joinToString(" ")
+    }
+
+    /**
+     * Seconds to whole milliseconds, floored at zero.
+     *
+     * The clamp is the parity contract, not defensive habit. These are wall-clock differences, and a clock
+     * that steps backwards mid-pass (an NTP correction is enough) yields a negative interval — the one
+     * input where Swift's round-half-away-from-zero and Kotlin's round-half-up disagree, at exactly
+     * -0.5 ms. Clamping first makes both sides provably identical instead of identical only while the
+     * clock behaves. A phase cannot take less than no time, so nothing true is lost.
+     */
+    private fun millis(seconds: Double): Long =
+        if (!seconds.isFinite() || seconds <= 0.0) 0L else (seconds * 1000).roundToLong()
+}
+
+/**
+ * Ordered phase stopwatch for one `analyzeRecent` pass, rendered by [AnalysisPhaseTally.logLine].
+ *
+ * A collector rather than the local closure the Swift side uses, and — unlike Swift — it brackets only
+ * `persistFitnessVitalityAndSteps` rather than the whole post-loop. That is a JVM constraint, not a choice:
+ * `analyzeRecentOnCpu` sits 210 bytes under the JaCoCo method-size ratchet that `IntelligenceEngineJacocoBudgetTest`
+ * holds, and marking its phases costs about 467. The ratchet's own note says to extract rather than raise it,
+ * and an extraction is a larger change than this one should carry, so Android measures the phase the cost was
+ * actually found in and names its scope honestly. Extending it to the rest of the post-loop needs that
+ * extraction first.
+ *
+ * Monotonic (`System.nanoTime`), matching the clock the day-loop tally beside it already uses.
+ */
+class AnalysisPhaseMarks {
+    private val collected = ArrayList<Pair<String, Double>>()
+    private var last = System.nanoTime()
+
+    /** Close the phase that ends here and name it. */
+    fun mark(name: String) {
+        val now = System.nanoTime()
+        collected.add(name to (now - last) / 1_000_000_000.0)
+        last = now
+    }
+
+    val phases: List<Pair<String, Double>> get() = collected
+}

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -2105,6 +2105,13 @@ object IntelligenceEngine {
             val dayKey = AnalyticsEngine.dayString(dayMid, tzOffsetSeconds)
             motionWindow.add(dayKey)
             val owner = resolveDayOwner(repo, ownerSource, candidatePriorities, dayKey, dayMid, dayEnd, importedDeviceId)
+            // Unlike the Swift twin there is no soft-failure branch here, and that is deliberate rather
+            // than an omission. Swift's store reads throw and this whole block wraps them in `try?`, so it
+            // has to say what a read it could not make means: a witness it cannot read bypasses the cache
+            // in both directions, and a zero fold from a FAILED read is not cached. Kotlin's repo reads
+            // propagate, so a failure aborts the pass before anything is written, which reaches the same
+            // place by a shorter route. Adding a catch here would not add safety; it would swallow an
+            // abort and start caching zeros that only mean "we could not look".
             val fp = repo.gravityFingerprintWindow(owner, dayMid, dayEnd)
             val key = StepsMotionCache.cacheKey(owner, fp.first, fp.second)
             val cached = stepsMotionCache[dayKey]

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -99,6 +99,11 @@ object IntelligenceEngine {
     private var dayScanCache = HashMap<String, CachedDayScan>()
     private var dayScanCacheConfigSig = ""
 
+    /** Per-day steps-calibration motion folds, `day -> (key, motion)`, keyed by [StepsMotionCache.cacheKey].
+     *  In-memory and per-process exactly like [dayScanCache]; see [StepsMotionCache] for why this one needs no
+     *  config signature. Pruned to the calibration window each pass so it cannot grow without bound. */
+    private var stepsMotionCache = HashMap<String, Pair<String, Double>>()
+
     /** One reused night: its per-day cache [key], the scored [res], and everything the pass-1 loop otherwise
      *  writes into function-scoped per-day maps that pass 2 reads (owner/hrRows/primary-session RHR/SpO₂
      *  candidate/HRV over-count), plus the always-on per-day [diagLines] to replay so a reused pass logs the
@@ -2003,6 +2008,11 @@ object IntelligenceEngine {
         persistStepsCalibration: (StepsEstimateEngine.Calibration) -> Unit,
         stepsTraceSink: ((String) -> Unit)?,
     ) {
+        // #1538: the pass after the day loop was never measured — the cost line brackets the day loop and is
+        // emitted the moment it returns, so the steps calibration re-folding sixty days of gravity every pass
+        // sat outside every number the pass printed. This brackets the two phases inside THIS helper; see
+        // AnalysisPhaseMarks for why Android stops here and Swift does not.
+        val postLoop = AnalysisPhaseMarks()
         // ── Fitness Age (Phase 2) , weekly, keyed to the week's Saturday ──
         val fa7 = dailies.sortedBy { it.day }.takeLast(7)
         val faRHRs = fa7.mapNotNull { it.restingHr }.map { it.toDouble() }
@@ -2049,6 +2059,7 @@ object IntelligenceEngine {
                 MetricSeriesRow(deviceId = computedId, day = satKey, key = "body_age", value = vRes.bodyAge)))
         }
 
+        postLoop.mark("weekly")
         // ── Steps ESTIMATE (WHOOP 4.0) , DAILY, keyed to each strap-only day ──
         // A WHOOP 4.0 sends no step count over BLE, so for days the phone DIDN'T also count steps we
         // estimate them: calibrate the strap's daily MOTION VOLUME against the phone's real step count on
@@ -2079,16 +2090,44 @@ object IntelligenceEngine {
         }
         // Per-day motion volume over the calibration window, read from the owner-resolved strap streams.
         // (Owner resolution mirrors the scoring loop; a single-device install resolves to importedDeviceId.)
+        //
+        // Each day is re-folded only when its own gravity witness moved. The fold is pure over that one
+        // stream, so an unchanged witness means an unchanged volume — see [StepsMotionCache]. The fingerprint
+        // is a COUNT/MAX aggregate over the same (deviceId, ts) index the read walks, so a hit replaces a
+        // read capped at STREAM_LIMIT rows with one that returns a single row.
         val motionByDay = HashMap<String, Double>()
+        var motionReused = 0
+        var motionFolded = 0
+        val motionWindow = HashSet<String>()
         for (off in 0 until stepsCalDays) {
             val dayMid = midnightLocal(nowLocalMidnight - off * SECONDS_PER_DAY, tzOffsetSeconds)
             val dayEnd = dayMid + SECONDS_PER_DAY - 1
             val dayKey = AnalyticsEngine.dayString(dayMid, tzOffsetSeconds)
+            motionWindow.add(dayKey)
             val owner = resolveDayOwner(repo, ownerSource, candidatePriorities, dayKey, dayMid, dayEnd, importedDeviceId)
-            val grav = repo.gravitySamplesForDevice(owner, dayMid, dayEnd, STREAM_LIMIT)
-            val m = StepsEstimateEngine.dayMotionIntensity(grav)
+            val fp = repo.gravityFingerprintWindow(owner, dayMid, dayEnd)
+            val key = StepsMotionCache.cacheKey(owner, fp.first, fp.second)
+            val cached = stepsMotionCache[dayKey]
+            val m: Double
+            if (cached != null && cached.first == key) {
+                m = cached.second
+                motionReused++
+            } else {
+                val grav = repo.gravitySamplesForDevice(owner, dayMid, dayEnd, STREAM_LIMIT)
+                m = StepsEstimateEngine.dayMotionIntensity(grav)
+                motionFolded++
+                // A ZERO fold is cached too. Storing only the days that moved would leave every unworn gap
+                // re-reading its whole stream on every pass to rediscover that it is empty, which is most of
+                // the window on exactly the sparse libraries this is worst for.
+                stepsMotionCache[dayKey] = key to m
+            }
+            // Unchanged: only a positive volume becomes a calibration/estimation input. The cache holds the
+            // fold, this holds the filter, so [motionByDay] is byte-identical to the old loop's — and #1816's
+            // stepsHasMotionSink, which reads its emptiness, is untouched.
             if (m > 0) motionByDay[dayKey] = m
         }
+        stepsMotionCache.keys.retainAll(motionWindow)
+        diag(StepsMotionCache.logLine(motionReused, motionFolded, stepsMotionCache.size))
         // #1816: persist whether the strap banked ANY motion in the calibration scan window, so the Today
         // tile can distinguish "Need N more phone-step days" (motion exists, phone half missing) from
         // "No motion synced yet" (the motion half is the blocker, and no number of phone-step days will
@@ -2133,6 +2172,8 @@ object IntelligenceEngine {
                 }
             }
         }
+        postLoop.mark("steps")
+        diag(AnalysisPhaseTally.logLine("persistSteps", postLoop.phases))
     }
 
     /**

--- a/android/app/src/main/java/com/noop/analytics/StepsMotionCache.kt
+++ b/android/app/src/main/java/com/noop/analytics/StepsMotionCache.kt
@@ -1,0 +1,47 @@
+package com.noop.analytics
+
+/**
+ * Per-day reuse identity for the steps-calibration motion fold in [IntelligenceEngine.analyzeRecent].
+ * Kotlin twin of the Swift `StepsMotionCache`.
+ *
+ * The drain this closes: the calibration fits one coefficient from sixty days of strap motion, and it
+ * re-folded all sixty on EVERY pass. Each day meant a `gravitySamplesForDevice` read capped at
+ * `STREAM_LIMIT` rows, so a worn library paid millions of materialised rows per pass to re-derive numbers
+ * that had not moved. The phase does not scale with the days being re-scored — it always reads the same
+ * sixty — so a two-day pass could cost more than a twenty-one-day one, which is what made it hard to see in
+ * a cost line keyed on the day loop.
+ *
+ * [StepsEstimateEngine.dayMotionIntensity] is a pure fold over one day's gravity stream. Nothing else
+ * reaches it: no profile field, no baseline, no toggle, no other stream. So unlike [AnalyzeRecentDayCache]
+ * there is no pass-config signature to invalidate against — the value changes exactly when that one day's
+ * gravity changes, and the key below is the whole story.
+ *
+ * Like the day-scan cache this is in-memory and per-process. It never persists, never crosses the
+ * `.noopbak` boundary, and a relaunch pays the full fold once. That is deliberate: the cost being closed is
+ * the repeat within a process, where an offload storm fires passes back to back.
+ */
+object StepsMotionCache {
+    /**
+     * The per-day reuse key. Reuse a cached motion volume iff this string is unchanged.
+     *
+     * - [owner]: the resolved owning device the fold was measured against. A day whose owner flips between
+     *   straps must re-fold, and the fingerprint below is device-scoped, so this makes that explicit rather
+     *   than relying on two devices never producing an identical count and newest timestamp for one window.
+     * - [gravityCount] / [gravityMaxTs]: the day window's gravity witness. Any gravity row added or removed
+     *   moves one of the two. Deliberately NOT the wider `dayStreamFingerprint`: that also counts HR, R-R,
+     *   respiration, SpO2, steps, skin temp and sleep state, so an ordinary HR offload would invalidate a
+     *   motion volume that cannot have changed by it.
+     */
+    fun cacheKey(owner: String, gravityCount: Int, gravityMaxTs: Long): String =
+        "$owner|$gravityCount|$gravityMaxTs"
+
+    /**
+     * The pass's one-line reuse readout, beside the phase cost line.
+     *
+     * [reused] and [folded] sum to the days scanned, so the ratio is readable without a second line. A pass
+     * reporting `folded=60` every time means the key is moving when it should not, which is the failure this
+     * cache can have and the reason the number is reported at all rather than assumed.
+     */
+    fun logLine(reused: Int, folded: Int, size: Int): String =
+        "analyzeRecent stepsMotion reused=$reused/${reused + folded} size=$size"
+}

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -83,6 +83,15 @@ data class HrBucket(
     val avgBpm: Double,
 )
 
+/** The per-day gravity witness the steps-calibration motion cache keys on: [c] rows in the window and
+ *  [m] the newest timestamp among them. Query result of [WhoopDao.gravityWitnessInWindow], not a table.
+ *  Both columns come from ONE aggregate so the pair always describes a state the day was actually in;
+ *  mirrors the tuple Swift's `WhoopStore.gravityFingerprint` returns. */
+data class GravityWitness(
+    val c: Int,
+    val m: Long,
+)
+
 /** Aggregate HR over a time window, sample count + avg/max bpm. Query result of
  *  [WhoopDao.hrWindowStats], not a table. Used to derive a workout's HR from strap samples when
  *  the imported session carries none (#77). avg/max are null when n == 0. */

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -1124,15 +1124,20 @@ interface WhoopDao : DeviceRegistryDao {
     suspend fun countHrInWindow(deviceId: String, from: Long, to: Long): Int
     @Query("SELECT COALESCE(MAX(ts), 0) FROM hrSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to")
     suspend fun maxHrTsInWindow(deviceId: String, from: Long, to: Long): Long
-    // Per-day (device + window) GRAVITY witness for the steps-calibration motion cache. The full
-    // DAY_STREAM_FINGERPRINT_SQL below also counts gravity, but alongside eight other streams, so a new
-    // HR row would invalidate a motion volume that cannot have changed. dayMotionIntensity folds one
-    // day's gravity and nothing else, so its key must move when that stream moves and at no other time.
-    // Same COUNT/MAX aggregate over the (deviceId, ts) index; mirrors Swift WhoopStore.gravityFingerprint.
-    @Query("SELECT COUNT(*) FROM gravitySample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to")
-    suspend fun countGravityInWindow(deviceId: String, from: Long, to: Long): Int
-    @Query("SELECT COALESCE(MAX(ts), 0) FROM gravitySample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to")
-    suspend fun maxGravityTsInWindow(deviceId: String, from: Long, to: Long): Long
+    // Per-day (device + window) GRAVITY witness for the steps-calibration motion cache. It is exactly the
+    // `g` segment of DAY_STREAM_FINGERPRINT_SQL below, on its own: that one counts gravity alongside eight
+    // other streams, so a new HR row would invalidate a motion volume that cannot have changed.
+    // dayMotionIntensity folds one day's gravity and nothing else, so its key must move when that stream
+    // moves and at no other time. Mirrors Swift WhoopStore.gravityFingerprint.
+    //
+    // ONE query returning both columns, not two returning one each. Two would let an insert land between
+    // them and yield a count from before it beside a newest-timestamp from after — a witness describing a
+    // state the day was never in. The pair has to be read atomically to mean anything.
+    @Query(
+        "SELECT COUNT(*) AS c, COALESCE(MAX(ts), 0) AS m FROM gravitySample " +
+            "WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to"
+    )
+    suspend fun gravityWitnessInWindow(deviceId: String, from: Long, to: Long): GravityWitness
     // #29: the same per-day (device + window) witness for every OTHER scored stream — see
     // DAY_STREAM_FINGERPRINT_SQL. Without it a night whose R-R landed after its HR keyed identically to the
     // HR-only scan it was scored from, and that HRV-less scan was re-served for the rest of the process.

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -1124,6 +1124,15 @@ interface WhoopDao : DeviceRegistryDao {
     suspend fun countHrInWindow(deviceId: String, from: Long, to: Long): Int
     @Query("SELECT COALESCE(MAX(ts), 0) FROM hrSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to")
     suspend fun maxHrTsInWindow(deviceId: String, from: Long, to: Long): Long
+    // Per-day (device + window) GRAVITY witness for the steps-calibration motion cache. The full
+    // DAY_STREAM_FINGERPRINT_SQL below also counts gravity, but alongside eight other streams, so a new
+    // HR row would invalidate a motion volume that cannot have changed. dayMotionIntensity folds one
+    // day's gravity and nothing else, so its key must move when that stream moves and at no other time.
+    // Same COUNT/MAX aggregate over the (deviceId, ts) index; mirrors Swift WhoopStore.gravityFingerprint.
+    @Query("SELECT COUNT(*) FROM gravitySample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to")
+    suspend fun countGravityInWindow(deviceId: String, from: Long, to: Long): Int
+    @Query("SELECT COALESCE(MAX(ts), 0) FROM gravitySample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to")
+    suspend fun maxGravityTsInWindow(deviceId: String, from: Long, to: Long): Long
     // #29: the same per-day (device + window) witness for every OTHER scored stream — see
     // DAY_STREAM_FINGERPRINT_SQL. Without it a night whose R-R landed after its HR keyed identically to the
     // HR-only scan it was scored from, and that HRV-less scan was re-served for the rest of the process.

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -700,7 +700,7 @@ class WhoopRepository(
      *  motion cache. Narrower than [dayStreamFingerprint] on purpose: dayMotionIntensity folds gravity
      *  alone, so a new HR row must not invalidate it. Mirrors Swift WhoopStore.gravityFingerprint. */
     suspend fun gravityFingerprintWindow(deviceId: String, from: Long, to: Long): Pair<Int, Long> =
-        Pair(dao.countGravityInWindow(deviceId, from, to), dao.maxGravityTsInWindow(deviceId, from, to))
+        dao.gravityWitnessInWindow(deviceId, from, to).let { it.c to it.m }
 
     /** #29 — the same per-day (device + window) witness for every OTHER stream analyzeDay scores: PPG-derived
      *  HR, R-R, respiration, SpO2, gravity, steps, skin temp and events. [hrFingerprintWindow] cannot see a

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -696,6 +696,12 @@ class WhoopRepository(
     suspend fun hrFingerprintWindow(deviceId: String, from: Long, to: Long): Pair<Int, Long> =
         Pair(dao.countHrInWindow(deviceId, from, to), dao.maxHrTsInWindow(deviceId, from, to))
 
+    /** Per-day (device + window) gravity fingerprint as (count, newestTs) for the steps-calibration
+     *  motion cache. Narrower than [dayStreamFingerprint] on purpose: dayMotionIntensity folds gravity
+     *  alone, so a new HR row must not invalidate it. Mirrors Swift WhoopStore.gravityFingerprint. */
+    suspend fun gravityFingerprintWindow(deviceId: String, from: Long, to: Long): Pair<Int, Long> =
+        Pair(dao.countGravityInWindow(deviceId, from, to), dao.maxGravityTsInWindow(deviceId, from, to))
+
     /** #29 — the same per-day (device + window) witness for every OTHER stream analyzeDay scores: PPG-derived
      *  HR, R-R, respiration, SpO2, gravity, steps, skin temp and events. [hrFingerprintWindow] cannot see a
      *  channel that lands after HR, and an offload commits its channels independently, so keyed on HR alone

--- a/android/app/src/test/java/com/noop/analytics/AnalysisPhaseTallyTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AnalysisPhaseTallyTest.kt
@@ -1,0 +1,74 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The post-loop phase line. Twin of the Swift `AnalysisPhaseTallyTests` against the SAME literals: the
+ * two platforms name their own phases (the passes genuinely differ after the day loop), but the
+ * rendering — order, rounding, the total, the empty case — is one contract.
+ */
+class AnalysisPhaseTallyTest {
+
+    @Test
+    fun phasesRenderInOrderWithATotal() {
+        assertEquals(
+            "analyzeRecent postLoop total=30042ms baselines=12ms score2=1100ms steps=28930ms",
+            AnalysisPhaseTally.logLine("postLoop", listOf("baselines" to 0.012, "score2" to 1.1, "steps" to 28.93)),
+        )
+    }
+
+    /**
+     * The phases are printed in the order GIVEN, never sorted by cost. Execution order is the point: the
+     * line is read front to back as the pass runs, and a sort would hide where in the pass the time sits.
+     */
+    @Test
+    fun orderIsExecutionOrderNotCost() {
+        assertEquals(
+            "analyzeRecent postLoop total=28942ms steps=28930ms baselines=12ms",
+            AnalysisPhaseTally.logLine("postLoop", listOf("steps" to 28.93, "baselines" to 0.012)),
+        )
+    }
+
+    /**
+     * A backwards clock step yields a negative interval. It floors at zero rather than printing a
+     * negative duration — and, more to the point, that is the one input where Swift's
+     * round-half-away-from-zero and Kotlin's round-half-up would disagree.
+     */
+    @Test
+    fun negativeAndNonFinitePhasesFloorAtZero() {
+        assertEquals("analyzeRecent postLoop total=0ms skew=0ms",
+            AnalysisPhaseTally.logLine("postLoop", listOf("skew" to -0.0005)))
+        assertEquals("analyzeRecent postLoop total=0ms nan=0ms",
+            AnalysisPhaseTally.logLine("postLoop", listOf("nan" to Double.NaN)))
+    }
+
+    /**
+     * The total is the sum of what was MEASURED, not of the pass. A phase nobody bracketed shows up as
+     * the gap between this number and `re-score: done`, which is how the next blind spot gets found.
+     */
+    @Test
+    fun totalIsTheSumOfMeasuredPhasesOnly() {
+        assertEquals("analyzeRecent postLoop total=750ms a=500ms b=250ms",
+            AnalysisPhaseTally.logLine("postLoop", listOf("a" to 0.5, "b" to 0.25)))
+    }
+
+    /**
+     * The scope is the caller's, not a constant. Android brackets only `persistFitnessVitalityAndSteps`
+     * (the JaCoCo method-size ratchet on `analyzeRecentOnCpu` leaves no room), so its line must not claim
+     * a `postLoop` total it never measured. Same phases, different scope, different line.
+     */
+    @Test
+    fun scopeNamesWhatWasActuallyBracketed() {
+        val phases = listOf("weekly" to 0.07, "steps" to 28.93)
+        assertEquals("analyzeRecent persistSteps total=29000ms weekly=70ms steps=28930ms",
+            AnalysisPhaseTally.logLine("persistSteps", phases))
+        assertEquals("analyzeRecent postLoop total=29000ms weekly=70ms steps=28930ms",
+            AnalysisPhaseTally.logLine("postLoop", phases))
+    }
+
+    @Test
+    fun noPhasesSaysSoRatherThanPrintingNothing() {
+        assertEquals("analyzeRecent postLoop total=0ms (no phases)", AnalysisPhaseTally.logLine("postLoop", emptyList()))
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceEngineJacocoBudgetTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceEngineJacocoBudgetTest.kt
@@ -1,6 +1,7 @@
 package com.noop.analytics
 
 import com.noop.data.DailyMetric
+import com.noop.data.GravityWitness
 import com.noop.data.WhoopDao
 import com.noop.data.WhoopRepository
 import java.lang.reflect.InvocationTargetException
@@ -248,14 +249,12 @@ class IntelligenceEngineJacocoBudgetTest {
                     events.add("gravity")
                     emptyList<Any>()
                 }
-                // The motion cache's witness: a COUNT and a MAX over the same window the read walks. Both
-                // are recorded, as one event per day, so the sequence below still says exactly which reads
-                // the helper makes and in what order.
-                "countGravityInWindow" -> {
+                // The motion cache's witness: one aggregate returning both the count and the newest
+                // timestamp, so the sequence below says exactly which reads the helper makes, in order.
+                "gravityWitnessInWindow" -> {
                     events.add("gravityFp")
-                    0
+                    GravityWitness(0, 0L)
                 }
-                "maxGravityTsInWindow" -> 0L
                 else -> throw UnsupportedOperationException("Extracted block must not call ${method.name}")
             }
         } as WhoopDao

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceEngineJacocoBudgetTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceEngineJacocoBudgetTest.kt
@@ -81,7 +81,13 @@ class IntelligenceEngineJacocoBudgetTest {
 
         val orderedOperations = listOf(
             "fitnessAgeRows" to Regex("""\bfitnessAgeRows\s*\("""),
-            "fitness diagnostic" to Regex("""\bdiag\s*\("""),
+            // Discriminating, not a bare `diag(`: the helper now emits three diagnostics, and the point of
+            // this list is that each one stays in its place relative to the reads and writes around it. A
+            // generic pattern would have to be loosened to "at least one" the moment a second landed, which
+            // is exactly the guarantee worth keeping. It discriminates by the ARGUMENT EXPRESSION, not by
+            // the message: `maskCommentsAndLiterals` has already blanked every string, so the two newer
+            // diagnostics are identifiable only because they pass a call rather than a literal.
+            "fitness diagnostic" to Regex("""\bdiag\s*\((?!\s*(?:StepsMotionCache|AnalysisPhaseTally)\b)"""),
             "Fitness upsert" to Regex(
                 """\brepo\s*\.\s*upsertMetricSeriesWithProvenance\s*\(\s*rows\s*=\s*faPts\b""",
             ),
@@ -90,6 +96,9 @@ class IntelligenceEngineJacocoBudgetTest {
             "Apple Health read" to Regex("""\brepo\s*\.\s*appleDaily\s*\(\s*WhoopRepository\s*\.\s*APPLE_HEALTH_SOURCE\b"""),
             "Health Connect read" to Regex("""\brepo\s*\.\s*appleDaily\s*\(\s*WhoopRepository\s*\.\s*HEALTH_CONNECT_SOURCE\b"""),
             "gravity samples" to Regex("""\brepo\s*\.\s*gravitySamplesForDevice\s*\("""),
+            // The motion-cache readout sits between the gravity reads it reports on and the fit that consumes
+            // them, so it names the pass that just happened rather than one still running.
+            "steps motion diagnostic" to Regex("""\bdiag\s*\(\s*StepsMotionCache\s*\.\s*logLine\s*\("""),
             "calibration" to Regex("""\bStepsEstimateEngine\s*\.\s*calibrate\s*\("""),
             "step upsert" to Regex("""\brepo\s*\.\s*upsertMetricSeries\s*\(\s*estRows\s*\)"""),
             "calibration persistence" to Regex("""\bpersistStepsCalibration\s*\("""),
@@ -113,6 +122,15 @@ class IntelligenceEngineJacocoBudgetTest {
             .toList()
         assertEquals("Expected exactly one stepsEst trace", 1, stepsEstimateTraces.size)
         assertTrue("stepsEst trace must remain after calibrationTrace", stepsEstimateTraces.single() > previous)
+
+        // The phase line closes the helper: it reports how long the helper took, so it can only be emitted
+        // once everything it times has run. Pinned last for the same reason the rest are pinned in order.
+        val phaseLine = requireExactlyOne(
+            helperCode,
+            Regex("""\bdiag\s*\(\s*AnalysisPhaseTally\s*\.\s*logLine\s*\("""),
+        )
+        assertTrue("the phase line must be emitted after every phase it times",
+            phaseLine > stepsEstimateTraces.single())
 
         val forbidden = listOf("withContext", "async", "launch", "coroutineScope", "supervisorScope")
         for (name in forbidden) {
@@ -142,10 +160,25 @@ class IntelligenceEngineJacocoBudgetTest {
         assertEquals("diag", events.first())
         assertEquals("apple:apple-health", events[1])
         assertEquals("apple:health-connect", events[2])
+        // Cold cache: every day is folded, so every day pays BOTH the witness and the read it guards.
+        assertEquals(60, events.count { it == "gravityFp" })
         assertEquals(60, events.count { it == "gravity" })
-        assertEquals("calibration", events[63])
-        assertTrue("calibration trace must follow persistence callback", events.drop(64).all { it == "trace" })
-        assertTrue("manual calibration must emit a trace", events.size > 64)
+        // Each day asks for the witness BEFORE the read it might skip; a read that came first would make
+        // the cache pointless while still passing a count.
+        assertEquals("gravityFp", events[3])
+        assertEquals("gravity", events[4])
+        // Three diagnostics now: the fitness gate first, the motion-cache readout once the reads are done,
+        // and the phase line last of all.
+        assertEquals(3, events.count { it == "diag" })
+        val calibration = events.indexOf("calibration")
+        assertTrue("calibration must follow every gravity read",
+            calibration > events.indexOfLast { it == "gravity" })
+        assertEquals("the motion readout belongs between the reads and the fit",
+            "diag", events[calibration - 1])
+        assertEquals("diag", events.last())
+        assertTrue("calibration trace must follow persistence callback",
+            events.subList(calibration + 1, events.size - 1).all { it == "trace" })
+        assertTrue("manual calibration must emit a trace", events.size > calibration + 2)
 
         val sentinel = IllegalStateException("apple read failed")
         val failureEvents = arrayListOf<String>()
@@ -162,6 +195,39 @@ class IntelligenceEngineJacocoBudgetTest {
             assertSame(sentinel, failure.cause)
         }
         assertEquals(listOf("diag", "apple:apple-health"), failureEvents)
+    }
+
+    /**
+     * The claim the motion cache makes, measured rather than asserted: a second pass over an UNCHANGED
+     * window reads the witness for every day and the gravity stream for none of them.
+     *
+     * This is the whole point of the change. The steps calibration re-folded sixty days of gravity on
+     * every pass — a read capped at STREAM_LIMIT rows per day, which does not scale with the days being
+     * re-scored — and the fold is pure over one day's gravity, so an unchanged witness means an unchanged
+     * volume. Deliberately NOT cold on the second invocation.
+     */
+    @Test
+    fun asecondPassOverUnchangedDaysReadsNoGravity() {
+        val first = arrayListOf<String>()
+        invokeExtractedBlock(
+            repo = recordingRepository(first),
+            diag = { first.add("diag") },
+            persistCalibration = { first.add("calibration") },
+            trace = { first.add("trace") },
+        )
+        assertEquals(60, first.count { it == "gravity" })
+
+        val second = arrayListOf<String>()
+        invokeExtractedBlock(
+            repo = recordingRepository(second),
+            diag = { second.add("diag") },
+            persistCalibration = { second.add("calibration") },
+            trace = { second.add("trace") },
+            coldCache = false,
+        )
+        assertEquals("an unchanged day must not be re-folded", 0, second.count { it == "gravity" })
+        // The witness is still read for every day — that is what makes the skip safe rather than a guess.
+        assertEquals(60, second.count { it == "gravityFp" })
     }
 
     private fun recordingRepository(
@@ -182,10 +248,30 @@ class IntelligenceEngineJacocoBudgetTest {
                     events.add("gravity")
                     emptyList<Any>()
                 }
+                // The motion cache's witness: a COUNT and a MAX over the same window the read walks. Both
+                // are recorded, as one event per day, so the sequence below still says exactly which reads
+                // the helper makes and in what order.
+                "countGravityInWindow" -> {
+                    events.add("gravityFp")
+                    0
+                }
+                "maxGravityTsInWindow" -> 0L
                 else -> throw UnsupportedOperationException("Extracted block must not call ${method.name}")
             }
         } as WhoopDao
         return WhoopRepository(dao)
+    }
+
+    /**
+     * The engine is a Kotlin `object`, so its steps-motion cache is process-global and OUTLIVES a test.
+     * Every invocation here starts cold unless a case is deliberately measuring the warm path, or the
+     * gravity-read count would depend on whatever ran before it in the same JVM.
+     */
+    private fun clearStepsMotionCache() {
+        val field = IntelligenceEngine::class.java.getDeclaredField("stepsMotionCache")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        (field.get(IntelligenceEngine) as MutableMap<String, *>).clear()
     }
 
     private fun invokeExtractedBlock(
@@ -193,11 +279,13 @@ class IntelligenceEngineJacocoBudgetTest {
         diag: (String) -> Unit,
         persistCalibration: (StepsEstimateEngine.Calibration) -> Unit,
         trace: (String) -> Unit,
+        coldCache: Boolean = true,
     ) {
         val method = IntelligenceEngine::class.java.declaredMethods.single {
             it.name == "persistFitnessVitalityAndSteps"
         }
         method.isAccessible = true
+        if (coldCache) clearStepsMotionCache()
         val continuation = object : Continuation<Unit> {
             override val context = EmptyCoroutineContext
             override fun resumeWith(result: Result<Unit>) = result.getOrThrow()

--- a/android/app/src/test/java/com/noop/analytics/IntelligenceEngineJacocoBudgetTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/IntelligenceEngineJacocoBudgetTest.kt
@@ -208,7 +208,7 @@ class IntelligenceEngineJacocoBudgetTest {
      * volume. Deliberately NOT cold on the second invocation.
      */
     @Test
-    fun asecondPassOverUnchangedDaysReadsNoGravity() {
+    fun aSecondPassOverUnchangedDaysReadsNoGravity() {
         val first = arrayListOf<String>()
         invokeExtractedBlock(
             repo = recordingRepository(first),

--- a/android/app/src/test/java/com/noop/analytics/StepsMotionCacheTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StepsMotionCacheTest.kt
@@ -1,7 +1,11 @@
 package com.noop.analytics
 
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -56,5 +60,52 @@ class StepsMotionCacheTest {
         // seeing it on every pass is the symptom that the key is moving when it should not.
         assertEquals("analyzeRecent stepsMotion reused=0/60 size=60",
             StepsMotionCache.logLine(0, 60, 60))
+    }
+
+    /**
+     * The invariant the whole cache rests on, and the one that would fail SILENTLY.
+     *
+     * A day is re-folded only when its gravity witness (row count and newest timestamp) moves. That is
+     * sound only while re-offloading a second already banked cannot rewrite its vector: with
+     * `OnConflictStrategy.IGNORE` the first value stands, so an unchanged witness means an unchanged
+     * fold. Flip it to REPLACE and the values under a day change while its count and newest timestamp
+     * hold still — the cache then serves a motion volume for data it no longer describes, with no
+     * failing read anywhere to notice.
+     *
+     * Asserted against the SOURCE rather than the annotation: Room's annotations are not retained at
+     * runtime, and this module has no Robolectric or in-memory Room, so the DAO cannot be exercised in a
+     * JVM unit test. The Swift twin pins the same contract behaviourally in `GravityWitnessTests`.
+     */
+    @Test
+    fun gravityInsertsMustKeepTheFirstVectorNotTheNewest() {
+        val dao = String(Files.readAllBytes(locateDaoSource()), StandardCharsets.UTF_8)
+        val declaration = Regex("""@Insert\(onConflict = OnConflictStrategy\.(\w+)\)\s*\n\s*suspend fun insertGravity\b""")
+            .find(dao)
+        assertTrue("Could not find the insertGravity declaration in WhoopDao.kt", declaration != null)
+        assertEquals(
+            "gravitySample inserts must IGNORE a conflicting second; REPLACE would rewrite a vector " +
+                "under an unchanged StepsMotionCache witness",
+            "IGNORE",
+            declaration!!.groupValues[1],
+        )
+    }
+
+    private fun locateDaoSource(): Path {
+        val suffixes = listOf(
+            Path.of("app/src/main/java/com/noop/data/WhoopDao.kt"),
+            Path.of("src/main/java/com/noop/data/WhoopDao.kt"),
+        )
+        val matches = LinkedHashSet<Path>()
+        var directory: Path? = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize()
+        while (directory != null) {
+            for (suffix in suffixes) {
+                val candidate = directory.resolve(suffix).normalize()
+                if (Files.isRegularFile(candidate)) matches.add(candidate.toRealPath())
+            }
+            directory = directory.parent
+        }
+        assertEquals("Could not locate WhoopDao.kt from user.dir=${System.getProperty("user.dir")}: $matches",
+            1, matches.size)
+        return matches.single()
     }
 }

--- a/android/app/src/test/java/com/noop/analytics/StepsMotionCacheTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StepsMotionCacheTest.kt
@@ -1,0 +1,60 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+/**
+ * The steps-calibration motion cache's key and readout. Twin of the Swift `StepsMotionCacheTests`,
+ * pinned against the SAME literals — the two sides must invalidate on the same facts, and pinning the
+ * rendered strings is how a one-sided change to either rule is caught.
+ */
+class StepsMotionCacheTest {
+
+    @Test
+    fun keyIsStableForUnchangedInputs() {
+        val a = StepsMotionCache.cacheKey("my-whoop", 8640, 1_757_000_000L)
+        val b = StepsMotionCache.cacheKey("my-whoop", 8640, 1_757_000_000L)
+        assertEquals(a, b)
+        assertEquals("my-whoop|8640|1757000000", a)
+    }
+
+    /**
+     * The three facts that MUST invalidate a fold, one at a time. A row added moves the count; a row
+     * replacing another at a newer timestamp moves the max; a day changing hands moves the owner.
+     */
+    @Test
+    fun everyInputInvalidates() {
+        val base = StepsMotionCache.cacheKey("my-whoop", 8640, 1_757_000_000L)
+        assertNotEquals(base, StepsMotionCache.cacheKey("my-whoop", 8641, 1_757_000_000L))
+        assertNotEquals(base, StepsMotionCache.cacheKey("my-whoop", 8640, 1_757_000_001L))
+        assertNotEquals(base, StepsMotionCache.cacheKey("whoop-5mg", 8640, 1_757_000_000L))
+    }
+
+    /**
+     * An empty day is a real, cacheable answer — the key for it is well-formed and distinct from a day
+     * that has rows. Caching it is what stops an unworn gap re-reading its whole stream every pass.
+     */
+    @Test
+    fun emptyDayHasItsOwnKey() {
+        assertEquals("my-whoop|0|0", StepsMotionCache.cacheKey("my-whoop", 0, 0L))
+        assertNotEquals(StepsMotionCache.cacheKey("my-whoop", 0, 0L),
+            StepsMotionCache.cacheKey("my-whoop", 1, 0L))
+    }
+
+    /** The owner is the FIRST field, so two devices cannot collide by arranging their counts. */
+    @Test
+    fun ownerBoundaryCannotBeForgedByCounts() {
+        assertNotEquals(StepsMotionCache.cacheKey("a", 1, 2L), StepsMotionCache.cacheKey("a|1", 2, 0L))
+    }
+
+    @Test
+    fun logLineReportsTheRatioAndSize() {
+        assertEquals("analyzeRecent stepsMotion reused=58/60 size=60",
+            StepsMotionCache.logLine(58, 2, 60))
+        // A cold process: everything folded, nothing reused. This is the line a FIRST pass prints, and
+        // seeing it on every pass is the symptom that the key is moving when it should not.
+        assertEquals("analyzeRecent stepsMotion reused=0/60 size=60",
+            StepsMotionCache.logLine(0, 60, 60))
+    }
+}


### PR DESCRIPTION
## Problem

The steps calibration fits one coefficient from sixty days of strap motion, and it re-folded all
sixty on **every** `analyzeRecent` pass. Each day is a `resolveDayOwner` plus a `gravitySamples`
read capped at 200,000 rows, so a worn library pays millions of materialised rows per pass to
re-derive numbers that have not moved.

It also does not scale with the days being re-scored, since it always reads the same sixty
regardless, so a two-day pass can cost more than a twenty-one-day one. Identical on both platforms
(`IntelligenceEngine.swift` and `IntelligenceEngine.kt`); Swift hoists the reads off the main actor,
which fixes the jank but not the work, and Android has no hoist at all.

## Change

`StepsEstimateEngine.dayMotionIntensity` is a pure fold over one day's gravity stream. Nothing else
reaches it: no profile field, no baseline, no toggle, no other stream. So a day is re-folded only
when that day's gravity witness moved.

- **The witness** is a new `gravityFingerprint` / `gravityFingerprintWindow`: `COUNT(*)` and
  `COALESCE(MAX(ts), 0)` over `gravitySample` for one device and window, on the same `(deviceId, ts)`
  index the read walks. A hit replaces a 200,000-row read with a single-row aggregate. Both columns
  come from ONE query on both platforms, so an insert cannot land between them and produce a key
  describing a state the day was never in.
- **Deliberately narrower than `dayStreamFingerprint`**, which also counts HR, R-R, respiration,
  SpO2, steps, skin temp and sleep state. An ordinary HR offload must not invalidate a motion volume
  it cannot have changed. It is not a new signal: this pair is exactly the `g` segment that
  fingerprint already computes for gravity, taken on its own.

### Why count and newest-timestamp are enough

`dayMotionIntensity` sums the distance between CONSECUTIVE samples, so it depends on the set of
x/y/z values and on their order. Order is fixed by `ORDER BY ts ASC` in both reads. That leaves one
question: can a day's gravity change without moving either column? Only by rewriting a timestamp in
place, and nothing does. Gravity rows are insert-only (`StreamStore` / the offload path), the
timestamp heal exclusively DELETEs out-of-range rows, and an offload re-inserting an existing `ts`
is absorbed by the conflict key without changing a value. Insert moves the count, delete moves the
count. There is no in-place `ts` mutation to reorder a day underneath an unchanged witness.
- **The cache** is in-memory and per-process, beside the day-scan cache it mirrors, and needs no
  pass-config signature for the reason above. It never persists and never crosses the `.noopbak`
  boundary; a relaunch pays the full fold once. That is the intent: the cost being closed is the
  repeat within a process, where an offload storm fires passes back to back.
- **A zero fold is cached too.** Storing only the days that moved would leave every unworn gap
  re-reading its whole stream forever to rediscover that it is empty, which is most of the window on
  the sparse libraries this is worst for.

**No behaviour change.** `motionByDay` keeps the same `m > 0` filter, so the calibration points, the
estimates and #1816's banked-motion flag are built from the same values as before. On Swift a
fingerprint that cannot be read bypasses the cache in both directions rather than keying on
`(0, 0)`, which a genuinely empty day also produces; Kotlin's store surfaces no soft failure there,
so a throw aborts the pass exactly as the gravity read already did.

## Why nobody saw it

#1538 added a per-phase cost line, but it brackets the day loop and is emitted the moment that loop
returns. Every phase after it was outside the tally, and the steps calibration runs about 700 lines
past the last number the pass printed. Swift now stamps each post-loop phase and renders them in
execution order beside `re-score: done`:

```
analyzeRecent postLoop total=31830ms dayReplay=10ms baselines=12ms score2=1100ms ... steps=28930ms ...
```

**Android measures less, and says so.** `analyzeRecentOnCpu` sits 210 bytes under the JaCoCo
method-size ratchet (55,490 against 55,700) and marking its phases costs about 467. That ratchet's
own note says to extract rather than raise it, and an extraction is a larger change than this one
should carry, so Android brackets the persist helper it can afford. The shared line takes an
explicit `scope` rather than reporting a `postLoop` total it never measured. Extending Android to
the rest of the post-loop needs that extraction first, and `analyzeRecentOnCpu` is untouched by this
PR.

## Tests

- Mirrored `StepsMotionCache` and `AnalysisPhaseTally` suites on both platforms, pinned against the
  same literals, covering each input that must invalidate, the empty-day key, the owner boundary,
  execution order, the scope, and the clock-skew floor that keeps Swift's round-half-away-from-zero
  and Kotlin's round-half-up agreeing.
- `IntelligenceEngineJacocoBudgetTest` is **repinned, not loosened**: the two new diagnostics take
  their own positions in the ordered-operations guard, discriminated by argument expression because
  that guard masks string literals.
- A new runtime case measures the actual claim rather than asserting it: a second pass over
  unchanged days reads the witness for all sixty and the gravity stream for none.
- Android analytics + data suites: **2,488 tests, 0 failures**. Swift package logic verified against a
  compiled standalone harness (no macOS available here); the Swift suites rest on CI.

## Cost noted, not hidden

Owner resolution still runs per day. On the default single-device install it short-circuits without
a store read (#970), but a multi-strap install still pays sixty LIMIT-1 probes, exactly as before.
The first pass in a process still folds all sixty days.

The steps phase was identified by @DX23876.