### PR TITLE
Count the day-owner lookup that runs in front of the probe

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/StoreProbeTally.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/StoreProbeTally.swift
@@ -8,8 +8,13 @@ import Foundation
 /// the `#1538` day-loop tally, so the remaining candidates — the sixty per-day probe queries, the one
 /// `appleDaily` read, and the in-memory calibration fit — were indistinguishable from each other.
 ///
-/// Two probes are worth counting because each has exactly ONE call site, so the counts attribute themselves
-/// with no bookkeeping at the call site and no way to drift:
+/// Three lookups are worth counting, each measured one level down so the counts attribute themselves with
+/// no bookkeeping at the call site. `gravityFp` has exactly one caller; the other two are one-sidedly
+/// looser on Swift, where `resolveDayOwner` is also reached by a manual Test Centre skin-temp backfill and
+/// can land in a concurrent pass's line. The call count is what reveals that, which is one reason it
+/// prints. See `StoreProbeCounts`.
+/// - `dayOwner`: `DeviceRegistryStore.dayOwner`, the resolver's LOCKED-override lookup, which runs on every
+///   call ahead of any presence probe.
 /// - `ownerHr`: `hasHrInWindow`, the day-owner resolver's per-candidate presence probe. Runs in BOTH the
 ///   scoring loop and the sixty-day steps loop, and is skipped entirely on a default single-strap install
 ///   (#970), so a two-strap library is the only one that pays it.

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StoreProbeTallyTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/StoreProbeTallyTests.swift
@@ -43,4 +43,18 @@ final class StoreProbeTallyTests: XCTestCase {
         ])
         XCTAssertEqual(line, "analyzeRecent storeProbes total=0ms ownerHr=3/0ms gravityFp=1/0ms")
     }
