### PR TITLE
Annotate the HRV and resting-HR detail charts with the personal baseline

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/TrendChart.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/TrendChart.swift
@@ -45,6 +45,13 @@ public struct TrendChart: View {
     /// filled `BarMark` per (down-sampled) sample. Display-only — the plotted series is identical; only
     /// the mark geometry changes. Default false (the classic line). `showsArea` is ignored in bar mode.
     public var showsBars: Bool
+
+    /// Optional personal-baseline reference, drawn as a dashed rule UNDER the series.
+    ///
+    /// A reference the readings are judged against, not a second series, so it is dashed and faint. Nil
+    /// (the default) draws nothing, and the rule rides the chart's own y domain, so a value outside the
+    /// plotted range simply falls off it rather than being clamped to an edge it does not sit on.
+    public var baselineValue: Double?
     public var height: CGFloat
     /// Whether hovering reveals a crosshair + tooltip for the nearest point.
     public var showsHover: Bool
@@ -79,6 +86,7 @@ public struct TrendChart: View {
         valueRange: ClosedRange<Double> = 0...100,
         showsArea: Bool = true,
         showsBars: Bool = false,
+        baselineValue: Double? = nil,
         height: CGFloat = 220,
         showsHover: Bool = true,
         valueFormat: @escaping (Double) -> String = { String(Int($0.rounded())) },
@@ -93,6 +101,7 @@ public struct TrendChart: View {
         self.valueRange = valueRange
         self.showsArea = showsArea
         self.showsBars = showsBars
+        self.baselineValue = baselineValue
         self.height = height
         self.showsHover = showsHover
         self.valueFormat = valueFormat
@@ -182,6 +191,11 @@ public struct TrendChart: View {
 
     public var body: some View {
         Chart {
+            if let baselineValue {
+                RuleMark(y: .value("Baseline", baselineValue))
+                    .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 4]))
+                    .foregroundStyle(.secondary.opacity(0.45))
+            }
             if showsBars {
                 // Bar mode: one value-ramp-filled BarMark per (down-sampled) sample, from the baseline.
                 // The line, area and point marks are all replaced. The same `displayPoints` feed it, so a

--- a/Strand/Screens/MetricExplorerView.swift
+++ b/Strand/Screens/MetricExplorerView.swift
@@ -720,6 +720,29 @@ struct MetricDetailView: View {
         }
     }
 
+    /// The personal baseline to annotate the chart with, or nil when there is not one worth drawing.
+    ///
+    /// HRV and resting HR only: both are levels whose absolute number means little without the reader's
+    /// own normal, while the daily scores are already interpretable on their own ranges and skin
+    /// temperature has its own signed-deviation view. Folded over the FULL history rather than the
+    /// visible window, because the reference is the reader's normal and does not change because they
+    /// narrowed the range. Nil until the state is TRUSTED, which is at least fourteen valid nights and
+    /// not stale: a rule folded from four would be a guess wearing the authority of a reference line.
+    ///
+    /// Same fold `VitalBands` bands against, so a reading the grid calls out of range cannot sit on the
+    /// comfortable side of the rule. Twin of Kotlin `vitalBaseline`.
+    private var personalBaseline: Double? {
+        let cfg: MetricCfg?
+        switch metric.key {
+        case "hrv": cfg = Baselines.hrvCfg
+        case "rhr": cfg = Baselines.restingHRCfg
+        default: cfg = nil
+        }
+        guard let cfg else { return nil }
+        let state = Baselines.foldHistory(series.map { $0.value }, cfg: cfg)
+        return state.trusted ? state.baseline : nil
+    }
+
     /// Padded value range so the line never sits flush against an axis.
     private func valueRange(_ windowValues: [Double]) -> ClosedRange<Double> {
         let v = windowValues
@@ -1223,6 +1246,7 @@ struct MetricDetailView: View {
                 // bars. Kotlin's twin had the mirror-image gap and #2011 made it visible by forcing bars
                 // per metric; both now follow the setting alone.
                 showsBars: TrendChartStyle(rawValue: trendChartStyleRaw) == .bar,
+                baselineValue: personalBaseline,
                 height: NoopMetrics.chartHeight,
                 valueFormat: { fmt($0) }
             )

--- a/android/app/src/main/java/com/noop/ui/Charts.kt
+++ b/android/app/src/main/java/com/noop/ui/Charts.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.nativeCanvas
@@ -115,17 +116,62 @@ internal fun pointsFor(
 ): List<Offset> {
     val clean = values.filter { it.isFinite() }
     if (clean.size < 2 || width <= 0f || height <= 0f) return emptyList()
+    val (lo, hi) = yBounds(clean, yDomain) ?: return emptyList()
+    return pointsFor(clean, width, height, topPad, bottomPad, timestamps, lo, hi)
+}
+
+/**
+ * The value range a chart plots into, shared by the series and by anything drawn ON the same scale.
+ *
+ * Extracted rather than repeated so a reference rule cannot drift from the series it annotates: a rule
+ * computed against its own bounds would sit at a plausible-looking wrong height the moment either copy
+ * changed, and nothing about the picture would say so.
+ *
+ * [values] must already be finite-filtered. Returns null when there is nothing to scale.
+ */
+internal fun yBounds(
+    values: List<Double>,
+    yDomain: ClosedFloatingPointRange<Double>?,
+): Pair<Double, Double>? {
+    if (values.isEmpty()) return null
     // A supplied domain never HIDES a reading: it widens to contain anything outside it, so anchoring can
     // only ever change the scale, never clip a value off the chart.
-    val lo = yDomain?.let { minOf(it.start, clean.min()) } ?: clean.min()
-    var hi = yDomain?.let { maxOf(it.endInclusive, clean.max()) } ?: clean.max()
+    val lo = yDomain?.let { minOf(it.start, values.min()) } ?: values.min()
+    var hi = yDomain?.let { maxOf(it.endInclusive, values.max()) } ?: values.max()
     // A series that is entirely flat AT the supplied floor would otherwise have zero span, and the
     // zero-span fallback puts a flat line mid-chart. That is right when the scale came from the data
     // (a steady 70bpm belongs in the middle) and wrong when a floor was asked for: an all-zero Effort
     // week must sit ON the floor, which is the whole property the floor exists to give. Widening by one
     // unit puts it there. Only when a domain was supplied, so auto-scaled charts keep their behaviour.
     if (yDomain != null && hi <= lo) hi = lo + 1.0
-    return pointsFor(clean, width, height, topPad, bottomPad, timestamps, lo, hi)
+    return lo to hi
+}
+
+/**
+ * The y pixel for one [value] under the same scale [pointsFor] gives the series, or null when the value
+ * falls outside the plotted range.
+ *
+ * Null rather than a clamped edge on purpose: a rule pinned to the top or bottom of the plot would read as
+ * "your baseline is the highest value here", which is a different claim from "your baseline is off this
+ * chart". Drawing nothing says the second honestly.
+ */
+internal fun yForValue(
+    value: Double,
+    values: List<Double>,
+    height: Float,
+    topPad: Float,
+    bottomPad: Float,
+    yDomain: ClosedFloatingPointRange<Double>? = null,
+): Float? {
+    if (!value.isFinite() || height <= 0f) return null
+    val clean = values.filter { it.isFinite() }
+    if (clean.size < 2) return null
+    val (lo, hi) = yBounds(clean, yDomain) ?: return null
+    if (value < lo || value > hi) return null
+    val span = hi - lo
+    val usableH = (height - topPad - bottomPad).coerceAtLeast(1f)
+    val norm = if (span > 0.0) ((value - lo) / span).toFloat() else 0.5f
+    return topPad + (1f - norm) * usableH
 }
 
 private fun pointsFor(
@@ -150,6 +196,22 @@ private fun pointsFor(
         val y = topPad + (1f - norm) * usableH
         Offset(x, y)
     }
+}
+
+/**
+ * A dashed horizontal rule at [y], for a personal-baseline reference drawn UNDER the series.
+ *
+ * Dashed and faint on purpose: it is a reference the readings are judged against, not a second series. A
+ * solid stroke at the line's own weight would read as data.
+ */
+private fun DrawScope.drawReferenceRule(y: Float, color: Color) {
+    drawLine(
+        color = color,
+        start = Offset(0f, y),
+        end = Offset(size.width, y),
+        strokeWidth = 1f,
+        pathEffect = PathEffect.dashPathEffect(floatArrayOf(6f, 6f), 0f),
+    )
 }
 
 /** Draw the faint zero/empty baseline used when there is nothing to plot. */
@@ -284,6 +346,10 @@ fun LineChart(
      * Opt-in, so the dense live charts (HR at 1 Hz) are untouched, where a dot per sample would be noise.
      */
     showsPoints: Boolean = false,
+    // Optional personal-baseline reference, drawn as a dashed rule under the series. Null (the default)
+    // draws nothing, so every existing caller is byte-identical. A value outside the plotted range draws
+    // nothing either: `yForValue` returns null rather than clamping a rule to an edge it does not sit on.
+    baselineValue: Double? = null,
 ) {
     val cleanValues = remember(values) { values.filter { it.isFinite() } }
     // Timestamps filtered by the SAME finiteness cut as cleanValues so indices stay aligned;
@@ -393,6 +459,11 @@ fun LineChart(
                     val topPad = strokePx + 4f
                     val bottomPad = strokePx + 4f
                     val pts = pointsFor(cleanValues, size.width, size.height, topPad, bottomPad, yDomain, cleanTimestamps)
+                    // Same bounds as the series, through the same helper, so the rule cannot end up at a
+                    // plausible-looking wrong height if either scale ever changes.
+                    val baselineY = baselineValue?.let {
+                        yForValue(it, cleanValues, size.height, topPad, bottomPad, yDomain)
+                    }
                     if (pts.isEmpty()) {
                         onDrawBehind { drawBaseline() }
                     } else {
@@ -429,6 +500,9 @@ fun LineChart(
                         }
                         val lineStroke = Stroke(width = strokePx, cap = StrokeCap.Round, join = StrokeJoin.Round)
                         onDrawBehind {
+                            // Under the fill and the line: the rule annotates the series rather than
+                            // competing with it.
+                            if (baselineY != null) drawReferenceRule(baselineY, Palette.hairlineStrong)
                             // Soft gradient fill under the curve.
                             if (fillBrush != null) {
                                 for (path in fillPaths) drawPath(path = path, brush = fillBrush)
@@ -636,6 +710,11 @@ fun BarChart(
     // non-integer — so a metric whose headline is rounded answered "72.4" on tap against a "72" beside
     // it. Same parameter, same default, same fallback as LineChart's.
     formatValue: ((Double) -> String)? = null,
+    // Optional personal-baseline reference, drawn as a dashed rule under the bars. Mapped on the BAR
+    // scale, which is zero-based (`v / maxV`) rather than the line chart's min..max: a rule placed by the
+    // line chart's arithmetic would sit at a confidently wrong height here. Null draws nothing, and so
+    // does a value outside 0..maxV, for the same reason `yForValue` refuses to clamp one to an edge.
+    baselineValue: Double? = null,
 ) {
     val cleanValues = remember(values) { values.map { if (it.isFinite() && it > 0.0) it else 0.0 } }
     // The cleaned list flattens a non-finite value to 0.0 so it draws nothing, which is right for the
@@ -722,6 +801,9 @@ fun BarChart(
                 } else {
                     val topPad = 4f
                     val usableH = (h - topPad).coerceAtLeast(1f)
+                    val baselineY = baselineValue
+                        ?.takeIf { it.isFinite() && it >= 0.0 && it <= maxV }
+                        ?.let { h - ((it / maxV).toFloat().coerceIn(0f, 1f) * usableH) }
                     val slot = w / clean.size
                     val barWidth = (slot * 0.64f).coerceAtLeast(1f)
                     val capRadius = (barWidth / 2f)
@@ -737,6 +819,8 @@ fun BarChart(
                         bars.add(BarSeg(cx, top))
                     }
                     onDrawBehind {
+                        // Under the bars, for the same reason as the line chart's: a reference, not data.
+                        if (baselineY != null) drawReferenceRule(baselineY, Palette.hairlineStrong)
                         bars.forEachIndexed { i, seg ->
                             drawLine(
                                 color = if (selectionEnabled && i == selectedIndex) color else unselectedColor,

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -2104,6 +2104,10 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                 // label for each, and on the ALL range that is hundreds of both. The slot count follows the
                 // RANGE rather than the metric, so a sparse series costs no more than a daily one.
                 val chartStyle = UnitPrefs.trendChartStyle(LocalContext.current)
+                // Folded over the FULL history, not the visible window: the reference is the reader's
+                // normal, which does not change because they narrowed the range to a week. Null for every
+                // metric but HRV and resting HR, and null until the baseline is trusted.
+                val baseline = remember(detail.readings, key) { vitalBaseline(key, detail.readings) }
                 val bars = remember(filteredReadings, key, chartStyle) {
                     if (vitalChartIsBars(chartStyle)) densifyByDay(filteredReadings) else null
                 }
@@ -2111,6 +2115,7 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                 val barLabels = remember(bars) { bars?.map { shortDayLabel(it.first) } }
                 if (barValues != null && barLabels != null) {
                     BarChart(
+                        baselineValue = baseline,
                         values = barValues,
                         modifier = Modifier.height(Metrics.chartHeight),
                         color = detail.color,
@@ -2153,6 +2158,7 @@ fun VitalDetailScreen(vm: AppViewModel, key: String) {
                     // Anchor the metrics whose natural range IS their interesting range, so a calm one
                     // stops being drawn as violently as a wild one.
                     yDomain = vitalChartYDomain(key),
+                    baselineValue = baseline,
                     // A daily trend has few enough readings for a marker each, and they are what say where
                     // the measurements actually are once gaps stretch the line between them.
                     showsPoints = true,

--- a/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthVitalDetailLogic.kt
@@ -1,5 +1,6 @@
 package com.noop.ui
 
+import com.noop.analytics.Baselines
 import com.noop.data.Vo2MaxEstimator
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -82,6 +83,34 @@ internal fun dayEpochSeconds(readings: List<VitalReading>): List<Long>? {
         out += day.toEpochDay() * 86_400L
     }
     return out
+}
+
+/**
+ * The personal baseline to annotate a vital chart with, or null when there is not one worth drawing.
+ *
+ * HRV and resting HR only. Both are LEVELS whose absolute number means little without the reader's own
+ * normal: "HRV 42" says nothing on its own, while "42, and your baseline is 54" says the thing they came
+ * to find out. The daily scores need no such reference, since 0..100 and 0..21 are already interpretable,
+ * and skin temperature already offers a signed deviation view of its own.
+ *
+ * The SAME fold the vitals grid bands against ([VitalBands.band] calls `Baselines.foldHistory` with this
+ * cfg), so a reading the grid calls out of range cannot sit on the right side of the rule on the chart
+ * next to it. One definition of "your normal" or the two surfaces will disagree in front of the reader.
+ *
+ * Null unless the state is TRUSTED, which is at least fourteen valid nights and not stale. A rule drawn
+ * from four nights would be a guess wearing the authority of a reference line, and the calibrating case
+ * is exactly when a reader is most likely to over-read it. Values arrive oldest to newest, which is what
+ * the EWMA fold expects, and what `ORDER BY day ASC` gives.
+ */
+internal fun vitalBaseline(key: String, readings: List<VitalReading>): Double? {
+    val cfgKey = when (key) {
+        "hrv" -> "hrv"
+        "rhr" -> "resting_hr"
+        else -> return null
+    }
+    val cfg = Baselines.metricCfg[cfgKey] ?: return null
+    val state = Baselines.foldHistory(readings.map { it.value }, cfg)
+    return if (state.trusted) state.baseline else null
 }
 
 /**

--- a/android/app/src/test/java/com/noop/ui/VitalBaselineLineTest.kt
+++ b/android/app/src/test/java/com/noop/ui/VitalBaselineLineTest.kt
@@ -1,0 +1,131 @@
+package com.noop.ui
+
+import com.noop.analytics.Baselines
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The personal-baseline reference rule on the HRV and resting-HR detail charts.
+ *
+ * Two properties matter and they fail in different ways. The rule has to come from the SAME fold the
+ * vitals grid bands against, or a reading the grid calls out of range can sit on the comfortable side of
+ * the rule on the chart beside it. And it has to be placed by the SAME scale as the series, or it sits at
+ * a confidently wrong height that nothing in the picture contradicts.
+ */
+class VitalBaselineLineTest {
+
+    private fun reading(day: String, value: Double) = VitalReading(day, value, "dev")
+
+    /** Enough nights for the fold to reach TRUSTED, around a steady centre. */
+    private fun steady(n: Int, value: Double) =
+        (1..n).map { reading("2026-01-%02d".format(it), value) }
+
+    // --- which metrics get a rule ---
+
+    /**
+     * HRV and resting HR are levels whose absolute number means little without the reader's own normal.
+     * The daily scores are already interpretable on their own ranges, and skin temperature has its own
+     * signed-deviation view, so neither gets a rule that would only add furniture.
+     */
+    @Test
+    fun `only hrv and resting hr get a baseline`() {
+        val history = steady(30, 60.0)
+        assertNotNull(vitalBaseline("hrv", history))
+        assertNotNull(vitalBaseline("rhr", history))
+        listOf("recovery", "rest", "strain", "skin", "resp", "spo2", "fitness_age", "vitality")
+            .forEach { assertNull(it, vitalBaseline(it, history)) }
+    }
+
+    /**
+     * `rhr` on this screen is `resting_hr` in the baseline configs. Pinned because the two names differ
+     * and a silent miss returns null, which looks exactly like "not trusted yet" rather than like a bug.
+     */
+    @Test
+    fun `the rhr key maps to the resting hr config`() {
+        assertNotNull(Baselines.metricCfg["resting_hr"])
+        assertNotNull("rhr must resolve through resting_hr", vitalBaseline("rhr", steady(30, 55.0)))
+    }
+
+    // --- when it is honest to draw one ---
+
+    /**
+     * A rule folded from a handful of nights would be a guess wearing the authority of a reference line,
+     * and a calibrating baseline is exactly when a reader is most likely to over-read it.
+     */
+    @Test
+    fun `no rule until the baseline is trusted`() {
+        assertNull(vitalBaseline("hrv", steady(4, 60.0)))
+        assertNotNull(vitalBaseline("hrv", steady(30, 60.0)))
+    }
+
+    @Test
+    fun `an empty history has no rule`() {
+        assertNull(vitalBaseline("hrv", emptyList()))
+    }
+
+    /** A steady series baselines at its own centre, so the rule lands where a reader would expect it. */
+    @Test
+    fun `a steady series baselines at its centre`() {
+        val b = vitalBaseline("hrv", steady(30, 60.0))
+        assertNotNull(b)
+        assertEquals(60.0, b!!, 1.0)
+    }
+
+    // --- placing it on the same scale as the series ---
+
+    /**
+     * The load-bearing one. A value that IS in the series must map to the same y the series point does,
+     * or the rule and the reading it explains are drawn by two different scales.
+     */
+    @Test
+    fun `a value in the series maps to the same height as its point`() {
+        val values = listOf(40.0, 50.0, 60.0, 70.0)
+        val h = 100f
+        val pts = pointsFor(values, width = 200f, height = h, topPad = 6f, bottomPad = 6f)
+        for (i in values.indices) {
+            val y = yForValue(values[i], values, h, topPad = 6f, bottomPad = 6f)
+            assertNotNull("index $i", y)
+            assertEquals("index $i", pts[i].y, y!!, 0.001f)
+        }
+    }
+
+    /**
+     * Out of range draws NOTHING rather than clamping to an edge. A rule pinned to the top of the plot
+     * reads as "your baseline is the highest value here", which is a different claim from "your baseline
+     * is off this chart", and only the second one is true.
+     */
+    @Test
+    fun `a baseline outside the plotted range is not drawn`() {
+        val values = listOf(40.0, 50.0, 60.0)
+        assertNull(yForValue(80.0, values, 100f, 6f, 6f))
+        assertNull(yForValue(10.0, values, 100f, 6f, 6f))
+        assertNotNull(yForValue(50.0, values, 100f, 6f, 6f))
+    }
+
+    /** A supplied domain widens the scale, so a rule inside the WIDENED range is drawn. */
+    @Test
+    fun `a supplied y domain widens what the rule can sit on`() {
+        val values = listOf(40.0, 50.0, 60.0)
+        assertNull(yForValue(20.0, values, 100f, 6f, 6f))
+        assertNotNull(yForValue(20.0, values, 100f, 6f, 6f, yDomain = 0.0..100.0))
+    }
+
+    /** Degenerate inputs refuse rather than divide by a zero span or a zero height. */
+    @Test
+    fun `degenerate inputs draw nothing`() {
+        assertNull(yForValue(50.0, listOf(50.0), 100f, 6f, 6f))
+        assertNull(yForValue(50.0, listOf(40.0, 60.0), 0f, 6f, 6f))
+        assertNull(yForValue(Double.NaN, listOf(40.0, 60.0), 100f, 6f, 6f))
+    }
+
+    /** A flat series still places a rule at its centre rather than dividing by a zero span. */
+    @Test
+    fun `a flat series places the rule mid plot`() {
+        val y = yForValue(50.0, listOf(50.0, 50.0, 50.0), 100f, 6f, 6f)
+        assertNotNull(y)
+        assertTrue("mid-plot, not an edge", y!! > 6f && y < 94f)
+    }
+}


### PR DESCRIPTION
## Why

An absolute HRV number says little on its own. "42" only means something once you know your own normal is 54, and the chart had no way to say so. Resting HR has the same problem: the shape shows movement, not whether today sits above or below where you usually are.

## What

A dashed rule at your personal baseline, under the series, on the HRV and resting-HR detail charts.

It is the **same fold the vitals grid already bands against** (`Baselines.foldHistory` with the same `MetricCfg`), so a reading the grid calls out of range cannot sit on the comfortable side of the rule on the chart beside it. One definition of "your normal", or the two surfaces disagree in front of the reader.

Folded over the full history rather than the visible window, because the reference is your normal and does not change because you narrowed the range to a week.

## Where it deliberately draws nothing

- **Other metrics.** The daily scores are already interpretable on their own ranges, and skin temperature has a signed-deviation view of its own. A rule there would be furniture.
- **Until the baseline is TRUSTED**, meaning at least fourteen valid nights and not stale. A rule folded from four nights is a guess wearing the authority of a reference line, and a calibrating baseline is exactly when it would be over-read.
- **When the baseline is outside the plotted range.** A rule clamped to the top of the plot reads as "your baseline is the highest value here", which is a different claim from "your baseline is off this chart". Only the second is true, and drawing nothing says it.

## Both chart shapes

The style is the reader's choice as of #2027, so a reference that vanished on switching to bars would be a puzzle. The bar scale is zero-based rather than min-to-max, so it places the rule with its own arithmetic; placing it with the line chart's would put it at a confidently wrong height that nothing in the picture contradicts.

The line chart's bounds are extracted into one helper so the rule and the series cannot be scaled by two copies of the same logic that later drift apart. A test pins that a value which IS in the series maps to the same height as its own point.

## Tests

10 new cases: which metrics get a rule, the `rhr` to `resting_hr` config mapping (the names differ, and a silent miss looks exactly like "not trusted yet"), the trusted gate, the scale agreement above, off-range refusal, domain widening, and degenerate inputs.

Android green with `--no-build-cache`: 687 classes / 5797 tests / 0 failures, against a measured `main` baseline of 5785. `Tools/doc_comment_lint.py` clean.

## Not verified here

The iOS half needs CI: `TrendChart` gains a `baselineValue` drawn as a `RuleMark`, and `MetricExplorerView` folds the same baseline from the same shared analytics. Both halves want an eyeball on device, since where a faint dashed rule reads well against a gradient fill is not something a test can answer.
