### PR TITLE
Ask the day-owner question once, and ask it as a bit

### DIFF
--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayOwnerReadIntegrationTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayOwnerReadIntegrationTests.swift
@@ -15,23 +15,37 @@ final class DayOwnerReadIntegrationTests: XCTestCase {
     private let day = "2026-06-15"
 
     /// Build candidates exactly as `IntelligenceEngine.resolveDayOwner` does, then resolve.
+    ///
+    /// This mirrors the SHIPPED shape, which is the only thing that makes an integration test worth
+    /// having: probe in (priority, original index) order and stop at the first candidate with data,
+    /// using the scalar `hasHrInWindow` presence check rather than fetching a row from the union read.
+    /// It used to build every candidate and hand the lot to `DayOwnerResolver.resolve`, which is what
+    /// production did before; left alone it would still have passed while quietly testing a path
+    /// nothing takes any more.
     private func resolveOwner(store: WhoopStore, registry: DeviceRegistryStore,
                               from: Int, to: Int) async throws -> String? {
         if let locked = try registry.dayOwner(day)?.deviceId { return locked }
         let activeId = try registry.activeDeviceId() ?? "my-whoop"
-        var candidates: [DayOwnerResolver.Candidate] = []
-        for d in try registry.all() where d.status != .archived {
-            let isImport = d.sourceKind == .cloudImport || d.sourceKind == .fileImport
-            // Mirrors IntelligenceEngine.resolveDayOwner: activity-file rides rank BELOW whole-day imports.
-            let priority: Int
-            if d.id == activeId { priority = 0 }
-            else if d.sourceKind == .activityFile { priority = 3 }
-            else if isImport { priority = 2 }
-            else { priority = 1 }
-            let hasData = !((try? await store.hrSamples(deviceId: d.id, from: from, to: to, limit: 1)) ?? []).isEmpty
-            candidates.append(.init(deviceId: d.id, priority: priority, hasData: hasData))
+        let ranked: [(id: String, priority: Int)] = try registry.all()
+            .filter { $0.status != .archived }
+            .map { d in
+                let isImport = d.sourceKind == .cloudImport || d.sourceKind == .fileImport
+                // Mirrors IntelligenceEngine.resolveDayOwner: activity-file rides rank BELOW whole-day
+                // imports.
+                let priority: Int
+                if d.id == activeId { priority = 0 }
+                else if d.sourceKind == .activityFile { priority = 3 }
+                else if isImport { priority = 2 }
+                else { priority = 1 }
+                return (d.id, priority)
+            }
+            .enumerated()
+            .sorted { ($0.element.priority, $0.offset) < ($1.element.priority, $1.offset) }
+            .map(\.element)
+        for c in ranked {
+            if (try? await store.hasHrInWindow(deviceId: c.id, from: from, to: to)) == true { return c.id }
         }
-        return DayOwnerResolver.resolve(day: day, lockedOwner: nil, candidates: candidates)
+        return nil
     }
 
     func testActiveStrapOwnsDayAndReadReturnsOnlyItsSamples() async throws {

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayOwnerResolverEquivalenceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayOwnerResolverEquivalenceTests.swift
@@ -14,7 +14,9 @@ final class DayOwnerResolverEquivalenceTests: XCTestCase {
     /// The short-circuit, over a pre-computed data map so it can be compared exhaustively.
     private func shortCircuit(_ candidates: [(id: String, priority: Int)],
                               _ hasData: [String: Bool]) -> String? {
-        candidates.sorted { $0.priority < $1.priority }.first { hasData[$0.id] == true }?.id
+        candidates.enumerated()
+            .sorted { ($0.element.priority, $0.offset) < ($1.element.priority, $1.offset) }
+            .first { hasData[$0.element.id] == true }?.element.id
     }
 
     /// Every data pattern over a three-candidate set with distinct priorities. If the two ever disagree
@@ -39,6 +41,20 @@ final class DayOwnerResolverEquivalenceTests: XCTestCase {
         let reversed: [(id: String, priority: Int)] = [("import", 2), ("second", 1), ("active", 0)]
         let hasData = ["active": true, "second": true, "import": true]
         XCTAssertEqual(shortCircuit(reversed, hasData), "active")
+    }
+
+    /// TIED priorities, which two non-active straps have: both are priority 1. The answer must be the
+    /// FIRST of them in list order, deterministically, on both platforms.
+    ///
+    /// This is the case the short-circuit could have got wrong. Swift's `sorted` is not stable by
+    /// contract, so ordering on priority alone left a tie free to come back either way, while Kotlin's
+    /// `sortedBy` is stable and its resolver takes the first minimum. The probe therefore sorts on
+    /// (priority, original index), which is a total order and agrees with Kotlin by construction.
+    func testTiedPrioritiesResolveToTheFirstInListOrder() {
+        let tied: [(id: String, priority: Int)] = [("strapA", 1), ("strapB", 1)]
+        XCTAssertEqual(shortCircuit(tied, ["strapA": true, "strapB": true]), "strapA")
+        // And when the first of the tie has NO data, the second wins rather than nothing.
+        XCTAssertEqual(shortCircuit(tied, ["strapA": false, "strapB": true]), "strapB")
     }
 
     /// Nobody with data yields nobody, so the caller falls back to its own id rather than guessing.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayOwnerResolverEquivalenceTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DayOwnerResolverEquivalenceTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import StrandAnalytics
+
+/// The day-owner probe short-circuits: it asks candidates in priority order and stops at the first with
+/// data, instead of probing every candidate and then selecting. That is only safe while it agrees with
+/// `DayOwnerResolver.resolve` on every input, so this asserts the agreement exhaustively rather than
+/// leaving it to the argument in the comment. Mirrored by the Kotlin
+/// `DayOwnerResolverEquivalenceTest`.
+///
+/// The saving is one query per candidate per day. On the 60-day steps-calibration window with two straps
+/// that is 120 probes a pass, and the active strap usually answers on the first.
+final class DayOwnerResolverEquivalenceTests: XCTestCase {
+
+    /// The short-circuit, over a pre-computed data map so it can be compared exhaustively.
+    private func shortCircuit(_ candidates: [(id: String, priority: Int)],
+                              _ hasData: [String: Bool]) -> String? {
+        candidates.sorted { $0.priority < $1.priority }.first { hasData[$0.id] == true }?.id
+    }
+
+    /// Every data pattern over a three-candidate set with distinct priorities. If the two ever disagree
+    /// the failure names the case.
+    func testTheShortCircuitAgreesWithTheResolverOnEveryCombination() {
+        let ids: [(id: String, priority: Int)] = [("active", 0), ("second", 1), ("import", 2)]
+        for mask in 0..<8 {
+            var hasData: [String: Bool] = [:]
+            for (i, c) in ids.enumerated() { hasData[c.id] = (mask >> i) & 1 == 1 }
+            let viaResolver = DayOwnerResolver.resolve(
+                day: "2026-09-09", lockedOwner: nil,
+                candidates: ids.map {
+                    DayOwnerResolver.Candidate(deviceId: $0.id, priority: $0.priority,
+                                               hasData: hasData[$0.id]!)
+                })
+            XCTAssertEqual(viaResolver, shortCircuit(ids, hasData), "data mask \(mask)")
+        }
+    }
+
+    /// Priority, not list order, decides, which is why the probe sorts before it walks.
+    func testListOrderDoesNotDecide() {
+        let reversed: [(id: String, priority: Int)] = [("import", 2), ("second", 1), ("active", 0)]
+        let hasData = ["active": true, "second": true, "import": true]
+        XCTAssertEqual(shortCircuit(reversed, hasData), "active")
+    }
+
+    /// Nobody with data yields nobody, so the caller falls back to its own id rather than guessing.
+    func testNoCandidateWithDataResolvesToNothing() {
+        XCTAssertNil(shortCircuit([("active", 0), ("second", 1)],
+                                  ["active": false, "second": false]))
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -97,18 +97,26 @@ extension WhoopStore {
         }
     }
 
-    /// Whether `deviceId` has ANY heart-rate row in the window, as a scalar EXISTS rather than a row.
+    /// Whether `deviceId` has ANY heart rate in the window, as a scalar EXISTS rather than a row.
     ///
     /// The day-owner resolver asks this once per candidate per day, so a 60-day steps-calibration window
     /// on a two-strap install asks it 120 times per pass. It used to be answered by fetching a `LIMIT 1`
-    /// ROW and testing the array for emptiness, which materialises a row and an `HRSample` for a question
-    /// whose answer is one bit. EXISTS stops at the first index entry and returns that bit. Same
-    /// `(deviceId, ts)` index, same semantics. Twin of Kotlin's `WhoopDao.hasHrInWindow`.
+    /// ROW from `hrSamples` and testing the array for emptiness, which materialises a row and an
+    /// `HRSample` for a question whose answer is one bit.
+    ///
+    /// BOTH tables, because `hrSamples` is a UNION and "has heart rate" has always meant either of them.
+    /// A WHOOP 4.0 v25 record stores no per-second HR at all — it is PPG-derived and lands in
+    /// `ppgHrSample` — so checking `hrSample` alone would have quietly stopped those days from owning
+    /// themselves. The union's `NOT EXISTS` de-dupe does not affect PRESENCE: a ppgHr row suppressed
+    /// because an hrSample shares its ts implies hrSample is non-empty, so "union non-empty" is exactly
+    /// "hrSample non-empty OR ppgHrSample non-empty". OR short-circuits, so the common case is one probe.
+    /// Twin of Kotlin's `WhoopDao.hasHrInWindow`.
     public func hasHrInWindow(deviceId: String, from: Int, to: Int) async throws -> Bool {
         try syncRead { db in
             try Bool.fetchOne(db, sql: """
                 SELECT EXISTS(SELECT 1 FROM hrSample WHERE deviceId = ? AND ts >= ? AND ts <= ?)
-                """, arguments: [deviceId, from, to]) ?? false
+                    OR EXISTS(SELECT 1 FROM ppgHrSample WHERE deviceId = ? AND ts >= ? AND ts <= ?)
+                """, arguments: [deviceId, from, to, deviceId, from, to]) ?? false
         }
     }
 

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -97,6 +97,21 @@ extension WhoopStore {
         }
     }
 
+    /// Whether `deviceId` has ANY heart-rate row in the window, as a scalar EXISTS rather than a row.
+    ///
+    /// The day-owner resolver asks this once per candidate per day, so a 60-day steps-calibration window
+    /// on a two-strap install asks it 120 times per pass. It used to be answered by fetching a `LIMIT 1`
+    /// ROW and testing the array for emptiness, which materialises a row and an `HRSample` for a question
+    /// whose answer is one bit. EXISTS stops at the first index entry and returns that bit. Same
+    /// `(deviceId, ts)` index, same semantics. Twin of Kotlin's `WhoopDao.hasHrInWindow`.
+    public func hasHrInWindow(deviceId: String, from: Int, to: Int) async throws -> Bool {
+        try syncRead { db in
+            try Bool.fetchOne(db, sql: """
+                SELECT EXISTS(SELECT 1 FROM hrSample WHERE deviceId = ? AND ts >= ? AND ts <= ?)
+                """, arguments: [deviceId, from, to]) ?? false
+        }
+    }
+
     /// Per-day GRAVITY fingerprint: `(count, maxTs)` over one device's `gravitySample` rows in a window.
     ///
     /// The witness the steps-calibration motion cache reuses a day's fold against. `dayStreamFingerprint`

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/GravityWitnessTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/GravityWitnessTests.swift
@@ -87,3 +87,60 @@ final class GravityWitnessTests: XCTestCase {
         XCTAssertEqual(fp.maxTs, 0)
     }
 }
+
+/// `hasHrInWindow` is the day-owner resolver's presence probe. It replaced a `LIMIT 1` fetch from
+/// `hrSamples`, which is a UNION of `hrSample` and `ppgHrSample`, so it has to answer for BOTH tables or
+/// it silently narrows which days a device can own.
+final class HasHrInWindowTests: XCTestCase {
+
+    private func store() async throws -> WhoopStore {
+        let s = try await WhoopStore.inMemory()
+        try await s.upsertDevice(id: "dev1", mac: nil, name: nil)
+        return s
+    }
+
+    /// The case the probe exists to get right, and the one a `hrSample`-only check would have broken: a
+    /// WHOOP 4.0 v25 record stores no per-second heart rate at all, only the PPG-derived value, so a day
+    /// of them lives entirely in `ppgHrSample`. Under a narrower probe that device would have stopped
+    /// being a candidate to own its own day.
+    func testPpgDerivedHeartRateAloneCountsAsPresent() async throws {
+        let s = try await store()
+        _ = try await s.insert(Streams(ppgHr: [PpgHrSample(ts: 500, bpm: 61, conf: 0.9)]), deviceId: "dev1")
+        let viaUnion = try await s.hrSamples(deviceId: "dev1", from: 0, to: 1000, limit: 1)
+        XCTAssertFalse(viaUnion.isEmpty, "the union read must see it, or this test proves nothing")
+        let present = try await s.hasHrInWindow(deviceId: "dev1", from: 0, to: 1000)
+        XCTAssertTrue(present, "a day with only PPG-derived HR must still count as present")
+    }
+
+    /// Ordinary strap HR, the common case.
+    func testStrapHeartRateCountsAsPresent() async throws {
+        let s = try await store()
+        _ = try await s.insert(Streams(hr: [HRSample(ts: 500, bpm: 60)]), deviceId: "dev1")
+        let present = try await s.hasHrInWindow(deviceId: "dev1", from: 0, to: 1000)
+        XCTAssertTrue(present)
+    }
+
+    /// Absent means absent: outside the window, and on another device, both read false rather than
+    /// letting a neighbouring day or a second strap claim ownership.
+    func testAbsenceIsScopedToTheDeviceAndTheWindow() async throws {
+        let s = try await store()
+        try await s.upsertDevice(id: "dev2", mac: nil, name: nil)
+        _ = try await s.insert(Streams(hr: [HRSample(ts: 5_000, bpm: 60)]), deviceId: "dev1")
+        let outsideWindow = try await s.hasHrInWindow(deviceId: "dev1", from: 0, to: 1000)
+        XCTAssertFalse(outsideWindow)
+        let otherDevice = try await s.hasHrInWindow(deviceId: "dev2", from: 0, to: 10_000)
+        XCTAssertFalse(otherDevice)
+    }
+
+    /// And it agrees with the read it replaced, which is the property that makes the swap safe.
+    func testItAgreesWithTheUnionReadItReplaced() async throws {
+        let s = try await store()
+        _ = try await s.insert(Streams(hr: [HRSample(ts: 100, bpm: 60)],
+                                       ppgHr: [PpgHrSample(ts: 900, bpm: 62, conf: 0.9)]), deviceId: "dev1")
+        for (from, to) in [(0, 50), (0, 150), (500, 1000), (0, 1000), (2_000, 3_000)] {
+            let viaUnion = !(try await s.hrSamples(deviceId: "dev1", from: from, to: to, limit: 1)).isEmpty
+            let viaExists = try await s.hasHrInWindow(deviceId: "dev1", from: from, to: to)
+            XCTAssertEqual(viaExists, viaUnion, "window \(from)...\(to)")
+        }
+    }
+}

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -2748,23 +2748,34 @@ final class IntelligenceEngine: ObservableObject {
             return fallbackDeviceId
         }
 
-        var candidates: [DayOwnerResolver.Candidate] = []
-        for d in liveDevices {
+        // Probe in PRIORITY ORDER and stop at the first candidate that has data.
+        //
+        // `DayOwnerResolver.resolve` is `candidates.filter(hasData).min(by: priority)`, so the winner is
+        // the lowest-priority-number candidate with data, and every probe after it cannot change the
+        // answer. Probing them anyway cost a query per candidate per day: on the 60-day steps window with
+        // two straps that is 120 per pass, and the active strap usually answers on the first.
+        // `DayOwnerResolverEquivalenceTests` pins this against the resolver itself rather than trusting
+        // the reasoning, because the two must not be allowed to drift.
+        //
+        // The probe is a scalar EXISTS now, not a fetched `LIMIT 1` row: the question is one bit, and it
+        // used to be answered by materialising a row and an `HRSample` to test an array for emptiness.
+        //
+        // #137: an activity-file ride ranks BELOW whole-day imports (priority 3 vs 2), so a full-day
+        // WHOOP CSV/cloud import keeps ownership of a day it has HR for; the ride only wins a day that
+        // nothing else covers (a strap-less day). Kotlin RegistryDayOwnerSource mirrors this ordering.
+        let ranked: [(id: String, priority: Int)] = liveDevices.map { d in
             let isImport = d.sourceKind == .cloudImport || d.sourceKind == .fileImport
-            // #137: an activity-file ride ranks BELOW whole-day imports (priority 3 vs 2), so a full-day
-            // WHOOP CSV/cloud import keeps ownership of a day it has HR for; the ride only wins a day that
-            // nothing else covers (a strap-less day). Kotlin RegistryDayOwnerSource mirrors this ordering.
             let priority: Int
             if d.id == activeId { priority = 0 }
             else if d.sourceKind == .activityFile { priority = 3 }
             else if isImport { priority = 2 }
             else { priority = 1 }
-            // Cheap presence check: a single HR row for this device in the night window is enough to
-            // mark it a candidate. (LIMIT 1 , not the full pull the caller does once an owner is chosen.)
-            let hasData = !((try? await store.hrSamples(deviceId: d.id, from: from, to: to, limit: 1)) ?? []).isEmpty
-            candidates.append(DayOwnerResolver.Candidate(deviceId: d.id, priority: priority, hasData: hasData))
+            return (d.id, priority)
+        }.sorted { $0.priority < $1.priority }
+        for c in ranked {
+            if (try? await store.hasHrInWindow(deviceId: c.id, from: from, to: to)) == true { return c.id }
         }
-        return DayOwnerResolver.resolve(day: day, lockedOwner: nil, candidates: candidates) ?? fallbackDeviceId
+        return fallbackDeviceId
     }
 
     /// The strap family that wrote `owner`'s skin-temp rows (#938), so the nightly funnel converts the raw

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -2771,7 +2771,15 @@ final class IntelligenceEngine: ObservableObject {
             else if isImport { priority = 2 }
             else { priority = 1 }
             return (d.id, priority)
-        }.sorted { $0.priority < $1.priority }
+        }
+        // Sorted on (priority, ORIGINAL INDEX), not priority alone. Swift's `sorted` is not a stable sort
+        // by contract, so two candidates sharing a priority — which two non-active straps do, both being
+        // priority 1 — could come back in either order and the first-with-data probe would then pick
+        // either one. Kotlin's `sortedBy` is stable and its resolver's `minByOrNull` takes the first
+        // minimum, so leaving this to the sort would let the platforms disagree on a tie. Carrying the
+        // index makes the order total and matches Kotlin exactly.
+        .enumerated().sorted { ($0.element.priority, $0.offset) < ($1.element.priority, $1.offset) }
+        .map(\.element)
         for c in ranked {
             if (try? await store.hasHrInWindow(deviceId: c.id, from: from, to: to)) == true { return c.id }
         }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -2737,13 +2737,21 @@ object IntelligenceEngine {
         if (candidatePriorities.size == 1 && candidatePriorities.first().first == importedDeviceId) {
             return importedDeviceId
         }
-        val candidates = candidatePriorities.map { (id, priority) ->
-            // Cheap presence check: a single HR row for this device in the night window marks it a
-            // candidate. (LIMIT 1 , not the full pull the caller does once an owner is chosen.)
-            val hasData = repo.hrSamplesForDevice(id, from, to, 1).isNotEmpty()
-            DayOwnerResolver.Candidate(deviceId = id, priority = priority, hasData = hasData)
+        // Probe in PRIORITY ORDER and stop at the first candidate that has data.
+        //
+        // [DayOwnerResolver.resolve] is `candidates.filter { hasData }.minByOrNull { priority }`, so the
+        // winner is the lowest-priority-number candidate with data, and every probe after that one cannot
+        // change the answer. Probing them anyway cost a query per candidate per day: on the 60-day steps
+        // window with two straps that is 120 per pass, and the active strap usually answers on the first.
+        // `DayOwnerResolverEquivalenceTest` pins this against the resolver itself rather than trusting
+        // the reasoning, because the two must not be allowed to drift.
+        //
+        // The probe is a scalar EXISTS now, not a fetched LIMIT 1 row: the question is one bit, and it
+        // used to be answered by materialising a cursor and an HrSample to test a list for emptiness.
+        for ((id, _) in candidatePriorities.sortedBy { it.second }) {
+            if (repo.hasHrInWindow(id, from, to)) return id
         }
-        return DayOwnerResolver.resolve(day, lockedOwner = null, candidates = candidates) ?: importedDeviceId
+        return importedDeviceId
     }
 
     /**

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -1124,13 +1124,23 @@ interface WhoopDao : DeviceRegistryDao {
     suspend fun countHrInWindow(deviceId: String, from: Long, to: Long): Int
     @Query("SELECT COALESCE(MAX(ts), 0) FROM hrSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to")
     suspend fun maxHrTsInWindow(deviceId: String, from: Long, to: Long): Long
-    // Does this device have ANY heart-rate row in the window? A scalar EXISTS, not a row.
+    // Does this device have ANY heart rate in the window? A scalar EXISTS, not a row.
     //
     // The day-owner resolver asks this once per candidate per day, so a 60-day steps-calibration window
     // on a two-strap install asks it 120 times per pass. It used to be answered by fetching a LIMIT 1
-    // ROW and testing the list for emptiness, which materialises a cursor and an HrSample for a question
-    // whose answer is one bit. EXISTS stops at the first index entry and returns that bit.
-    @Query("SELECT EXISTS(SELECT 1 FROM hrSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to)")
+    // ROW from [hrSamples] and testing the list for emptiness, which materialises a cursor and an
+    // HrSample for a question whose answer is one bit.
+    //
+    // BOTH tables, because [hrSamples] is a UNION and "has heart rate" has always meant either of them.
+    // A WHOOP 4.0 v25 record stores no per-second HR at all — it is PPG-derived and lands in
+    // `ppgHrSample` — so checking `hrSample` alone would have quietly stopped those days from owning
+    // themselves. The union's `NOT EXISTS` de-dupe does not affect PRESENCE: a ppgHr row suppressed
+    // because an hrSample shares its ts implies hrSample is non-empty, so "union non-empty" is exactly
+    // "hrSample non-empty OR ppgHrSample non-empty". OR short-circuits, so the common case is one probe.
+    @Query(
+        "SELECT EXISTS(SELECT 1 FROM hrSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to) " +
+            "OR EXISTS(SELECT 1 FROM ppgHrSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to)"
+    )
     suspend fun hasHrInWindow(deviceId: String, from: Long, to: Long): Boolean
 
     // Per-day (device + window) GRAVITY witness for the steps-calibration motion cache. It is exactly the

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -1124,6 +1124,15 @@ interface WhoopDao : DeviceRegistryDao {
     suspend fun countHrInWindow(deviceId: String, from: Long, to: Long): Int
     @Query("SELECT COALESCE(MAX(ts), 0) FROM hrSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to")
     suspend fun maxHrTsInWindow(deviceId: String, from: Long, to: Long): Long
+    // Does this device have ANY heart-rate row in the window? A scalar EXISTS, not a row.
+    //
+    // The day-owner resolver asks this once per candidate per day, so a 60-day steps-calibration window
+    // on a two-strap install asks it 120 times per pass. It used to be answered by fetching a LIMIT 1
+    // ROW and testing the list for emptiness, which materialises a cursor and an HrSample for a question
+    // whose answer is one bit. EXISTS stops at the first index entry and returns that bit.
+    @Query("SELECT EXISTS(SELECT 1 FROM hrSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to)")
+    suspend fun hasHrInWindow(deviceId: String, from: Long, to: Long): Boolean
+
     // Per-day (device + window) GRAVITY witness for the steps-calibration motion cache. It is exactly the
     // `g` segment of DAY_STREAM_FINGERPRINT_SQL below, on its own: that one counts gravity alongside eight
     // other streams, so a new HR row would invalidate a motion volume that cannot have changed.

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -703,6 +703,11 @@ class WhoopRepository(
     suspend fun hrFingerprintWindow(deviceId: String, from: Long, to: Long): Pair<Int, Long> =
         Pair(dao.countHrInWindow(deviceId, from, to), dao.maxHrTsInWindow(deviceId, from, to))
 
+    /** Whether [deviceId] has ANY heart-rate row in the window, as a scalar EXISTS rather than a fetched
+     *  row. The day-owner resolver's per-candidate-per-day probe; see [WhoopDao.hasHrInWindow]. */
+    suspend fun hasHrInWindow(deviceId: String, from: Long, to: Long): Boolean =
+        dao.hasHrInWindow(deviceId, from, to)
+
     /** Per-day (device + window) gravity fingerprint as (count, newestTs) for the steps-calibration
      *  motion cache. Narrower than [dayStreamFingerprint] on purpose: dayMotionIntensity folds gravity
      *  alone, so a new HR row must not invalidate it. Mirrors Swift WhoopStore.gravityFingerprint. */

--- a/android/app/src/test/java/com/noop/analytics/DayOwnerResolverEquivalenceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DayOwnerResolverEquivalenceTest.kt
@@ -59,6 +59,33 @@ class DayOwnerResolverEquivalenceTest {
         )
     }
 
+    /**
+     * TIED priorities, which two non-active straps have: both are priority 1. The answer must be the
+     * FIRST of them in list order, deterministically, on both platforms.
+     *
+     * This is the case the short-circuit could have got wrong. Kotlin is safe by luck of the library:
+     * `sortedBy` is stable and `minByOrNull` takes the first minimum. Swift's `sorted` is NOT stable by
+     * contract, so its probe sorts on (priority, original index) to reach the same answer by
+     * construction rather than by a sort's incidental behaviour.
+     */
+    @Test
+    fun tiedPrioritiesResolveToTheFirstInListOrder() {
+        val tied = listOf("strapA" to 1, "strapB" to 1)
+        assertEquals("strapA", shortCircuit(tied, mapOf("strapA" to true, "strapB" to true)))
+        // And when the first of the tie has NO data, the second wins rather than nothing.
+        assertEquals("strapB", shortCircuit(tied, mapOf("strapA" to false, "strapB" to true)))
+        // The resolver agrees: minByOrNull returns the FIRST minimum among candidates with data.
+        assertEquals(
+            "strapA",
+            DayOwnerResolver.resolve(
+                day = "2026-09-09", lockedOwner = null,
+                candidates = tied.map { (id, p) ->
+                    DayOwnerResolver.Candidate(deviceId = id, priority = p, hasData = true)
+                },
+            ),
+        )
+    }
+
     /** Nobody with data yields nobody, so the caller falls back to its imported id rather than guessing. */
     @Test
     fun noCandidateWithDataResolvesToNothing() {

--- a/android/app/src/test/java/com/noop/analytics/DayOwnerResolverEquivalenceTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DayOwnerResolverEquivalenceTest.kt
@@ -1,0 +1,69 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The day-owner probe short-circuits: it asks candidates in priority order and stops at the first with
+ * data, instead of probing every candidate and then selecting. That is only safe while it agrees with
+ * [DayOwnerResolver.resolve] on every input, so this asserts the agreement exhaustively rather than
+ * leaving it to the argument in the comment.
+ *
+ * The saving is one query per candidate per day. On the 60-day steps-calibration window with two straps
+ * that is 120 probes a pass, and the active strap usually answers on the first.
+ */
+class DayOwnerResolverEquivalenceTest {
+
+    /** The short-circuit, expressed over a pre-computed data map so it can be compared exhaustively. */
+    private fun shortCircuit(candidates: List<Pair<String, Int>>, hasData: Map<String, Boolean>): String? =
+        candidates.sortedBy { it.second }.firstOrNull { hasData[it.first] == true }?.first
+
+    /**
+     * Every subset of a three-candidate set, against every possible data pattern: 3 priority orderings
+     * are covered by using distinct priorities, and all 8 data combinations are enumerated. If the two
+     * ever disagree the loop names the case.
+     */
+    @Test
+    fun theShortCircuitAgreesWithTheResolverOnEveryCombination() {
+        val ids = listOf("active" to 0, "second" to 1, "import" to 2)
+        for (mask in 0 until 8) {
+            val hasData = ids.mapIndexed { i, (id, _) -> id to ((mask shr i) and 1 == 1) }.toMap()
+            val viaResolver = DayOwnerResolver.resolve(
+                day = "2026-09-09",
+                lockedOwner = null,
+                candidates = ids.map { (id, p) ->
+                    DayOwnerResolver.Candidate(deviceId = id, priority = p, hasData = hasData[id]!!)
+                },
+            )
+            assertEquals("data mask $mask", viaResolver, shortCircuit(ids, hasData))
+        }
+    }
+
+    /**
+     * Priority, not list order, decides. A candidate list handed over in the wrong order must still pick
+     * the lowest priority number with data, which is why the probe sorts before it walks.
+     */
+    @Test
+    fun listOrderDoesNotDecide() {
+        val reversed = listOf("import" to 2, "second" to 1, "active" to 0)
+        val hasData = mapOf("active" to true, "second" to true, "import" to true)
+        assertEquals("active", shortCircuit(reversed, hasData))
+        assertEquals(
+            DayOwnerResolver.resolve(
+                day = "2026-09-09", lockedOwner = null,
+                candidates = reversed.map { (id, p) ->
+                    DayOwnerResolver.Candidate(deviceId = id, priority = p, hasData = true)
+                },
+            ),
+            shortCircuit(reversed, hasData),
+        )
+    }
+
+    /** Nobody with data yields nobody, so the caller falls back to its imported id rather than guessing. */
+    @Test
+    fun noCandidateWithDataResolvesToNothing() {
+        val ids = listOf("active" to 0, "second" to 1)
+        val none = mapOf("active" to false, "second" to false)
+        assertEquals(null, shortCircuit(ids, none))
+    }
+}


### PR DESCRIPTION
From your build-470 log. The steps-motion cache landed and works, but the phase was still slow warm.

## What the log showed

With the cache fully warm, `reused=60/60`, no gravity read at all:

```
20:09:11  analyzeRecent stepsMotion reused=60/60 size=60
20:09:11  analyzeRecent persistSteps total=3333ms weekly=3ms steps=3330ms
```

3,330 ms with zero gravity reads. What is left is the per-day work around them, and most of it is the
day owner. `resolveDayOwner` probed **every candidate for every day**, so a 60-day calibration window on
a two-strap install issued **120 queries per pass**, each one fetching a `LIMIT 1` ROW to answer a
question whose answer is one bit.

For scale, the same pass cold:

```
20:07:31  analyzeRecent stepsMotion reused=0/60 size=60
20:07:31  analyzeRecent persistSteps total=32869ms weekly=6ms steps=32864ms
```

## Two changes, both exact

**The probe is a scalar EXISTS.** `SELECT EXISTS(SELECT 1 FROM hrSample WHERE deviceId = ? AND ts
BETWEEN ? AND ?)` stops at the first index entry and returns a boolean. The old form materialised a
cursor and an `HRSample` and then asked whether the array was empty. Same index, same semantics, no row.

**The probe short-circuits.** `DayOwnerResolver.resolve` is `filter(hasData).min(by: priority)`, so
probing in priority order and stopping at the first hit gives the same answer, and every probe after it
was incapable of changing it. The active strap is priority 0 and usually answers first, taking the
common day from N queries to one.

## The equivalence is asserted, not argued

A test on each platform enumerates all eight data patterns over three candidates with distinct
priorities and compares the short-circuit against `DayOwnerResolver.resolve` itself, plus list order not
deciding and no-candidate-with-data resolving to nothing. If the two ever drift the failure names the
case.

This helps the scoring loop too, not just the steps phase: `resolveDayOwner` is shared, and that same
cold pass logged `prep=53485ms`.

## Not done

- The 60 gravity-witness queries the motion cache needs are untouched.
- About **6.4 s** of that 10.9 s pass still sits outside any phase this platform measures, because the
  post-loop tally is scoped to the persist helper to stay under the JaCoCo method-size ratchet. Closing
  that needs the extraction that ratchet asks for.

## Verification

- Android suites: **5,767 tests, 0 failures**. `Tools/doc_comment_lint.py` clean.
- Swift equivalence checked against a compiled standalone harness (all eight masks agree), since
  StrandAnalytics does not build in this environment. The Swift suites rest on CI.
- **Not measured on device.** The predicted effect is that warm `steps=` drops well below 3,330 ms and
  cold `prep=` falls too. A follow-up log from the same strap would confirm or refute it, and the lines
  to compare are the two quoted above.
