### PR TITLE
fix: include skin temperature before recovery scoring

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1949,11 +1949,10 @@ final class IntelligenceEngine: ObservableObject {
             var daily = sleepEditedDaily(night.daily, detected: night.cachedSleep, editsByStart: editsByStart,
                                          habitualMidsleepSec: habitualMidsleepSec)
             daily = DayCycleIntelligenceIntegration.applying(physiologicalSteps, to: daily)
-            // Pass 1 has no seeded skin baseline. Score and explain the same deviation we persist.
-            let skinDev = recomputeSkinTempDev(night.nightlySkin, baselines2.skinTemp)
-            daily = daily.with(recovery: daily.recovery, skinTempDevC: skinDev,
-                               skinTempC: night.nightlySkin)
-            let recovery = recomputeRecovery(daily, baselines2)
+            daily = Self.recomputeRecoveryDaily(daily, nightlySkinTempC: night.nightlySkin,
+                                               baselines: baselines2)
+            let recovery = daily.recovery
+            let skinDev = daily.skinTempDevC
             // Charge term-breakdown trace (Group G): only when the Recovery test mode is on. Emits which
             // term moved Charge and which was nil and forced the renorm, tagged `.recovery`. The trace's
             // score is RecoveryScorer.recovery verbatim, so the `recovery` written above is unchanged.
@@ -2040,8 +2039,7 @@ final class IntelligenceEngine: ObservableObject {
             // Persist the ABSOLUTE beside the deviation derived from it (#1636). Same value, same pass,
             // same `night.nightlySkin` the line above takes the deviation from — so the two can never
             // describe different nights, and no second derivation exists to drift.
-            dailies.append(daily.with(recovery: recovery, skinTempDevC: skinDev,
-                                      skinTempC: night.nightlySkin))
+            dailies.append(daily)
             if let rest = AnalyticsEngine.Rest.composite(daily: daily) {
                 restPoints.append(MetricPoint(day: daily.day, key: "sleep_performance", value: rest))
             }
@@ -2909,12 +2907,22 @@ final class IntelligenceEngine: ObservableObject {
         if !updated.isEmpty { _ = try? await store.upsertWorkouts(updated, deviceId: deviceId) }
     }
 
+    /// Pass 1 has no seeded skin baseline. Attach the deviation before scoring so the score,
+    /// explanation, trace and persisted row all consume the same temperature. Internal for regression tests.
+    static func recomputeRecoveryDaily(_ daily: DailyMetric, nightlySkinTempC: Double?,
+                                       baselines: AnalyticsEngine.ProfileBaselines) -> DailyMetric {
+        let skinDev = recomputeSkinTempDev(nightlySkinTempC, baselines.skinTemp)
+        let input = daily.with(recovery: daily.recovery, skinTempDevC: skinDev, skinTempC: nightlySkinTempC)
+        return input.with(recovery: recomputeRecovery(input, baselines), skinTempDevC: skinDev,
+                          skinTempC: nightlySkinTempC)
+    }
+
     /// Re-score ONLY the recovery composite for a day against a (re-seeded) baseline. Every other field
     /// in `daily` is baseline-independent and already final from pass 1. Returns nil until the HRV
     /// baseline is usable (RecoveryScorer gates on `hrvBaseline.usable`, i.e. ≥ minNightsSeed valid
     /// nights) , so the honest null-until-4-nights cold-start is free. Mirrors AnalyticsEngine's own
     /// recovery call + Android IntelligenceEngine.recomputeRecovery. (#78)
-    private func recomputeRecovery(_ daily: DailyMetric, _ baselines: AnalyticsEngine.ProfileBaselines) -> Double? {
+    private static func recomputeRecovery(_ daily: DailyMetric, _ baselines: AnalyticsEngine.ProfileBaselines) -> Double? {
         guard let hrvVal = daily.avgHrv, let rhrVal = daily.restingHr, let hrvBase = baselines.hrv else { return nil }
         // Charge enrichment: feed the Rest COMPOSITE (÷100) as the sleep-quality term instead of raw
         // efficiency, and fold in the night's skin-temp deviation. Both come from the persisted daily
@@ -3071,7 +3079,7 @@ final class IntelligenceEngine: ObservableObject {
     /// baseline, mirroring the avgHrv→recovery re-score. Nil when the night had no wear-gated mean or
     /// the skin-temp baseline isn't usable yet (< minNightsSeed) , honest cold-start. Rounded to 2 dp
     /// to match the imported/demo precision. APPROXIMATE.
-    private func recomputeSkinTempDev(_ nightly: Double?, _ base: BaselineState?) -> Double? {
+    private static func recomputeSkinTempDev(_ nightly: Double?, _ base: BaselineState?) -> Double? {
         guard let v = nightly, let b = base, b.usable else { return nil }
         return (Baselines.deviation(v, state: b).delta * 100.0).rounded() / 100.0
     }

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -1949,6 +1949,10 @@ final class IntelligenceEngine: ObservableObject {
             var daily = sleepEditedDaily(night.daily, detected: night.cachedSleep, editsByStart: editsByStart,
                                          habitualMidsleepSec: habitualMidsleepSec)
             daily = DayCycleIntelligenceIntegration.applying(physiologicalSteps, to: daily)
+            // Pass 1 has no seeded skin baseline. Score and explain the same deviation we persist.
+            let skinDev = recomputeSkinTempDev(night.nightlySkin, baselines2.skinTemp)
+            daily = daily.with(recovery: daily.recovery, skinTempDevC: skinDev,
+                               skinTempC: night.nightlySkin)
             let recovery = recomputeRecovery(daily, baselines2)
             // Charge term-breakdown trace (Group G): only when the Recovery test mode is on. Emits which
             // term moved Charge and which was nil and forced the renorm, tagged `.recovery`. The trace's
@@ -1956,7 +1960,6 @@ final class IntelligenceEngine: ObservableObject {
             if recoveryTraceActive {
                 for line in recoveryTraceLines(daily, baselines2) { diagnosticSink?(line, .recovery) }
             }
-            let skinDev = recomputeSkinTempDev(night.nightlySkin, baselines2.skinTemp)
             let source = DaySource.classify(day: daily.day, importedWhoopDays: importedWhoopDays,
                                             appleHealthDays: appleHealthDays)
             // SHARED CONTRACT enrichment: the ordered Charge driver list + the relative skin-temp marker,

--- a/StrandTests/DayCycleRecoveryTests.swift
+++ b/StrandTests/DayCycleRecoveryTests.swift
@@ -85,4 +85,70 @@ final class DayCycleRecoveryTests: XCTestCase {
         XCTAssertTrue(result.stepsByWakeDay.isEmpty)
         XCTAssertTrue(result.onsetByWakeDay.isEmpty)
     }
+
+    func testPass2SkinTempDeviationBeforeRecoveryScoring() async throws {
+        let store = try await WhoopStore.inMemory()
+        let day = "2026-09-09"
+        let nightlySkinTempC = 34.8
+        let skinTempBaseline = Baselines.Baseline(
+            baseline: 34.5, spread: 0.4, nValid: 14, nightsSinceUpdate: 0,
+            status: .trusted)
+        let hrvBaseline = Baselines.Baseline(
+            baseline: 50.0, spread: 6.0, nValid: 14, nightsSinceUpdate: 0,
+            status: .trusted)
+
+        let baselines = Baselines(
+            hrv: hrvBaseline, rhr: nil, resp: nil, skinTemp: skinTempBaseline, strain: nil, vo2max: nil)
+        let skinTempDevC = nightlySkinTempC - skinTempBaseline.baseline
+        let hrv = 48.0
+        let rhr = 58.0
+
+        let scoreWithSkinDev = RecoveryScorer.recovery(
+            hrv: hrv, rhr: rhr, resp: nil,
+            hrvBaseline: RecoveryScorer.DriverBaseline(hrvBaseline),
+            rhrBaseline: nil, respBaseline: nil,
+            sleepPerf: 0.85, skinTempDev: skinTempDevC)
+
+        let scoreWithoutSkinDev = RecoveryScorer.recovery(
+            hrv: hrv, rhr: rhr, resp: nil,
+            hrvBaseline: RecoveryScorer.DriverBaseline(hrvBaseline),
+            rhrBaseline: nil, respBaseline: nil,
+            sleepPerf: 0.85, skinTempDev: nil)
+
+        XCTAssertNotNil(scoreWithSkinDev)
+        XCTAssertNotNil(scoreWithoutSkinDev)
+        XCTAssertNotEqual(scoreWithSkinDev, scoreWithoutSkinDev,
+                          "Charge with non-nil skinTempDev must differ from nil-deviation when deviation is non-trivial")
+
+        try await store.writeSync { db in
+            try db.execute(sql: """
+                INSERT INTO daily_metric (day, avg_hrv, resting_hr, total_sleep_min, efficiency)
+                VALUES (?, ?, ?, 420, 0.85)
+                """, arguments: [day, hrv, rhr])
+        }
+
+        let nights = [IntelligenceEngine.ScoredNight(
+            daily: DailyMetric(
+                day: day, totalSleepMin: 420, efficiency: 0.85, deepMin: nil, remMin: nil,
+                lightMin: nil, disturbances: nil, restingHr: rhr, avgHrv: hrv,
+                recovery: nil, strain: nil, exerciseCount: nil, spo2Pct: nil,
+                skinTempDevC: nil, respRateBpm: nil, steps: nil, activeKcalEst: nil,
+                skinTempC: nil, sleepHrOnly: false),
+            cachedSleep: [],
+            nightlySkin: nightlySkinTempC)]
+
+        let computed = await IntelligenceEngine.score(
+            scoredNights: nights, editedRows: [], baselines: baselines,
+            importedWhoopDays: [], appleHealthDays: [], tzOffset: 0, nowSeconds: 0,
+            resolvedScoreOwnerByDay: [:], candidatePriorities: [], habitualMidsleepSec: nil,
+            store: store, stepTicksPerStep: 1, physiologicalStepsResult: nil,
+            stepsTraceActive: false, dayCycleMode: .sleepOnset, profile: UserProfile(),
+            maxHROverride: nil, effortMethod: .edwards, diagnosticSink: nil)
+
+        XCTAssertEqual(computed.count, 1)
+        let result = computed.first!
+        XCTAssertEqual(result.recovery, scoreWithSkinDev,
+                       "Pass-2 Charge must match RecoveryScorer called WITH skinTempDev, not nil")
+        XCTAssertNotNil(result.skinTempRel)
+    }
 }

--- a/StrandTests/DayCycleRecoveryTests.swift
+++ b/StrandTests/DayCycleRecoveryTests.swift
@@ -86,69 +86,78 @@ final class DayCycleRecoveryTests: XCTestCase {
         XCTAssertTrue(result.onsetByWakeDay.isEmpty)
     }
 
-    func testPass2SkinTempDeviationBeforeRecoveryScoring() async throws {
-        let store = try await WhoopStore.inMemory()
-        let day = "2026-09-09"
-        let nightlySkinTempC = 34.8
-        let skinTempBaseline = Baselines.Baseline(
-            baseline: 34.5, spread: 0.4, nValid: 14, nightsSinceUpdate: 0,
-            status: .trusted)
-        let hrvBaseline = Baselines.Baseline(
-            baseline: 50.0, spread: 6.0, nValid: 14, nightsSinceUpdate: 0,
-            status: .trusted)
+    func testPass2SkinTempDeviationBeforeRecoveryScoring() throws {
+        let daily = recoveryDailyFixture()
+        let baselines = AnalyticsEngine.ProfileBaselines(
+            hrv: recoveryBaseline(50, spread: 6), skinTemp: recoveryBaseline(34.5, spread: 0.4))
+        let withoutSkin = expectedRecovery(daily, baselines: baselines, skinDev: nil)
 
-        let baselines = Baselines(
-            hrv: hrvBaseline, rhr: nil, resp: nil, skinTemp: skinTempBaseline, strain: nil, vo2max: nil)
-        let skinTempDevC = nightlySkinTempC - skinTempBaseline.baseline
-        let hrv = 48.0
-        let rhr = 58.0
-
-        let scoreWithSkinDev = RecoveryScorer.recovery(
-            hrv: hrv, rhr: rhr, resp: nil,
-            hrvBaseline: RecoveryScorer.DriverBaseline(hrvBaseline),
-            rhrBaseline: nil, respBaseline: nil,
-            sleepPerf: 0.85, skinTempDev: skinTempDevC)
-
-        let scoreWithoutSkinDev = RecoveryScorer.recovery(
-            hrv: hrv, rhr: rhr, resp: nil,
-            hrvBaseline: RecoveryScorer.DriverBaseline(hrvBaseline),
-            rhrBaseline: nil, respBaseline: nil,
-            sleepPerf: 0.85, skinTempDev: nil)
-
-        XCTAssertNotNil(scoreWithSkinDev)
-        XCTAssertNotNil(scoreWithoutSkinDev)
-        XCTAssertNotEqual(scoreWithSkinDev, scoreWithoutSkinDev,
-                          "Charge with non-nil skinTempDev must differ from nil-deviation when deviation is non-trivial")
-
-        try await store.writeSync { db in
-            try db.execute(sql: """
-                INSERT INTO daily_metric (day, avg_hrv, resting_hr, total_sleep_min, efficiency)
-                VALUES (?, ?, ?, 420, 0.85)
-                """, arguments: [day, hrv, rhr])
+        for (nightly, deviation) in [(34.804, 0.3), (34.196, -0.3)] {
+            let result = IntelligenceEngine.recomputeRecoveryDaily(
+                daily, nightlySkinTempC: nightly, baselines: baselines)
+            let expected = try XCTUnwrap(expectedRecovery(daily, baselines: baselines, skinDev: deviation))
+            XCTAssertNotEqual(expected, withoutSkin)
+            XCTAssertEqual(result.recovery, expected)
+            XCTAssertEqual(result.skinTempDevC, deviation)
+            XCTAssertEqual(result.skinTempC, nightly)
+            // Undo only the three intended substitutions; every other daily field must survive.
+            XCTAssertEqual(result.with(recovery: daily.recovery, skinTempDevC: daily.skinTempDevC,
+                                       skinTempC: daily.skinTempC), daily)
         }
+    }
 
-        let nights = [IntelligenceEngine.ScoredNight(
-            daily: DailyMetric(
-                day: day, totalSleepMin: 420, efficiency: 0.85, deepMin: nil, remMin: nil,
-                lightMin: nil, disturbances: nil, restingHr: rhr, avgHrv: hrv,
-                recovery: nil, strain: nil, exerciseCount: nil, spo2Pct: nil,
-                skinTempDevC: nil, respRateBpm: nil, steps: nil, activeKcalEst: nil,
-                skinTempC: nil, sleepHrOnly: false),
-            cachedSleep: [],
-            nightlySkin: nightlySkinTempC)]
+    func testPass2MissingOrUnusableSkinBaselineClearsStaleDeviation() {
+        let daily = recoveryDailyFixture().with(recovery: 99, skinTempDevC: 9, skinTempC: 36)
+        let usable = recoveryBaseline(34.5, spread: 0.4)
+        let cases: [(Double?, BaselineState?)] = [
+            (nil, usable), (34.8, nil),
+            (34.8, recoveryBaseline(34.5, spread: 0.4, status: .calibrating)),
+            (34.8, recoveryBaseline(34.5, spread: 0.4, status: .stale))
+        ]
+        for (nightly, skinBaseline) in cases {
+            let baselines = AnalyticsEngine.ProfileBaselines(
+                hrv: recoveryBaseline(50, spread: 6), skinTemp: skinBaseline)
+            let result = IntelligenceEngine.recomputeRecoveryDaily(
+                daily, nightlySkinTempC: nightly, baselines: baselines)
+            XCTAssertNil(result.skinTempDevC)
+            XCTAssertEqual(result.skinTempC, nightly)
+            XCTAssertEqual(result.recovery, expectedRecovery(daily, baselines: baselines, skinDev: nil))
+        }
+    }
 
-        let computed = await IntelligenceEngine.score(
-            scoredNights: nights, editedRows: [], baselines: baselines,
-            importedWhoopDays: [], appleHealthDays: [], tzOffset: 0, nowSeconds: 0,
-            resolvedScoreOwnerByDay: [:], candidatePriorities: [], habitualMidsleepSec: nil,
-            store: store, stepTicksPerStep: 1, physiologicalStepsResult: nil,
-            stepsTraceActive: false, dayCycleMode: .sleepOnset, profile: UserProfile(),
-            maxHROverride: nil, effortMethod: .edwards, diagnosticSink: nil)
+    func testPass2SkinTemperatureDoesNotBypassHrvColdStart() {
+        let hrvBaselines: [BaselineState?] = [nil, recoveryBaseline(50, spread: 6, status: .calibrating)]
+        for hrv in hrvBaselines {
+            let result = IntelligenceEngine.recomputeRecoveryDaily(
+                recoveryDailyFixture(), nightlySkinTempC: 34.8,
+                baselines: AnalyticsEngine.ProfileBaselines(
+                    hrv: hrv, skinTemp: recoveryBaseline(34.5, spread: 0.4)))
+            XCTAssertNil(result.recovery)
+            XCTAssertEqual(result.skinTempDevC, 0.3)
+        }
+    }
 
-        XCTAssertEqual(computed.count, 1)
-        let result = computed.first!
-        XCTAssertEqual(result.recovery, scoreWithSkinDev,
-                       "Pass-2 Charge must match RecoveryScorer called WITH skinTempDev, not nil")
-        XCTAssertNotNil(result.skinTempRel)
+    private func recoveryBaseline(_ mean: Double, spread: Double,
+                                  status: BaselineStatus = .trusted) -> BaselineState {
+        BaselineState(baseline: mean, spread: spread,
+                      nValid: status == .calibrating ? 3 : 14, nightsSinceUpdate: status == .stale ? 15 : 0,
+                      status: status)
+    }
+
+    private func recoveryDailyFixture() -> DailyMetric {
+        DailyMetric(day: "2026-09-09", totalSleepMin: 420, efficiency: 0.85,
+                    deepMin: 80, remMin: 90, lightMin: 250, disturbances: 2,
+                    restingHr: 58, avgHrv: 48, recovery: 99, strain: 61, exerciseCount: 2,
+                    spo2Pct: 97, skinTempDevC: nil, respRateBpm: 15, steps: 42, activeKcalEst: 1_840,
+                    spo2Red: 100, spo2Ir: 200, avgSdnn: 44, skinTempC: nil, sleepHrOnly: true)
+    }
+
+    private func expectedRecovery(_ daily: DailyMetric, baselines: AnalyticsEngine.ProfileBaselines,
+                                  skinDev: Double?) -> Double? {
+        RecoveryScorer.recovery(
+            hrv: 48, rhr: 58, resp: 15, hrvBaseline: baselines.hrv!, rhrBaseline: nil,
+            respBaseline: nil,
+            sleepPerf: AnalyticsEngine.Rest.composite(daily: daily).map { $0 / 100.0 } ?? daily.efficiency,
+            skinTempDev: skinDev)
     }
 }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1626,10 +1626,12 @@ object IntelligenceEngine {
             val dayEditedRows = editedRowsForDay(editedRows, res.daily.day, tzOffsetSeconds)
             // Substitute an edited block's (reshaped) stages for its detected twin before the daily
             // sleep aggregate feeds Rest + recovery. No edit touching this night → `daily` is unchanged.
+            // Pass 1 has no seeded skin baseline. Score and explain the same deviation we persist.
+            val skinTempDevC = recomputeSkinTempDev(res.nightlySkinTempC, baselines2.skinTemp)
             val daily = editedCycleDaily(
                 res, dayEditedRows, tzOffsetSeconds, habitualMidsleepSec,
                 physiologicalSteps, computedId, restRows,
-            )
+            ).copy(skinTempDevC = skinTempDevC, skinTempC = res.nightlySkinTempC)
             val recovery = recomputeRecovery(daily, baselines2)
             // Charge term-breakdown trace (Test Centre Group G): only when the Recovery test mode is on
             // (recoveryTraceSink non-null). Emits which term moved Charge and which was nil and forced the
@@ -1639,7 +1641,6 @@ object IntelligenceEngine {
             if (recoveryTraceSink != null) {
                 for (line in recoveryTraceLines(daily, baselines2)) recoveryTraceSink(line)
             }
-            val skinTempDevC = recomputeSkinTempDev(res.nightlySkinTempC, baselines2.skinTemp)
             RestScorer.restFromDaily(daily)?.let { rest ->
                 restRows.add(MetricSeriesRow(deviceId = computedId, day = daily.day, key = "sleep_performance", value = rest))
             }

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -1626,13 +1626,13 @@ object IntelligenceEngine {
             val dayEditedRows = editedRowsForDay(editedRows, res.daily.day, tzOffsetSeconds)
             // Substitute an edited block's (reshaped) stages for its detected twin before the daily
             // sleep aggregate feeds Rest + recovery. No edit touching this night → `daily` is unchanged.
-            // Pass 1 has no seeded skin baseline. Score and explain the same deviation we persist.
-            val skinTempDevC = recomputeSkinTempDev(res.nightlySkinTempC, baselines2.skinTemp)
-            val daily = editedCycleDaily(
+            val editedDaily = editedCycleDaily(
                 res, dayEditedRows, tzOffsetSeconds, habitualMidsleepSec,
                 physiologicalSteps, computedId, restRows,
-            ).copy(skinTempDevC = skinTempDevC, skinTempC = res.nightlySkinTempC)
-            val recovery = recomputeRecovery(daily, baselines2)
+            )
+            val daily = recomputeRecoveryDaily(editedDaily, res.nightlySkinTempC, baselines2)
+            val recovery = daily.recovery
+            val skinTempDevC = daily.skinTempDevC
             // Charge term-breakdown trace (Test Centre Group G): only when the Recovery test mode is on
             // (recoveryTraceSink non-null). Emits which term moved Charge and which was nil and forced the
             // renorm, tagged .recovery. The trace's score is RecoveryScorer.recovery verbatim, so the
@@ -2340,6 +2340,20 @@ object IntelligenceEngine {
             sleepPerf = restQuality,
             skinTempDev = daily.skinTempDevC,
         )
+    }
+
+    /**
+     * Pass 1 has no seeded skin baseline. Attach the deviation before scoring so the score,
+     * trace and persisted row all consume the same temperature. Mirrors Swift recomputeRecoveryDaily.
+     */
+    internal fun recomputeRecoveryDaily(
+        daily: DailyMetric, nightlySkinTempC: Double?, baselines: ProfileBaselines,
+    ): DailyMetric {
+        val input = daily.copy(
+            skinTempDevC = recomputeSkinTempDev(nightlySkinTempC, baselines.skinTemp),
+            skinTempC = nightlySkinTempC,
+        )
+        return input.copy(recovery = recomputeRecovery(input, baselines))
     }
 
     /** One day's source-only (daily-aggregate) recovery output, keyed by day. Mirrors Swift WatchScoredDay. */

--- a/android/app/src/test/java/com/noop/analytics/RecoveryDriversTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RecoveryDriversTest.kt
@@ -276,4 +276,43 @@ class RecoveryDriversTest {
             rhrBaseline = null, respBaseline = null, sleepPerf = 0.9,
         ))
     }
+
+    @Test fun pass2SkinTempDeviationBeforeRecoveryScoring() {
+        val nightlySkinTempC = 34.8
+        val skinTempBaseline = baseline(34.5, 0.4, nValid = 14)
+        val hrvBaseline = baseline(50.0, 6.0, nValid = 14)
+        val skinTempDevC = nightlySkinTempC - skinTempBaseline.baseline
+        val hrv = 48.0
+        val rhr = 58.0
+
+        val scoreWithSkinDev = RecoveryScorer.recovery(
+            hrv = hrv, rhr = rhr, resp = null,
+            hrvBaseline = RecoveryScorer.DriverBaseline(hrvBaseline),
+            rhrBaseline = null, respBaseline = null,
+            sleepPerf = 0.85, skinTempDev = skinTempDevC,
+        )
+
+        val scoreWithoutSkinDev = RecoveryScorer.recovery(
+            hrv = hrv, rhr = rhr, resp = null,
+            hrvBaseline = RecoveryScorer.DriverBaseline(hrvBaseline),
+            rhrBaseline = null, respBaseline = null,
+            sleepPerf = 0.85, skinTempDev = null,
+        )
+
+        assertTrue("Charge with non-nil skinTempDev must be present", scoreWithSkinDev != null)
+        assertTrue("Charge without skinTempDev must be present", scoreWithoutSkinDev != null)
+        assertTrue(
+            "Charge with non-nil skinTempDev must differ from nil-deviation when deviation is non-trivial (0.3°C)",
+            scoreWithSkinDev != scoreWithoutSkinDev,
+        )
+
+        val drivers = RecoveryDrivers.chargeDrivers(
+            hrv = hrv, rhr = rhr, resp = null,
+            hrvBaseline = hrvBaseline, rhrBaseline = null, respBaseline = null,
+            sleepPerf = 0.85, skinTempDev = skinTempDevC,
+        )
+        val skinDriver = drivers.firstOrNull { it.label == ChargeDriverLabel.SKIN_TEMPERATURE }
+        assertTrue("Skin-temp driver must exist when deviation is non-nil", skinDriver != null)
+        assertEquals(skinTempDevC.toBits(), skinDriver!!.value.toBits())
+    }
 }

--- a/android/app/src/test/java/com/noop/analytics/RecoveryDriversTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/RecoveryDriversTest.kt
@@ -1,5 +1,6 @@
 package com.noop.analytics
 
+import com.noop.data.DailyMetric
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -278,41 +279,74 @@ class RecoveryDriversTest {
     }
 
     @Test fun pass2SkinTempDeviationBeforeRecoveryScoring() {
-        val nightlySkinTempC = 34.8
-        val skinTempBaseline = baseline(34.5, 0.4, nValid = 14)
-        val hrvBaseline = baseline(50.0, 6.0, nValid = 14)
-        val skinTempDevC = nightlySkinTempC - skinTempBaseline.baseline
-        val hrv = 48.0
-        val rhr = 58.0
-
-        val scoreWithSkinDev = RecoveryScorer.recovery(
-            hrv = hrv, rhr = rhr, resp = null,
-            hrvBaseline = RecoveryScorer.DriverBaseline(hrvBaseline),
-            rhrBaseline = null, respBaseline = null,
-            sleepPerf = 0.85, skinTempDev = skinTempDevC,
+        val daily = recoveryDailyFixture()
+        val baselines = ProfileBaselines(
+            hrv = recoveryBaseline(50.0, 6.0), skinTemp = recoveryBaseline(34.5, 0.4),
         )
+        val withoutSkin = expectedRecovery(daily, baselines, null)
 
-        val scoreWithoutSkinDev = RecoveryScorer.recovery(
-            hrv = hrv, rhr = rhr, resp = null,
-            hrvBaseline = RecoveryScorer.DriverBaseline(hrvBaseline),
-            rhrBaseline = null, respBaseline = null,
-            sleepPerf = 0.85, skinTempDev = null,
-        )
-
-        assertTrue("Charge with non-nil skinTempDev must be present", scoreWithSkinDev != null)
-        assertTrue("Charge without skinTempDev must be present", scoreWithoutSkinDev != null)
-        assertTrue(
-            "Charge with non-nil skinTempDev must differ from nil-deviation when deviation is non-trivial (0.3°C)",
-            scoreWithSkinDev != scoreWithoutSkinDev,
-        )
-
-        val drivers = RecoveryDrivers.chargeDrivers(
-            hrv = hrv, rhr = rhr, resp = null,
-            hrvBaseline = hrvBaseline, rhrBaseline = null, respBaseline = null,
-            sleepPerf = 0.85, skinTempDev = skinTempDevC,
-        )
-        val skinDriver = drivers.firstOrNull { it.label == ChargeDriverLabel.SKIN_TEMPERATURE }
-        assertTrue("Skin-temp driver must exist when deviation is non-nil", skinDriver != null)
-        assertEquals(skinTempDevC.toBits(), skinDriver!!.value.toBits())
+        for ((nightly, deviation) in listOf(34.804 to 0.3, 34.196 to -0.3)) {
+            val result = IntelligenceEngine.recomputeRecoveryDaily(daily, nightly, baselines)
+            val expected = requireNotNull(expectedRecovery(daily, baselines, deviation))
+            assertTrue("Fixture must distinguish a missing temperature term", expected != withoutSkin)
+            assertEquals(expected, result.recovery)
+            assertEquals(deviation, result.skinTempDevC)
+            assertEquals(nightly, result.skinTempC)
+            // Undo only the three intended substitutions; every other daily field must survive.
+            assertEquals(daily, result.copy(
+                recovery = daily.recovery, skinTempDevC = daily.skinTempDevC, skinTempC = daily.skinTempC,
+            ))
+        }
     }
+
+    @Test fun pass2MissingOrUnusableSkinBaselineClearsStaleDeviation() {
+        val daily = recoveryDailyFixture().copy(recovery = 99.0, skinTempDevC = 9.0, skinTempC = 36.0)
+        val usable = recoveryBaseline(34.5, 0.4)
+        val cases = listOf(
+            null to usable, 34.8 to null,
+            34.8 to recoveryBaseline(34.5, 0.4, BaselineStatus.CALIBRATING),
+            34.8 to recoveryBaseline(34.5, 0.4, BaselineStatus.STALE),
+        )
+        for ((nightly, skinBaseline) in cases) {
+            val baselines = ProfileBaselines(hrv = recoveryBaseline(50.0, 6.0), skinTemp = skinBaseline)
+            val result = IntelligenceEngine.recomputeRecoveryDaily(daily, nightly, baselines)
+            assertNull(result.skinTempDevC)
+            assertEquals(nightly, result.skinTempC)
+            assertEquals(expectedRecovery(daily, baselines, null), result.recovery)
+        }
+    }
+
+    @Test fun pass2SkinTemperatureDoesNotBypassHrvColdStart() {
+        for (hrv in listOf(null, recoveryBaseline(50.0, 6.0, BaselineStatus.CALIBRATING))) {
+            val result = IntelligenceEngine.recomputeRecoveryDaily(
+                recoveryDailyFixture(), 34.8,
+                ProfileBaselines(hrv = hrv, skinTemp = recoveryBaseline(34.5, 0.4)),
+            )
+            assertNull(result.recovery)
+            assertEquals(0.3, result.skinTempDevC)
+        }
+    }
+
+    private fun recoveryBaseline(
+        mean: Double, spread: Double, status: BaselineStatus = BaselineStatus.TRUSTED,
+    ) = BaselineState(
+        baseline = mean, spread = spread, nValid = if (status == BaselineStatus.CALIBRATING) 3 else 14,
+        nightsSinceUpdate = if (status == BaselineStatus.STALE) 15 else 0, status = status,
+    )
+
+    private fun recoveryDailyFixture() = DailyMetric(
+        deviceId = "test-noop", day = "2026-09-09", totalSleepMin = 420.0, efficiency = 0.85,
+        deepMin = 80.0, remMin = 90.0, lightMin = 250.0, disturbances = 2,
+        restingHr = 58, avgHrv = 48.0, recovery = 99.0, strain = 61.0, exerciseCount = 2,
+        spo2Pct = 97.0, skinTempDevC = null, respRateBpm = 15.0, steps = 42, activeKcalEst = 1_840.0,
+        spo2Red = 100, spo2Ir = 200, avgSdnn = 44.0, skinTempC = null, sleepHrOnly = true,
+    )
+
+    private fun expectedRecovery(daily: DailyMetric, baselines: ProfileBaselines, skinDev: Double?) =
+        RecoveryScorer.recovery(
+            hrv = 48.0, rhr = 58.0, resp = 15.0, hrvBaseline = baselines.hrv!!, rhrBaseline = null,
+            respBaseline = null,
+            sleepPerf = RestScorer.restFromDaily(daily)?.let { it / 100.0 } ?: daily.efficiency,
+            skinTempDev = skinDev,
+        )
 }


### PR DESCRIPTION
## What this PR does

Pass 2 computes recovery before attaching the nightly skin-temperature deviation calculated from the seeded baseline. Recovery, its explanation and its trace therefore receive a nil temperature term even when the saved daily row subsequently contains a deviation.

Attach the deviation to the daily input before scoring, explaining and tracing recovery. Apply the same ordering correction in Swift and Kotlin through a small `recomputeRecoveryDaily` helper used by Pass 2 and the regression tests. This uses the existing decoded temperature and scoring formula; it does not add WHOOP 5 temperature decoding support.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- macOS app build and full `StrandTests`: 1,644 tests, 1 skipped, 0 failures with `xcodebuild ... -testRegion US test`. The default Australian region exposes two existing date-format assertions; the US region run passes without changing those tests.
- Android: 5,800 tests, 6 skipped, 2 failures on JetBrains JDK 21.0.8. Both failures are the existing exact half-tie assertions in `RecoveryDriversTest` (`-0.5` versus `-0.4999999999999929`); both reproduce on the unchanged PR head `0df45558`. The final 46 targeted regression, recovery-trace, skin-temperature and JaCoCo method-budget checks pass.
- Both platform regression tests fail when recovery is deliberately computed from the pre-temperature daily input, then pass after restoring the fix. They cover positive/negative rounded deviations, missing or unusable skin baselines, HRV cold start, and preservation of other daily fields.
- Source hygiene and `git diff --check` pass. No new dependencies or protocol changes.

## Checklist

- [x] Swift package tests pass for any package I touched — no packages changed
- [ ] Full Android unit suite passes — 46 targeted checks pass; two reproduced pre-existing rounding failures remain as described above
- [x] No new build warnings introduced by the changed code
- [x] UI changes use only `StrandDesign` tokens — no UI changes
- [x] No hardcoded hex frame bytes; no protocol changes
- [x] Follows the conventions in `docs/CONTRIBUTING.md` — paired regression tests exercise the engine helper used by Pass 2
- [x] No generated Xcode project, credentials or private captures committed

## Scoring behavior

The existing weighted-mean formula is unchanged. Adding the temperature term can raise Charge on a poor night when that term is less negative than the other inputs. Swift's driver list now includes the available temperature term. Routine rescoring updates the recent window; older banked days retain their previous Charge until rescored.

## Related issues

None.
