### PR TITLE
The vital detail chart follows the chart-style setting on both platforms

### DIFF
--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -564,6 +564,10 @@ struct MetricDetailView: View {
     // Effort display scale (#268) — routes the Effort metric's numbers + unit; display-only, the plotted
     // series stays 0–100. Every other metric is scale-agnostic (see MetricDescriptor.format).
     @AppStorage(UnitPrefs.effortScaleKey) private var effortScaleRaw = EffortScale.hundred.rawValue
+    /// Line vs bar for the hero chart, the same preference `TrendsView` reads. This view had never
+    /// consulted it, so a chosen `bar` drew a line here while the trend chart for the SAME metric drew
+    /// bars. Display-only: nothing about the plotted series changes.
+    @AppStorage(UnitPrefs.trendChartStyleKey) private var trendChartStyleRaw = TrendChartStyle.line.rawValue
     /// #1846/#1848: which skin-temp number the explorer leads with — absent/`""` = a temperature
     /// (the default), or `SkinTempDisplay.Kind.deviation.rawValue` to lead with the ±baseline move.
     /// Same key as Today/Health/Settings; display-only, nothing stored ever changes.
@@ -1214,6 +1218,11 @@ struct MetricDetailView: View {
                 gradient: metricGradient(metric),
                 valueRange: valueRange(windowed.map(\.value)),
                 showsArea: true,
+                // The chart-style setting, the same one `TrendsView` reads. This view had never consulted
+                // it, so a chosen `bar` drew a line here while the trend chart for the SAME metric drew
+                // bars. Kotlin's twin had the mirror-image gap and #2011 made it visible by forcing bars
+                // per metric; both now follow the setting alone.
+                showsBars: TrendChartStyle(rawValue: trendChartStyleRaw) == .bar,
                 height: NoopMetrics.chartHeight,
                 valueFormat: { fmt($0) }
             )

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2086,16 +2086,26 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                         color = Palette.textTertiary,
                     )
                 }
-                // #2008 follow-up: the daily SCORES are drawn as bars. A line asserts continuity between
-                // readings, and on a series swinging ~20 points a day that climb-and-dive through values
-                // which never existed is most of what reads as noise. One slot per DAY positions the bars
-                // by date and turns a missing day into an empty slot. Levels (resting HR, HRV, skin temp)
-                // stay lines: those really do vary continuously between measurements.
+                // BARS or a line is the user's chart-style setting, and nothing else. #2008's follow-up
+                // decided it per METRIC here, forcing bars for the daily scores because a line asserts a
+                // continuity a daily score never travelled. That reasoning holds and the slot layout below
+                // is unchanged, but this screen had never read the setting, so a chosen LINE drew bars and
+                // a chosen BAR drew lines for every other metric. Trends applies the same preference to
+                // every metric, so a detail chart reached from a Today ring now agrees with the trend chart
+                // for that metric instead of contradicting it. See `vitalChartIsBars`.
+                //
+                // Read on recompose exactly as Trends reads it: SharedPreferences is not reactive, and
+                // reaching Settings means leaving this screen, so returning re-reads it. `chartStyle` is a
+                // remember key so flipping the setting rebuilds or drops the slots rather than serving the
+                // previous shape.
+                //
+                // One slot per DAY positions bars by date and turns a missing day into an empty slot.
                 // Remembered like `dayLabels` beside it: densifying rebuilds a slot per day and formats a
