### PR TITLE
Say a Rest score is provisional instead of hiding it

### DIFF
--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -3156,7 +3156,8 @@ struct TodayView: View {
             }
             heroRingColumn(section: .effort, domain: .effort) { effortRing(d: d, diameter: ring) }
             heroRingColumn(section: .rest, domain: .rest, provenanceKey: "sleep_performance",
-                           caption: restIsPendingSync ? "Pending sync" : nil) { restRing(diameter: ring) }
+                           caption: restIsPendingSync ? "Pending sync" : nil,
+                           captionWidth: ring) { restRing(diameter: ring) }
         }
         .frame(maxWidth: .infinity, alignment: .center)
         // Zero-impact width reader: a clear background that publishes the row's width up via preference. It
@@ -3210,6 +3211,7 @@ struct TodayView: View {
     private func heroRingColumn<RingBody: View>(
         section: ScoreSection, domain: DomainTheme, provenanceKey: String? = nil,
         onRingTap: (() -> Void)? = nil, caption: String? = nil,
+        captionWidth: CGFloat = 98,
         @ViewBuilder ring: () -> RingBody
     ) -> some View {
         VStack(spacing: 8) {
@@ -3287,12 +3289,18 @@ struct TodayView: View {
             // column's badge a line lower than its neighbours'. The row is top-aligned and self-sizing
             // (#762), so a caption grows the row and leaves every ring where it was.
             if let caption {
+                // Bounded to the RING's width, not left to size itself. Unlike Android, whose three hero
+                // columns are laid out at a fixed `col` width, these columns take the width of what is in
+                // them — so an unbounded caption would widen this one on a longer translation and tip the
+                // trio off centre. Two lines at the ring's width fits the longest of them; the shrink is
+                // the same allowance the domain label above it already uses.
                 Text(caption)
                     .font(StrandFont.footnote)
                     .foregroundStyle(StrandPalette.textTertiary)
-                    .lineLimit(1)
+                    .lineLimit(2)
                     .minimumScaleFactor(0.7)
                     .multilineTextAlignment(.center)
+                    .frame(maxWidth: captionWidth)
             }
         }
     }

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -733,10 +733,14 @@ struct TodayView: View {
         return lastValue
     }
 
-    /// #1164 — should today's Rest show "Pending sync" instead of a provisional number? When the strap has
-    /// banked records not yet offloaded, the Rest score is computed from partial data and will change once
-    /// the full night lands and `analyzeRecent` re-scores it. Surfacing it as "Pending sync" rather than a
-    /// confident number that then moves reads honestly instead of as a bug.
+    /// #1164/#2012 — should today's Rest be MARKED provisional? When the strap has banked records not yet
+    /// offloaded, the Rest score is computed from partial data and may change once the full night lands and
+    /// `analyzeRecent` re-scores it. Saying so reads honestly instead of as a bug when the number moves.
+    ///
+    /// True means "caption it as pending", NOT "hide it". #2012: the number used to be withheld on both
+    /// surfaces while this was true, so a user whose night was scored saw nothing for as long as the strap
+    /// had anything left to send, which on a continuously banking strap is most of the day. A number that
+    /// may still move is not the same as no number, and it is the one the screen exists to show.
     ///
     /// Two honest signals, either of which means more data is expected:
     /// - `backfilling`: an offload is actively running right now (data is draining).
@@ -745,8 +749,8 @@ struct TodayView: View {
     ///   before the first offload starts).
     ///
     /// Only applies to TODAY (a past day's score is final — no more data is coming for it) and only when a
-    /// Rest score EXISTS (pending suppresses a provisional number; it does not fabricate one when there is
-    /// none). Pure + unit-testable. Mirror EXACTLY in Kotlin.
+    /// Rest score EXISTS (pending annotates a score; it never fabricates one where there is none). Pure +
+    /// unit-testable. Mirror EXACTLY in Kotlin.
     static func restPendingSync(restScore: Double?, backfilling: Bool,
                                 historyPendingSync: Bool, isTodaySelected: Bool) -> Bool {
         guard isTodaySelected, restScore != nil else { return false }
@@ -3257,14 +3261,6 @@ struct TodayView: View {
             .buttonStyle(.plain)
             .accessibilityLabel(onRingTap == nil ? Self.domainGuideAccessibilityLabel(domain)
                                                   : "See what shaped your Charge")
-            if let caption {
-                Text(caption)
-                    .font(StrandFont.footnote)
-                    .foregroundStyle(StrandPalette.textTertiary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.7)
-                    .multilineTextAlignment(.center)
-            }
             // Component 4, the real per-day source under the ring (only when this score has a value for
             // the day AND we resolved its winner; a calibrating / empty ring shows no provenance badge).
             // Apple Watch (M1): a watch-sourced score reads "Apple Watch" with its confidence bound to the
@@ -3285,6 +3281,18 @@ struct TodayView: View {
                     SourceBadge("\(label)", tint: provenanceTint(key))
                         .accessibilityLabel("Source: \(label)")
                 }
+            }
+            // LAST in the column, below the provenance badge rather than above it. The badges sit at the
+            // same height across the three columns and a caption on one of them must not push that
+            // column's badge a line lower than its neighbours'. The row is top-aligned and self-sizing
+            // (#762), so a caption grows the row and leaves every ring where it was.
+            if let caption {
+                Text(caption)
+                    .font(StrandFont.footnote)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                    .multilineTextAlignment(.center)
             }
         }
     }

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -3151,7 +3151,8 @@ struct TodayView: View {
                 chargeRing(score: score, d: d, diameter: ring)
             }
             heroRingColumn(section: .effort, domain: .effort) { effortRing(d: d, diameter: ring) }
-            heroRingColumn(section: .rest, domain: .rest, provenanceKey: "sleep_performance") { restRing(diameter: ring) }
+            heroRingColumn(section: .rest, domain: .rest, provenanceKey: "sleep_performance",
+                           caption: restIsPendingSync ? "Pending sync" : nil) { restRing(diameter: ring) }
         }
         .frame(maxWidth: .infinity, alignment: .center)
         // Zero-impact width reader: a clear background that publishes the row's width up via preference. It
@@ -3195,9 +3196,16 @@ struct TodayView: View {
     /// intrinsically diameter×diameter, so the column just centres it and stretches to an equal share
     /// of the row width.
     @ViewBuilder
+    /// `caption` is an optional one-line note under the domain label — currently Rest's "Pending sync".
+    ///
+    /// It lives HERE, under the label, rather than over the ring, for two reasons. It cannot cover the
+    /// score, which is what made the old overlay hide a number the user had every right to see. And it is
+    /// laid out at the COLUMN's width rather than the ring's, so it has room to render: the overlay was
+    /// measured against the circle and ellipsised its own explanation mid-word while spilling past the
+    /// ring's edge. Mirrors Android's `HeroRingColumn(caption:)`.
     private func heroRingColumn<RingBody: View>(
         section: ScoreSection, domain: DomainTheme, provenanceKey: String? = nil,
-        onRingTap: (() -> Void)? = nil,
+        onRingTap: (() -> Void)? = nil, caption: String? = nil,
         @ViewBuilder ring: () -> RingBody
     ) -> some View {
         VStack(spacing: 8) {
@@ -3249,6 +3257,14 @@ struct TodayView: View {
             .buttonStyle(.plain)
             .accessibilityLabel(onRingTap == nil ? Self.domainGuideAccessibilityLabel(domain)
                                                   : "See what shaped your Charge")
+            if let caption {
+                Text(caption)
+                    .font(StrandFont.footnote)
+                    .foregroundStyle(StrandPalette.textTertiary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                    .multilineTextAlignment(.center)
+            }
             // Component 4, the real per-day source under the ring (only when this score has a value for
             // the day AND we resolved its winner; a calibrating / empty ring shows no provenance badge).
             // Apple Watch (M1): a watch-sourced score reads "Apple Watch" with its confidence bound to the
@@ -3316,17 +3332,22 @@ struct TodayView: View {
         }
     }
 
+    /// Whether today's Rest is provisional because the strap still has records to send. Resolved once and
+    /// read by both surfaces that say so — the hero column's caption and the Rest tile's — so the two can
+    /// never disagree about the same moment.
+    private var restIsPendingSync: Bool {
+        Self.restPendingSync(restScore: restScore, backfilling: liveBackfillingFlag,
+                             historyPendingSync: liveHistoryPendingSyncFlag,
+                             isTodaySelected: selectedDayOffset == 0)
+    }
+
     /// Rest (sleep composite 0–100) hero ring.
     @ViewBuilder
     private func restRing(diameter: CGFloat) -> some View {
-        // #1164: when the strap has banked records not yet offloaded, today's Rest is provisional — it
-        // will change once the full night lands and `analyzeRecent` re-scores it. Show "Pending sync"
-        // instead of a confident number that then moves. Past days are final (no more data coming).
-        if Self.restPendingSync(restScore: restScore, backfilling: liveBackfillingFlag,
-                                historyPendingSync: liveHistoryPendingSyncFlag,
-                                isTodaySelected: selectedDayOffset == 0) {
-            emptyHeroRing(diameter: diameter) { ringPendingSync() }
-        } else if let s = restScore {
+        // #1164/#2012: when the strap has banked records not yet offloaded, today's Rest is provisional —
+        // it may change once the full night lands and `analyzeRecent` re-scores it. That is now SAID, in
+        // the column's caption, rather than shown by withholding the number. Past days are final.
+        if let s = restScore {
             GlowRing(fraction: s / 100, value: s, format: { "\(Int($0.rounded()))" },
                      color: StrandPalette.restColor, diameter: diameter, lineWidth: diameter * 0.10)
         } else if displayDay?.recovery != nil {
@@ -3350,20 +3371,6 @@ struct TodayView: View {
             Text("Calibrating").font(StrandFont.headline).foregroundStyle(StrandPalette.textTertiary)
                 .lineLimit(1).minimumScaleFactor(0.7).fixedSize()
             Text("needs a tracked night").font(StrandFont.footnote).foregroundStyle(StrandPalette.textSecondary)
-                .lineLimit(1).minimumScaleFactor(0.6).fixedSize()
-        }
-    }
-
-    /// #1164: the Rest ring's overlay when today's score is provisional because the strap still has
-    /// banked records not yet offloaded. Shows "Pending sync" instead of a number that will change once
-    /// the full night lands and `analyzeRecent` re-scores it. Mirrors Android's RingPendingSync.
-    @ViewBuilder
-    private func ringPendingSync() -> some View {
-        VStack(spacing: 3) {
-            Text("Pending sync").font(StrandFont.headline).foregroundStyle(StrandPalette.textTertiary)
-                .lineLimit(1).minimumScaleFactor(0.7).fixedSize()
-            Text("strap history still offloading").font(StrandFont.footnote)
-                .foregroundStyle(StrandPalette.textSecondary)
                 .lineLimit(1).minimumScaleFactor(0.6).fixedSize()
         }
     }
@@ -3838,40 +3845,30 @@ struct TodayView: View {
                 accessory: { scoreInfoButton(.effort) }
             )
         case .rest:
-            // #1164: when today's Rest is provisional (strap has banked records not yet offloaded), show
-            // "Pending sync" instead of a number that will change once the full night lands. Past days
-            // are final (no more data coming), so the pending state is today-only.
-            if Self.restPendingSync(restScore: restScore, backfilling: liveBackfillingFlag,
-                                     historyPendingSync: liveHistoryPendingSyncFlag,
-                                     isTodaySelected: selectedDayOffset == 0) {
-                StatTile(
-                    label: "Rest",
-                    value: "—",
-                    caption: String(localized: "Pending sync · strap history still offloading"),
-                    accent: StrandPalette.textPrimary,
-                    sparkline: sparks["sleep_performance"],
-                    sparkColor: StrandPalette.metricPurple,
-                    accessory: { scoreInfoButton(.rest) }
-                )
-            } else {
-                // Unscored TODAY → "building, wear it tonight" instead of a lone ", " caption (#527);
-                // a scored day keeps its sleep-duration / efficiency caption.
-                StatTile(
-                    label: "Rest",
-                    value: restScore.map { "\(Int($0.rounded()))%" } ?? "—",
-                    // Component 2: a scored day shows its duration/efficiency caption; an unscored TODAY shows
-                    // the "building" hint; a past day with no Rest falls to the honest "Needs the strap" rather
-                    // than a bare blank, so the tile always carries a state.
-                    caption: restScore != nil ? restCaption(d)
-                        : (buildingHint(.rest) ?? restCaption(d) ?? Self.needsStrapCaption),
-                    accent: restScore.map { StrandPalette.recoveryColor($0) } ?? StrandPalette.textPrimary,
-                    // The Rest composite (0–100) trend, not raw sleep minutes, tracks the score above (#614).
-                    sparkline: sparks["sleep_performance"],
-                    sparkColor: StrandPalette.metricPurple,
-                    // Inline ⓘ in the tile header (not a corner overlay) so it never sits over the value (#495).
-                    accessory: { scoreInfoButton(.rest) }
-                )
-            }
+            // #1164/#2012: a provisional Rest is SAID to be provisional, in the caption, rather than
+            // withheld. Blanking the number too left a user who had slept, and whose score was computed,
+            // looking at "—" for as long as the strap had anything left to send, which on a continuously
+            // banking strap is most of the day. Past days are final, so the state is today-only.
+            //
+            // Unscored TODAY → "building, wear it tonight" instead of a lone caption (#527); a scored day
+            // keeps its sleep-duration / efficiency caption.
+            StatTile(
+                label: "Rest",
+                value: restScore.map { "\(Int($0.rounded()))%" } ?? "—",
+                // Component 2: a scored day shows its duration/efficiency caption; an unscored TODAY shows
+                // the "building" hint; a past day with no Rest falls to the honest "Needs the strap" rather
+                // than a bare blank, so the tile always carries a state.
+                caption: restIsPendingSync
+                    ? String(localized: "Pending sync · strap history still offloading")
+                    : (restScore != nil ? restCaption(d)
+                        : (buildingHint(.rest) ?? restCaption(d) ?? Self.needsStrapCaption)),
+                accent: restScore.map { StrandPalette.recoveryColor($0) } ?? StrandPalette.textPrimary,
+                // The Rest composite (0–100) trend, not raw sleep minutes, tracks the score above (#614).
+                sparkline: sparks["sleep_performance"],
+                sparkColor: StrandPalette.metricPurple,
+                // Inline ⓘ in the tile header (not a corner overlay) so it never sits over the value (#495).
+                accessory: { scoreInfoButton(.rest) }
+            )
         case .hrv:
             // Carry the last scored night's HRV at the rollover (#543), today's wins, the carried value
             // is stamped "Last night · <date>", and a never-scored metric still shows ", ".

--- a/StrandTests/RestFreshnessTests.swift
+++ b/StrandTests/RestFreshnessTests.swift
@@ -60,7 +60,8 @@ final class RestFreshnessTests: XCTestCase {
 
     // MARK: - #1164 Rest pending-sync (provisional before full offload)
 
-    /// An active offload (`backfilling`) with today's Rest present → pending, not a provisional number.
+    /// An active offload (`backfilling`) with today's Rest present → the score is captioned as pending.
+    /// #2012: "pending" marks the number, it does not withhold it.
     func testPendingSync_backfillingWithRestScore_showsPending() {
         XCTAssertTrue(TodayView.restPendingSync(
             restScore: 72, backfilling: true, historyPendingSync: false, isTodaySelected: true))

--- a/android/app/src/main/java/com/noop/ui/TodayScoring.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScoring.kt
@@ -291,10 +291,14 @@ internal fun scoreStateForToday(
 }
 
 /**
- * #1164 — should today's Rest show "Pending sync" instead of a provisional number? When the strap has
- * banked records not yet offloaded, the Rest score is computed from partial data and will change once
- * the full night lands and `analyzeRecent` re-scores it. Surfacing it as "Pending sync" rather than a
- * confident number that then moves reads honestly instead of as a bug.
+ * #1164/#2012 — should today's Rest be MARKED provisional? When the strap has banked records not yet
+ * offloaded, the Rest score is computed from partial data and may change once the full night lands and
+ * `analyzeRecent` re-scores it. Saying so reads honestly instead of as a bug when the number moves.
+ *
+ * True means "caption it as pending", NOT "hide it". #2012: the number used to be withheld on both
+ * surfaces while this was true, so a user whose night was scored saw nothing for as long as the strap
+ * had anything left to send, which on a continuously banking strap is most of the day. A number that
+ * may still move is not the same as no number, and it is the one the screen exists to show.
  *
  * Two honest signals, either of which means more data is expected:
  * - [backfilling]: an offload is actively running right now (data is draining).
@@ -303,8 +307,8 @@ internal fun scoreStateForToday(
  *   the first offload starts).
  *
  * Only applies to TODAY (a past day's score is final — no more data is coming for it) and only when a
- * Rest score EXISTS (pending suppresses a provisional number; it does not fabricate one when there is
- * none). Pure + unit-tested. Mirror EXACTLY of Swift `TodayView.restPendingSync`.
+ * Rest score EXISTS (pending annotates a score; it never fabricates one where there is none). Pure +
+ * unit-tested. Mirror EXACTLY of Swift `TodayView.restPendingSync`.
  */
 internal fun restPendingSync(
     restScore: Double?,

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2743,6 +2743,13 @@ private fun ScoreHeroRow(
                             R.string.today_action_open_detail,
                             uiString(R.string.today_metric_rest),
                         ),
+                        // #1164/#2012: the provisional state is now said BESIDE the number instead of
+                        // replacing it. See [HeroRingColumn]'s caption for why.
+                        caption = if (restPendingSync) {
+                            uiString(R.string.l10n_today_screen_pending_sync_cbe01f9e)
+                        } else {
+                            null
+                        },
                     ) {
                         Box(contentAlignment = Alignment.Center) {
                             HeroScoreVessel(
@@ -2751,15 +2758,10 @@ private fun ScoreHeroRow(
                                 tint = Palette.recoveryColor(restScore ?: 0.0),
                                 diameter = ring,
                                 animated = animated,
-                                showsValue = restScore != null && !restPendingSync,
+                                showsValue = restScore != null,
                                 onTap = restRingTap,
                             )
-                            // #1164: when today's Rest is provisional (strap has banked records not yet
-                            // offloaded), show "Pending sync" instead of a number that will change once the
-                            // full night lands. Past days are final (no more data coming). Mirrors iOS restRing.
-                            if (restPendingSync) {
-                                RingPendingSync()
-                            } else if (restScore == null) {
+                            if (restScore == null) {
                                 // #898: an aggregate-import user (a daily HRV/RHR import, no in-bed session) gets a
                                 // Charge from WatchRecovery but NO sleep_performance, so Rest used to read a bare
                                 // "No Data" next to a lit Charge , reading as broken. When a Charge IS present for the
@@ -2816,6 +2818,14 @@ private fun HeroRingColumn(
     // Charge's ring opens a breakdown, so "see what shaped" is honest there. Effort and Rest open a
     // trend detail instead, so they override it rather than announce a breakdown they do not show.
     ringTapLabel: String? = null,
+    // #2012: an optional one-line note under the domain label — currently Rest's "Pending sync".
+    //
+    // It lives HERE, under the label, rather than over the ring, for two reasons. It cannot cover the
+    // score, which is what made the old overlay hide a number the user had every right to see. And it is
+    // laid out at the COLUMN's width rather than the vessel's, so it has room to render: the overlay was
+    // measured against the circle and ellipsised its own explanation mid-word ("strap history still o...")
+    // while spilling past the vessel's edge.
+    caption: String? = null,
     ring: @Composable () -> Unit,
 ) {
     val domainLabel = uiString(
@@ -2890,6 +2900,16 @@ private fun HeroRingColumn(
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
                     .size(Metrics.space14),
+            )
+        }
+        if (caption != null) {
+            AutoSizeValue(
+                text = caption,
+                style = NoopType.footnote,
+                color = Palette.textTertiary,
+                modifier = Modifier.fillMaxWidth().padding(horizontal = Metrics.space2),
+                minScale = 0.7f,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
             )
         }
     }
@@ -3221,23 +3241,6 @@ private fun RingNeedsTrackedNight() {
 /** #1164: the Rest ring's overlay when today's score is provisional because the strap still has banked
  *  records not yet offloaded. Shows "Pending sync" instead of a number that will change once the full
  *  night lands and `analyzeRecent` re-scores it. Mirrors iOS ringPendingSync. */
-@Composable
-private fun RingPendingSync() {
-    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        AutoSizeValue(
-            uiString(R.string.l10n_today_screen_pending_sync_cbe01f9e),
-            style = NoopType.headline,
-            color = Palette.textTertiary,
-            minScale = 0.7f,
-        )
-        AutoSizeValue(
-            uiString(R.string.l10n_today_screen_strap_history_still_offloading_80140264),
-            style = NoopType.footnote,
-            color = Palette.textSecondary,
-        )
-    }
-}
-
 // MARK: - Hero vitals metric rows, HRV / Resting HR / Respiratory, re-homed below the ring hero
 //
 // The WHOOP-style redesign (#23) dropped the big gold RecoveryRing hero that used to carry these; the
@@ -5412,10 +5415,12 @@ private fun MetricGrid(
         ),
         KeyMetric.REST to KeyTileData(
             label = uiString(R.string.l10n_today_screen_rest_b79e5f48),
-            // #1164: when today's Rest is provisional, show "—" with a "Pending sync" caption instead of
-            // a number that will change once the full night lands. Past days are final.
-            value = if (restPendingSync) NO_DATA else restScore?.let { "${it.roundToInt()}" } ?: NO_DATA,
-            unit = if (!restPendingSync && restScore != null) "%" else "",
+            // #1164/#2012: a provisional Rest is now SAID to be provisional rather than withheld. The
+            // caption below carries that; blanking the number as well left a user who had slept, and
+            // whose score was computed, looking at "—" for as long as the strap had anything left to
+            // send — which on a continuously-banking strap is most of the day.
+            value = restScore?.let { "${it.roundToInt()}" } ?: NO_DATA,
+            unit = if (restScore != null) "%" else "",
             tint = restScore?.let { Palette.recoveryColor(it) } ?: Palette.restColor,
             frac = restScore?.let { (it / 100.0).coerceIn(0.0, 1.0) },
             spark = restSpark,

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -2903,13 +2903,19 @@ private fun HeroRingColumn(
             )
         }
         if (caption != null) {
-            AutoSizeValue(
+            // A plain wrapping Text, NOT AutoSizeValue: that one is maxLines = 1 with softWrap off and an
+            // ellipsis, so a longer translation would shrink to its floor and then cut itself off
+            // mid-word. Truncating its own explanation is precisely what the old in-ring overlay did and
+            // what moving the caption out here was meant to stop, so it must not come back through the
+            // component. Two lines at the column's width holds every locale we ship.
+            Text(
                 text = caption,
                 style = NoopType.footnote,
                 color = Palette.textTertiary,
-                modifier = Modifier.fillMaxWidth().padding(horizontal = Metrics.space2),
-                minScale = 0.7f,
+                maxLines = 2,
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
                 textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                modifier = Modifier.fillMaxWidth().padding(horizontal = Metrics.space2),
             )
         }
     }
@@ -5424,7 +5430,15 @@ private fun MetricGrid(
             tint = restScore?.let { Palette.recoveryColor(it) } ?: Palette.restColor,
             frac = restScore?.let { (it / 100.0).coerceIn(0.0, 1.0) },
             spark = restSpark,
-            caption = if (restPendingSync) uiString(R.string.l10n_today_screen_strap_history_still_offloading_80140264) else null,
+            // Composed from the two shipped strings rather than a third one needing four translations.
+            // Matches the single iOS caption "Pending sync · strap history still offloading": the second
+            // half alone read as a fragment, and more so now that a real number sits above it (#2012).
+            caption = if (restPendingSync) {
+                uiString(R.string.l10n_today_screen_pending_sync_cbe01f9e) + " · " +
+                    uiString(R.string.l10n_today_screen_strap_history_still_offloading_80140264)
+            } else {
+                null
+            },
         ),
         KeyMetric.HRV to run {
             val v = d?.avgHrv ?: carriedDay?.avgHrv

--- a/android/app/src/test/java/com/noop/ui/TodayExplainabilityTest.kt
+++ b/android/app/src/test/java/com/noop/ui/TodayExplainabilityTest.kt
@@ -126,29 +126,30 @@ class TodayExplainabilityTest {
      * The flag that drives this must not be able to latch on forever, which is the failure both
      * `shouldAutoContinue` guards already exist for: a future-dated strap clock reads ahead of ANY
      * frontier, and a phantom gap advertises newer data while banking no rows. Either would pin Rest to
-     * "Pending sync" and never show a score, which is worse than the provisional number it replaces.
+     * "Pending sync" forever. Since #2012 that no longer withholds the number, so it is a stuck caption
+     * rather than a blank ring — still wrong, and still a contract the caller owes.
      * The helper itself is pure, so this pins the CONTRACT it is handed: a caller must not pass true
      * for a gap it cannot close.
      */
     @Test
-    fun restPendingSyncOnlySuppressesWhileThereIsAScoreAndTodayIsSelected() {
-        // A gap the caller has judged real: suppress.
+    fun restPendingSyncOnlyMarksWhileThereIsAScoreAndTodayIsSelected() {
+        // A gap the caller has judged real: mark the score provisional (#2012: mark, never hide).
         assertTrue(restPendingSync(restScore = 71.0, backfilling = false,
                                    historyPendingSync = true, isTodaySelected = true))
-        // No score yet: calibrating / no-data states own that, so never fabricate a suppression.
+        // No score yet: calibrating / no-data states own that, so never claim a pending score.
         assertFalse(restPendingSync(restScore = null, backfilling = true,
                                     historyPendingSync = true, isTodaySelected = true))
         // A past day is final, whatever the strap is doing now.
         assertFalse(restPendingSync(restScore = 71.0, backfilling = true,
                                     historyPendingSync = true, isTodaySelected = false))
-        // Caught up and idle: show the number.
+        // Caught up and idle: no caption. The number shows either way since #2012.
         assertFalse(restPendingSync(restScore = 71.0, backfilling = false,
                                     historyPendingSync = false, isTodaySelected = true))
     }
 
     @Test
     fun restPendingSync_backfillingWithRestScore_showsPending() {
-        // An active offload with today's Rest present → pending, not a provisional number.
+        // An active offload with today's Rest present → the score is captioned as pending.
         assertTrue(restPendingSync(restScore = 72.0, backfilling = true, historyPendingSync = false, isTodaySelected = true))
     }
 
@@ -167,7 +168,7 @@ class TodayExplainabilityTest {
 
     @Test
     fun restPendingSync_noRestScore_neverPending_evenWithSignals() {
-        // No Rest score → never pending (pending suppresses a provisional NUMBER; it does not fabricate
+        // No Rest score → never pending (pending annotates an existing NUMBER; it does not fabricate
         // one when there is none — the calibrating/no-data states already cover that).
         assertFalse(restPendingSync(restScore = null, backfilling = true, historyPendingSync = true, isTodaySelected = true))
     }


### PR DESCRIPTION
Reported in #2012.

## What was happening

At 16:50, for a night that ended at 07:20, the Rest hero read "Pending sync / strap history still
offloading" with no number. It reads as the app deciding to recalculate a settled night. It is not
doing that, and nothing is re-derived by that message, but the state is wrong for a different reason.

#1164's proposal was to "surface Rest as **pending sync** rather than a provisional number", and that
is exactly what shipped: the number is withheld entirely, on **both** surfaces:

- the hero ring drew an empty track with a two-line overlay in place of the score;
- the Rest tile rendered its no-data placeholder in place of the number.

So a user who had slept, and whose score had been computed, saw nothing at all for as long as the
strap had anything left to send. On a strap that banks continuously that is most of the day, every
day.

## This reverses #1164's chosen approach, deliberately

Worth stating plainly rather than filing as a defect. Withholding the number was the right answer for
a state expected to be brief. The trigger turned out not to be brief: it fires on "the strap is ahead
of us at all" or "an offload is running", so on a continuously banking strap it holds for most of the
day. Hiding a computed score for most of the day is a worse failure than a number that moves once
with a note saying it might.

If the trigger is narrowed to the night being scored (see below), the state becomes short again and
withholding is defensible once more. This change is reversible on its own if you would rather keep
#1164's approach and wait for a log to narrow the trigger first.

## Change

Hiding the value is a stronger response than the problem needs. A number that may still move is not
the same as no number, and it is the one the user opened the screen for. Both surfaces now render
the score and **say** it is provisional beside it:

- the hero carries a caption below its provenance badge, bounded to the ring's width so a longer
  translation cannot widen the column and tip the three rings off centre;
- the tile keeps the caption slot it already had, with the number restored above it.

That also fixes what the overlay did to its own explanation. It was laid out against the ring's
width, so it spilled past the vessel's edge and ellipsised mid-word. The reporter's screenshot shows
it arriving as "strap history still o...". The caption sits under the label at the **column's** width,
where the text has room, and it cannot cover the score by construction.

Swift resolves the state once in `restIsPendingSync`, read by both surfaces, so the hero and the tile
can no longer disagree about the same moment. Android already passes one `restPendingSync` value to
both.

## What is deliberately NOT changed

`restPendingSync` itself. It still means what it meant, is still today-only, and is still gated on a
score existing. Its **trigger** is a separate defect and wants evidence first: it fires on
`historyPendingSync` ("the strap has banked HR more than five minutes newer than our newest local
row") or `backfilling` ("an offload is running"). Neither is scoped to the night being scored, so
records banked long after wake can raise it, and nothing offloaded after 07:20 can change a score for
a night that ended then.

Which of the two fired here cannot be told from a screenshot. Live HR is clearly streaming in it
(101 bpm, "Now"), which should keep the HR frontier at roughly now and close `historyPendingSync`'s
gap, so `backfilling` is the likelier of the two, but that is inference. Narrowing the trigger
properly means comparing our ingest coverage against the scored night's end, and it should be done
against a log rather than a guess. Asked for one on the issue.

## Verification

- Android UI suites: **984 tests, 0 failures**. `compileFullDebugKotlin` clean.
- `Tools/i18n_audit.py --ci origin/main` clean; `Tools/doc_comment_lint.py` clean.
- No new strings on either platform: the hero caption reuses the existing "Pending sync" key, the
  tile keeps the longer string it already had, and both remain referenced.
- Swift app-target rests on CI (no macOS here).
- **On-device QA still wanted**: the caption's fit at large font scales and in the longer locales.

Reported by @bartmuskala.