### PR TITLE
The Today heart-rate Min and Max read the samples, not the mean curve

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Reads.swift
@@ -9,13 +9,31 @@ import WhoopProtocol
 public struct HRBucket: Sendable, Equatable {
     public let ts: Int
     public let bpm: Double
+    /// The lowest and highest sample IN the bucket, not the bucket's mean.
+    ///
+    /// A chart plots `bpm`, which is what makes a day read as a curve rather than a spike field, but a
+    /// Min/Max readout taken from that series describes the calmest and busiest FIVE MINUTES rather than
+    /// the day. A forty-second interval is averaged against the four minutes around it before the reader
+    /// sees it, which is why a workout's max could exceed the day's (#2032). Same scan and grouping as
+    /// the mean, so carrying them costs nothing.
+    public let minBpm: Double
+    public let maxBpm: Double
     /// The WEAKEST signal confidence contributing to this bucket: 1.0 for measured `hrSample`
     /// rows, the stored autocorrelation `conf` for PPG-derived fallback rows. Lets a chart render
     /// a weak-optical stretch distinctly instead of identically to a clean measured beat. Defaults
     /// to 1.0 so existing constructors/tests are unchanged. (adopted from ryanAtriumAi #988 —
     /// purely additive surfacing; the acceptance floor itself is unchanged.)
     public let conf: Double
-    public init(ts: Int, bpm: Double, conf: Double = 1.0) { self.ts = ts; self.bpm = bpm; self.conf = conf }
+    /// `minBpm` and `maxBpm` are required rather than defaulted. A default would let a caller build a
+    /// bucket whose extremes silently equal its mean, which is precisely the shape of the bug (#2032):
+    /// a number that looks like a reading and describes something else.
+    public init(ts: Int, bpm: Double, minBpm: Double, maxBpm: Double, conf: Double = 1.0) {
+        self.ts = ts
+        self.bpm = bpm
+        self.minBpm = minBpm
+        self.maxBpm = maxBpm
+        self.conf = conf
+    }
 }
 
 /// Aggregate HR over a time window: sample count + mean/peak bpm. Result of [WhoopStore.hrWindowStats],