+
+    /// The three-probe line as the engine actually renders it, pinned against the Kotlin twin's literal in
+    /// `StoreProbeTallyTest.dayOwnerAndOwnerHrAreCountedSeparately`. The shape matters as much as the
+    /// numbers: the LOOKUP and the PROBE are separate columns because collapsing them is what hid the
+    /// lookup, and `gravityFp` renders even at zero so a pass that never reached the steps loop says so.
+    func testThreeProbeLineMatchesTheKotlinTwin() {
+        let line = StoreProbeTally.logLine([
+            (name: "dayOwner", calls: 81, seconds: 1.62),
+            (name: "ownerHr", calls: 132, seconds: 0.132),
+            (name: "gravityFp", calls: 0, seconds: 0),
+        ])
+        XCTAssertEqual(line,
+                       "analyzeRecent storeProbes total=1752ms dayOwner=81/1620ms ownerHr=132/132ms gravityFp=0/0ms")
+    }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -118,7 +118,7 @@ extension WhoopStore {
         // most of these runs inside a detached task. One call site each makes the count unambiguous.
         // See `StoreProbeTally` (StrandAnalytics). Instrumentation only.
         let probeStarted = DispatchTime.now().uptimeNanoseconds
-        defer { probeCounts.ownerHr.record(nanos: DispatchTime.now().uptimeNanoseconds &- probeStarted) }
+        defer { StoreProbeRecorder.record(.ownerHr, nanos: DispatchTime.now().uptimeNanoseconds &- probeStarted) }
         return try syncRead { db in
             try Bool.fetchOne(db, sql: """
                 SELECT EXISTS(SELECT 1 FROM hrSample WHERE deviceId = ? AND ts >= ? AND ts <= ?)
@@ -138,7 +138,7 @@ extension WhoopStore {
     public func gravityFingerprint(deviceId: String, from: Int, to: Int) async throws -> (count: Int, maxTs: Int) {
         // Counted for the same reason as `hasHrInWindow` above; see `StoreProbeTally`.
         let probeStarted = DispatchTime.now().uptimeNanoseconds
-        defer { probeCounts.gravityFp.record(nanos: DispatchTime.now().uptimeNanoseconds &- probeStarted) }
+        defer { StoreProbeRecorder.record(.gravityFp, nanos: DispatchTime.now().uptimeNanoseconds &- probeStarted) }
         return try syncRead { db in
             guard let row = try Row.fetchOne(db, sql: """
                 SELECT COUNT(*) AS c, COALESCE(MAX(ts), 0) AS m FROM gravitySample

--- a/Packages/WhoopStore/Sources/WhoopStore/StoreProbeCounts.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/StoreProbeCounts.swift
@@ -1,17 +1,25 @@
-import Dispatch
 import Foundation
 
-/// Per-pass call/time counters for the two per-day PROBE reads, rendered by
+/// Per-pass call/time counters for the per-day lookups `analyzeRecent` makes, rendered by
 /// `StrandAnalytics.StoreProbeTally`. Twin of the Kotlin `StoreProbeTally` counters.
 ///
-/// Lives on the store because that is where each probe has exactly ONE call site, which is what makes the
-/// counts attribute themselves: `hasHrInWindow` is only ever the day-owner resolver's presence probe and
-/// `gravityFingerprint` only ever the steps loop's per-day motion witness. Counting at the call sites
-/// instead would mean threading an accumulator through a `nonisolated static` resolver and a detached task,
-/// and on Android through a method with no ratchet margin to spend.
+/// Counted one level down from the call sites, which is what makes the counts attribute themselves:
+/// counting at the call sites would mean threading an accumulator through a `nonisolated static` resolver
+/// and a detached task, and on Android through a method with no ratchet margin to spend.
 ///
-/// Actor-isolated by living on `WhoopStore`, so no lock and no `Sendable` gymnastics. Instrumentation only:
-/// nothing reads these but the diagnostic line.
+/// Drained per pass, which is exact for `gravityFingerprint` (the steps loop is its only caller) but NOT
+/// quite for the other two: `IntelligenceEngine.resolveDayOwner` has a second Swift caller in
+/// `SkinTempBackfillWalker`, a manual Test Centre action. Run it while a scoring pass is in flight and its
+/// lookups and presence probes land in that pass's line. The Kotlin twin's resolver is private to the
+/// engine, so this is one-sided as well as imprecise.
+///
+/// Left as-is deliberately: suppressing it would have to reach through the resolver into the store's own
+/// probe, and a global "stop counting" switch would UNDERCOUNT a genuine concurrent pass, which is the
+/// worse failure. The CALL COUNT is the tell instead, which is why it prints beside the time. A clean pass
+/// over a 21-day scoring window and a 60-day steps window resolves 81 owners; a line reporting many more
+/// than that had company, and should be read as contaminated rather than as a slow lookup.
+///
+/// Instrumentation only: nothing reads these but the diagnostic line.
 public struct StoreProbeCounts: Sendable, Equatable {
     /// One probe's calls and accumulated time.
     public struct Probe: Sendable, Equatable {
@@ -43,6 +51,11 @@ public struct StoreProbeCounts: Sendable, Equatable {
         }
     }
 
+    /// `DeviceRegistryStore.dayOwner` — the resolver's LOCKED-override lookup, which runs on every call
+    /// before any presence probe. Measured because the first cut of this instrumentation counted the probe
+    /// and not the lookup in front of it, so it reported the cheap half of owner resolution while a warm
+    /// pass still had seconds unaccounted for.
+    public var dayOwner = Probe()
     /// `hasHrInWindow` — the day-owner resolver's per-candidate presence probe, in BOTH the scoring loop
     /// and the sixty-day steps loop. Skipped entirely on a default single-strap install (#970).
     public var ownerHr = Probe()
@@ -52,12 +65,40 @@ public struct StoreProbeCounts: Sendable, Equatable {
     public init() {}
 }
 
-public extension WhoopStore {
+/// Process-wide recorder for `StoreProbeCounts`.
+///
+/// Nonisolated and lock-guarded rather than actor state, because the three call sites cannot share one
+/// isolation: `gravityFingerprint` and `hasHrInWindow` are `WhoopStore` actor methods, while the day-owner
+/// lookup runs inside `IntelligenceEngine.resolveDayOwner`, which is `nonisolated static` precisely so the
+/// day loop does not hop back to the main actor on every iteration. A recorder only the actor could reach
+/// would have measured two of the three and left the third invisible, which is the exact gap this round of
+/// instrumentation exists to close. It also makes the shape identical to the Kotlin twin's `object` of
+/// atomics rather than merely equivalent.
+public enum StoreProbeRecorder {
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var counts = StoreProbeCounts()
+
+    /// Which probe a measurement belongs to.
+    public enum Probe: Sendable { case dayOwner, ownerHr, gravityFp }
+
+    /// Record one call. `elapsed` must come from a monotonic source.
+    public static func record(_ probe: Probe, nanos elapsed: UInt64) {
+        lock.lock()
+        defer { lock.unlock() }
+        switch probe {
+        case .dayOwner: counts.dayOwner.record(nanos: elapsed)
+        case .ownerHr: counts.ownerHr.record(nanos: elapsed)
+        case .gravityFp: counts.gravityFp.record(nanos: elapsed)
+        }
+    }
+
     /// Read the counters and zero them, so a line describes ONE pass and never accumulates across the
     /// back-to-back passes an offload storm is made of.
-    func takeProbeCounts() -> StoreProbeCounts {
-        let counts = probeCounts
-        probeCounts = StoreProbeCounts()
-        return counts
+    public static func take() -> StoreProbeCounts {
+        lock.lock()
+        defer { lock.unlock() }
+        let taken = counts
+        counts = StoreProbeCounts()
+        return taken
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/WhoopStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/WhoopStore.swift
@@ -59,10 +59,6 @@ private actor StoreOpenGate {
 /// data or the query results.
 public actor WhoopStore {
 
-    /// Per-pass call/time counters for the two per-day PROBE reads, drained by `takeProbeCounts()`.
-    /// Instrumentation only — nothing reads them but a diagnostic line. See `StoreProbeCounts`.
-    var probeCounts = StoreProbeCounts()
-
     /// PPG waveform rows banked since its retention sweep last ran, PER DEVICE, for the same reason as
     /// `v18AuxRowsSincePrune` below: the sweep is per device, so a shared counter would let one strap
     /// spend another's budget. Separate counter from the v18 aux one because the two caps differ and a

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/StoreProbeCountsTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/StoreProbeCountsTests.swift
@@ -29,16 +29,30 @@ final class StoreProbeCountsTests: XCTestCase {
         XCTAssertEqual(probe.seconds, 0)
     }
 
-    /// `takeProbeCounts()` DRAINS. A line has to describe one pass, and the passes this runs under are the
+    /// `StoreProbeRecorder.take()` DRAINS. A line has to describe one pass, and the passes this runs under are the
     /// back-to-back ones an offload storm is made of, so a read that left the counters standing would make
     /// every pass after the first report its predecessors' work as its own.
     func testTakeDrainsSoAPassCannotInheritTheLastOne() async throws {
+        _ = StoreProbeRecorder.take()
         let store = try await WhoopStore.inMemory()
         _ = try? await store.hasHrInWindow(deviceId: "d", from: 0, to: 1)
-        let first = await store.takeProbeCounts()
+        let first = StoreProbeRecorder.take()
         XCTAssertEqual(first.ownerHr.calls, 1)
-        let second = await store.takeProbeCounts()
+        let second = StoreProbeRecorder.take()
         XCTAssertEqual(second.ownerHr.calls, 0)
         XCTAssertEqual(second.ownerHr.seconds, 0)
+    }
+
+    /// The day-owner LOOKUP is counted separately from the presence probe. They are different queries with
+    /// different costs, and collapsing them is what hid the lookup in the first place.
+    func testDayOwnerAndOwnerHrAreCountedSeparately() {
+        _ = StoreProbeRecorder.take()
+        StoreProbeRecorder.record(.dayOwner, nanos: 3_000_000)
+        StoreProbeRecorder.record(.ownerHr, nanos: 1_000_000)
+        let counts = StoreProbeRecorder.take()
+        XCTAssertEqual(counts.dayOwner.calls, 1)
+        XCTAssertEqual(counts.dayOwner.nanos, 3_000_000)
+        XCTAssertEqual(counts.ownerHr.calls, 1)
+        XCTAssertEqual(counts.gravityFp.calls, 0)
     }
 }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1,3 +1,4 @@
+import Dispatch
 import Foundation
 import Combine
 import WhoopProtocol
@@ -857,7 +858,7 @@ final class IntelligenceEngine: ObservableObject {
         // Zero the per-day probe counters so the line emitted after the steps phase describes THIS pass
         // and never accumulates across the back-to-back passes an offload storm is made of. Must precede
         // the day loop below, which is the scoring half of the owner probes. See `StoreProbeTally`.
-        _ = await store.takeProbeCounts()
+        _ = StoreProbeRecorder.take()
         // ── #1005 BATTERY: per-day reuse cache setup (see `dayScanCache`) ────────────────────────────
         // The stager toggles are read per-day inside the loop below, but they are global (same value every
         // day); read them ONCE here too so the config signature can fold them without reaching into the
@@ -2483,8 +2484,9 @@ final class IntelligenceEngine: ObservableObject {
         diagnosticSink?(stepsMotionLogLine, nil)
         // What the pass spent on its per-day probe queries, beside the `stepsMotion reused=N/M` line above.
         // Together they say whether a warm pass that folded nothing still went into the round trips.
-        let probeCounts = await store.takeProbeCounts()
+        let probeCounts = StoreProbeRecorder.take()
         diagnosticSink?(StoreProbeTally.logLine([
+            (name: "dayOwner", calls: probeCounts.dayOwner.calls, seconds: probeCounts.dayOwner.seconds),
             (name: "ownerHr", calls: probeCounts.ownerHr.calls, seconds: probeCounts.ownerHr.seconds),
             (name: "gravityFp", calls: probeCounts.gravityFp.calls, seconds: probeCounts.gravityFp.seconds),
         ]), nil)
@@ -2772,9 +2774,15 @@ final class IntelligenceEngine: ObservableObject {
                                             devices: [PairedDevice], activeId: String,
                                             registry: DeviceRegistryStore,
                                             fallbackDeviceId: String) async -> String {
-        // A locked override wins outright and skips the presence checks entirely.
-        if let locked = (try? registry.dayOwner(day))?.deviceId {
-            return locked
+        // A locked override wins outright and skips the presence checks entirely. Timed because it runs on
+        // EVERY call, ahead of any presence probe, and the first cut of this instrumentation counted only
+        // the probe: that reported the cheap half of owner resolution while a warm pass still had seconds
+        // unaccounted for. See `StoreProbeRecorder`.
+        let lockedStarted = DispatchTime.now().uptimeNanoseconds
+        let lockedOwner = (try? registry.dayOwner(day))?.deviceId
+        StoreProbeRecorder.record(.dayOwner, nanos: DispatchTime.now().uptimeNanoseconds &- lockedStarted)
+        if let lockedOwner {
+            return lockedOwner
         }
         // No registry rows (shouldn't happen , v15 seeds one , but be safe): keep the legacy id.
         guard !devices.isEmpty else { return fallbackDeviceId }

--- a/android/app/src/main/java/com/noop/analytics/StoreProbeTally.kt
+++ b/android/app/src/main/java/com/noop/analytics/StoreProbeTally.kt
@@ -13,8 +13,15 @@ import kotlin.math.roundToLong
  * the #1538 day-loop tally, so the remaining candidates — the sixty per-day probe queries, the one
  * `appleDaily` read, and the in-memory calibration fit — were indistinguishable from each other.
  *
- * Two probes are worth counting because each has exactly ONE call site, so the counts attribute themselves
- * with no bookkeeping at the call site and no way to drift:
+ * These are counted one level down rather than at the call site, so the counts attribute themselves with no
+ * bookkeeping. Every one of them has exactly ONE caller here, since [IntelligenceEngine.resolveDayOwner] is
+ * private to this object, so a Kotlin line describes exactly one pass. The Swift twin is one-sidedly
+ * looser: its resolver is also called by a manual Test Centre skin-temp backfill, which can land in a
+ * concurrent pass's line. The call count is what reveals that, which is one reason it prints.
+ * - `dayOwner`: [com.noop.data.DeviceRegistry.dayOwner], the resolver's LOCKED-override lookup, which runs
+ *   on every call before any presence probe. Measured because the first cut of this instrumentation counted
+ *   the probe and not the lookup in front of it, and so reported the cheap half of owner resolution while a
+ *   warm pass still had seconds unaccounted for.
  * - `ownerHr`: [com.noop.data.WhoopRepository.hasHrInWindow], the day-owner resolver's per-candidate
  *   presence probe. Runs in BOTH the scoring loop and the sixty-day steps loop, and is skipped entirely on
  *   a default single-strap install (#970), so a two-strap library is the only one that pays it.
@@ -35,10 +42,20 @@ import kotlin.math.roundToLong
  * Instrumentation only: nothing reads these counts but the log line.
  */
 object StoreProbeTally {
+    private val dayOwnerCalls = AtomicLong()
+    private val dayOwnerNanos = AtomicLong()
     private val ownerHrCalls = AtomicLong()
     private val ownerHrNanos = AtomicLong()
     private val gravityFpCalls = AtomicLong()
     private val gravityFpNanos = AtomicLong()
+
+    /** Record one day-owner LOCKED-override lookup. Runs on every resolver call, ahead of any presence
+     *  probe, and is counted separately because the first cut of this instrumentation counted only the
+     *  probe and so reported the cheap half of owner resolution. */
+    fun recordDayOwner(nanos: Long) {
+        dayOwnerCalls.incrementAndGet()
+        dayOwnerNanos.addAndGet(nanos)
+    }
 
     /** Record one day-owner HR presence probe. Called from the repository, off the pass's hot method. */
     fun recordOwnerHr(nanos: Long) {
@@ -55,6 +72,7 @@ object StoreProbeTally {
     /** Zero the counters at the start of a pass, so a line describes ONE pass and never accumulates across
      *  the back-to-back passes an offload storm is made of. */
     fun reset() {
+        dayOwnerCalls.set(0); dayOwnerNanos.set(0)
         ownerHrCalls.set(0); ownerHrNanos.set(0)
         gravityFpCalls.set(0); gravityFpNanos.set(0)
     }
@@ -62,6 +80,7 @@ object StoreProbeTally {
     /** This pass's line, in the shared format. */
     fun line(): String = logLine(
         listOf(
+            Triple("dayOwner", dayOwnerCalls.get(), dayOwnerNanos.get() / 1_000_000_000.0),
             Triple("ownerHr", ownerHrCalls.get(), ownerHrNanos.get() / 1_000_000_000.0),
             Triple("gravityFp", gravityFpCalls.get(), gravityFpNanos.get() / 1_000_000_000.0),
         )

--- a/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
+++ b/android/app/src/main/java/com/noop/data/DeviceRegistry.kt
@@ -231,5 +231,13 @@ class DeviceRegistry(
         dao.setDayOwner(DayOwnershipRow(day = day, deviceId = deviceId, locked = locked))
 
     /** The owner override for a day, or null if none. */
-    suspend fun dayOwner(day: String): DayOwnershipRow? = dao.dayOwner(day)
+    suspend fun dayOwner(day: String): DayOwnershipRow? {
+        // Timed here rather than at the call site, matching the other per-day probes: the resolver that
+        // drives these sits inside `analyzeRecentOnCpu`, which has no ratchet margin for a stopwatch.
+        // See StoreProbeTally. Instrumentation only.
+        val started = System.nanoTime()
+        val row = dao.dayOwner(day)
+        com.noop.analytics.StoreProbeTally.recordDayOwner(System.nanoTime() - started)
+        return row
+    }
 }

--- a/android/app/src/test/java/com/noop/analytics/StoreProbeTallyTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/StoreProbeTallyTest.kt
@@ -68,7 +68,7 @@ class StoreProbeTallyTest {
         StoreProbeTally.reset()
         repeat(60) { StoreProbeTally.recordGravityFp(20_000_000L) }
         assertEquals(
-            "analyzeRecent storeProbes total=1200ms ownerHr=0/0ms gravityFp=60/1200ms",
+            "analyzeRecent storeProbes total=1200ms dayOwner=0/0ms ownerHr=0/0ms gravityFp=60/1200ms",
             StoreProbeTally.line(),
         )
     }
@@ -84,7 +84,24 @@ class StoreProbeTallyTest {
         StoreProbeTally.recordOwnerHr(5_000_000L)
         StoreProbeTally.reset()
         assertEquals(
-            "analyzeRecent storeProbes total=0ms ownerHr=0/0ms gravityFp=0/0ms",
+            "analyzeRecent storeProbes total=0ms dayOwner=0/0ms ownerHr=0/0ms gravityFp=0/0ms",
+            StoreProbeTally.line(),
+        )
+    }
+
+    /**
+     * The LOCKED-override lookup is counted separately from the presence probe. They are different queries
+     * with different costs, and collapsing them is exactly what hid the lookup: the first cut counted the
+     * probe alone, reported it as nearly free, and left a warm pass with seconds unaccounted for. The Swift
+     * twin `StoreProbeCountsTests.testDayOwnerAndOwnerHrAreCountedSeparately` pins the same separation.
+     */
+    @Test
+    fun dayOwnerAndOwnerHrAreCountedSeparately() {
+        StoreProbeTally.reset()
+        repeat(81) { StoreProbeTally.recordDayOwner(20_000_000L) }
+        repeat(132) { StoreProbeTally.recordOwnerHr(1_000_000L) }
+        assertEquals(
+            "analyzeRecent storeProbes total=1752ms dayOwner=81/1620ms ownerHr=132/132ms gravityFp=0/0ms",
             StoreProbeTally.line(),
         )
     }


### PR DESCRIPTION
## What the log said

Build 472's new line answered what it was added to answer, and exposed what it could not see:

```
analyzeRecent storeProbes total=1592ms ownerHr=132/82ms gravityFp=60/1509ms
```

**`ownerHr` is 0.6ms a call.** The presence probe is free, so batching it, which is the change I would have built on reasoning alone, is not worth doing. That is the measurement earning its keep.

But a warm pass still spent seconds outside the two probes. The resolver's LOCKED-override lookup is why: it runs on **every** call, ahead of any presence probe, and was not counted. The line measured the cheap half of owner resolution and reported it as the whole.

## What this adds

`dayOwner` as its own column. One counter, one call site, no query changes.

Counting it needs one recorder rather than actor state, because the three call sites cannot share an isolation: two are `WhoopStore` actor methods and the third runs inside `resolveDayOwner`, which is `nonisolated static` precisely so the day loop does not hop to the main actor per iteration. A recorder only the actor could reach would have measured two of three and hidden the one this exists to find. It also makes the Swift shape identical to the Kotlin object of atomics rather than merely equivalent.

## Deliberately only that

The same log already shows `gravityFingerprint` at 25ms a call, sixty times a pass, which is worth collapsing into one grouped query per device. That change is **held back** until this line says whether the lookup or the witness holds the remaining seconds. Batching the witness first would optimise the smaller half on a guess, which is the mistake this instrumentation exists to prevent.

It is also a materially riskier change: a grouped query, day-bucket arithmetic that must match `midnightLocal` exactly, a fallback for locked owners the prefetch cannot know about, and two budget tests to repin. It deserves its own PR and its own review, against a number rather than a hypothesis.

## One imprecision, stated rather than hidden

The counters are process-wide and drained per pass, which is exact for `gravityFingerprint` (the steps loop is its only caller) but not quite for the other two. `resolveDayOwner` has a **second Swift caller**, `SkinTempBackfillWalker`, driven by a manual Test Centre action. Run that while a scoring pass is in flight and its lookups land in that pass's line. Kotlin's resolver is private to the engine, so this is one-sided as well as imprecise.

Left as-is deliberately. Suppressing it would have to reach through the resolver into the store's own probe, and a global "stop counting" switch would UNDERCOUNT a genuine concurrent pass, which is the worse failure. The **call count** is the tell instead, which is why it prints beside the time: a clean pass over a 21-day scoring window and a 60-day steps window resolves 81 owners, so a line reporting many more than that had company and should be read as contaminated rather than as a slow lookup.

## Tests

- Android green with `--no-build-cache`: 686 classes / **5785** tests / 0 failures, against a measured `main` baseline of 5784. Delta is exactly the one test added.
- Both platforms pin the same three-probe literal, `dayOwner=81/1620ms ownerHr=132/132ms gravityFp=0/0ms`, so a one-sided change to the column order or rendering fails a test rather than quietly making two logs incomparable.
- The drain is pinned on both sides, and the Swift test drains before it measures so a sibling test cannot leak into it.
- `Tools/doc_comment_lint.py` clean.

## Not verified here

`WhoopStore` and `StrandAnalytics` do not build under WSL, so the recorder and its test need CI. On device, the next warm pass tells us where the remaining seconds live.
