### PR TITLE
Read the v26 per-burst counter as the u16 it is

### DIFF
--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
@@ -630,9 +630,20 @@ private func decodeWhoop5HistoricalV26(_ frame: [UInt8], fb: FieldBuilder) {
     // 2 — but a later capture read 65, far outside any 26-channel sweep, so @21 is not a stable channel id.
     // Re-surfaced as the neutral `burst_index` (gated bi > 0, the observed always-set sentinel) with NO
     // channel/LED semantics claimed; the physical optical-channel mapping is unproven and left unasserted.
-    if let bi = readDType(frame, 21, "u8"), bi > 0 {
-        fb.add(21, 1, "burst_index", "ppg", value: .int(bi),
-               note: "per-burst counter (raw); NOT a channel id")
+    // Sixteen bits, not eight. The field is a per-burst COUNTER and a u8 wraps the moment it passes 255;
+    // @21 has already been observed at 65 (see above), so wrapping is reachable rather than hypothetical,
+    // and a wrapped counter is indistinguishable from a genuine low one.
+    //
+    // The evidence for the width is the LAYOUT, not our fixtures: 21..23 counter, 23..27 the absolute
+    // base (#2019), 27..75 the 24 deltas, which accounts for every byte between the record header and the
+    // samples with nothing left over. An independent decode of this record reads the same two bytes as one
+    // u16 LE. Every v26 frame held here carries byte 22 = 0, so our own captures CANNOT discriminate a u16
+    // from a u8 beside a constant zero, and that is recorded as the weaker half of the case rather than
+    // left implied. Reading it wide is the safe direction: under 256 the two readings agree exactly, and
+    // above it only the wide one is right.
+    if let bi = readDType(frame, 21, "u16"), bi > 0 {
+        fb.add(21, 2, "burst_index", "ppg", value: .int(bi),
+               note: "per-burst counter (raw, u16 LE); NOT a channel id")
     }
     // record_index@11 (PR#563): the same monotonic lifetime per-record counter the v18/v20/v21 records
     // carry at @11 — +1 per record, independent of unix (advances across gaps). The only @11+ v26 field

--- a/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
+++ b/Packages/WhoopProtocol/Sources/WhoopProtocol/Interpreter.swift
@@ -676,9 +676,15 @@ private func decodeWhoop5HistoricalV26(_ frame: [UInt8], fb: FieldBuilder) {
     }
     // PR#563: the remaining per-record v26 bytes, surfaced as RAW NEUTRAL fields — read off the real
     // fixtures but with NO invented semantics (deliberately not named segment_id / signal_quality / etc.).
-    // Each is gated only to "present in range"; meaning is unpinned. The header @19/@23/@25 frame the
-    // waveform block; @75/@79/@81/@82 trail it. (`@27…@75` is the proven waveform handled above.)
-    for (name, off) in [("raw_u8_19", 19), ("raw_u8_23", 23), ("raw_u8_25", 25),
+    // Each is gated only to "present in range"; meaning is unpinned. @19 sits ahead of the waveform
+    // block and @75/@79/@81/@82 trail it. (`@27…@75` is the proven waveform handled above.)
+    //
+    // @23 and @25 USED to be here, described as framing the block. They are not: #2019 identified
+    // @23…@27 as the window's absolute optical base, which `ppg_base_code` above now carries as one u32.
+    // Leaving them would describe the same two bytes twice, once as an identified field and once as a
+    // byte whose "meaning is not pinned", and the second reading is simply no longer true. A field
+    // viewer showing both would invite someone to re-derive what has already been worked out.
+    for (name, off) in [("raw_u8_19", 19),
                         ("raw_u8_75", 75), ("raw_u8_79", 79), ("raw_u8_81", 81), ("raw_u8_82", 82)] {
         if let v = readDType(frame, off, "u8") {
             fb.add(off, 1, name, "raw", value: .int(v), note: "raw byte @\(off); meaning not pinned")

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5PpgWaveformTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5PpgWaveformTests.swift
@@ -225,3 +225,53 @@ final class PpgWaveformCensusTests: XCTestCase {
         XCTAssertFalse(isSaturatedPpgDelta(0))
     }
 }
+
+/// #2019 follow-up: the per-burst counter is a u16, not a u8. Mirrored by the Kotlin
+/// `Whoop5BurstIndexWidthTest` against the same synthetic frames.
+final class Whoop5BurstIndexWidthTests: XCTestCase {
+
+    /// A counter past 255 is the whole reason for the width. Read as a u8 this frame reports 0, which is
+    /// the sentinel meaning "absent", so a wrapped counter would not merely be wrong, it would vanish.
+    func testACounterPastAByteSurvives() {
+        let f = v26Frame(burstLow: 0x00, burstHigh: 0x01)   // 256
+        let p = parseFrame(f, family: .whoop5)
+        XCTAssertEqual(p.parsed["burst_index"]?.intValue, 256)
+    }
+
+    /// And the two readings agree exactly below 256, which is why every fixture we hold is unmoved: our
+    /// captures carry byte 22 = 0, so they cannot tell a u16 from a u8 beside a constant zero.
+    func testTheTwoReadingsAgreeBelow256() {
+        for low in [1, 2, 65, 255] {
+            let p = parseFrame(v26Frame(burstLow: UInt8(low), burstHigh: 0), family: .whoop5)
+            XCTAssertEqual(p.parsed["burst_index"]?.intValue, low, "index \(low) must be unchanged")
+        }
+    }
+
+    /// Zero stays the absent sentinel across both bytes, so a widened read cannot invent a burst.
+    func testZeroIsStillAbsent() {
+        let p = parseFrame(v26Frame(burstLow: 0, burstHigh: 0), family: .whoop5)
+        XCTAssertNil(p.parsed["burst_index"])
+    }
+
+    /// A v26 frame with the counter bytes planted, sealed exactly as a strap seals one.
+    private func v26Frame(burstLow: UInt8, burstHigh: UInt8) -> [UInt8] {
+        var f = bytes(v26Hex)
+        f[21] = burstLow
+        f[22] = burstHigh
+        let payloadEnd = f.count - 4
+        let c = crc32(f, 8, payloadEnd)
+        for b in 0..<4 { f[payloadEnd + b] = UInt8((c >> (8 * UInt32(b))) & 0xFF) }
+        return f
+    }
+
+    private let v26Hex =
+        "aa015000010035412f1a80ad418401f0a3266aae470100c3c5050068faccfa8dfb46fc8bfd4c"
+        + "febafedafe6dff56ffd5fffbff37ff6afce5f9d7f8dffa5efc98fddbfe5afe84fe15ff5cff40"
+        + "5fb33c50080101006cb67c17"
+
+    private func bytes(_ s: String) -> [UInt8] {
+        stride(from: 0, to: s.count, by: 2).map {
+            UInt8(s[s.index(s.startIndex, offsetBy: $0)...s.index(s.startIndex, offsetBy: $0 + 1)], radix: 16)!
+        }
+    }
+}

--- a/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5PpgWaveformTests.swift
+++ b/Packages/WhoopProtocol/Tests/WhoopProtocolTests/Whoop5PpgWaveformTests.swift
@@ -253,6 +253,16 @@ final class Whoop5BurstIndexWidthTests: XCTestCase {
         XCTAssertNil(p.parsed["burst_index"])
     }
 
+    /// The case where the two readings DISAGREE, pinned so the choice is deliberate rather than
+    /// incidental. A low byte of 0 with a high byte set reads as absent under a u8 and as 1280 under a
+    /// u16. If the high byte really is the counter's, 1280 is right and the u8 lost the burst entirely.
+    /// If it is a separate field, this is where a fabricated index would come from, which is why the
+    /// falsifiable prediction is a persisted index jumping by a multiple of 256.
+    func testTheDivergentCaseIsPinned() {
+        let p = parseFrame(v26Frame(burstLow: 0, burstHigh: 5), family: .whoop5)
+        XCTAssertEqual(p.parsed["burst_index"]?.intValue, 1280)
+    }
+
     /// A v26 frame with the counter bytes planted, sealed exactly as a strap seals one.
     private func v26Frame(burstLow: UInt8, burstHigh: UInt8) -> [UInt8] {
         var f = bytes(v26Hex)

--- a/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
+++ b/android/app/src/main/java/com/noop/protocol/HistoricalStreams.kt
@@ -640,7 +640,18 @@ private fun decodeWhoop5HistoricalV26(frame: ByteArray): V26Record? {
         off += 2
     }
     if (samples.isEmpty()) return null
-    val rawBurstIndex = frame.histU8(21)
+    // Sixteen bits, not eight. The field is a per-burst COUNTER and a u8 wraps the moment it passes
+    // 255; @21 has already been observed at 65 in a real capture, so wrapping is reachable rather than
+    // hypothetical, and a wrapped counter is indistinguishable from a genuine low one.
+    //
+    // The evidence for the width is the LAYOUT, not our fixtures: 21..23 counter, 23..27 the absolute
+    // base (#2019), 27..75 the 24 deltas, which accounts for every byte between the record header and
+    // the samples with nothing left over. An independent decode of this record reads the same two bytes
+    // as one u16 LE. Every v26 frame held here carries byte 22 = 0 with an index of 1, 2 or 65, so our
+    // own captures CANNOT discriminate a u16 from a u8 beside a constant zero, and this is recorded as
+    // the weaker half of the case rather than left implied. Reading it wide is the safe direction: for
+    // every index under 256 the two readings agree exactly, and above it only the wide one is right.
+    val rawBurstIndex = frame.histU16(21)
     return V26Record(unix = unix, samples = samples,
         burstIndex = rawBurstIndex?.takeIf { it > 0 }, baseCode = baseCode)
 }

--- a/android/app/src/test/java/com/noop/protocol/Whoop5BurstIndexWidthTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5BurstIndexWidthTest.kt
@@ -1,0 +1,74 @@
+package com.noop.protocol
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #2019 follow-up: the per-burst counter is a u16, not a u8. Twin of the Swift
+ * `Whoop5BurstIndexWidthTests` against the same synthetic frames.
+ */
+class Whoop5BurstIndexWidthTest {
+
+    /**
+     * A counter past 255 is the whole reason for the width. Read as a u8 this frame reports 0, which is
+     * the sentinel meaning "absent", so a wrapped counter would not merely be wrong, it would vanish.
+     */
+    @Test
+    fun aCounterPastAByteSurvives() {
+        assertEquals(256, burstIndexOf(v26Frame(0x00, 0x01)))
+    }
+
+    /**
+     * And the two readings agree exactly below 256, which is why every fixture we hold is unmoved: our
+     * captures carry byte 22 = 0, so they cannot tell a u16 from a u8 beside a constant zero.
+     */
+    @Test
+    fun theTwoReadingsAgreeBelow256() {
+        for (low in listOf(1, 2, 65, 255)) {
+            assertEquals("index $low must be unchanged", low, burstIndexOf(v26Frame(low, 0)))
+        }
+    }
+
+    /** Zero stays the absent sentinel across both bytes, so a widened read cannot invent a burst. */
+    @Test
+    fun zeroIsStillAbsent() {
+        assertNull(burstIndexOf(v26Frame(0, 0)))
+    }
+
+    /**
+     * v26 does NOT go through [decodeHistorical] on this platform: that function returns null for it, and
+     * the layout is decoded by `decodeWhoop5HistoricalV26` from [extractHistoricalStreams] instead. The
+     * burst index is only observable on the row that comes out, which is also where it is persisted from,
+     * so this is the honest entry point to assert against. Swift routes v26 through its interpreter and
+     * its twin reads `parsed["burst_index"]` directly.
+     */
+    private fun burstIndexOf(frame: ByteArray): Int? =
+        extractHistoricalStreams(
+            listOf(frame),
+            deviceClockRef = 1_780_917_232,
+            wallClockRef = 1_780_917_232,
+            family = DeviceFamily.WHOOP5,
+        ).ppgWaveform.single().burstIndex
+
+    /** A v26 frame with the counter bytes planted, sealed exactly as a strap seals one. */
+    private fun v26Frame(burstLow: Int, burstHigh: Int): ByteArray {
+        val f = bytes(V26_HEX)
+        f[21] = burstLow.toByte()
+        f[22] = burstHigh.toByte()
+        val payloadEnd = f.size - 4
+        val c = Crc.crc32(f, 8, payloadEnd)
+        for (b in 0 until 4) f[payloadEnd + b] = ((c shr (8 * b)) and 0xFF).toByte()
+        return f
+    }
+
+    private fun bytes(s: String): ByteArray =
+        ByteArray(s.length / 2) { ((Character.digit(s[it * 2], 16) shl 4) + Character.digit(s[it * 2 + 1], 16)).toByte() }
+
+    private companion object {
+        const val V26_HEX =
+            "aa015000010035412f1a80ad418401f0a3266aae470100c3c5050068faccfa8dfb46fc8bfd4c" +
+                "febafedafe6dff56ffd5fffbff37ff6afce5f9d7f8dffa5efc98fddbfe5afe84fe15ff5cff40" +
+                "5fb33c50080101006cb67c17"
+    }
+}

--- a/android/app/src/test/java/com/noop/protocol/Whoop5BurstIndexWidthTest.kt
+++ b/android/app/src/test/java/com/noop/protocol/Whoop5BurstIndexWidthTest.kt
@@ -37,6 +37,18 @@ class Whoop5BurstIndexWidthTest {
     }
 
     /**
+     * The case where the two readings DISAGREE, pinned so the choice is deliberate rather than
+     * incidental. A low byte of 0 with a high byte set reads as absent under a u8 and as 1280 under a
+     * u16. If the high byte really is the counter's, 1280 is right and the u8 lost the burst entirely.
+     * If it is a separate field, this is where a fabricated index would come from, which is why the
+     * falsifiable prediction is a persisted index jumping by a multiple of 256.
+     */
+    @Test
+    fun theDivergentCaseIsPinned() {
+        assertEquals(1280, burstIndexOf(v26Frame(0, 5)))
+    }
+
+    /**
      * v26 does NOT go through [decodeHistorical] on this platform: that function returns null for it, and
      * the layout is decoded by `decodeWhoop5HistoricalV26` from [extractHistoricalStreams] instead. The
      * burst index is only observable on the row that comes out, which is also where it is persisted from,


### PR DESCRIPTION
Follow-up to #2019, from reviewing an external RE writeup of the same record.

## What was wrong

`burst_index` was read as a **u8** at frame-abs 21. It is a per-burst COUNTER, so a u8 wraps once it
passes 255, and @21 has already been observed at **65** on a real capture, which puts wrapping within
reach rather than in theory.

Wrapping is worse than a wrong number here. Zero is this field's sentinel for "absent", so an index of
exactly 256 would not read as 0, it would **vanish**.

## The evidence, and which half of it is weak

**Strong:** the layout accounts for every byte with nothing left over once the counter is two wide:

| frame | field |
|---|---|
| 21..23 | per-burst counter |
| 23..27 | absolute optical base (#2019) |
| 27..75 | 24 deltas |

and an independent decode of this record reads the same two bytes as one u16 LE.

**Weak:** our own captures cannot discriminate it. Every v26 frame held here carries byte 22 = 0 with
an index of 1, 2 or 65, which is what a small u16 looks like AND what a u8 beside a constant zero looks
like. The same source describes frame 21 on the *v18* record as "constant zero across millions of
records", so a constant-zero neighbour is not a strange thing for this firmware to have. I could not
settle it from our data and am not claiming otherwise.

Worth noting I checked another claim from that same writeup and **refuted it**: it reads frame 44/48/52
as big-endian float32 "sensor-fusion state", where we read 45/49/53 little-endian as the gravity
vector. On a real v18 frame ours gives |v| = 1.0086 g and theirs 0.78, with both cross-combinations
returning about 1e37. So this source is not being taken on trust; this particular claim survived
checking and that one did not.

## Why widening is the safe direction

Below 256 the two readings agree exactly. That is not an argument, it is measured: the entire Android
and Swift suites pass with every fixture untouched, precisely because byte 22 is zero in all of them.
Above 256 only the wide reading is right.

**The falsifiable prediction**, for whoever sees this next: if byte 22 is really a separate field rather
than the counter's high byte, a persisted burst index will one day jump by a multiple of 256. That is
the thing to watch for.

## Scope

No schema change: the column is already a nullable integer and a u16 fits. Not repairable for rows
already written, on the same terms as the base code in #2019: a value that wrapped was stored wrapped
and the high byte was never kept.

Swift reads it through the interpreter and asserts on `parsed["burst_index"]`. Kotlin's v26 does not go
through `decodeHistorical` at all, so its twin asserts on the persisted row out of
`extractHistoricalStreams`. Different entry points because the platforms genuinely differ for this
layout; the value asserted is the same.

## Verification

- Android suites: **5,763 tests, 0 failures**. `WhoopProtocol`: **696 tests, 0 failures** (local).
- `Tools/doc_comment_lint.py` clean. The WhoopStore suites rest on CI.
- New tests on both platforms: a counter past 255 survives, the two readings agree at 1/2/65/255, and
  zero stays the absent sentinel so a widened read cannot invent a burst.