-                // label for each, and on the ALL range that is hundreds of both. Recomputing them every
-                // recomposition is the cost this screen already avoids for the line path's derived lists.
-                val bars = remember(filteredReadings, key) {
-                    if (vitalChartIsBars(key)) densifyByDay(filteredReadings) else null
+                // label for each, and on the ALL range that is hundreds of both. The slot count follows the
+                // RANGE rather than the metric, so a sparse series costs no more than a daily one.
+                val chartStyle = UnitPrefs.trendChartStyle(LocalContext.current)
+                val bars = remember(filteredReadings, key, chartStyle) {
+                    if (vitalChartIsBars(chartStyle)) densifyByDay(filteredReadings) else null
                 }
                 val barValues = remember(bars) { bars?.map { it.second } }
                 val barLabels = remember(bars) { bars?.map { shortDayLabel(it.first) } }

--- a/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
@@ -85,21 +85,24 @@ internal fun dayEpochSeconds(readings: List<VitalReading>): List<Long>? {
 }
 
 /**
- * Which metrics are drawn as BARS rather than as a line.
+ * Whether this screen draws BARS rather than a line: the user's chart-style setting, and nothing else.
  *
- * A line asserts continuity between points: it says the value travelled from one reading to the next. For
- * a daily score that is false, and it is most of what makes a spiky series look chaotic. The reported
- * Effort swings 19.8 points a day on a 0..42 range, so a line spends the whole chart climbing and diving
- * through values that never existed.
+ * #2011 chose bars per METRIC instead, forcing them for the daily scores because a line asserts continuity
+ * between points and a daily score never travelled between its readings. The reasoning holds, but the rule
+ * did not: this screen had never consulted the setting at all, so the override made a chosen `LINE` draw
+ * bars anyway. It also left the inverse broken in the other direction, where a chosen `BAR` still got lines
+ * here for every metric outside those three.
  *
- * Bars claim nothing between slots. A zero day is a short bar beside a tall one instead of a plunge, and a
- * day with no reading is simply an empty slot.
+ * The setting is the setting. Trends already applies it to every metric ([TrendsScreen] reads the same
+ * preference), so a detail chart reached from a Today ring now agrees with the trend chart for the same
+ * metric rather than contradicting it.
  *
- * Only the daily SCORES. Resting HR, HRV, skin temperature, respiratory rate and blood oxygen are levels
- * that genuinely do vary continuously between measurements, so a line is the honest shape for them, and
- * Fitness Age and Vitality are too sparse to fill a bar chart.
+ * That leaves #2011's argument attached to the DEFAULT rather than to an override, which is where it can be
+ * acted on visibly: if bars really are the honest shape for a daily score, the default belongs on bars, in
+ * the picker, where the setting and the chart say the same thing. Overriding a user silently is not the
+ * same claim and should not be made on its behalf.
  */
-internal fun vitalChartIsBars(key: String): Boolean = key in setOf("recovery", "rest", "strain")
+internal fun vitalChartIsBars(style: TrendChartStyle): Boolean = style == TrendChartStyle.BAR
 
 /**
  * One slot per DAY across the window, rather than one per reading.

--- a/android/app/src/test/java/com/noop/ui/VitalBarChartTest.kt
+++ b/android/app/src/test/java/com/noop/ui/VitalBarChartTest.kt
@@ -7,30 +7,64 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Daily SCORES are drawn as bars. A line asserts continuity between readings, and on a series swinging
- * about twenty points a day that climb-and-dive through values which never existed is most of what reads
- * as noise. Bars claim nothing between slots.
+ * The vital detail chart's shape is the user's chart-style setting, and the day slots it lays bars on.
+ *
+ * #2011 decided the shape per METRIC instead, forcing bars for the daily scores because a line asserts
+ * continuity between readings that a daily score never travelled. The reasoning holds and the slot layout
+ * below is unchanged; the rule did not, because this screen had never read the setting at all. A chosen
+ * LINE drew bars, and a chosen BAR drew lines for every metric outside those three.
  */
 class VitalBarChartTest {
 
     private fun reading(day: String, value: Double) = VitalReading(day, value, "dev")
 
+    /**
+     * The reported regression. #2011 forced bars for the daily scores per METRIC, and this screen had never
+     * read the chart-style setting, so a chosen LINE drew bars anyway. A chosen LINE means lines, including
+     * for the three metrics that override used to capture.
+     */
     @Test
-    fun `the daily scores are bars`() {
-        assertTrue(vitalChartIsBars("strain"))
-        assertTrue(vitalChartIsBars("rest"))
-        assertTrue(vitalChartIsBars("recovery"))
+    fun `a chosen line draws lines, including for the daily scores`() {
+        assertFalse(vitalChartIsBars(TrendChartStyle.LINE))
     }
 
     /**
-     * Levels stay lines. Resting HR, HRV, skin temperature, respiratory rate and blood oxygen genuinely do
-     * vary continuously between measurements, so a connecting line is the honest shape for them; drawing
-     * them as bars would be the mirror of the mistake this corrects.
+     * The inverse, which was broken in the other direction and reported by nobody: a chosen BAR drew lines
+     * here for every metric outside those three, while Trends drew bars for the same metric.
      */
     @Test
-    fun `levels and sparse series stay lines`() {
-        listOf("rhr", "hrv", "skin", "resp", "spo2", "fitness_age", "vitality", "vo2max_est")
-            .forEach { assertFalse(it, vitalChartIsBars(it)) }
+    fun `a chosen bar draws bars`() {
+        assertTrue(vitalChartIsBars(TrendChartStyle.BAR))
+    }
+
+    /**
+     * The METRIC does not decide any more. Pinned as an enumeration rather than as one call, because the
+     * failure this guards is a future re-introduction of a per-metric override beside the setting: the
+     * daily scores and the levels have to answer the same way for the same style, or the setting is only
+     * being honoured for some of the screen.
+     */
+    @Test
+    fun `the metric no longer decides`() {
+        val keys = listOf(
+            "strain", "rest", "recovery",
+            "rhr", "hrv", "skin", "resp", "spo2", "fitness_age", "vitality", "vo2max_est",
+        )
+        for (style in TrendChartStyle.entries) {
+            val expected = style == TrendChartStyle.BAR
+            keys.forEach { assertEquals("$it under $style", expected, vitalChartIsBars(style)) }
+        }
+    }
+
+    /**
+     * An unset preference resolves to LINE, so an install that never opened the picker gets lines. That is
+     * the deliberate cost of honouring the setting: #2011's argument that a daily score never travelled
+     * between its readings now belongs to the DEFAULT, where it can be changed visibly in the picker, and
+     * not to an override that contradicts what the picker says.
+     */
+    @Test
+    fun `an unset preference resolves to line`() {
+        assertEquals(TrendChartStyle.LINE, TrendChartStyle.fromRaw(null))
+        assertFalse(vitalChartIsBars(TrendChartStyle.fromRaw(null)))
     }
 
     // --- one slot per day ---


### PR DESCRIPTION
## Reported

Pick **Line** in Settings, tap a ring on Today, and the detail chart draws bars anyway.

## Cause

This screen had never read the chart-style setting. It is honoured in exactly one place, `TrendsScreen.kt:852`, and the detail chart simply always drew a line, which happened to match Line and silently ignored Bar. The earlier daily-scores change then chose the shape per METRIC here:

```kotlin
internal fun vitalChartIsBars(key: String): Boolean = key in setOf("recovery", "rest", "strain")
```

No setting consulted. That turned a dormant gap into a visible contradiction: the picker says Line and the chart draws bars.

**The inverse was broken the whole time**, and nobody reported it because it fails quietly in the direction people do not notice. A reader who picked Bar got lines on this screen for every metric outside those three, while the trend chart for the same metric drew bars.

## Change

The setting decides, and the metric does not:

```kotlin
internal fun vitalChartIsBars(style: TrendChartStyle): Boolean = style == TrendChartStyle.BAR
```

Trends already applies the preference to every metric, so a detail chart reached from a ring now agrees with the trend chart for that metric rather than contradicting it. `chartStyle` is a remember key, so flipping the setting rebuilds or drops the slots instead of serving the previous shape.

**iOS had the same gap**, and no equivalent of the override since that change was Android only: `MetricExplorerView` never consulted the preference, so a chosen Bar drew a line there too. `TrendChart` already takes `showsBars`, so this is one rule expressed once per platform rather than two behaviours.

## What is deliberately NOT changed

The argument for bars is a good one: a line asserts travel between readings that a daily score never made, and on Effort swinging about twenty points a day that is most of what reads as noise. That argument is not discarded, it moves to where it can be acted on.

If a line really does misrepresent a daily score, the honest response is to change the **default** to bars, visibly, in the picker, where the setting and the chart say the same thing. Overriding a reader who chose otherwise is a different claim. The default is left alone here because it is global and would move Trends too, so it wants its own decision.

A three-state preference (unset / line / bar) was considered and rejected: the picker reads the collapsing accessor, so an untouched install would see **Line already selected** while drawing bars. Making that honest needs a visible third option with its own label and localisation, which is a bigger change than the reported bug warrants.

## Scope, stated plainly

The setting is labelled **"Trend charts"** on both platforms, which is broader than the internal comments assume ("the Trends tab"). After this change two screens honour it, Trends and the vital detail, and both draw the same kind of thing: a metric's day-over-day trend across a range.

Ten other chart call sites on Android and six on iOS still ignore it. That is deliberate rather than overlooked, and blanket application is not obviously right: `WorkoutsScreen`'s chart is an HR curve over a session window, an intraday trace where the value genuinely does travel between samples, so bars would misrepresent it in exactly the way a line misrepresents a daily score. The same choice does not mean the same thing on an intraday trace as on a day-over-day series.

Those sites also do not contradict anything today. They always drew lines, so a reader who picked Line sees what they asked for; only a Bar reader is quietly given a line, which is the same class of gap this addresses but was not reported and needs its own decision about which charts the setting is meant to govern.

## Known residual

The two screens still lay bars out differently. The detail chart densifies to one slot per DAY so bars position by date, while Trends draws one bar per reading and disables selection so a dense window mean-bins. That predates this change and is out of scope. The slot count follows the RANGE rather than the metric, so extending bars to sparser series costs no more than the daily ones already did.

## Tests

Repinned rather than deleted, since the invariant moved rather than disappeared:

- a chosen Line draws lines, **including for the daily scores** (the reported regression)
- a chosen Bar draws bars (the unreported inverse)
- the metric key no longer changes the answer, enumerated across every key and both styles, so a future per-metric override beside the setting fails a test
- an unset preference resolves to Line, pinning the deliberate cost above

Android green with `--no-build-cache`: 686 classes / 5787 tests / 0 failures, against a measured `main` baseline of 5785. `Tools/doc_comment_lint.py` clean.

## Not verified here

The iOS half needs CI, and both halves want an eyeball on device: set Line, open a ring, confirm lines; set Bar, confirm bars on a metric outside the three.
