### PR TITLE
Arm the realtime HR stream while the Breathe screen is visible

### DIFF
--- a/Strand/Screens/BreathingView.swift
+++ b/Strand/Screens/BreathingView.swift
@@ -230,10 +230,11 @@ private struct BreathingContent: View {
             on ? tonePlayer.activate() : tonePlayer.deactivate()
         }
         .onAppear {
+            model.startRealtimeHR()
             controllerBox.prepare(model: model, live: live)
             if audioCues { tonePlayer.activate() }
         }
-        .onDisappear { stop(); controller.stop(); tonePlayer.deactivate() }
+        .onDisappear { model.stopRealtimeHR(); stop(); controller.stop(); tonePlayer.deactivate() }
     }
 
     // MARK: - Mode switch

--- a/android/app/src/main/java/com/noop/ui/BreatheScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BreatheScreen.kt
@@ -241,6 +241,14 @@ fun BreatheScreen(viewModel: AppViewModel) {
     }
     val tonePlayer = remember { BreathTonePlayer(context) }
     DisposableEffect(Unit) { onDispose { tonePlayer.release() } }
+    // Keep the realtime HR stream on while this screen is visible (ref-counted in the ViewModel, so
+    // navigating to Live — which also wants it — doesn't stop it). The BPM hero + R-R readouts are
+    // live-derived and shown before a session starts, so the want is unconditional (not gated on
+    // `running`).
+    DisposableEffect(Unit) {
+        viewModel.requestRealtimeHr()
+        onDispose { viewModel.releaseRealtimeHr() }
+    }
     var phase by remember { mutableStateOf(UiPhase.Inhale) }
     var phaseLabel by remember { mutableStateOf<String?>(null) }
     var stageIndex by remember { mutableIntStateOf(0) }


### PR DESCRIPTION
What this PR does
The Breathe screen displays AppViewModel.bpm (smoothed, live-only) and consumes live R-R data, but never took a realtime want. With Breathe as the only live-HR surface on screen the reference-counted stream was never armed, so ingestHr() received no fresh samples and the BPM hero / RMSSD / R-R readouts froze on whatever the last arming screen left behind. Reproduced on a WHOOP 5/MG. BreathingView.swift had the twin omission (parity contract).
This change takes one ref-count for the Breathe screen's visible lifetime and releases it on disposal:
- Android: standalone DisposableEffect(Unit) in BreatheScreen — requestRealtimeHr() / releaseRealtimeHr() on dispose, the LiveScreen pattern. Balanced 1:1, so realtimeWanters can't wedge.
- iOS/macOS: one model.startRealtimeHR() in .onAppear / one model.stopRealtimeHR() in .onDisappear in BreathingView — the LiveWorkoutView pattern, with no re-count on bond/connect events (the #681 trap); rearmRealtimeIfWanted() re-arms the BLE side on a fresh connection.
The want is unconditional, not gated on running, since the BPM hero and R-R readouts render before any session starts.
Why it's safe:
- Live→Breathe goes 1→2→1; the stream never drops between two arming screens, and leaving Breathe last takes 1→0.
- Continuous HRV capture unaffected: reconcileRealtime ORs screen wants with capture wants in both directions.
- The 0→1 edge calls resetSmoothing() — the brief blank on entry matches Live/Health.
- No BLE contract change: no new write to hardware, only the existing TOGGLE_REALTIME_HR path driven through the existing ref-count.
Type of change
- Bug fix
- New feature
- Refactor / cleanup
- Documentation
- CI / tooling
How it was tested
Hardware (WHOOP 5/MG): stale BPM reproduced before the fix; after the fix, opening Breathe from a non-live screen arms the realtime stream and the BPM hero updates while the screen is visible.
Android (automated):
- ./gradlew compileFullDebugKotlin — green
- ./gradlew testFullDebugUnitTest — green
- ./gradlew assembleFullDebug — green
No new automated tests: there is no Compose UI test scaffolding in the repo (no androidTest/, no Robolectric), and AppViewModel requires a NoopApplication and isn't constructable in the plain-JVM unit-test setup. The ref-count logic itself is unchanged.
Not yet run: macOS/iOS app-target builds (need a Mac — app-build.yml is disabled and swift-packages doesn't compile Strand/) and the iOS/macOS strap leg of the same matrix.
Checklist
- Swift package tests pass for any package I touched (swift test in Packages/<name>) — no packages touched
- Android unit tests pass if I touched android/ (./gradlew testFullDebugUnitTest)
- No new build warnings introduced
- UI changes use only StrandDesign tokens — no hardcoded colors, fonts, or spacing — lifecycle-only change, no styling
- No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- Follows the conventions in docs/CONTRIBUTING.md (../docs/CONTRIBUTING.md)
- I did not commit generated output (Strand.xcodeproj/) or any secrets/keystores