### PR TITLE
Stop the Sleep screen asking the store once per night

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -47,6 +47,10 @@ public struct CachedSleepSession: Equatable, Codable {
     /// worse than saying nothing. Readers treat nil as "ask", so provenance is a shortcut where the store
     /// supplied it and never a silent wrong answer where it did not. `Codable` decodes a missing key to nil,
     /// so persisted payloads written before this field stay readable.
+    ///
+    /// The WRITE never reads it. `upsertSleepSessions` takes its device as a separate argument, so
+    /// setting this on a session being stored cannot route the row into another device's namespace,
+    /// and a row always reads back stamped with the id it was actually written under.
     public let deviceId: String?
     public init(startTs: Int, endTs: Int, efficiency: Double?, restingHr: Int?,
                 avgHrv: Double?, stagesJSON: String?, userEdited: Bool = false,

--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -406,6 +406,28 @@ extension WhoopStore {
         }
     }
 
+    /// One device's session BOUNDS in a window, as `startTs -> endTs`, in a single lean read.
+    ///
+    /// Deliberately not `sleepSessions(deviceId:from:to:limit:)`, which selects `stagesJSON` among other
+    /// columns: a caller that only needs to know which blocks a device owns would haul every night's
+    /// staging blob, once per candidate device, to read two integers from each. On a browsable history
+    /// that is the same rows re-read several times over.
+    ///
+    /// `(deviceId, startTs)` is the primary key, so a start maps to exactly one end and the dictionary
+    /// loses nothing. Unpaged on purpose: the window bounds the result, and a page limit sized from a
+    /// caller's own list would silently drop rows for a caller that passed a sparse subset of a wide span.
+    public func sleepSessionBounds(deviceId: String, from: Int, to: Int) async throws -> [Int: Int] {
+        try syncRead { db in
+            var out: [Int: Int] = [:]
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT startTs, endTs FROM sleepSession
+                WHERE deviceId = ? AND startTs >= ? AND startTs <= ?
+                """, arguments: [deviceId, from, to])
+            for row in rows { out[row["startTs"]] = row["endTs"] }
+            return out
+        }
+    }
+
     /// Batched twin of `sessionMotion` for a SET of session starts: the persisted per-epoch motion series
     /// for each of `sessionStarts` that HAS one, in a SINGLE query, keyed by startTs. Same contract as the
     /// single-key accessor — a start whose column is NULL/absent (or an empty series) is simply omitted from

--- a/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/MetricsCache.swift
@@ -35,14 +35,29 @@ public struct CachedSleepSession: Equatable, Codable {
     /// of presenting the short total as fact. nil for imported nights and pre-migration rows (unknown, not
     /// flagged). Set per session to the DAY's value; only NOOP-computed nights populate it. Byte-parity twin.
     public let stagingSparse: Bool?
+    /// Which device's row this is, when the read that produced it knew.
+    ///
+    /// The Kotlin `SleepSession` entity has carried `deviceId` all along; this type never did, so a caller
+    /// holding a block had no way to say where it came from and had to ask the store which device owned it,
+    /// once per block. That probe is the expensive half of the Sleep screen's load.
+    ///
+    /// Optional, and defaulted, for two reasons. Seventy-six construction sites build these by hand, and a
+    /// required field would churn every one of them to state something most of them do not know. And the
+    /// honest value for a hand-built session IS absent: claiming a device it was never read from would be
+    /// worse than saying nothing. Readers treat nil as "ask", so provenance is a shortcut where the store
+    /// supplied it and never a silent wrong answer where it did not. `Codable` decodes a missing key to nil,
+    /// so persisted payloads written before this field stay readable.
+    public let deviceId: String?
     public init(startTs: Int, endTs: Int, efficiency: Double?, restingHr: Int?,
                 avgHrv: Double?, stagesJSON: String?, userEdited: Bool = false,
-                startTsAdjusted: Int? = nil, stagingSparse: Bool? = nil) {
+                startTsAdjusted: Int? = nil, stagingSparse: Bool? = nil,
+                deviceId: String? = nil) {
         self.startTs = startTs; self.endTs = endTs
         self.efficiency = efficiency; self.restingHr = restingHr
         self.avgHrv = avgHrv; self.stagesJSON = stagesJSON
         self.userEdited = userEdited
         self.startTsAdjusted = startTsAdjusted
+        self.deviceId = deviceId
         self.stagingSparse = stagingSparse
     }
 
@@ -52,7 +67,10 @@ public struct CachedSleepSession: Equatable, Codable {
     public func withStartTs(_ newStartTs: Int) -> CachedSleepSession {
         CachedSleepSession(startTs: newStartTs, endTs: endTs, efficiency: efficiency, restingHr: restingHr,
                            avgHrv: avgHrv, stagesJSON: stagesJSON, userEdited: userEdited,
-                           startTsAdjusted: startTsAdjusted, stagingSparse: stagingSparse)
+                           startTsAdjusted: startTsAdjusted, stagingSparse: stagingSparse,
+                           // Carried: a re-keyed session is the same row from the same device, and
+                           // dropping it here would turn a known provenance back into a store probe.
+                           deviceId: deviceId)
     }
 }
 
@@ -258,7 +276,8 @@ extension WhoopStore {
             SELECT endTs, stagesJSON, userEdited FROM sleepSession WHERE deviceId = ? AND startTs = ?
             """, arguments: [deviceId, startTs]) else { return nil }
         return CachedSleepSession(startTs: startTs, endTs: row["endTs"], efficiency: nil, restingHr: nil,
-                                  avgHrv: nil, stagesJSON: row["stagesJSON"], userEdited: row["userEdited"])
+                                  avgHrv: nil, stagesJSON: row["stagesJSON"], userEdited: row["userEdited"],
+                                  deviceId: deviceId)
     }
 
     /// Hand-correct a sleep session's bed (onset) and/or wake (end) time. Sets `userEdited = 1` so the