@@ -336,7 +354,8 @@ extension WhoopStore {
             // (conservative), and a purely-measured bucket stays 1.0. Purely additive projection:
             // the bpm aggregate and the anti-join semantics are byte-identical. (ryanAtriumAi #988)
             try Row.fetchAll(db, sql: """
-                SELECT (ts / ?) * ? AS bucket, AVG(bpm) AS avgBpm, MIN(conf) AS minConf FROM (
+                SELECT (ts / ?) * ? AS bucket, AVG(bpm) AS avgBpm, MIN(conf) AS minConf,
+                       MIN(bpm) AS minBpm, MAX(bpm) AS maxBpm FROM (
                     SELECT ts, bpm, 1.0 AS conf FROM hrSample
                     WHERE deviceId = ? AND ts >= ? AND ts <= ?
                     UNION ALL
@@ -352,7 +371,9 @@ extension WhoopStore {
                                  deviceId, from, to,
                                  deviceId, from, to,
                                  bucket])
-                .map { HRBucket(ts: $0["bucket"], bpm: $0["avgBpm"], conf: $0["minConf"] ?? 1.0) }
+                .map { HRBucket(ts: $0["bucket"], bpm: $0["avgBpm"],
+                                minBpm: $0["minBpm"], maxBpm: $0["maxBpm"],
+                                conf: $0["minConf"] ?? 1.0) }
         }
     }
 

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/ReadTests.swift
@@ -144,10 +144,15 @@ final class ReadTests: XCTestCase {
         //   ts100 → bucket 0   → mean 60
         //   ts200, ts300 → bucket 200 → mean (61+62)/2 = 61.5
         let buckets = try await store.hrBuckets(deviceId: "dev1", from: 0, to: 1000, bucketSeconds: 200)
-        XCTAssertEqual(buckets, [HRBucket(ts: 0, bpm: 60), HRBucket(ts: 200, bpm: 61.5)])
+        // #2032: bucket 200 is the case the readout used to get wrong. Its mean is 61.5 and its highest
+        // sample is 62, so a Max taken off the means understates the busiest moment. The extremes are
+        // asserted beside the mean here so a query that stopped carrying them fails rather than silently
+        // handing the card the mean again.
+        XCTAssertEqual(buckets, [HRBucket(ts: 0, bpm: 60, minBpm: 60, maxBpm: 60),
+                                 HRBucket(ts: 200, bpm: 61.5, minBpm: 61, maxBpm: 62)])
         // The decoy on "other" (ts200, bpm99) must never bleed into dev1's bucket.
         let other = try await store.hrBuckets(deviceId: "other", from: 0, to: 1000, bucketSeconds: 200)
-        XCTAssertEqual(other, [HRBucket(ts: 200, bpm: 99)])
+        XCTAssertEqual(other, [HRBucket(ts: 200, bpm: 99, minBpm: 99, maxBpm: 99)])
     }
 
     /// Both same-second beats survive the v24 key. Since #823 the read order is EMISSION order, and

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -352,6 +352,11 @@ struct TodayView: View {
 
     // Today's heart rate as 5-minute bucket means (midnight → now), for the 24h trend chart.
     @State private var hrPoints: [TrendPoint] = []
+    /// The day's true lowest and highest SAMPLES, not the extremes of the plotted five-minute means.
+    /// `hrPoints` carries only each bucket's mean, so a Min/Max read off it describes the calmest and
+    /// busiest five minutes rather than the day, which is why a workout's max could exceed it (#2032).
+    @State private var hrDayMin: Double?
+    @State private var hrDayMax: Double?
 
     // The night's sleep session overlapping the HR window, shaded as a band on the HR chart and
     // used to anchor the recovery marker at wake time (WHOOP-style Overview HR annotations).
@@ -3531,9 +3536,12 @@ struct TodayView: View {
                     )
                 } footer: {
                     ChartFooter([
-                        ("Min", "\(Int((v.min() ?? 0).rounded()))"),
+                        // #2032: Min and Max come from the SAMPLES, not from the mean curve above them.
+                        // They fall back to the curve only if the extremes are somehow absent, which
+                        // cannot happen on this branch since the buckets that built `v` carry them.
+                        ("Min", "\(Int((hrDayMin ?? v.min() ?? 0).rounded()))"),
                         ("Avg", "\(Int((v.reduce(0, +) / Double(v.count)).rounded()))"),
-                        ("Max", "\(Int((v.max() ?? 0).rounded()))"),
+                        ("Max", "\(Int((hrDayMax ?? v.max() ?? 0).rounded()))"),
                     ])
                 }
                 // #829 - pinch/drag hint + Reset, OUTSIDE the card (the card force-fits its chart() closure
@@ -4842,9 +4850,13 @@ struct TodayView: View {
         let windowEndExclusive = cycleMarkers.last(where: { $0.day == nextDayKey }).map { Int($0.value) }
             ?? calendarEnd
         let windowEndInclusive = max(windowStart, windowEndExclusive - 1)
-        let hrPointsLocal = await repo.hrBuckets(from: windowStart, to: windowEndInclusive, bucketSeconds: 300)
+        let hrBucketsLocal = await repo.hrBuckets(from: windowStart, to: windowEndInclusive, bucketSeconds: 300)
+        let hrPointsLocal = hrBucketsLocal
             .map { TrendPoint(date: Date(timeIntervalSince1970: TimeInterval($0.ts)), value: $0.bpm) }
         hrPoints = hrPointsLocal
+        // The chart keeps plotting means; only the footer reads the samples behind them (#2032).
+        hrDayMin = hrBucketsLocal.map(\.minBpm).min()
+        hrDayMax = hrBucketsLocal.map(\.maxBpm).max()
 
         // #316 / @63, the selected day's representative activity class for the Steps tile icon. Reads the
         // day's step samples (now carrying `activityClass` after the v19 column) and takes the LAST non-nil

--- a/StrandTests/ShortcutHealthExportTests.swift
+++ b/StrandTests/ShortcutHealthExportTests.swift
@@ -10,6 +10,16 @@ import WhoopProtocol
 /// moved past a failed write would silently drop that span from Apple Health forever.
 final class ShortcutHealthExportTests: XCTestCase {
 
+    /// A synthetic bucket whose extremes equal its mean.
+    ///
+    /// The export path reads only `bpm`, so a spread inside the bucket is not what these tests are
+    /// about. Written once here rather than repeated at every call site, and deliberately NOT a default
+    /// on `HRBucket` itself: production builds those from `MIN(bpm)`/`MAX(bpm)`, and a type-level default
+    /// would let a real one silently claim its mean as its range, which is the bug #2032 was.
+    private func flatBucket(ts: Int, bpm: Double) -> HRBucket {
+        HRBucket(ts: ts, bpm: bpm, minBpm: bpm, maxBpm: bpm)
+    }
+
     private let utc = TimeZone(secondsFromGMT: 0)!
     private var defaults: UserDefaults!
     private var suiteName: String!
@@ -100,14 +110,14 @@ final class ShortcutHealthExportTests: XCTestCase {
 
     func testAggregateBucketsHRIntoWindowsAscending() {
         // hrBuckets(900) keys are already the window starts; bpm means round half-up.
-        let hr = [HRBucket(ts: 900, bpm: 61.5), HRBucket(ts: 0, bpm: 61.4)]
+        let hr = [flatBucket(ts: 900, bpm: 61.5), flatBucket(ts: 0, bpm: 61.4)]
         let windows = ShortcutHealthExport.aggregate(hr: hr, rr: [], steps: [], end: 1800)
         XCTAssertEqual(windows, [Window(start: 0, hr: 61), Window(start: 900, hr: 62)])
     }
 
     // Only windows holding ≥1 value are emitted — an empty middle window produces NO line.
     func testAggregateSkipsEmptyWindows() {
-        let hr = [HRBucket(ts: 0, bpm: 60), HRBucket(ts: 1800, bpm: 70)]
+        let hr = [flatBucket(ts: 0, bpm: 60), flatBucket(ts: 1800, bpm: 70)]
         let windows = ShortcutHealthExport.aggregate(hr: hr, rr: [], steps: [], end: 2700)
         XCTAssertEqual(windows.map(\.start), [0, 1800])
     }
@@ -115,7 +125,7 @@ final class ShortcutHealthExportTests: XCTestCase {
     // Data at/after `end` (the still-open window) is excluded — it would otherwise be frozen
     // partial and never revisited once the watermark advances.
     func testAggregateExcludesOpenWindow() {
-        let hr = [HRBucket(ts: 0, bpm: 60), HRBucket(ts: 900, bpm: 70)]
+        let hr = [flatBucket(ts: 0, bpm: 60), flatBucket(ts: 900, bpm: 70)]
         let windows = ShortcutHealthExport.aggregate(hr: hr, rr: [], steps: [], end: 900)
         XCTAssertEqual(windows, [Window(start: 0, hr: 60)])
     }
@@ -201,7 +211,7 @@ final class ShortcutHealthExportTests: XCTestCase {
     // MARK: - Export + watermark (advance only on success)
 
     func testExportWritesFileAndAdvancesWatermark() async throws {
-        let source = FakeReads(hr: [HRBucket(ts: 0, bpm: 62)])
+        let source = FakeReads(hr: [flatBucket(ts: 0, bpm: 62)])
         let outcome = await ShortcutHealthExport.export(
             source: source, deviceId: "dev", now: Date(timeIntervalSince1970: 10_000),
             defaults: defaults, directory: dir, timeZone: utc)
@@ -223,7 +233,7 @@ final class ShortcutHealthExportTests: XCTestCase {
     func testExportWriteFailureLeavesWatermark() async {
         // Destination directory doesn't exist → the atomic write throws → watermark must not move.
         let missing = dir.appendingPathComponent("nope")
-        let source = FakeReads(hr: [HRBucket(ts: 0, bpm: 62)])
+        let source = FakeReads(hr: [flatBucket(ts: 0, bpm: 62)])
         let outcome = await ShortcutHealthExport.export(
             source: source, deviceId: "dev", now: Date(timeIntervalSince1970: 10_000),
             defaults: defaults, directory: missing, timeZone: utc)
@@ -234,7 +244,7 @@ final class ShortcutHealthExportTests: XCTestCase {
     func testExportNothingNewWhenWatermarkCoversNow() async throws {
         defaults.set(9_900, forKey: ShortcutHealthExport.watermarkKey)
         let outcome = await ShortcutHealthExport.export(
-            source: FakeReads(hr: [HRBucket(ts: 0, bpm: 62)]), deviceId: "dev",
+            source: FakeReads(hr: [flatBucket(ts: 0, bpm: 62)]), deviceId: "dev",
             now: Date(timeIntervalSince1970: 10_000),
             defaults: defaults, directory: dir, timeZone: utc)
         XCTAssertEqual(outcome, .nothingNew)
@@ -248,12 +258,12 @@ final class ShortcutHealthExportTests: XCTestCase {
     // the file must be EMPTY, or the Shortcut re-imports the previous rows on every automation run.
     func testNothingNewTruncatesStaleFileSoShortcutCannotReimport() async throws {
         _ = await ShortcutHealthExport.export(
-            source: FakeReads(hr: [HRBucket(ts: 0, bpm: 62)]), deviceId: "dev",
+            source: FakeReads(hr: [flatBucket(ts: 0, bpm: 62)]), deviceId: "dev",
             now: Date(timeIntervalSince1970: 10_000),
             defaults: defaults, directory: dir, timeZone: utc)
         XCTAssertEqual(try fileText(), "62,,,1970-01-01 00:00")
         let second = await ShortcutHealthExport.export(
-            source: FakeReads(hr: [HRBucket(ts: 0, bpm: 62)]), deviceId: "dev",
+            source: FakeReads(hr: [flatBucket(ts: 0, bpm: 62)]), deviceId: "dev",
             now: Date(timeIntervalSince1970: 10_060),   // +60s — same 15-min window, nothing new
             defaults: defaults, directory: dir, timeZone: utc)
         XCTAssertEqual(second, .nothingNew)
@@ -264,11 +274,11 @@ final class ShortcutHealthExportTests: XCTestCase {
     // (the Shortcut has no dedup; re-offered lines would be double-logged into Health).
     func testExportReplacesWholeFile() async throws {
         _ = await ShortcutHealthExport.export(
-            source: FakeReads(hr: [HRBucket(ts: 0, bpm: 62)]), deviceId: "dev",
+            source: FakeReads(hr: [flatBucket(ts: 0, bpm: 62)]), deviceId: "dev",
             now: Date(timeIntervalSince1970: 10_000),
             defaults: defaults, directory: dir, timeZone: utc)
         let outcome = await ShortcutHealthExport.export(
-            source: FakeReads(hr: [HRBucket(ts: 9_900, bpm: 70)]), deviceId: "dev",
+            source: FakeReads(hr: [flatBucket(ts: 9_900, bpm: 70)]), deviceId: "dev",
             now: Date(timeIntervalSince1970: 20_000),
             defaults: defaults, directory: dir, timeZone: utc)
         XCTAssertEqual(outcome, .written(lines: 1))

--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -81,6 +81,15 @@ data class PpgHrSample(
 data class HrBucket(
     val bucket: Long,
     val avgBpm: Double,
+    /** The lowest and highest sample IN the bucket, not the bucket's mean.
+     *
+     *  The card plots [avgBpm], which is what makes a day read as a curve rather than a spike field, but
+     *  a Min/Max readout taken from that series describes the calmest and busiest FIVE MINUTES rather than
+     *  the day. A forty-second interval is averaged against the four minutes around it before the reader
+     *  ever sees it, which is why a workout's max could exceed the day's (#2032). Same scan, same
+     *  grouping, so carrying them costs nothing. */
+    val minBpm: Double,
+    val maxBpm: Double,
 )
 
 /** The per-day gravity witness the steps-calibration motion cache keys on: [c] rows in the window and

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -412,7 +412,8 @@ interface WhoopDao : DeviceRegistryDao {
      *  selects are UNION ALL'd into one bpm stream, then bucket-averaged exactly as before. Matches
      *  the Swift hrBuckets COALESCE union. */
     @Query(
-        "SELECT (ts / :bucketSeconds) * :bucketSeconds AS bucket, AVG(bpm) AS avgBpm FROM (" +
+        "SELECT (ts / :bucketSeconds) * :bucketSeconds AS bucket, AVG(bpm) AS avgBpm, " +
+            "MIN(bpm) AS minBpm, MAX(bpm) AS maxBpm FROM (" +
             "SELECT ts, bpm FROM hrSample " +
             "WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to " +
             "UNION ALL " +

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -5997,8 +5997,13 @@ private fun HeartRateTrendCard(
     // TODAY that is the identical full-buckets list, so the default path is byte-for-byte the old one.
     val bpm = remember(winBuckets) { winBuckets.map { it.avgBpm } }
     val latest = bpm.last().roundToInt()
-    val min = bpm.min().roundToInt()
-    val max = bpm.max().roundToInt()
+    // #2032: the Min/Max READOUT reads the samples, not the mean curve. Taken from `bpm` these described
+    // the calmest and busiest five minutes, so a hard interval read lower here than in the workout that
+    // contained it, and the resting dip read higher than it was. The y-rail below stays on the means,
+    // because that is the series it labels: raw extremes there would squash the drawn curve into the
+    // middle of its own axis. Avg is left on the means deliberately, see the PR.
+    val min = remember(winBuckets) { winBuckets.minOf { it.minBpm } }.roundToInt()
+    val max = remember(winBuckets) { winBuckets.maxOf { it.maxBpm } }.roundToInt()
     val avg = bpm.average().roundToInt()
 
     // #829 - the RENDERED subset: the zoom window narrows which of the loaded buckets draw (the gesture

--- a/android/app/src/test/java/com/noop/data/HrReadUnionTest.kt
+++ b/android/app/src/test/java/com/noop/data/HrReadUnionTest.kt
@@ -1,7 +1,9 @@
 package com.noop.data
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -28,7 +30,10 @@ class HrReadUnionTest {
     private fun sample(ts: Long, bpm: Int, source: String = canonical) =
         HrSample(deviceId = source, ts = ts, bpm = bpm)
 
-    private fun bucket(start: Long, avg: Double) = HrBucket(bucket = start, avgBpm = avg)
+    // A flat synthetic bucket: these tests are about which bucket WINS a union, not about the spread
+    // inside one, so the extremes equal the mean rather than inventing a range nothing here reads.
+    private fun bucket(start: Long, avg: Double) =
+        HrBucket(bucket = start, avgBpm = avg, minBpm = avg, maxBpm = avg)
 
     private fun step(ts: Long, activityClass: Int?, source: String = canonical) =
         StepSample(deviceId = source, ts = ts, counter = 0, activityClass = activityClass)
@@ -172,5 +177,39 @@ class HrReadUnionTest {
     @Test
     fun latestActivityClassEmptyUnionIsNull() {
         assertEquals(null, WhoopRepository.latestActivityClass(listOf(emptyList(), emptyList())))
+    }
+
+    // --- (d) the union carries a bucket's EXTREMES, not just its mean (#2032) ---
+
+    /**
+     * The active strap's bucket wins whole, extremes included.
+     *
+     * `mergeHrBucketsByStart` dedupes by bucket start with the first list winning, and it has always
+     * carried the winning row rather than blending values. That stayed true when the row gained its
+     * min and max, but a merge that reached inside to recombine fields would be wrong in a way nothing
+     * else here would catch: it would mix one strap's spread with another's mean.
+     */
+    @Test
+    fun aMergedBucketKeepsTheWinningStrapsExtremes() {
+        val active = listOf(HrBucket(bucket = 300L, avgBpm = 61.5, minBpm = 61.0, maxBpm = 62.0))
+        val other = listOf(HrBucket(bucket = 300L, avgBpm = 99.0, minBpm = 40.0, maxBpm = 190.0))
+        val merged = WhoopRepository.mergeHrBucketsByStart(listOf(active, other))
+        assertEquals(1, merged.size)
+        assertEquals(61.5, merged[0].avgBpm, 0.0)
+        assertEquals("the winner's own low, not the other strap's", 61.0, merged[0].minBpm, 0.0)
+        assertEquals("the winner's own peak, not the other strap's", 62.0, merged[0].maxBpm, 0.0)
+    }
+
+    /**
+     * A bucket's extremes are independent of its mean, which is the whole point of carrying them: a
+     * five-minute mean of 61.5 can hide a 62 peak, and that gap is what made a workout's max exceed the
+     * day's on the Today card.
+     */
+    @Test
+    fun aBucketsExtremesAreNotItsMean() {
+        val b = HrBucket(bucket = 0L, avgBpm = 61.5, minBpm = 61.0, maxBpm = 62.0)
+        assertNotEquals(b.avgBpm, b.maxBpm, 0.0)
+        assertTrue("the peak is at or above the mean", b.maxBpm >= b.avgBpm)
+        assertTrue("the low is at or below the mean", b.minBpm <= b.avgBpm)
     }
 }

--- a/android/app/src/test/java/com/noop/testcentre/CircadianVerdictTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/CircadianVerdictTest.kt
@@ -59,7 +59,9 @@ class CircadianVerdictTest {
      */
     @Test fun theReportedBucketFloorIsTheOneCircadianBinsFromActuallyApplies() {
         fun binsFor(n: Int) = com.noop.ui.circadianBinsFrom(
-            (0 until n).map { com.noop.data.HrBucket(bucket = it * 3600L, avgBpm = 60.0) }, 0L,
+            (0 until n).map {
+                com.noop.data.HrBucket(bucket = it * 3600L, avgBpm = 60.0, minBpm = 60.0, maxBpm = 60.0)
+            }, 0L,
         ).first
         val floor = AndroidDiagnostics.CIRCADIAN_MIN_BUCKETS
         assertTrue("one under the reported floor must still be refused", binsFor(floor - 1).isEmpty())

--- a/android/app/src/test/java/com/noop/ui/CircadianBinsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/CircadianBinsTest.kt
@@ -18,7 +18,9 @@ class CircadianBinsTest {
 
     /** One bucket per hour for [hours] consecutive hours from [startTs], all at [bpm]. */
     private fun series(startTs: Long, hours: Int, bpm: Double = 60.0) =
-        (0 until hours).map { HrBucket(bucket = startTs + it * 3_600L, avgBpm = bpm) }
+        (0 until hours).map {
+            HrBucket(bucket = startTs + it * 3_600L, avgBpm = bpm, minBpm = bpm, maxBpm = bpm)
+        }
 
     @Test fun underTwentyFourBucketsIsRefused() {
         val (bins, days) = circadianBinsFrom(series(0, 23), tzOffsetSeconds = 0)
@@ -65,7 +67,9 @@ class CircadianBinsTest {
     @Test fun onlyPopulatedHoursBecomeBins() {
         // 30 buckets all landing in the same 6 local hours (one per hour across 5 days).
         val sparse = (0 until 5).flatMap { d ->
-            (0 until 6).map { h -> HrBucket(bucket = d * 86_400L + h * 3_600L, avgBpm = 55.0) }
+            (0 until 6).map { h ->
+                HrBucket(bucket = d * 86_400L + h * 3_600L, avgBpm = 55.0, minBpm = 55.0, maxBpm = 55.0)
+            }
         }
         val (bins, days) = circadianBinsFrom(sparse, tzOffsetSeconds = 0)
         assertEquals(6, bins.size)


### PR DESCRIPTION
Reported by @riebschlaegerstar-sys in #2032: a workout's max heart rate exceeded the same day's max on the Today card. Their diagnosis was right, mechanism included.

## Cause

The card is built from five-minute bucket means, and the Min/Avg/Max readout was computed from that series:

```kotlin
val bpm = winBuckets.map { it.avgBpm }
val max = bpm.max().roundToInt()
```

`HrBucket` carried only `bucket` and `avgBpm`, so there was no per-bucket extreme to read even if the card had wanted one. The number labelled **Max** was the highest five-minute **average** of the day. A forty-second interval is averaged against the four minutes around it before the card ever sees it.

**Min was wrong the same way**, in the other direction: the lowest five-minute average sits above the true resting dip. Nobody reported that half because there is nothing to compare it against.

Both platforms. The Apple query takes the same `AVG(bpm)` shape.

## Change

The bucket query carries `MIN(bpm)` and `MAX(bpm)` beside its average, and the readout reads them. Same scan, same grouping, so it costs nothing.

## Why the card will now agree with the workout

A workout's max comes from `hrWindowStats`, which is `MAX(bpm)` over the same union of `hrSample` and the `ppgHrSample` gap-fill. The card's extremes are now that same aggregate over the same rows, so the two agree **by construction** rather than by coincidence. That is the part that made the reporter doubt the number.

Worth saying why `hrWindowStats` could not simply be called instead: it exposes no minimum, and it unions two ids where the card unions every registered strap. Adding the extremes to the query the card already runs is one scan rather than two, and it rides the existing multi-device merge unchanged.

## Deliberately unchanged

**The chart still plots means.** That is what makes a day read as a curve rather than a spike field.

**The y-axis rail still labels those means.** Raw extremes there would squash the drawn curve into the middle of its own axis. The rail describes the series; the footer describes the day. They are different questions and now give different answers, which is correct.

**Avg stays on the means.** A mean of means is biased when buckets hold different sample counts, and correcting it needs a `COUNT` and a weighted average. That is a different change from the one reported, and it would move a number nobody has complained about.

## Tests

- **Swift, against a real store:** the existing bucket test now asserts the extremes beside the mean. Its bucket at ts 200 holds samples 61 and 62, so the mean is 61.5 and the true max is 62. That is exactly the gap the readout used to lose, and a query that stopped carrying the extremes fails rather than silently handing the card the mean again.
- **Android:** no in-memory Room harness exists in this suite, so the DAO cannot be driven directly. Pinned instead at the merge, where a bucket that wins the multi-strap union keeps its own extremes rather than blending another strap's, plus that a bucket's extremes are independent of its mean.
- Android green with `--no-build-cache`: 687 classes / 5799 tests / 0 failures. `Tools/doc_comment_lint.py` clean.

## Notes

`HrBucket` is a query result rather than a table, so there is **no schema change and no migration**.

The Swift init requires the extremes rather than defaulting them. A default would let a caller build a bucket whose extremes silently equal its mean, which is the exact shape of this bug: a number that looks like a reading and describes something else.

## Not verified here

The Apple half needs CI, and the numbers want an eyeball on device: the day's Max on Today should now match or exceed the max of any workout inside it, rather than sitting below one.
