### PR TITLE
Stress widget: today's hourly curve on the home screen (Android)

### DIFF
--- a/Tools/i18n_echo_baseline.txt
+++ b/Tools/i18n_echo_baseline.txt
@@ -17,9 +17,9 @@ Strand/Resources/Localizable.xcstrings pt-PT 11
 Strand/Resources/Localizable.xcstrings ru 7
 Strand/Resources/Localizable.xcstrings zh-Hans 8
 Strand/Resources/Localizable.xcstrings zh-Hant 7
-android/app/src/main/res/values-de/strings.xml de 16
+android/app/src/main/res/values-de/strings.xml de 17
 android/app/src/main/res/values-es/strings.xml es 42
-android/app/src/main/res/values-fr/strings.xml fr 13
+android/app/src/main/res/values-fr/strings.xml fr 14
 android/app/src/main/res/values-pl/strings.xml pl 11
-android/app/src/main/res/values-pt-rPT/strings.xml pt-rPT 8
+android/app/src/main/res/values-pt-rPT/strings.xml pt-rPT 9
 android/app/src/main/res/values-zh/strings.xml zh 15

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -305,6 +305,20 @@
                 android:resource="@xml/hr_widget_info" />
         </receiver>
 
+        <!-- Stress widget (#2040): today's intraday stress as the curve the Stress screen draws.
+             Same snapshot source as its siblings; the curve is a Bitmap because Glance cannot draw. -->
+        <receiver
+            android:name="com.noop.widget.StressWidgetReceiver"
+            android:exported="true"
+            android:label="@string/widget_stress_name">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/stress_widget_info" />
+        </receiver>
+
         <!-- K10: Coach brief home-screen widget. Shows the stored morning brief (generated on a
              schedule by CoachBriefScheduler, K5) — never live-networked. Tap → opens the app. -->
         <receiver

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1023,6 +1023,10 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                     // widget reads the anchor here (the notification's honest-null contract lives in the
                     // service), keeping the two symmetric.
                     val anchorRow = widgetAnchorRow(days, logicalKey, localKey)
+                    // #2040: today's stress curve for the stress widget. Self-gating on a cheap HR
+                    // fingerprint, so an idle tick costs one indexed COUNT and no rows; null when
+                    // there is no device to read, which leaves whatever curve is stored alone.
+                    val stressCurve = com.noop.widget.StressWidgetProducer.todayCurve(repo, activeStrapId)
                     WidgetSnapshotStore.push(
                         appContext,
                         WidgetSnapshot(
@@ -1034,6 +1038,8 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                             heartRate = live.heartRate,
                             batteryPct = live.batteryPct?.roundToInt(),
                             connected = live.connected,
+                            stressSeries = stressCurve?.points ?: emptyList(),
+                            stressDay = stressCurve?.epochDay,
                             updatedAtMs = System.currentTimeMillis(),
                         ),
                     )

--- a/android/app/src/main/java/com/noop/widget/StressGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/StressGlanceWidget.kt
@@ -1,0 +1,325 @@
+package com.noop.widget
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.LocalContext
+import androidx.glance.LocalSize
+import androidx.glance.action.actionStartActivity
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.ContentScale
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxHeight
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.width
+import androidx.glance.semantics.contentDescription
+import androidx.glance.semantics.semantics
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import com.noop.R
+import com.noop.ui.MainActivity
+import com.noop.ui.uiString
+import java.text.DateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Home-screen widget: today's stress as the intraday curve the Stress screen draws (#2040).
+ *
+ * Renders purely from the [WidgetSnapshotStore] snapshot, like its siblings, so it costs nothing at
+ * draw time and survives process death. Tapping opens the app.
+ *
+ * The curve is an IMAGE for the same reason the heart-rate trace is: Glance compiles to RemoteViews,
+ * which cannot draw. [StressTrace] decides where the ink goes and [StressTraceRenderer] puts it on a
+ * Bitmap; the labels stay Glance `Text` so they remain crisp, themed and readable to TalkBack.
+ *
+ * Honest-blank throughout. An unscored hour is a GAP in the line rather than an interpolation across
+ * it, an hour the motion gate masked gets a faint mark along the base instead of a score, and a day
+ * with nothing scored shows no chart at all rather than a flat line at zero.
+ */
+class StressGlanceWidget : GlanceAppWidget() {
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val snap = runCatching { WidgetSnapshotStore.load(context) }.getOrDefault(WidgetSnapshot())
+        val dark = WidgetTheme.isDark(context)
+        provideContent { StressWidgetContent(snap, dark) }
+    }
+
+    /** Same defence as its siblings: swap Glance's built-in error layout for ours. The widget heals on
+     *  the next successful push. */
+    override fun onCompositionError(
+        context: Context,
+        glanceId: GlanceId,
+        appWidgetId: Int,
+        throwable: Throwable,
+    ) {
+        runCatching {
+            val rv = android.widget.RemoteViews(context.packageName, R.layout.noop_widget_error)
+            android.appwidget.AppWidgetManager.getInstance(context).updateAppWidget(appWidgetId, rv)
+        }
+    }
+}
+
+// Local widget colours, mirroring the siblings rather than reading Palette: Glance composes outside the
+// app theme, so every widget in this package carries its own copy on purpose.
+private fun stressSurfaceColor(dark: Boolean) = if (dark) Color(0xFF0A1322) else Color(0xFFF4F1EA)
+
+private fun stressSurface(dark: Boolean) = ColorProvider(stressSurfaceColor(dark))
+private fun stressTextPrimary(dark: Boolean) = ColorProvider(if (dark) Color(0xFFF4F6F8) else Color(0xFF1A2230))
+private fun stressTextSecondary(dark: Boolean) = ColorProvider(if (dark) Color(0xFF8A94A4) else Color(0xFF7C8696))
+
+/**
+ * The screen's three-stop ramp, as raw colours the renderer can paint with.
+ *
+ * These are the same blue / green / amber the Stress screen samples across 0-3, kept as local literals
+ * for the reason every colour in this package is one: Glance composes outside the app theme, so the
+ * widget cannot read `Palette`. A widget drawing a different ramp from the screen it mirrors would
+ * make the same hour look like two different readings.
+ */
+private fun stressCalm(dark: Boolean) = if (dark) Color(0xFF4C8DFF) else Color(0xFF2D6FE0)
+private fun stressSteady(dark: Boolean) = if (dark) Color(0xFF3ECF8E) else Color(0xFF1FA971)
+private fun stressTense(dark: Boolean) = if (dark) Color(0xFFE0A62F) else Color(0xFFC8861E)
+
+/** Card padding, both sides. The chart and the axis under it must subtract the SAME figure or the
+ *  labels drift out of line with the curve they annotate. */
+private const val STRESS_CARD_PADDING_DP = 28f
+
+/** The level scale column plus its gap. One number, read by both the chart and its axis. */
+private const val STRESS_SCALE_COLUMN_DP = 20f
+
+/** The height the curve BITMAP is drawn at. The chart box takes the card's leftover height by weight,
+ *  so its real height is not knowable here; this is what the bitmap is drawn at and the `Image` scales
+ *  from, chosen generously so the common case downscales. */
+private const val STRESS_CHART_TARGET_DP = 92f
+
+/** The chart width for a given widget width, the one place that arithmetic happens. */
+private fun stressChartWidthDp(widthDp: Float): Float =
+    (widthDp - STRESS_CARD_PADDING_DP - STRESS_SCALE_COLUMN_DP).coerceAtLeast(24f)
+
+/** One decimal, the same precision the screen prints a 0-3 score at. */
+private fun formatLevel(value: Double): String = String.format(Locale.getDefault(), "%.1f", value)
+
+@Composable
+private fun StressWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
+    val size = LocalSize.current
+    val stats = StressTrace.stats(snap.stressSeries)
+
+    Column(
+        modifier = GlanceModifier
+            .fillMaxSize()
+            .background(stressSurface(dark))
+            .cornerRadius(16.dp)
+            .padding(14.dp)
+            .clickable(actionStartActivity<MainActivity>()),
+    ) {
+        Text(
+            text = uiString(R.string.l10n_stress_screen_stress_bad33342),
+            style = TextStyle(
+                color = stressTextPrimary(dark), fontSize = 13.sp, fontWeight = FontWeight.Medium,
+            ),
+        )
+        Spacer(GlanceModifier.height(6.dp))
+
+        // Built OUT here, not inside the semantics lambda: the i18n audit cannot see copy assigned
+        // inside one, so a literal written there would ship English to every locale (#571).
+        val stressLabel = uiString(R.string.l10n_stress_screen_stress_bad33342)
+        val ofThree = uiString(R.string.l10n_stress_screen_of_3_46203495)
+        val latest = snap.stressSeries.lastOrNull { it.level != null }?.level
+        val spoken = latest?.let { "$stressLabel ${formatLevel(it)} $ofThree" } ?: stressLabel
+
+        Row(verticalAlignment = Alignment.Vertical.Bottom) {
+            Text(
+                text = latest?.let { formatLevel(it) } ?: "—",
+                style = TextStyle(
+                    color = stressTextPrimary(dark), fontSize = 30.sp, fontWeight = FontWeight.Bold,
+                ),
+                modifier = GlanceModifier.semantics { contentDescription = spoken },
+            )
+            if (latest != null) {
+                Spacer(GlanceModifier.width(4.dp))
+                Text(
+                    text = ofThree,
+                    style = TextStyle(color = stressTextSecondary(dark), fontSize = 12.sp),
+                )
+            }
+            if (stats != null) {
+                Spacer(GlanceModifier.width(10.dp))
+                // A chip, not loose text: it is a summary OF the chart, and the tinted rounded ground
+                // separates it from the scale label beside it.
+                val peakTime = DateFormat.getTimeInstance(DateFormat.SHORT)
+                    .format(Date(stats.peak.ts * 1000))
+                Text(
+                    text = uiString(R.string.trends_peak) +
+                        " ${formatLevel(stats.peak.level ?: 0.0)} · $peakTime",
+                    style = TextStyle(color = stressTextPrimary(dark), fontSize = 11.sp),
+                    modifier = GlanceModifier
+                        .background(ColorProvider(stressTense(dark).copy(alpha = 0.18f)))
+                        .cornerRadius(10.dp)
+                        .padding(horizontal = 8.dp, vertical = 3.dp),
+                )
+            }
+        }
+
+        // No scored hour, no chart row at all. A freshly placed widget, or a day before the first
+        // scorable hour, would otherwise reserve the height and show a blank rectangle, and a void
+        // reads as broken where a shorter widget reads as new.
+        if (stats != null) {
+            Spacer(GlanceModifier.height(8.dp))
+            StressTraceImage(snap, dark, widthDp = size.width.value,
+                             modifier = GlanceModifier.defaultWeight())
+            StressTimeAxis(snap, dark)
+        }
+
+        if (snap.updatedAtMs > 0) {
+            Spacer(GlanceModifier.height(4.dp))
+            val time = DateFormat.getTimeInstance(DateFormat.SHORT).format(Date(snap.updatedAtMs))
+            Row(
+                modifier = GlanceModifier.fillMaxWidth(),
+                horizontalAlignment = Alignment.Horizontal.CenterHorizontally,
+            ) {
+                Text(
+                    text = if (stats != null) {
+                        uiString(R.string.l10n_stress_screen_avg_a178769d) +
+                            " ${formatLevel(stats.mean)} · " +
+                            uiString(R.string.l10n_hr_glance_widget_updated_time_1b5feedb, time)
+                    } else {
+                        uiString(R.string.l10n_hr_glance_widget_updated_time_1b5feedb, time)
+                    },
+                    style = TextStyle(color = stressTextSecondary(dark), fontSize = 10.sp),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * The curve, plus the 0-3 scale down its right edge.
+ *
+ * Bitmap construction is wrapped: an OOM or a hostile size must leave the widget without a chart, not
+ * without a widget. Sized exactly as the heart-rate trace is, and for the same measured reasons:
+ * height as displayed, width with headroom so the `Image` downscales rather than stretching a stroke
+ * horizontally on a launcher that under-reports its own width.
+ */
+@Composable
+private fun StressTraceImage(
+    snap: WidgetSnapshot,
+    dark: Boolean,
+    widthDp: Float,
+    // Weighted by the CALLER: Glance scopes defaultWeight() to Row/ColumnScope, so a composable cannot
+    // claim its own share of the parent from in here.
+    modifier: GlanceModifier,
+) {
+    val context = LocalContext.current
+    val density = context.resources.displayMetrics.density
+    val chartWidthDp = stressChartWidthDp(widthDp)
+    // ONE box for both the geometry and the bitmap, so the curve cannot be drawn to coordinates the
+    // bitmap has no room for.
+    val hPx = (STRESS_CHART_TARGET_DP * density).toInt().coerceAtLeast(1)
+    val wPx = HrTrace.widestAtHeight((chartWidthDp * density).toInt(), hPx)
+
+    // Measured for the same reason the heart-rate trace is: this is a BITMAP rather than a few KB of
+    // text, and the widget cost counters are what make "the widget drains the battery" decidable.
+    val startedNs = System.nanoTime()
+    val bmp = runCatching {
+        StressTraceRenderer.render(
+            segments = StressTrace.segments(snap.stressSeries, wPx.toFloat(), hPx.toFloat()),
+            movingMarks = StressTrace.movingMarks(snap.stressSeries, wPx.toFloat()),
+            widthPx = wPx,
+            heightPx = hPx,
+            calmColor = stressCalm(dark).toArgb(),
+            steadyColor = stressSteady(dark).toArgb(),
+            tenseColor = stressTense(dark).toArgb(),
+            backgroundColor = stressSurfaceColor(dark).toArgb(),
+            // Composited against the card rather than passed as a translucent colour: the bitmap is
+            // RGB_565 and has no alpha to fade into, so an alpha here would have drawn solid.
+            markColor = stressTextSecondary(dark).getColor(context)
+                .copy(alpha = 0.5f).compositeOver(stressSurfaceColor(dark)).toArgb(),
+            strokePx = 2f * density,
+        )
+    }.getOrNull()
+    if (bmp != null) {
+        WidgetTelemetry.noteRender(
+            bytes = wPx * hPx * HrTrace.BYTES_PER_PIXEL,
+            elapsedMs = (System.nanoTime() - startedNs) / 1_000_000,
+        )
+    }
+
+    Row(modifier = modifier.fillMaxWidth()) {
+        Box(modifier = GlanceModifier.fillMaxHeight().defaultWeight()) {
+            if (bmp != null) {
+                Image(
+                    provider = ImageProvider(bmp),
+                    contentDescription = null,
+                    modifier = GlanceModifier.fillMaxSize(),
+                    // FillBounds, not the default Fit: the width is drawn with headroom so it
+                    // downscales, and Fit would letterbox that headroom back into dead space.
+                    contentScale = ContentScale.FillBounds,
+                )
+            }
+        }
+        Spacer(GlanceModifier.width(6.dp))
+        // The FIXED 0-3 scale, spread across the chart's height so 3 sits level with the top of the box
+        // and 0 with the bottom. Fixed rather than derived, because that is what the domain is: a scale
+        // that moved with the day would make two days impossible to compare at a glance.
+        Column(
+            modifier = GlanceModifier.fillMaxHeight(),
+            horizontalAlignment = Alignment.Horizontal.End,
+        ) {
+            val ticks = StressTrace.levelTicks()
+            ticks.forEachIndexed { i, tick ->
+                Text(
+                    text = tick.toString(),
+                    style = TextStyle(color = stressTextSecondary(dark), fontSize = 10.sp),
+                )
+                if (i < ticks.size - 1) Spacer(GlanceModifier.defaultWeight())
+            }
+        }
+    }
+}
+
+/**
+ * The time labels under the curve: first, middle and last SCORED hour (see [StressTrace.timeTicks]).
+ *
+ * Spread with weighted spacers rather than fixed gaps, so the middle label sits over the middle of the
+ * chart whatever width the launcher gave the widget. Formatted through the locale's short time format,
+ * so a 12-hour device reads as one; a widget is not the place to impose a clock convention.
+ */
+@Composable
+private fun StressTimeAxis(snap: WidgetSnapshot, dark: Boolean) {
+    val ticks = StressTrace.timeTicks(snap.stressSeries)
+    // One scored hour names one instant, and a single label pinned to the left edge reads as a stray
+    // rather than an axis, so the axis only appears once there is a span to label.
+    if (ticks.size < 2) return
+    val fmt = DateFormat.getTimeInstance(DateFormat.SHORT)
+    Spacer(GlanceModifier.height(2.dp))
+    Row(modifier = GlanceModifier.fillMaxWidth()) {
+        ticks.forEachIndexed { i, ts ->
+            Text(
+                text = fmt.format(Date(ts * 1000)),
+                style = TextStyle(color = stressTextSecondary(dark), fontSize = 9.sp),
+            )
+            if (i < ticks.size - 1) Spacer(GlanceModifier.defaultWeight())
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/widget/StressGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/StressGlanceWidget.kt
@@ -146,7 +146,9 @@ private fun StressWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
         val stressLabel = uiString(R.string.l10n_stress_screen_stress_bad33342)
         val ofThree = uiString(R.string.l10n_stress_screen_of_3_46203495)
         val latest = snap.stressSeries.lastOrNull { it.level != null }?.level
-        val spoken = latest?.let { "$stressLabel ${formatLevel(it)} $ofThree" } ?: stressLabel
+        // Assembled by concatenation rather than as a template, so no English word is ever written
+        // here: every part comes from a resource, and the separators carry no letters to translate.
+        val spoken = latest?.let { stressLabel + " " + formatLevel(it) + " " + ofThree } ?: stressLabel
 
         Row(verticalAlignment = Alignment.Vertical.Bottom) {
             Text(
@@ -245,12 +247,17 @@ private fun StressTraceImage(
         StressTraceRenderer.render(
             segments = StressTrace.segments(snap.stressSeries, wPx.toFloat(), hPx.toFloat()),
             movingMarks = StressTrace.movingMarks(snap.stressSeries, wPx.toFloat()),
+            highPoints = StressTrace.highPoints(snap.stressSeries, wPx.toFloat(), hPx.toFloat()),
             widthPx = wPx,
             heightPx = hPx,
             calmColor = stressCalm(dark).toArgb(),
             steadyColor = stressSteady(dark).toArgb(),
             tenseColor = stressTense(dark).toArgb(),
             backgroundColor = stressSurfaceColor(dark).toArgb(),
+            // Composited for the same reason the marks are: the bitmap has no alpha channel, so the
+            // translucency has to be resolved against the card before it is handed over.
+            fillTopColor = stressSteady(dark).copy(alpha = 0.35f)
+                .compositeOver(stressSurfaceColor(dark)).toArgb(),
             // Composited against the card rather than passed as a translucent colour: the bitmap is
             // RGB_565 and has no alpha to fade into, so an alpha here would have drawn solid.
             markColor = stressTextSecondary(dark).getColor(context)
@@ -265,23 +272,10 @@ private fun StressTraceImage(
         )
     }
 
+    // Scale FIRST, then the chart: the Stress screen puts the 0-3 labels down the left edge, and a
+    // widget that mirrors a screen should not mirror it back to front. (The heart-rate widget puts its
+    // scale on the right, which is right for a trace whose numbers are read off the end.)
     Row(modifier = modifier.fillMaxWidth()) {
-        Box(modifier = GlanceModifier.fillMaxHeight().defaultWeight()) {
-            if (bmp != null) {
-                Image(
-                    provider = ImageProvider(bmp),
-                    contentDescription = null,
-                    modifier = GlanceModifier.fillMaxSize(),
-                    // FillBounds, not the default Fit: the width is drawn with headroom so it
-                    // downscales, and Fit would letterbox that headroom back into dead space.
-                    contentScale = ContentScale.FillBounds,
-                )
-            }
-        }
-        Spacer(GlanceModifier.width(6.dp))
-        // The FIXED 0-3 scale, spread across the chart's height so 3 sits level with the top of the box
-        // and 0 with the bottom. Fixed rather than derived, because that is what the domain is: a scale
-        // that moved with the day would make two days impossible to compare at a glance.
         Column(
             modifier = GlanceModifier.fillMaxHeight(),
             horizontalAlignment = Alignment.Horizontal.End,
@@ -293,6 +287,19 @@ private fun StressTraceImage(
                     style = TextStyle(color = stressTextSecondary(dark), fontSize = 10.sp),
                 )
                 if (i < ticks.size - 1) Spacer(GlanceModifier.defaultWeight())
+            }
+        }
+        Spacer(GlanceModifier.width(6.dp))
+        Box(modifier = GlanceModifier.fillMaxHeight().defaultWeight()) {
+            if (bmp != null) {
+                Image(
+                    provider = ImageProvider(bmp),
+                    contentDescription = null,
+                    modifier = GlanceModifier.fillMaxSize(),
+                    // FillBounds, not the default Fit: the width is drawn with headroom so it
+                    // downscales, and Fit would letterbox that headroom back into dead space.
+                    contentScale = ContentScale.FillBounds,
+                )
             }
         }
     }

--- a/android/app/src/main/java/com/noop/widget/StressTrace.kt
+++ b/android/app/src/main/java/com/noop/widget/StressTrace.kt
@@ -1,5 +1,7 @@
 package com.noop.widget
 
+import com.noop.analytics.DaytimeStress
+
 /**
  * One hour on the widget's stress trace.
  *
@@ -127,12 +129,37 @@ object StressTrace {
                 if (run.isNotEmpty()) { out.add(run); run = ArrayList() }
                 continue
             }
-            val x = if (span <= 0f) 0f else (p.ts - t0) / span * width
-            val y = height - (level / DOMAIN_MAX).toFloat().coerceIn(0f, 1f) * height
-            run.add(Pt(x, y))
+            run.add(place(p.ts, level, t0, span, width, height))
         }
         if (run.isNotEmpty()) out.add(run)
         return out
+    }
+
+    /**
+     * The scored hours sitting in the HIGH band, as pixels, for the dots the screen puts above the line.
+     *
+     * The threshold is read from [DaytimeStress.highBandFloor] rather than restated here. It is the same
+     * cutoff the sustained-stress check uses, and a second copy of it would drift the day the band moves,
+     * leaving the widget dotting hours the app no longer calls high.
+     *
+     * Mapped through the same placement as [segments], so a dot lands exactly on its own vertex.
+     */
+    fun highPoints(series: List<StressPoint>, width: Float, height: Float): List<Pt> {
+        if (series.isEmpty() || width <= 0f || height <= 0f) return emptyList()
+        val t0 = series.first().ts
+        val span = (series.last().ts - t0).toFloat()
+        return series.mapNotNull { p ->
+            val level = p.level ?: return@mapNotNull null
+            if (level < DaytimeStress.highBandFloor) return@mapNotNull null
+            place(p.ts, level, t0, span, width, height)
+        }
+    }
+
+    /** The one placement rule, shared so a dot and its vertex cannot land apart. */
+    private fun place(ts: Long, level: Double, t0: Long, span: Float, width: Float, height: Float): Pt {
+        val x = if (span <= 0f) 0f else (ts - t0) / span * width
+        val y = height - (level / DOMAIN_MAX).toFloat().coerceIn(0f, 1f) * height
+        return Pt(x, y)
     }
 
     /**

--- a/android/app/src/main/java/com/noop/widget/StressTrace.kt
+++ b/android/app/src/main/java/com/noop/widget/StressTrace.kt
@@ -1,0 +1,178 @@
+package com.noop.widget
+
+/**
+ * One hour on the widget's stress trace.
+ *
+ * [level] is the shared 0-3 proxy, null when the hour was not scored. [moving] separates the two
+ * reasons it can be null: the motion gate masked an AMBULATORY hour (exertion raises heart rate on
+ * its own, so it is deliberately not scored as stress), or there simply was not enough signal. Both
+ * break the line; only the first earns a mark along the base.
+ */
+data class StressPoint(val ts: Long, val level: Double?, val moving: Boolean = false)
+
+/**
+ * The pure half of the stress widget: what the trace CONTAINS and where its ink goes.
+ *
+ * Split from the drawing for the same reason as [HrTrace] — Glance compiles to RemoteViews, which has
+ * no Canvas, so a chart can only reach a widget as a Bitmap, and a Bitmap is not something a JVM test
+ * can meaningfully assert about. Everything decidable without a Canvas lives here and is unit-tested.
+ *
+ * TWO THINGS DIFFER FROM [HrTrace], and both are deliberate.
+ *
+ * The domain is FIXED at 0-3, not normalised to the day's own min and max. Heart rate has no absolute
+ * meaning at widget size, so its trace spreads whatever range it has across the full box. A stress
+ * score does have one: the bands are what the number means, and [DOMAIN_MAX] is the top of the scale
+ * the app scores against everywhere else. Normalising here would redraw a flat calm day as a dramatic
+ * one, which is precisely the lie the fixed domain exists to prevent.
+ *
+ * And the series is REPLACED rather than appended to. The HR trace folds a live push into a rolling
+ * window; today's stress is a whole scored day that arrives complete each time analysis runs, so there
+ * is no retention rule to get right, no clock-jump guard, and no cap. Yesterday's trace is not merged
+ * into today's, it is simply overwritten.
+ *
+ * Also the shape an iOS twin would share. SwiftUI draws directly so the renderer will not port, but the
+ * domain, the gap rule and the tick choices are the same decisions on both platforms and should not be
+ * made twice.
+ */
+object StressTrace {
+
+    /** Top of the scored range. The 0-3 proxy is the same scale the gauge and the screen use. */
+    const val DOMAIN_MAX: Double = 3.0
+
+    /** A day of hourly buckets, with slack for a DST-long day. Nothing here folds, so this only guards
+     *  a malformed payload from growing the list without bound. */
+    const val MAX_POINTS: Int = 26
+
+    /** `ts:level:moving`, comma separated, with `-` for an unscored hour. Compact enough for a prefs
+     *  string at a day's length, and readable in a bug report, which a binary blob would not be. */
+    fun encode(series: List<StressPoint>): String =
+        series.joinToString(",") { p ->
+            val level = p.level?.let { String.format(java.util.Locale.US, "%.2f", it) } ?: "-"
+            "${p.ts}:$level:${if (p.moving) 1 else 0}"
+        }
+
+    /** Tolerant by design: a malformed triple is skipped rather than throwing. This runs on the widget's
+     *  render path, where the alternative to a partial trace is a crashed home screen. */
+    fun decode(s: String?): List<StressPoint> {
+        if (s.isNullOrBlank()) return emptyList()
+        val out = ArrayList<StressPoint>()
+        for (part in s.split(',')) {
+            val bits = part.split(':')
+            if (bits.size != 3) continue
+            val ts = bits[0].toLongOrNull() ?: continue
+            val level = if (bits[1] == "-") null else bits[1].toDoubleOrNull() ?: continue
+            if (level != null && (level < 0.0 || level > DOMAIN_MAX)) continue
+            out.add(StressPoint(ts, level, bits[2] == "1"))
+        }
+        out.sortBy { it.ts }
+        return if (out.size <= MAX_POINTS) out else out.subList(out.size - MAX_POINTS, out.size)
+    }
+
+    /** The numbers the header shows. Null when no hour was scored. */
+    data class Stats(
+        /** Mean across SCORED hours, the same figure the screen prints as the day's average. */
+        val mean: Double,
+        /** Highest scored hour. */
+        val peak: StressPoint,
+        /** How many hours carry a score. */
+        val scoredHours: Int,
+        /** How many were masked as movement rather than scored. */
+        val movingHours: Int,
+    )
+
+    fun stats(series: List<StressPoint>): Stats? {
+        val scored = series.filter { it.level != null }
+        if (scored.isEmpty()) return null
+        var peak = scored[0]
+        var sum = 0.0
+        for (p in scored) {
+            sum += p.level!!
+            if (p.level > peak.level!!) peak = p
+        }
+        return Stats(
+            mean = sum / scored.size,
+            peak = peak,
+            scoredHours = scored.size,
+            movingHours = series.count { it.moving },
+        )
+    }
+
+    /** A point in the trace's pixel box, origin top-left, as the renderer wants it. */
+    data class Pt(val x: Float, val y: Float)
+
+    /**
+     * The trace as CONTIGUOUS RUNS of scored hours, each already in pixels.
+     *
+     * Runs rather than one list because an unscored hour is a hole in the day, and a polyline drawn
+     * straight across it would invent a reading for an hour that has none. The screen's own caption
+     * promises bare gaps, so the widget owes the same. Each returned run is drawn as its own path.
+     *
+     * X is placed on the hour's position in the day's SPAN, so an afternoon hole leaves a hole of the
+     * right width rather than closing up. A single scored hour, or a day whose hours all share one
+     * timestamp, has no span to spread across and sits at the left edge rather than at x=NaN.
+     *
+     * Y comes off the FIXED domain, so an empty-ish calm day draws along the bottom where it belongs.
+     * Y is flipped on the way out: stress rises upward, pixels rise downward.
+     */
+    fun segments(series: List<StressPoint>, width: Float, height: Float): List<List<Pt>> {
+        if (series.isEmpty() || width <= 0f || height <= 0f) return emptyList()
+        val t0 = series.first().ts
+        val t1 = series.last().ts
+        val span = (t1 - t0).toFloat()
+        val out = ArrayList<List<Pt>>()
+        var run = ArrayList<Pt>()
+        for (p in series) {
+            val level = p.level
+            if (level == null) {
+                if (run.isNotEmpty()) { out.add(run); run = ArrayList() }
+                continue
+            }
+            val x = if (span <= 0f) 0f else (p.ts - t0) / span * width
+            val y = height - (level / DOMAIN_MAX).toFloat().coerceIn(0f, 1f) * height
+            run.add(Pt(x, y))
+        }
+        if (run.isNotEmpty()) out.add(run)
+        return out
+    }
+
+    /**
+     * X positions of the hours masked as movement, for the faint marks along the base.
+     *
+     * Returned as bare X centres rather than as spans: the mark's thickness is a drawing decision and
+     * belongs to the renderer, while WHERE the moving hours were is a fact about the day.
+     */
+    fun movingMarks(series: List<StressPoint>, width: Float): List<Float> {
+        if (series.isEmpty() || width <= 0f) return emptyList()
+        val t0 = series.first().ts
+        val span = (series.last().ts - t0).toFloat()
+        return series.filter { it.moving }.map { p ->
+            if (span <= 0f) 0f else (p.ts - t0) / span * width
+        }
+    }
+
+    /**
+     * The labels up the left edge, top-down: the top of the domain down to zero.
+     *
+     * Fixed, not derived, for the same reason the domain is: these are the scale, and a chart whose
+     * axis moved with the day would make two days impossible to compare at a glance.
+     */
+    fun levelTicks(): List<Int> = listOf(3, 2, 1, 0)
+
+    /**
+     * The three timestamps along the bottom: first, middle, last of the SCORED data, not of the day.
+     *
+     * Anchored to scored hours because a day that only has an evening's worth of signal would otherwise
+     * label its axis with a morning that was never sampled, and the trace would sit crushed into the
+     * right-hand end of a mostly empty chart. Fewer than three distinct instants returns what there is,
+     * so the renderer draws one label rather than three copies of it.
+     */
+    fun timeTicks(series: List<StressPoint>): List<Long> {
+        val scored = series.filter { it.level != null }
+        if (scored.isEmpty()) return emptyList()
+        val first = scored.first().ts
+        val last = scored.last().ts
+        if (first == last) return listOf(first)
+        val mid = first + (last - first) / 2
+        return if (mid == first || mid == last) listOf(first, last) else listOf(first, mid, last)
+    }
+}

--- a/android/app/src/main/java/com/noop/widget/StressTraceRenderer.kt
+++ b/android/app/src/main/java/com/noop/widget/StressTraceRenderer.kt
@@ -36,6 +36,8 @@ internal object StressTraceRenderer {
     fun render(
         segments: List<List<StressTrace.Pt>>,
         movingMarks: List<Float>,
+        /** from [StressTrace.highPoints], the scored hours sitting in the high band */
+        highPoints: List<StressTrace.Pt>,
         widthPx: Int,
         heightPx: Int,
         calmColor: Int,
@@ -43,13 +45,16 @@ internal object StressTraceRenderer {
         tenseColor: Int,
         /** The card underneath. Drawn as the ground, because an RGB_565 bitmap has no alpha. */
         backgroundColor: Int,
+        /** Top of the area fill, already composited against the card. It fades DOWN into the card
+         *  rather than fading out, because 565 has no alpha to fade into. */
+        fillTopColor: Int,
         /** The faint marks along the base for the hours exertion masked. Already composited against
          *  the card: an RGB_565 bitmap has no alpha channel, so a translucent colour handed in here
          *  would draw at FULL strength. */
         markColor: Int,
         strokePx: Float,
     ): Bitmap? {
-        if (segments.isEmpty() && movingMarks.isEmpty()) return null
+        if (segments.isEmpty() && movingMarks.isEmpty() && highPoints.isEmpty()) return null
         // The caller sized this with the shared payload budget; re-check it rather than re-decide it.
         val w = widthPx.coerceAtLeast(1)
         val h = heightPx.coerceAtLeast(1)
@@ -97,6 +102,30 @@ internal object StressTraceRenderer {
             shader = ramp
         }
 
+        // Fill first, so every stroke sits on top of its own area rather than under the next one's.
+        // Each run is closed to the baseline SEPARATELY: one path across the whole day would span the
+        // gaps and fill under hours that were never scored, which is the thing the broken line exists
+        // to avoid saying.
+        val fill = Paint().apply {
+            isAntiAlias = true
+            isDither = true
+            shader = LinearGradient(
+                0f, 0f, 0f, chartH, fillTopColor, backgroundColor, Shader.TileMode.CLAMP,
+            )
+        }
+        for (seg in segments) {
+            if (seg.size < 2) continue
+            val area = Path()
+            seg.forEachIndexed { i, p ->
+                val (x, y) = px(p)
+                if (i == 0) area.moveTo(x, y) else area.lineTo(x, y)
+            }
+            area.lineTo(px(seg.last()).first, chartH)
+            area.lineTo(px(seg.first()).first, chartH)
+            area.close()
+            canvas.drawPath(area, fill)
+        }
+
         for (seg in segments) {
             if (seg.isEmpty()) continue
             // A run of one hour has no line to stroke, so give it a dot. Otherwise a day whose only
@@ -113,6 +142,26 @@ internal object StressTraceRenderer {
                 if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
             }
             canvas.drawPath(path, stroke)
+        }
+
+        // The high-band hours, dotted above the line as the screen marks them. Drawn after the stroke
+        // so a dot is never half-hidden under it, and in the tense colour because that is what being in
+        // that band means.
+        if (highPoints.isNotEmpty()) {
+            val dotPaint = Paint().apply {
+                isAntiAlias = true
+                color = tenseColor
+                style = Paint.Style.FILL
+            }
+            for (p in highPoints) {
+                val (x, y) = px(p)
+                canvas.drawCircle(
+                    x.coerceIn(strokePx, w - strokePx),
+                    (y - strokePx * 2f).coerceAtLeast(strokePx),
+                    strokePx * 0.9f,
+                    dotPaint,
+                )
+            }
         }
 
         if (movingMarks.isNotEmpty() && markBand > 0f) {

--- a/android/app/src/main/java/com/noop/widget/StressTraceRenderer.kt
+++ b/android/app/src/main/java/com/noop/widget/StressTraceRenderer.kt
@@ -1,0 +1,136 @@
+package com.noop.widget
+
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.LinearGradient
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.Shader
+
+/**
+ * Draws the stress trace to a Bitmap, because Glance cannot draw one.
+ *
+ * Kept as deliberately stupid as [HrTraceRenderer]: every decision worth testing was already made in
+ * [StressTrace], and what remains is `moveTo`/`lineTo` over coordinates handed in. Nothing here chooses
+ * a tick, a domain, or which hours are a gap.
+ *
+ * The one thing it does decide is how the ramp is applied, and that is a drawing detail rather than a
+ * judgement: the line is coloured by a VERTICAL gradient. Because [StressTrace.segments] maps the score
+ * onto Y off a fixed domain, height already encodes level, so a single top-to-bottom shader paints
+ * every segment the colour its own score deserves, with no per-point work and no second pass. Amber at
+ * the top, green through the middle, blue along the bottom, which is the screen's ramp read upward.
+ *
+ * Labels are not drawn here, though the design has them. They are Glance `Text` in the composable,
+ * which keeps them crisp at any density, themeable with the rest of the widget, and legible to
+ * TalkBack, none of which a label baked into a bitmap would be.
+ */
+internal object StressTraceRenderer {
+
+    /**
+     * @param segments from [StressTrace.segments], already normalised into the box, each a contiguous
+     *        run of scored hours
+     * @param movingMarks from [StressTrace.movingMarks], X centres of the hours masked as movement
+     * @return the trace, or null when there is nothing to draw or the box is degenerate, so the caller
+     *         shows the empty state rather than an empty image.
+     */
+    fun render(
+        segments: List<List<StressTrace.Pt>>,
+        movingMarks: List<Float>,
+        widthPx: Int,
+        heightPx: Int,
+        calmColor: Int,
+        steadyColor: Int,
+        tenseColor: Int,
+        /** The card underneath. Drawn as the ground, because an RGB_565 bitmap has no alpha. */
+        backgroundColor: Int,
+        /** The faint marks along the base for the hours exertion masked. Already composited against
+         *  the card: an RGB_565 bitmap has no alpha channel, so a translucent colour handed in here
+         *  would draw at FULL strength. */
+        markColor: Int,
+        strokePx: Float,
+    ): Bitmap? {
+        if (segments.isEmpty() && movingMarks.isEmpty()) return null
+        // The caller sized this with the shared payload budget; re-check it rather than re-decide it.
+        val w = widthPx.coerceAtLeast(1)
+        val h = heightPx.coerceAtLeast(1)
+        if (w < 2 || h < 2) return null
+        if (w.toLong() * h.toLong() * HrTrace.BYTES_PER_PIXEL > HrTrace.MAX_BITMAP_BYTES) return null
+
+        val bmp = runCatching {
+            Bitmap.createBitmap(w, h, Bitmap.Config.RGB_565)
+        }.getOrNull() ?: return null
+        val canvas = Canvas(bmp)
+        canvas.drawColor(backgroundColor)
+
+        // Reserve the bottom strip for the movement marks so a calm hour's line, which sits at the very
+        // bottom of a fixed domain, cannot be confused with them.
+        val markBand = if (movingMarks.isEmpty()) 0f else (strokePx * 2f).coerceAtMost(h / 6f)
+        val chartH = (h - markBand).coerceAtLeast(1f)
+
+        // Inset by the stroke so a point sitting exactly on the top or bottom edge is not shaved in half.
+        val inset = strokePx / 2f
+        val usableH = (chartH - strokePx).coerceAtLeast(1f)
+        // Normalised by the FULL box height, because that is the height the caller built the
+        // coordinates against. Dividing by the shortened band instead pushed a calm day, whose y sits
+        // at the very bottom of the full box, past the bottom of the chart and into the marks.
+        fun px(p: StressTrace.Pt) = p.x to (inset + p.y / h.toFloat() * usableH)
+
+        // One shader for every segment: Y encodes the score, so vertical position IS the ramp.
+        val ramp = LinearGradient(
+            0f, 0f, 0f, chartH,
+            intArrayOf(tenseColor, steadyColor, calmColor),
+            floatArrayOf(0f, 0.5f, 1f),
+            Shader.TileMode.CLAMP,
+        )
+        val stroke = Paint().apply {
+            isAntiAlias = true
+            isDither = true   // 565 bands a smooth ramp without it
+            style = Paint.Style.STROKE
+            strokeWidth = strokePx
+            strokeCap = Paint.Cap.ROUND
+            strokeJoin = Paint.Join.ROUND
+            shader = ramp
+        }
+        val dot = Paint().apply {
+            isAntiAlias = true
+            isDither = true
+            shader = ramp
+        }
+
+        for (seg in segments) {
+            if (seg.isEmpty()) continue
+            // A run of one hour has no line to stroke, so give it a dot. Otherwise a day whose only
+            // scored hours are isolated renders as an empty chart, which reads as "no data" rather than
+            // as the sparse day it is.
+            if (seg.size == 1) {
+                val (x, y) = px(seg[0])
+                canvas.drawCircle(x.coerceAtLeast(strokePx), y, strokePx, dot)
+                continue
+            }
+            val path = Path()
+            seg.forEachIndexed { i, p ->
+                val (x, y) = px(p)
+                if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+            }
+            canvas.drawPath(path, stroke)
+        }
+
+        if (movingMarks.isNotEmpty() && markBand > 0f) {
+            val markPaint = Paint().apply {
+                isAntiAlias = true
+                color = markColor
+                style = Paint.Style.FILL
+            }
+            val halfWidth = (strokePx * 1.5f).coerceAtLeast(1f)
+            val top = h - markBand
+            for (x in movingMarks) {
+                canvas.drawRoundRect(
+                    (x - halfWidth).coerceAtLeast(0f), top,
+                    (x + halfWidth).coerceAtMost(w.toFloat()), h.toFloat(),
+                    halfWidth, halfWidth, markPaint,
+                )
+            }
+        }
+        return bmp
+    }
+}

--- a/android/app/src/main/java/com/noop/widget/StressWidgetProducer.kt
+++ b/android/app/src/main/java/com/noop/widget/StressWidgetProducer.kt
@@ -1,0 +1,106 @@
+package com.noop.widget
+
+import com.noop.analytics.DaytimeStress
+import com.noop.data.WhoopRepository
+import com.noop.ui.stressLocalDayWindowContaining
+import java.time.Instant
+import java.time.ZoneId
+
+/**
+ * Scores today's hourly stress for the widget, and does it as rarely as it can get away with.
+ *
+ * THE GATE IS THE POINT. Scoring a day means reading today's heart rate, R-R and gravity, three
+ * unioned reads bounded at 200 000 rows each, which is the same work the Stress screen does when you
+ * open it. The screen does that once, on a deliberate act. A widget producer sits on a periodic tick,
+ * and putting three reads of that size on a repeating cadence is precisely the pattern this codebase
+ * has had to unpick before (the analyze-pass storm, and the 21-night re-score behind it).
+ *
+ * So nothing is read until [WhoopRepository.hrFingerprintWindow] says today's heart rate actually
+ * moved. That fingerprint is a COUNT and a MAX over an indexed column: no rows, no decode. On an idle
+ * tick, which is almost every tick, this costs one cheap query and returns the previous curve. Stress
+ * is scored hourly, so even a busy day recomputes about as often as it has new hours.
+ *
+ * SCORING MODE. Always the DayRelative default, never the opt-in personal-baseline lens. Resolving
+ * that mode reads fourteen trailing days of heart rate to decide whether enough worn history exists,
+ * and that is a cost the screen can afford on demand and a background tick cannot. The consequence is
+ * worth stating plainly: with the personal-baseline toggle on, the widget shows the default lens while
+ * the screen shows the refined one, so the two can differ. Honouring the toggle here would mean
+ * fourteen days of reads on a repeating schedule, which is the worse of the two.
+ */
+internal object StressWidgetProducer {
+
+    /** Today's curve and the local day it belongs to. */
+    data class Curve(val points: List<StressPoint>, val epochDay: Long)
+
+    /** What the last computation saw and produced, swapped in as ONE value.
+     *
+     *  Three separate fields could tear: a second caller arriving between two of the assignments would
+     *  read one call's fingerprint beside another's points and serve a curve for a day it was not
+     *  scored against. Only the view model calls this today, so that is a narrow window, but an
+     *  immutable holder closes it for free and survives a second caller being added later. */
+    private data class Memo(
+        val fingerprint: Pair<Int, Long>,
+        val day: Long,
+        val points: List<StressPoint>,
+    )
+
+    @Volatile
+    private var memo: Memo? = null
+
+    /**
+     * Today's curve, recomputed only when today's heart rate has moved since the last call.
+     *
+     * Returns null when there is no device to read, which is the one case a caller must not treat as
+     * "today scored nothing": a null means "say nothing about stress in this push", and the widget
+     * keeps whatever it already had.
+     */
+    suspend fun todayCurve(
+        repo: WhoopRepository,
+        deviceId: String?,
+        nowSeconds: Long = System.currentTimeMillis() / 1000L,
+        zone: ZoneId = ZoneId.systemDefault(),
+    ): Curve? {
+        if (deviceId.isNullOrBlank()) return null
+        return runCatching {
+            val window = stressLocalDayWindowContaining(nowSeconds, zone)
+            val day = window.day.toEpochDay()
+            val from = window.fromEpochSecond
+
+            val fingerprint = repo.hrFingerprintWindow(deviceId, from, nowSeconds)
+            // Same day, same heart rate: nothing can have changed the score, so nothing is read. The day
+            // is part of the check because a fingerprint that happens to match across midnight would
+            // otherwise serve yesterday's curve as today's.
+            memo?.let { if (it.day == day && it.fingerprint == fingerprint) return Curve(it.points, day) }
+
+            val hr = repo.hrSamplesUnion(deviceId, from, nowSeconds, limit = 200_000)
+            val points = if (hr.size < DaytimeStress.minHourHrSamples) {
+                // Too little signal to score honestly. An EMPTY curve, not a null: this is a real
+                // answer about today, and the widget should drop yesterday's line rather than keep it.
+                emptyList()
+            } else {
+                val rr = repo.rrIntervalsUnion(deviceId, from, nowSeconds, limit = 200_000)
+                // Wrist accelerometer for the motion gate, so an ambulatory hour reads as exertion
+                // rather than as stress. Empty on hardware or imports without gravity, which degrades
+                // to no masking exactly as the screen does.
+                val gravity = repo.gravitySamplesUnion(deviceId, from, nowSeconds, limit = 200_000)
+                val tzOffsetSeconds =
+                    zone.rules.getOffset(Instant.ofEpochSecond(nowSeconds)).totalSeconds.toLong()
+                DaytimeStress.analyze(
+                    hr, rr, gravity, tzOffsetSeconds, DaytimeStress.ScoringMode.DayRelative,
+                ).hours.map {
+                    // startTs is the wall-clock bucket start with the local shift already undone, so it
+                    // is a true instant and formats correctly against the device's zone.
+                    StressPoint(ts = it.startTs, level = it.level, moving = it.maskedForActivity)
+                }
+            }
+
+            memo = Memo(fingerprint, day, points)
+            Curve(points, day)
+        }.getOrNull()
+    }
+
+    /** Drops the memo so a test starts from a known state. */
+    fun resetForTest() {
+        memo = null
+    }
+}

--- a/android/app/src/main/java/com/noop/widget/StressWidgetReceiver.kt
+++ b/android/app/src/main/java/com/noop/widget/StressWidgetReceiver.kt
@@ -1,0 +1,9 @@
+package com.noop.widget
+
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+/** Manifest entry point for the stress widget — all rendering lives in [StressGlanceWidget]. */
+class StressWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = StressGlanceWidget()
+}

--- a/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
@@ -178,6 +178,9 @@ object WidgetSnapshotStore {
 
     fun load(context: Context): WidgetSnapshot {
         val p = context.getSharedPreferences(FILE, Context.MODE_PRIVATE)
+        // Resolved ONCE. Asking twice let the two stress fields straddle midnight and disagree, the
+        // same inconsistency the Swift twin avoids by deriving both from a single value.
+        val today = java.time.LocalDate.now().toEpochDay()
         val (hr, hrStale) = HrDisplay.resolve(
             lastHr = p.getInt("hr", -1).takeIf { it > 0 },
             lastHrAtMs = p.getLong("hrAt", 0L),
@@ -203,14 +206,13 @@ object WidgetSnapshotStore {
             // uses for age: a widget read at 00:30 would otherwise show yesterday's curve as today's
             // until the first hour of the new day happens to be scorable.
             stressSeries = p.getLong(KEY_STRESS_DAY, Long.MIN_VALUE)
-                .takeIf { it == java.time.LocalDate.now().toEpochDay() }
+                .takeIf { it == today }
                 ?.let { StressTrace.decode(p.getString(KEY_STRESS, null)) }
                 ?: emptyList(),
             // Surfaced only when it IS today, so this field can never disagree with the series above:
             // a loaded snapshot reporting yesterday's day beside an emptied curve would be a trap for
             // anything that later treated the pair as writable state.
-            stressDay = p.getLong(KEY_STRESS_DAY, Long.MIN_VALUE)
-                .takeIf { it == java.time.LocalDate.now().toEpochDay() },
+            stressDay = p.getLong(KEY_STRESS_DAY, Long.MIN_VALUE).takeIf { it == today },
             updatedAtMs = p.getLong("updatedAt", 0L),
         )
     }

--- a/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
@@ -29,6 +29,20 @@ data class WidgetSnapshot(
      *  hands back the pruned series, so nothing that pushes a snapshot had to learn about it. Empty
      *  until a live sample lands, which is also what a fresh install and a quiet strap look like. */
     val hrSeries: List<HrPoint> = emptyList(),
+    /** Today's hourly stress curve for the stress widget (#2040), earliest to latest.
+     *
+     *  Unlike [hrSeries] this is NOT folded by the store. It arrives complete from whichever producer
+     *  scored the day, so a push either carries a whole day or says nothing about stress at all, and
+     *  `save` leaves the stored curve alone in the second case. That matters because the background
+     *  service pushes heart rate without ever scoring stress, and a naive write would blank the curve
+     *  every time the strap reported a beat. */
+    val stressSeries: List<StressPoint> = emptyList(),
+    /** Local epoch-day [stressSeries] was scored for, or null when this push carries no curve.
+     *
+     *  The nullability is the write signal, and the value is the staleness one: `load` drops a curve
+     *  from any day but today, so the widget cannot show yesterday's afternoon under today's date while
+     *  waiting for the first scorable hour after midnight. */
+    val stressDay: Long? = null,
     /** Wall-clock millis of the last push, so the widget can show honest staleness. */
     val updatedAtMs: Long = 0L,
 )
@@ -49,6 +63,12 @@ object WidgetSnapshotStore {
     /** Prefs key for the encoded heart-rate trace (#1957). Its own key so an older build, or a wipe of
      *  the trace, leaves every scalar the other widgets read untouched. */
     private const val KEY_SERIES = "hrSeries"
+
+    /** Prefs keys for the stress curve and the day it belongs to (#2040). Their own keys for the same
+     *  reason the trace has one: an older build, or a day with nothing scored, must leave every scalar
+     *  the other widgets read untouched. */
+    private const val KEY_STRESS = "stressSeries"
+    private const val KEY_STRESS_DAY = "stressDay"
 
     suspend fun push(context: Context, snap: WidgetSnapshot) {
         val app = context.applicationContext
@@ -80,7 +100,10 @@ object WidgetSnapshotStore {
         val hrIds = runCatching {
             GlanceAppWidgetManager(app).getGlanceIds(HrGlanceWidget::class.java)
         }.getOrDefault(emptyList())
-        if (standardIds.isEmpty() && compactIds.isEmpty() && hrIds.isEmpty()) {
+        val stressIds = runCatching {
+            GlanceAppWidgetManager(app).getGlanceIds(StressGlanceWidget::class.java)
+        }.getOrDefault(emptyList())
+        if (standardIds.isEmpty() && compactIds.isEmpty() && hrIds.isEmpty() && stressIds.isEmpty()) {
             // Admitted, but there is nowhere for it to go. Recorded rather than returned silently: an
             // export taken with the widget removed is half of the comparison that answers whether it
             // costs anything, and counting this as a send would have made both halves look alike.
@@ -114,6 +137,7 @@ object WidgetSnapshotStore {
         if (standardIds.isNotEmpty()) runCatching { NoopGlanceWidget().updateAll(app) }
         if (compactIds.isNotEmpty()) runCatching { NoopCompactGlanceWidget().updateAll(app) }
         if (hrIds.isNotEmpty()) runCatching { HrGlanceWidget().updateAll(app) }
+        if (stressIds.isNotEmpty()) runCatching { StressGlanceWidget().updateAll(app) }
     }
 
     fun save(context: Context, snap: WidgetSnapshot) {
@@ -142,6 +166,13 @@ object WidgetSnapshotStore {
             )
             e.putString(KEY_SERIES, HrTrace.encode(folded))
         }
+        // Stress is written only by a push that scored it. A null day means "this push says nothing
+        // about stress", which is every push from the BLE service, and overwriting on those would leave
+        // the widget blank for all the minutes between one scoring pass and the next.
+        if (snap.stressDay != null) {
+            e.putString(KEY_STRESS, StressTrace.encode(snap.stressSeries))
+                .putLong(KEY_STRESS_DAY, snap.stressDay)
+        }
         e.apply()
     }
 
@@ -168,6 +199,18 @@ object WidgetSnapshotStore {
                 HrTrace.decode(p.getString(KEY_SERIES, null)),
                 nowSec = System.currentTimeMillis() / 1000,
             ),
+            // Dropped on the way OUT when it belongs to a past day, the same discipline the trace
+            // uses for age: a widget read at 00:30 would otherwise show yesterday's curve as today's
+            // until the first hour of the new day happens to be scorable.
+            stressSeries = p.getLong(KEY_STRESS_DAY, Long.MIN_VALUE)
+                .takeIf { it == java.time.LocalDate.now().toEpochDay() }
+                ?.let { StressTrace.decode(p.getString(KEY_STRESS, null)) }
+                ?: emptyList(),
+            // Surfaced only when it IS today, so this field can never disagree with the series above:
+            // a loaded snapshot reporting yesterday's day beside an emptied curve would be a trap for
+            // anything that later treated the pair as writable state.
+            stressDay = p.getLong(KEY_STRESS_DAY, Long.MIN_VALUE)
+                .takeIf { it == java.time.LocalDate.now().toEpochDay() },
             updatedAtMs = p.getLong("updatedAt", 0L),
         )
     }
@@ -242,9 +285,14 @@ internal object RenderedGate {
     @Synchronized
     fun changed(visible: WidgetSnapshot, dark: Boolean): Boolean {
         val newest = visible.hrSeries.lastOrNull()
+        // The stress curve joins the key (#2040). Without it a pass that scored a fresh hour, and
+        // changed nothing else, would be declined here as "nothing the widgets display changed" and the
+        // curve would sit an hour behind whatever unrelated value moved next.
+        val newestStress = visible.stressSeries.lastOrNull { it.level != null }
         val key = "${visible.recoveryPct}|${visible.restPct}|${visible.effortPct}|" +
             "${visible.batteryPct}|${visible.connected}|${visible.heartRate}|" +
             "${visible.heartRateStale}|${visible.hrSeries.size}|${newest?.ts}|${newest?.bpm}|" +
+            "${visible.stressSeries.size}|${newestStress?.ts}|${newestStress?.level}|" +
             "$dark"
         val differs = key != last
         last = key
@@ -271,6 +319,13 @@ internal object PushGate {
     private fun keyOf(snap: WidgetSnapshot): String =
         // Rest + Effort join the change-key (#516) so a freshly-scored 2x2 score lands immediately, the
         // same way recovery does — not waiting out the HR refresh window.
+        // Stress is deliberately NOT in this key. Two producers push snapshots and only one of them
+        // scores stress, so keying on the curve would make the count alternate between N and 0 as the
+        // BLE service and the view model took turns, flipping the key on every push and admitting all
+        // of them — the exact throttle this gate exists to apply. [RenderedGate] covers the curve
+        // instead, and covers it better: it reads back what was STORED, so it sees the same thing
+        // whichever producer last wrote. A curve that arrives while this gate is closed waits at most
+        // HR_REFRESH_MS, against an hourly score.
         "${snap.recoveryPct}|${snap.restPct}|${snap.effortPct}|" +
             "${snap.batteryPct?.div(5)}|${snap.connected}|${snap.heartRate != null}"
 

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2756,6 +2756,8 @@
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Aktualisiert %1$s</string>
     <string name="widget_hr_name">NOOP Herzfrequenz</string>
     <string name="widget_hr_description">Live-Herzfrequenz mit den letzten drei Stunden als Verlauf.</string>
+    <string name="widget_stress_name">NOOP Stress</string>
+    <string name="widget_stress_description">Der heutige Stress als Stundenverlauf.</string>
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Ladungs-Trend ansehen</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Jeder Tageswert im Zeitverlauf.</string>
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Ein Coach, der den Faden behält, deine Herzfrequenz auf dem Homescreen und Diagramme, die weniger behaupten</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2743,6 +2743,8 @@
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Actualizado %1$s</string>
     <string name="widget_hr_name">NOOP Frecuencia cardíaca</string>
     <string name="widget_hr_description">Frecuencia cardíaca en directo con las últimas tres horas como gráfico.</string>
+    <string name="widget_stress_name">NOOP Estrés</string>
+    <string name="widget_stress_description">El estrés de hoy como una curva hora a hora.</string>
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Ver la tendencia de Carga</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">La puntuación de cada día, a lo largo del tiempo.</string>
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Un coach que mantiene el hilo, tu frecuencia cardíaca en la pantalla de inicio y gráficos que afirman menos</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2742,6 +2742,8 @@
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Mis à jour %1$s</string>
     <string name="widget_hr_name">NOOP Fréquence cardiaque</string>
     <string name="widget_hr_description">Fréquence cardiaque en direct avec les trois dernières heures en courbe.</string>
+    <string name="widget_stress_name">NOOP Stress</string>
+    <string name="widget_stress_description">Le stress du jour en courbe, heure par heure.</string>
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Voir la tendance de la charge</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Le score de chaque jour, dans la durée.</string>
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Un coach qui garde le fil, votre fréquence cardiaque sur l\'écran d\'accueil, et des graphiques qui affirment moins</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2747,6 +2747,8 @@
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Zaktualizowano %1$s</string>
     <string name="widget_hr_name">NOOP Tętno</string>
     <string name="widget_hr_description">Tętno na żywo z ostatnimi trzema godzinami jako wykres.</string>
+    <string name="widget_stress_name">NOOP Stres</string>
+    <string name="widget_stress_description">Dzisiejszy stres jako wykres godzina po godzinie.</string>
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Zobacz trend Energii</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Wynik każdego dnia w czasie.</string>
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Trener, który nie gubi wątku, tętno na ekranie głównym i wykresy, które mniej zakładają</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2735,6 +2735,8 @@
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Atualizado %1$s</string>
     <string name="widget_hr_name">NOOP Frequência cardíaca</string>
     <string name="widget_hr_description">Frequência cardíaca em direto com as últimas três horas em gráfico.</string>
+    <string name="widget_stress_name">NOOP Stress</string>
+    <string name="widget_stress_description">O stress de hoje como uma curva hora a hora.</string>
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Ver a tendência da Carga</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">A pontuação de cada dia, ao longo do tempo.</string>
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Um treinador que mantém o fio, a sua frequência cardíaca no ecrã principal e gráficos que afirmam menos</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -2626,6 +2626,8 @@
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">Обновлено %1$s</string>
     <string name="widget_hr_name">NOOP Пульс</string>
     <string name="widget_hr_description">Пульс в реальном времени и график за последние три часа.</string>
+    <string name="widget_stress_name">NOOP Стресс</string>
+    <string name="widget_stress_description">Сегодняшний стресс в виде почасового графика.</string>
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Посмотреть динамику Заряда</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Оценка за каждый день во времени.</string>
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Тренер, который не теряет нить, ваш пульс на главном экране и графики, которые меньше домысливают</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2656,6 +2656,8 @@
     <string name="l10n_hr_glance_widget_updated_time_1b5feedb">更新于 %1$s</string>
     <string name="widget_hr_name">NOOP 心率</string>
     <string name="widget_hr_description">实时心率，并显示最近三小时的曲线。</string>
+    <string name="widget_stress_name">NOOP 压力</string>
+    <string name="widget_stress_description">以逐小时曲线显示今天的压力。</string>
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">查看充能趋势</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">每天的分数，随时间变化。</string>
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">能接住话头的教练、主屏幕上的心率，以及不再过度断言的图表</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -4,6 +4,8 @@
     <string name="widget_description">Today\'s Rest, Charge and Effort, with live heart rate and strap battery at a glance.</string>
     <string name="widget_hr_name">NOOP Heart Rate</string>
     <string name="widget_hr_description">Live heart rate with the last three hours as a trace.</string>
+    <string name="widget_stress_name">NOOP Stress</string>
+    <string name="widget_stress_description">Today\'s stress as an hour-by-hour curve.</string>
     <string name="widget_compact_name">NOOP Compact</string>
     <string name="widget_compact_description">Compact Rest, Charge and Effort widget, with live heart rate and strap battery.</string>
     <string name="widget_error">NOOP widget couldn\'t draw — it will recover on the next update.</string>

--- a/android/app/src/main/res/xml/stress_widget_info.xml
+++ b/android/app/src/main/res/xml/stress_widget_info.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Same 4x2 footprint as the heart-rate widget: this is a day-long curve, so it needs horizontal room
+     far more than height, and nothing here is stacked. updatePeriodMillis is 0 because
+     WidgetSnapshotStore pushes on the app's own cadence; letting the system poll as well would wake the
+     widget on a schedule that has nothing to do with when an hour was scored, and today's stress only
+     changes once an hour at most. -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/widget_stress_description"
+    android:minWidth="250dp"
+    android:minHeight="110dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="2"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/glance_default_loading_layout" />

--- a/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
+++ b/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
@@ -81,6 +81,32 @@ class StressTraceTest {
         assertEquals(50f, marks.single(), 0.001f)
     }
 
+    // MARK: - the high band
+
+    @Test
+    fun `only hours at or above the high band get a dot`() {
+        val day = listOf(at(0, 1.0), at(1, 1.9), at(2, 2.0), at(3, 2.8), at(4, null))
+        val dots = StressTrace.highPoints(day, 100f, 100f)
+        // 2.0 is the floor itself, so it counts; 1.9 does not.
+        assertEquals(2, dots.size)
+    }
+
+    @Test
+    fun `a dot lands on its own vertex`() {
+        val day = listOf(at(0, 0.5), at(1, 2.5))
+        val vertex = StressTrace.segments(day, 100f, 100f).single()[1]
+        val dot = StressTrace.highPoints(day, 100f, 100f).single()
+        // The dot and the line are placed by the same rule, so a nudge to one cannot leave the other
+        // behind. The renderer lifts the dot above the stroke; the geometry must agree exactly.
+        assertEquals(vertex.x, dot.x, 0.001f)
+        assertEquals(vertex.y, dot.y, 0.001f)
+    }
+
+    @Test
+    fun `a calm day gets no dots at all`() {
+        assertTrue(StressTrace.highPoints(listOf(at(0, 0.4), at(1, 1.2)), 100f, 100f).isEmpty())
+    }
+
     // MARK: - stats
 
     @Test

--- a/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
+++ b/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
@@ -1,0 +1,145 @@
+package com.noop.widget
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The stress widget's pure half. The two tests that matter most are the ones pinning where it departs
+ * from [HrTrace]: the domain is fixed rather than normalised, and an unscored hour is a hole rather
+ * than a point to draw through.
+ */
+class StressTraceTest {
+
+    private val h = 3_600L
+    private fun at(hour: Int, level: Double?, moving: Boolean = false) =
+        StressPoint(ts = hour * h, level = level, moving = moving)
+
+    // MARK: - the fixed domain
+
+    @Test
+    fun `a calm day is drawn low, not stretched across the box`() {
+        val calm = listOf(at(0, 0.2), at(1, 0.3), at(2, 0.25))
+        val pts = StressTrace.segments(calm, width = 100f, height = 100f).single()
+        // Every point sits in the bottom tenth, because 0.3 of 3 IS low. Normalising to the day's own
+        // range would have spread these three across the full height and drawn a dramatic day.
+        assertTrue("calm day should hug the bottom, got $pts", pts.all { it.y >= 88f })
+    }
+
+    @Test
+    fun `the same shape at a higher level draws higher`() {
+        val calm = StressTrace.segments(listOf(at(0, 0.2), at(1, 0.4)), 100f, 100f).single()
+        val tense = StressTrace.segments(listOf(at(0, 2.2), at(1, 2.4)), 100f, 100f).single()
+        // Identical spread, different absolute level: under a normalising domain these would be drawn
+        // identically, which is the lie the fixed domain exists to prevent.
+        assertTrue("tense day must sit above the calm one", tense[0].y < calm[0].y)
+    }
+
+    @Test
+    fun `the top of the domain is the top of the box and zero is the bottom`() {
+        val pts = StressTrace.segments(listOf(at(0, 3.0), at(1, 0.0)), 100f, 100f).single()
+        assertEquals(0f, pts[0].y, 0.001f)
+        assertEquals(100f, pts[1].y, 0.001f)
+    }
+
+    // MARK: - gaps
+
+    @Test
+    fun `an unscored hour splits the line rather than being drawn through`() {
+        val day = listOf(at(0, 1.0), at(1, 1.2), at(2, null), at(3, 0.9), at(4, 1.1))
+        val segs = StressTrace.segments(day, 100f, 100f)
+        assertEquals("the hole must break the line in two", 2, segs.size)
+        assertEquals(2, segs[0].size)
+        assertEquals(2, segs[1].size)
+    }
+
+    @Test
+    fun `the gap keeps its width, so the afternoon does not slide left`() {
+        val day = listOf(at(0, 1.0), at(1, null), at(2, 1.0))
+        val segs = StressTrace.segments(day, 100f, 100f)
+        // x is placed on the hour's position in the day's span, so the survivors sit at the ends.
+        assertEquals(0f, segs[0].single().x, 0.001f)
+        assertEquals(100f, segs[1].single().x, 0.001f)
+    }
+
+    @Test
+    fun `a day with nothing scored draws nothing`() {
+        val day = listOf(at(0, null), at(1, null, moving = true))
+        assertTrue(StressTrace.segments(day, 100f, 100f).isEmpty())
+        assertNull(StressTrace.stats(day))
+    }
+
+    // MARK: - movement
+
+    @Test
+    fun `hours masked as movement are marked and do not join the line`() {
+        val day = listOf(at(0, 1.0), at(1, null, moving = true), at(2, 1.0))
+        assertEquals(2, StressTrace.segments(day, 100f, 100f).size)
+        val marks = StressTrace.movingMarks(day, 100f)
+        assertEquals(1, marks.size)
+        assertEquals(50f, marks.single(), 0.001f)
+    }
+
+    // MARK: - stats
+
+    @Test
+    fun `mean covers scored hours only and peak is the highest of them`() {
+        val day = listOf(at(0, 1.0), at(1, null), at(2, 2.0), at(3, null, moving = true))
+        val stats = StressTrace.stats(day)!!
+        assertEquals(1.5, stats.mean, 0.0001)
+        assertEquals(2.0, stats.peak.level!!, 0.0001)
+        assertEquals(2 * h, stats.peak.ts)
+        assertEquals(2, stats.scoredHours)
+        assertEquals(1, stats.movingHours)
+    }
+
+    // MARK: - the prefs round trip
+
+    @Test
+    fun `encode and decode preserve levels, holes and movement`() {
+        val day = listOf(at(0, 1.25), at(1, null), at(2, null, moving = true), at(3, 2.5))
+        val back = StressTrace.decode(StressTrace.encode(day))
+        assertEquals(day.size, back.size)
+        assertEquals(1.25, back[0].level!!, 0.001)
+        assertNull(back[1].level)
+        assertTrue(back[2].moving)
+        assertEquals(2.5, back[3].level!!, 0.001)
+    }
+
+    @Test
+    fun `decode skips malformed pieces instead of throwing`() {
+        // This runs on the widget's render path, where the alternative to a partial curve is a crashed
+        // home screen.
+        val back = StressTrace.decode("0:1.0:0,nonsense,7::1,3600:2.0:1,,9999:99:0")
+        assertEquals(2, back.size)
+        assertEquals(1.0, back[0].level!!, 0.001)
+        assertTrue(back[1].moving)
+    }
+
+    @Test
+    fun `decode of nothing is empty rather than a crash`() {
+        assertTrue(StressTrace.decode(null).isEmpty())
+        assertTrue(StressTrace.decode("").isEmpty())
+    }
+
+    // MARK: - axes
+
+    @Test
+    fun `the level scale is fixed so two days can be compared`() {
+        assertEquals(listOf(3, 2, 1, 0), StressTrace.levelTicks())
+    }
+
+    @Test
+    fun `time ticks anchor to the scored hours, not to the day`() {
+        val day = listOf(at(0, null), at(8, 1.0), at(12, 1.5), at(16, 2.0), at(23, null))
+        val ticks = StressTrace.timeTicks(day)
+        // An evening-only day must not label its axis with a morning that was never sampled.
+        assertEquals(listOf(8 * h, 12 * h, 16 * h), ticks)
+    }
+
+    @Test
+    fun `one scored hour names one instant`() {
+        assertEquals(listOf(9 * h), StressTrace.timeTicks(listOf(at(9, 1.0), at(10, null))))
+    }
+}


### PR DESCRIPTION
Addresses #2040, Android side.

A user asked for a stress widget with graphing, pointing at the Stress screen's intraday panel. This
is that panel at widget size: the 0-3 curve across the day, the peak called out with its time, faint
marks along the base for the hours the motion gate masked, and the day's average beside the update
stamp.

### Shape

The chart is a Bitmap because Glance compiles to RemoteViews and cannot draw, which is the shape the
heart-rate widget already takes. `StressTrace` decides where the ink goes and is unit-tested,
`StressTraceRenderer` does nothing but stroke coordinates handed to it, and the labels stay Glance
`Text` so they remain crisp, themed and audible to TalkBack. The bitmap budget helpers are reused from
`HrTrace` rather than copied or extracted: that ceiling is a property of the RemoteViews transaction,
not of heart rate, and a second copy of that reasoning is how two charts end up disagreeing about it.

Two things deliberately differ from the heart-rate trace, and both are pinned by tests:

- The domain is FIXED at 0-3 rather than normalised to the day's own range. A stress score means
  something absolute, so normalising would redraw a flat calm day as a dramatic one.
- An unscored hour is a HOLE. The line breaks rather than being drawn through it, which is what the
  screen's own caption promises, and the gap keeps its width so the afternoon does not slide left.

### The producer, which is the part worth reviewing

Scoring a day costs three unioned reads bounded at 200 000 rows, the same work the screen does when
opened. A widget producer sits on a periodic tick, and three reads of that size on a repeating cadence
is the pattern this codebase has had to unpick before. So nothing is read until `hrFingerprintWindow`,
a COUNT and a MAX over an indexed column, says today's heart rate actually moved. An idle tick costs
that one query and reuses the previous curve.

`RenderedGate` learned about the curve, otherwise a pass that scored a fresh hour and changed nothing
else would have been discarded as "nothing the widgets display changed". `PushGate` deliberately did
NOT: two producers push snapshots and only one scores stress, so keying on the curve would make the
count alternate between N and 0 as they take turns, flipping the key on every push and admitting all
of them. `RenderedGate` is the better home regardless, because it reads back what was STORED and so
sees the same thing whichever producer last wrote.

The curve is stored with the local day it belongs to and dropped on read when that day is not today,
so a widget read after midnight cannot show yesterday's afternoon while waiting for the first scorable
hour. A push carrying no curve leaves the stored one alone, which is every push from the BLE service.

### Stated limits

Scoring is always the DayRelative default. Resolving the opt-in personal-baseline mode reads fourteen
trailing days of heart rate, which the screen can afford on demand and a background tick cannot, so
with that toggle on the widget shows the default lens and the screen the refined one.

The iOS twin is NOT in this change. The Swift analytics twin already exists, but the widget extension
cannot be built here, and the parts needing care are the publish path and the producer gate rather
than the drawing, so it lands better as its own change than as several hundred lines of Swift steered
blind through CI. Calling that out rather than leaving it implied, since the repo convention is both
platforms or a reason.

### Verification

- `./gradlew compileFullDebugKotlin` clean.
- `./gradlew testFullDebugUnitTest --tests "com.noop.widget.*" --no-build-cache`: 14 new tests in
  `StressTraceTest`, 0 failures, and the result XML checked to confirm they actually ran rather than
  the filter matching nothing.
- `./gradlew lintVitalFullRelease -PstagingRelease` clean, the check that treats `ExtraTranslation` as
  fatal after a `strings.xml` edit.
- `Tools/i18n_audit.py` reports no locale gaps: the two new registration strings are translated into
  all eight locale directories, and everything else the widget prints reuses existing keys.
- `Tools/doc_comment_lint.py` clean.
- NOT verified: the widget on a real launcher. The layout constants are inherited from the heart-rate
  widget, which had to learn them from real launchers under-reporting their own width, but a Bitmap
  chart is exactly the kind of thing that looks different in the wild.