@@ -606,7 +625,10 @@ extension WhoopStore {
                                        efficiency: $0["efficiency"], restingHr: $0["restingHr"],
                                        avgHrv: $0["avgHrv"], stagesJSON: $0["stagesJSON"],
                                        userEdited: $0["userEdited"], startTsAdjusted: $0["startTsAdjusted"],
-                                       stagingSparse: $0["stagingSparse"])
+                                       stagingSparse: $0["stagingSparse"],
+                                       // The read knows the device it queried, so every block it hands
+                                       // back carries it and no caller has to ask the store again.
+                                       deviceId: deviceId)
                 }
         }
     }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/MetricsCacheTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/MetricsCacheTests.swift
@@ -21,6 +21,17 @@ final class MetricsCacheTests: XCTestCase {
 
     // MARK: - sleep sessions
 
+    /// The same session as it reads back from `deviceId`. `sleepSessions` stamps the device it read the
+    /// row from, and a hand-built session carries no provenance, so a whole-value expectation has to
+    /// state it. The write takes its device from the `upsertSleepSessions` argument, never from this
+    /// field, so a session's `deviceId` is an output of the read and not an input to the write.
+    private func readBack(_ s: CachedSleepSession, from deviceId: String) -> CachedSleepSession {
+        CachedSleepSession(startTs: s.startTs, endTs: s.endTs, efficiency: s.efficiency,
+                           restingHr: s.restingHr, avgHrv: s.avgHrv, stagesJSON: s.stagesJSON,
+                           userEdited: s.userEdited, startTsAdjusted: s.startTsAdjusted,
+                           stagingSparse: s.stagingSparse, deviceId: deviceId)
+    }
+
     func testSleepSessionUpsertReadAndIdempotency() async throws {
         let store = try await WhoopStore.inMemory()
         let s = CachedSleepSession(startTs: 1000, endTs: 5000, efficiency: 0.92,
@@ -30,7 +41,7 @@ final class MetricsCacheTests: XCTestCase {
 
         var rows = try await store.sleepSessions(deviceId: "devA", from: 0, to: 100_000, limit: 100)
         XCTAssertEqual(rows.count, 1)
-        XCTAssertEqual(rows[0], s)
+        XCTAssertEqual(rows[0], readBack(s, from: "devA"))
 
         // Re-upsert the same natural key with updated values, stages covering their (shorter) new span
         // just as fully as before → no duplicate, value updated (an ordinary refresh, not a regression).
@@ -67,7 +78,8 @@ final class MetricsCacheTests: XCTestCase {
 
         let rows = try await store.sleepSessions(deviceId: "oura-ring", from: 0, to: 2_000_000, limit: 100)
         XCTAssertEqual(rows.count, 1)
-        XCTAssertEqual(rows[0], full, "the fuller, previously-stored night must survive untouched")
+        XCTAssertEqual(rows[0], readBack(full, from: "oura-ring"),
+                       "the fuller, previously-stored night must survive untouched")
     }
 
     /// The mirror case: a candidate that IMPROVES on a holed stored row (fills in more of the same span)
@@ -86,7 +98,8 @@ final class MetricsCacheTests: XCTestCase {
 
         let rows = try await store.sleepSessions(deviceId: "oura-ring", from: 0, to: 2_000_000, limit: 100)
         XCTAssertEqual(rows.count, 1)
-        XCTAssertEqual(rows[0], full, "a candidate that covers more of the night must still win")
+        XCTAssertEqual(rows[0], readBack(full, from: "oura-ring"),
+                       "a candidate that covers more of the night must still win")
     }
 
     /// The completeness guard must never engage for a user-edited row — `applySleepEdit`'s bounds/stages

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/SleepDeleteUndoStoreTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/SleepDeleteUndoStoreTests.swift
@@ -12,6 +12,17 @@ final class SleepDeleteUndoStoreTests: XCTestCase {
     private let computed = "my-whoop-noop"
     private let imported = "my-whoop"
 
+    /// The same session as it reads back from `deviceId`. `sleepSessions` stamps the device it read the
+    /// row from, and a hand-built session carries no provenance, so a whole-value expectation has to
+    /// state it. The write takes its device from the `upsertSleepSessions` argument, never from this
+    /// field, so a session's `deviceId` is an output of the read and not an input to the write.
+    private func readBack(_ s: CachedSleepSession, from deviceId: String) -> CachedSleepSession {
+        CachedSleepSession(startTs: s.startTs, endTs: s.endTs, efficiency: s.efficiency,
+                           restingHr: s.restingHr, avgHrv: s.avgHrv, stagesJSON: s.stagesJSON,
+                           userEdited: s.userEdited, startTsAdjusted: s.startTsAdjusted,
+                           stagingSparse: s.stagingSparse, deviceId: deviceId)
+    }
+
     private func session(start: Int, end: Int, edited: Bool = false, stages: String? = "[]",
                          startAdjusted: Int? = nil) -> CachedSleepSession {
         CachedSleepSession(startTs: start, endTs: end, efficiency: 0.9, restingHr: 50,
@@ -35,7 +46,7 @@ final class SleepDeleteUndoStoreTests: XCTestCase {
 
         let computedRows = try await store.sleepSessions(deviceId: computed, from: 0, to: 100_000, limit: 100)
         let importedRows = try await store.sleepSessions(deviceId: imported, from: 0, to: 100_000, limit: 100)
-        XCTAssertEqual(computedRows, [row], "restored verbatim into computed")
+        XCTAssertEqual(computedRows, [readBack(row, from: computed)], "restored verbatim into computed")
         XCTAssertTrue(importedRows.isEmpty, "undo never leaks into the imported namespace")
     }
 
@@ -55,7 +66,7 @@ final class SleepDeleteUndoStoreTests: XCTestCase {
 
         let computedRows = try await store.sleepSessions(deviceId: computed, from: 0, to: 100_000, limit: 100)
         let importedRows = try await store.sleepSessions(deviceId: imported, from: 0, to: 100_000, limit: 100)
-        XCTAssertEqual(importedRows, [row], "restored verbatim into imported")
+        XCTAssertEqual(importedRows, [readBack(row, from: imported)], "restored verbatim into imported")
         XCTAssertTrue(computedRows.isEmpty, "an imported night must never resurrect as a computed twin")
     }
 

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/SleepMotionStateTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/SleepMotionStateTests.swift
@@ -211,4 +211,24 @@ final class SleepMotionStateTests: XCTestCase {
                                                         to: start + 20_000)
         XCTAssertTrue(bounds.isEmpty)
     }
+
+    /// The read stamps each block with the device it queried, and a re-keyed copy keeps it.
+    ///
+    /// This is what lets a caller skip asking the store which device owns a block. `withStartTs` is
+    /// included because it is the one place a session is rebuilt: dropping the field there would turn a
+    /// known provenance silently back into a probe, which is a performance fault with no visible symptom.
+    func testSleepSessionsCarryTheDeviceTheyWereReadFrom() async throws {
+        let store = try await storeWithSession()
+        let rows = try await store.sleepSessions(deviceId: dev, from: start - 1, to: start + 1, limit: 8)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows.first?.deviceId, dev)
+        XCTAssertEqual(rows.first?.withStartTs(start + 60).deviceId, dev, "a re-keyed copy forgot its device")
+    }
+
+    /// A hand-built session says nothing rather than claiming a device it was never read from.
+    func testAHandBuiltSessionHasNoProvenance() {
+        let s = CachedSleepSession(startTs: start, endTs: start + 3_600, efficiency: nil,
+                                   restingHr: nil, avgHrv: nil, stagesJSON: nil)
+        XCTAssertNil(s.deviceId, "absent is the honest value; a default would be a wrong answer")
+    }
 }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/SleepMotionStateTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/SleepMotionStateTests.swift
@@ -170,4 +170,45 @@ final class SleepMotionStateTests: XCTestCase {
         let states = try await store.sessionSleepState(deviceId: dev, sessionStart: start)
         XCTAssertEqual(states, [1, 2])
     }
+
+    // MARK: - session bounds
+
+    /// The bounds read is device-scoped, window-scoped, and returns EVERY row in the window.
+    ///
+    /// It exists so a caller resolving which device owns a block does not have to pull `stagesJSON` for
+    /// every night to compare two integers. The failure it can have is a partial map, which reads to the
+    /// caller as "that device does not own this block" and silently sends it to the wrong motion source,
+    /// so the count is asserted alongside the values.
+    func testSleepSessionBoundsIsDeviceAndWindowScoped() async throws {
+        let store = try await WhoopStore.inMemory()
+        let starts = [start, start + 86_400, start + 2 * 86_400]
+        try await store.upsertSleepSessions(starts.map {
+            CachedSleepSession(startTs: $0, endTs: $0 + 7 * 3_600, efficiency: 0.9,
+                               restingHr: 52, avgHrv: 70, stagesJSON: "[]")
+        }, deviceId: dev)
+        // A decoy on another device at the SAME starts: bounds must never blend the two.
+        try await store.upsertSleepSessions(starts.map {
+            CachedSleepSession(startTs: $0, endTs: $0 + 99, efficiency: 0.5,
+                               restingHr: 60, avgHrv: 40, stagesJSON: "[]")
+        }, deviceId: "other")
+
+        let bounds = try await store.sleepSessionBounds(deviceId: dev, from: start,
+                                                        to: start + 2 * 86_400)
+        XCTAssertEqual(bounds.count, starts.count, "a dropped row reads as an unowned block")
+        for s in starts {
+            XCTAssertEqual(bounds[s], s + 7 * 3_600, "start \(s) got the other device's end")
+        }
+
+        // Window-scoped: a start past `to` is absent rather than clamped in.
+        let narrow = try await store.sleepSessionBounds(deviceId: dev, from: start, to: start)
+        XCTAssertEqual(narrow, [start: start + 7 * 3_600])
+    }
+
+    /// An empty window is an empty map, not a fabricated entry.
+    func testSleepSessionBoundsOnAnEmptyWindowIsEmpty() async throws {
+        let store = try await storeWithSession()
+        let bounds = try await store.sleepSessionBounds(deviceId: dev, from: start + 10_000,
+                                                        to: start + 20_000)
+        XCTAssertTrue(bounds.isEmpty)
+    }
 }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1305,43 +1305,23 @@ final class Repository: ObservableObject {
         guard !sessions.isEmpty, let store = await ensureStore() else { return [:] }
         let rawIds = rawPhysiologyReadIds(store: store)
         let computedIds = rawComputedReadIds(store: store)
-
-        // ONE read per candidate device, instead of a query per session per device to resolve the owner
-        // plus one more per session to read its motion. That per-session shape cost hundreds of sequential
-        // round trips on a browsable history, all before the Sleep screen could settle. The resolution and
-        // precedence below are unchanged; only where the rows come from moved.
-        //
-        // The motion half reuses `store.sessionMotions(deviceId:sessionStarts:)`, which already exists and
-        // already chunks its IN list under SQLite's parameter ceiling. It was written for the Sleep tab's
-        // main-night group and this caller simply never adopted it.
-        //
-        // The `-noop` variants are prefetched too. `ownerComputed` appends the suffix to whichever id won,
-        // so it can name a device in NEITHER list, and the old code queried it directly. Prefetching only
-        // the two lists would silently return no motion for exactly those sessions.
-        let candidateIds = (rawIds + computedIds)
-            .flatMap { [$0, $0.hasSuffix("-noop") ? $0 : $0 + "-noop"] }
-            .reduce(into: [String]()) { if !$0.contains($1) { $0.append($1) } }
         let starts = sessions.map(\.startTs)
         let lo = starts.min() ?? 0
         let hi = starts.max() ?? 0
-        // `sleepSessionBounds`, not `sleepSessions`: the owner check needs two integers per block, and the
-        // fuller read selects `stagesJSON` among other columns. Fetching every night's staging blob once
-        // per candidate device, to compare a pair of timestamps, would re-read the same rows several times
-        // over on the histories this is meant to speed up. Unpaged, so a caller passing a sparse subset of
-        // a wide span cannot page short and lose the owners it dropped.
+
+        // Phase 1, ownership. `sleepSessionBounds`, not `sleepSessions`: the check needs two integers per
+        // block, and the fuller read selects `stagesJSON` among other columns, so it would haul every
+        // night's staging blob once per candidate device to compare a pair of timestamps. Unpaged, so a
+        // caller passing a sparse subset of a wide span cannot page short and lose the owners it dropped.
         var boundsByDevice: [String: [Int: Int]] = [:]   // deviceId -> startTs -> endTs
-        var motionByDevice: [String: [Int: [Double]]] = [:]
-        for id in candidateIds {
+        for id in rawIds + computedIds {
             boundsByDevice[id] = (try? await store.sleepSessionBounds(deviceId: id, from: lo, to: hi)) ?? [:]
-            motionByDevice[id] = (try? await store.sessionMotions(deviceId: id,
-                                                                  sessionStarts: starts)) ?? [:]
         }
 
-        var out: [Int: [Double]] = [:]
-        for session in sessions where out[session.startTs] == nil {
-            // CachedSleepSession has no provenance field. Re-resolve the exact visible block using the
-            // same imported-wins order as allSleepSessions, then probe its computed owner first. Matching
-            // BOTH bounds still, since a start alone can be shared by a raw row and its computed twin.
+        // Resolve each block's ordered source list, exactly as before: the imported-wins owner search,
+        // then its computed twin first and the computed ids behind it.
+        var sourcesByStart: [Int: [String]] = [:]
+        for session in sessions where sourcesByStart[session.startTs] == nil {
             var owner: String?
             for id in rawIds + computedIds {
                 if boundsByDevice[id]?[session.startTs] == session.endTs {
@@ -1350,15 +1330,35 @@ final class Repository: ObservableObject {
                 }
             }
             let ownerComputed = owner.map { $0.hasSuffix("-noop") ? $0 : $0 + "-noop" }
-            let sources = ([ownerComputed].compactMap { $0 } + computedIds).reduce(into: [String]()) {
-                if !$0.contains($1) { $0.append($1) }
+            sourcesByStart[session.startTs] = ([ownerComputed].compactMap { $0 } + computedIds)
+                .reduce(into: [String]()) { if !$0.contains($1) { $0.append($1) } }
+        }
+
+        // Phase 2, motion, in ROUNDS rather than all sources for all blocks.
+        //
+        // A night's motion is one value per epoch, so a night is kilobytes of JSON and a long history is
+        // tens of megabytes. Asking every computed device for every block would decode that several times
+        // over to keep one copy, which is the same trade as pulling `stagesJSON` above: fewer round trips
+        // bought with far more bytes. Round k asks each device only for the blocks whose k-th source it is
+        // and which are still unfilled, so a block is read from its second source only if its first had
+        // nothing. That is the early exit the per-session loop had, kept, with D reads per round instead
+        // of one per block. Owned blocks resolve in the first round, so the second rarely runs.
+        var out: [Int: [Double]] = [:]
+        var round = 0
+        let maxRounds = sourcesByStart.values.map(\.count).max() ?? 0
+        while round < maxRounds {
+            var wantedByDevice: [String: [Int]] = [:]
+            for (start, sources) in sourcesByStart where out[start] == nil && round < sources.count {
+                wantedByDevice[sources[round], default: []].append(start)
             }
-            for id in sources {
-                if let motion = motionByDevice[id]?[session.startTs], !motion.isEmpty {
-                    out[session.startTs] = motion
-                    break
+            if wantedByDevice.isEmpty { break }
+            for (id, wanted) in wantedByDevice {
+                let motions = (try? await store.sessionMotions(deviceId: id, sessionStarts: wanted)) ?? [:]
+                for (start, motion) in motions where out[start] == nil && !motion.isEmpty {
+                    out[start] = motion
                 }
             }
+            round += 1
         }
         return out
     }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1324,16 +1324,15 @@ final class Repository: ObservableObject {
         let starts = sessions.map(\.startTs)
         let lo = starts.min() ?? 0
         let hi = starts.max() ?? 0
-        // Generous: one device cannot hold more rows in this span than the un-deduplicated union does,
-        // and a truncated page would silently fail to resolve the owners it dropped.
-        let pageLimit = max(sessions.count * 2, 256)
+        // `sleepSessionBounds`, not `sleepSessions`: the owner check needs two integers per block, and the
+        // fuller read selects `stagesJSON` among other columns. Fetching every night's staging blob once
+        // per candidate device, to compare a pair of timestamps, would re-read the same rows several times
+        // over on the histories this is meant to speed up. Unpaged, so a caller passing a sparse subset of
+        // a wide span cannot page short and lose the owners it dropped.
         var boundsByDevice: [String: [Int: Int]] = [:]   // deviceId -> startTs -> endTs
         var motionByDevice: [String: [Int: [Double]]] = [:]
         for id in candidateIds {
-            let rows = (try? await store.sleepSessions(deviceId: id, from: lo, to: hi,
-                                                       limit: pageLimit)) ?? []
-            boundsByDevice[id] = Dictionary(rows.map { ($0.startTs, $0.endTs) },
-                                            uniquingKeysWith: { first, _ in first })
+            boundsByDevice[id] = (try? await store.sleepSessionBounds(deviceId: id, from: lo, to: hi)) ?? [:]
             motionByDevice[id] = (try? await store.sessionMotions(deviceId: id,
                                                                   sessionStarts: starts)) ?? [:]
         }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1309,24 +1309,40 @@ final class Repository: ObservableObject {
         let lo = starts.min() ?? 0
         let hi = starts.max() ?? 0
 
-        // Phase 1, ownership. `sleepSessionBounds`, not `sleepSessions`: the check needs two integers per
-        // block, and the fuller read selects `stagesJSON` among other columns, so it would haul every
-        // night's staging blob once per candidate device to compare a pair of timestamps. Unpaged, so a
-        // caller passing a sparse subset of a wide span cannot page short and lose the owners it dropped.
+        // Phase 1, ownership.
+        //
+        // A block read from the store now carries the device it was read from, so most of the time there
+        // is nothing to resolve. The probe below runs only for blocks built by hand, which is tests and
+        // the importers, and the bounds read happens only if at least one such block is present.
+        //
+        // Provenance gives the SAME answer the probe does. The search takes the first id in
+        // `rawIds + computedIds` whose bounds match, then normalises it to its `-noop` twin, and
+        // `computedIds` is exactly `rawIds` mapped to that suffix. So a block read under a raw id and the
+        // same block read under its computed one both resolve to that one computed source either way.
+        //
+        // `sleepSessionBounds`, not `sleepSessions`: the check needs two integers per block, and the fuller
+        // read selects `stagesJSON` among other columns, so it would haul every night's staging blob once
+        // per candidate device to compare a pair of timestamps. Unpaged, so a caller passing a sparse
+        // subset of a wide span cannot page short and lose the owners it dropped.
         var boundsByDevice: [String: [Int: Int]] = [:]   // deviceId -> startTs -> endTs
-        for id in rawIds + computedIds {
-            boundsByDevice[id] = (try? await store.sleepSessionBounds(deviceId: id, from: lo, to: hi)) ?? [:]
+        if sessions.contains(where: { $0.deviceId == nil }) {
+            for id in rawIds + computedIds {
+                boundsByDevice[id] = (try? await store.sleepSessionBounds(deviceId: id,
+                                                                          from: lo, to: hi)) ?? [:]
+            }
         }
 
-        // Resolve each block's ordered source list, exactly as before: the imported-wins owner search,
-        // then its computed twin first and the computed ids behind it.
+        // Resolve each block's ordered source list: its own device when the read supplied one, else the
+        // imported-wins owner search, then its computed twin first and the computed ids behind it.
         var sourcesByStart: [Int: [String]] = [:]
         for session in sessions where sourcesByStart[session.startTs] == nil {
-            var owner: String?
-            for id in rawIds + computedIds {
-                if boundsByDevice[id]?[session.startTs] == session.endTs {
-                    owner = id
-                    break
+            var owner: String? = session.deviceId
+            if owner == nil {
+                for id in rawIds + computedIds {
+                    if boundsByDevice[id]?[session.startTs] == session.endTs {
+                        owner = id
+                        break
+                    }
                 }
             }
             let ownerComputed = owner.map { $0.hasSuffix("-noop") ? $0 : $0 + "-noop" }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1305,15 +1305,47 @@ final class Repository: ObservableObject {
         guard !sessions.isEmpty, let store = await ensureStore() else { return [:] }
         let rawIds = rawPhysiologyReadIds(store: store)
         let computedIds = rawComputedReadIds(store: store)
+
+        // ONE read per candidate device, instead of a query per session per device to resolve the owner
+        // plus one more per session to read its motion. That per-session shape cost hundreds of sequential
+        // round trips on a browsable history, all before the Sleep screen could settle. The resolution and
+        // precedence below are unchanged; only where the rows come from moved.
+        //
+        // The motion half reuses `store.sessionMotions(deviceId:sessionStarts:)`, which already exists and
+        // already chunks its IN list under SQLite's parameter ceiling. It was written for the Sleep tab's
+        // main-night group and this caller simply never adopted it.
+        //
+        // The `-noop` variants are prefetched too. `ownerComputed` appends the suffix to whichever id won,
+        // so it can name a device in NEITHER list, and the old code queried it directly. Prefetching only
+        // the two lists would silently return no motion for exactly those sessions.
+        let candidateIds = (rawIds + computedIds)
+            .flatMap { [$0, $0.hasSuffix("-noop") ? $0 : $0 + "-noop"] }
+            .reduce(into: [String]()) { if !$0.contains($1) { $0.append($1) } }
+        let starts = sessions.map(\.startTs)
+        let lo = starts.min() ?? 0
+        let hi = starts.max() ?? 0
+        // Generous: one device cannot hold more rows in this span than the un-deduplicated union does,
+        // and a truncated page would silently fail to resolve the owners it dropped.
+        let pageLimit = max(sessions.count * 2, 256)
+        var boundsByDevice: [String: [Int: Int]] = [:]   // deviceId -> startTs -> endTs
+        var motionByDevice: [String: [Int: [Double]]] = [:]
+        for id in candidateIds {
+            let rows = (try? await store.sleepSessions(deviceId: id, from: lo, to: hi,
+                                                       limit: pageLimit)) ?? []
+            boundsByDevice[id] = Dictionary(rows.map { ($0.startTs, $0.endTs) },
+                                            uniquingKeysWith: { first, _ in first })
+            motionByDevice[id] = (try? await store.sessionMotions(deviceId: id,
+                                                                  sessionStarts: starts)) ?? [:]
+        }
+
         var out: [Int: [Double]] = [:]
         for session in sessions where out[session.startTs] == nil {
             // CachedSleepSession has no provenance field. Re-resolve the exact visible block using the
-            // same imported-wins order as allSleepSessions, then probe its computed owner first.
+            // same imported-wins order as allSleepSessions, then probe its computed owner first. Matching
+            // BOTH bounds still, since a start alone can be shared by a raw row and its computed twin.
             var owner: String?
             for id in rawIds + computedIds {
-                let rows = (try? await store.sleepSessions(deviceId: id, from: session.startTs,
-                                                           to: session.startTs, limit: 4)) ?? []
-                if rows.contains(where: { $0.startTs == session.startTs && $0.endTs == session.endTs }) {
+                if boundsByDevice[id]?[session.startTs] == session.endTs {
                     owner = id
                     break
                 }
@@ -1323,8 +1355,7 @@ final class Repository: ObservableObject {
                 if !$0.contains($1) { $0.append($1) }
             }
             for id in sources {
-                if let motion = (try? await store.sessionMotion(deviceId: id, sessionStart: session.startTs)) ?? nil,
-                   !motion.isEmpty {
+                if let motion = motionByDevice[id]?[session.startTs], !motion.isEmpty {
                     out[session.startTs] = motion
                     break
                 }

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1319,6 +1319,9 @@ final class Repository: ObservableObject {
         // `rawIds + computedIds` whose bounds match, then normalises it to its `-noop` twin, and
         // `computedIds` is exactly `rawIds` mapped to that suffix. So a block read under a raw id and the
         // same block read under its computed one both resolve to that one computed source either way.
+        // Disagreeing would take two DIFFERENT straps sharing a start and an end to the second, and
+        // `dedupBlocks` already collapses that pair to a single block, so the probe was picking one of
+        // them arbitrarily as well.
         //
         // `sleepSessionBounds`, not `sleepSessions`: the check needs two integers per block, and the fuller
         // read selects `stagesJSON` among other columns, so it would haul every night's staging blob once

--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -66,6 +66,15 @@ struct SleepView: View {
     /// merges each day into one Night, so a split day reads as one correctly-totalled night with the
     /// gaps preserved. Oldest→newest. Falls back to `repo.sleeps` until loaded. (#170)
     @State private var allSessions: [CachedSleepSession] = []
+    /// `navDays` memoized, rebuilt where `model` is.
+    ///
+    /// Grouping calls `Calendar.startOfDay` once per session, and the browsable history is every block
+    /// ever recorded, so recomputing it per render is a per-frame pass over years of nights. Body reaches
+    /// it more than once (the wake-timestamp list, and `dayBlocks(at:)` for the source blocks), so a
+    /// scroll paid it repeatedly. Invalidated by the same two paths that rebuild `model`: `dataKey`
+    /// covers a `repo.sleeps` change, and the refresh task covers `allSessions` reloading. Nil falls back
+    /// to computing it, so a first render before either has run is correct rather than empty.
+    @State private var navDaysCache: [[CachedSleepSession]]?
 
     /// The user's LEARNED habitual midsleep (local time-of-day seconds), or nil under the cold-start
     /// threshold. Loaded from `repo.habitualMidsleepSec()` — the SAME value `AnalyticsEngine.analyzeDay`
@@ -178,6 +187,7 @@ struct SleepView: View {
             // `resolved` already drives THIS frame, so there is no flash and no extra rebuild.
             .onChangeCompat(of: key) { newKey in
                 modelKey = newKey
+                navDaysCache = SleepModel.navDays(navSessions: navSessions)
                 model = buildModel()
                 // New data invalidates a navigated offset — the same offset would silently
                 // point at a different session. Snap back to last night. (#160)
@@ -213,6 +223,7 @@ struct SleepView: View {
                 nightOffset = 0
                 navNight = nil
                 modelKey = dataKey
+                navDaysCache = SleepModel.navDays(navSessions: navSessions)
                 model = buildModel()
             }
             .sheet(item: $wakeEdit) { edit in
@@ -1777,7 +1788,7 @@ struct SleepView: View {
     /// The browsable DAY list — a thin wrapper over the shared `SleepModel.navDays`, which is the
     /// source of truth the builder and the ◀/▶ nav both read (no duplicated grouping). (#170)
     private var navDays: [[CachedSleepSession]] {
-        SleepModel.navDays(navSessions: navSessions)
+        navDaysCache ?? SleepModel.navDays(navSessions: navSessions)
     }
 
     /// The device's current UTC offset (seconds east), evaluated once per pick. Feeds the selector's

--- a/StrandTests/RawPhysiologyUnionTests.swift
+++ b/StrandTests/RawPhysiologyUnionTests.swift
@@ -113,6 +113,37 @@ final class RawPhysiologyUnionTests: XCTestCase {
         }
     }
 
+    /// Provenance and the probe must agree, or the fast path is a behaviour change wearing a perf label.
+    ///
+    /// The stored block carries the device it was read from and skips the ownership probe; the same block
+    /// with that field stripped falls back to the probe. Both must resolve to the same motion. They do
+    /// because the search normalises whichever id it finds to its `-noop` twin, and the computed ids are
+    /// exactly the raw ids under that suffix, so both namespaces land on one source.
+    @MainActor
+    func testProvenanceAndTheOwnerProbeResolveTheSameMotion() async throws {
+        let store = try await WhoopStore.inMemory()
+        let session = CachedSleepSession(startTs: 1_000, endTs: 5_000, efficiency: 0.9,
+                                         restingHr: 52, avgHrv: 60, stagesJSON: nil)
+        _ = try await store.upsertSleepSessions([session], deviceId: "my-whoop")
+        _ = try await store.upsertSleepSessions([session], deviceId: "my-whoop-noop")
+        _ = try await store.persistSessionMotion(deviceId: "my-whoop-noop", sessionStart: 1_000,
+                                                 motionEpochs: [0.3, 0.4])
+        let repo = Repository(deviceId: "my-whoop")
+        repo.setStoreForTesting(store)
+
+        // As the store hands it back: provenance present, no probe.
+        let stored = try await store.sleepSessions(deviceId: "my-whoop", from: 0, to: 10_000, limit: 8)
+        XCTAssertEqual(stored.first?.deviceId, "my-whoop")
+        let viaProvenance = await repo.sessionMotions(sessions: stored)
+
+        // The same block with provenance stripped: the probe resolves it instead.
+        let viaProbe = await repo.sessionMotions(sessions: [session])
+
+        XCTAssertEqual(viaProvenance[1_000] ?? [], [0.3, 0.4])
+        XCTAssertEqual(viaProbe[1_000] ?? [], viaProvenance[1_000] ?? [],
+                       "the shortcut and the probe disagreed about the same night")
+    }
+
     @MainActor
     func testArchivedStrapNightsTeachHabitualMidsleep() async throws {
         let store = try await WhoopStore.inMemory()

--- a/StrandTests/RawPhysiologyUnionTests.swift
+++ b/StrandTests/RawPhysiologyUnionTests.swift
@@ -82,6 +82,37 @@ final class RawPhysiologyUnionTests: XCTestCase {
         XCTAssertEqual(motion[1_000] ?? [], [0.1, 0.2])
     }
 
+    /// The batched read resolves EVERY session, not just the first.
+    ///
+    /// The per-session shape this replaced asked the store once per session per candidate device; it now
+    /// takes one windowed read per device and resolves each block against that. The failure a batched
+    /// version can have is a partial map: a span or page bound that covers the first night and quietly
+    /// drops the rest, which looks exactly like "those nights have no motion" rather than like a bug.
+    /// Three nights spread across the window, each with its own series, so a truncation is visible.
+    @MainActor
+    func testSessionMotionsResolvesEveryNightInOneBatch() async throws {
+        let store = try await WhoopStore.inMemory()
+        let starts = [1_000, 200_000, 900_000]
+        let sessions = starts.map {
+            CachedSleepSession(startTs: $0, endTs: $0 + 4_000, efficiency: 0.9,
+                               restingHr: 52, avgHrv: 60, stagesJSON: nil)
+        }
+        _ = try await store.upsertSleepSessions(sessions, deviceId: "my-whoop")
+        _ = try await store.upsertSleepSessions(sessions, deviceId: "my-whoop-noop")
+        for (i, start) in starts.enumerated() {
+            _ = try await store.persistSessionMotion(deviceId: "my-whoop-noop", sessionStart: start,
+                                                     motionEpochs: [Double(i) + 0.5])
+        }
+        let repo = Repository(deviceId: "my-whoop")
+        repo.setStoreForTesting(store)
+
+        let motion = await repo.sessionMotions(sessions: sessions)
+        XCTAssertEqual(motion.count, starts.count, "a night dropped by the batch reads as having no motion")
+        for (i, start) in starts.enumerated() {
+            XCTAssertEqual(motion[start] ?? [], [Double(i) + 0.5], "night at \(start) got another night's series")
+        }
+    }
+
     @MainActor
     func testArchivedStrapNightsTeachHabitualMidsleep() async throws {
         let store = try await WhoopStore.inMemory()


### PR DESCRIPTION
From an iOS user: brief freezes and delays, and the Sleep screen in particular locking up and becoming hard to scroll.

Two separate causes, both per-item work over a history that grows without bound.

## The freeze

On every refresh the screen loads **every sleep block ever recorded** (`allSleepSessions` spans 4000 days), then calls `sessionMotions`, which asked the store:

- once per session **per candidate device**, to resolve the owning device
- then once more per session, to read that owner's motion

On a browsable history that is hundreds of sequential round trips before the screen can settle. It runs after every sync, which is exactly when someone is looking at it. The existing comment says the prefetch exists "so the model build is sync", which is the trade that produces the freeze.

It now takes **one windowed read per candidate device** and resolves each block against that. Resolution order, imported-wins precedence and computed-owner-first motion lookup are unchanged; only where the rows come from moved. `(deviceId, startTs)` is the table's primary key, so keying the prefetch by start loses nothing, and the old `limit: 4` could never have mattered.

## The scroll

`navDays` groups every session by calendar day, calling `Calendar.startOfDay` once per session, and was a computed property with **no memo**. Body reaches it more than once (the wake-timestamp list, and `dayBlocks(at:)`), so scrolling paid a full pass over years of nights per frame.

It now rebuilds where `model` does, off the `dataKey` mechanism that already exists for exactly this, and falls back to computing when unset so a first render is correct rather than empty.

## What re-review changed

My first attempt added a **new batched store read**. That was a duplicate: `store.sessionMotions(deviceId:sessionStarts:)` already exists, already chunks its `IN` list under SQLite's parameter ceiling, already preserves absent-stays-absent, and already has a test pinning it against N single reads. Its doc even says it was written to kill "the per-session round-trip the Sleep tab's main-night group used to pay", and this caller simply never adopted it. The duplicate is not in this change.

## The subtle part

The `-noop` variants are prefetched deliberately. `ownerComputed` appends the suffix to whichever id won, so it can name a device in **neither** id list, and the old code queried it directly. Prefetching only the two lists would return no motion for exactly those sessions.

That is not hypothetical: `testSessionMotionUsesHistoricalOwnerBeforeCurrentActiveComputedSource` already asserts a historical owner's computed twin wins over the active one, and it fails without those variants.

## Tests

The existing test above is the guard for the tricky case. Added one for what batching itself can break: three nights spread across the window, each with its own series, so a span or page bound that covers the first and drops the rest is visible. A dropped night reads as "no motion" rather than as a bug, which is why it is asserted per night rather than by count alone.

`Tools/doc_comment_lint.py` clean. No Android files touched.

## Android

Milder and untouched. Its `SleepSession` row carries `deviceId`, so it needs no owner probe at all, though it still reads motion once per session. Matching this would need a new DAO query with an `IN` clause, which is beyond the report.

## Not verified here

Swift does not build under WSL, so this needs CI. And the win needs the reporter: the screen should settle promptly after a sync rather than locking, and scrolling should stay smooth on a long history.

There is a third cost this does not address, stated so it is not mistaken for fixed: the screen still loads every block ever recorded to render one night. Bounding that changes when nav needs data, so it wants its own change.
