### PR TITLE
Stress widget: the iOS twin

### DIFF
--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -1143,6 +1143,25 @@ final class Repository: ObservableObject {
         return byTs.values.sorted { $0.ts < $1.ts }
     }
 
+    /// Cheap change-detector over a window of heart rate: a COUNT and a MAX on an indexed column, no
+    /// rows and no decode.
+    ///
+    /// Exists for the stress widget (#2040), whose producer must not read a day's streams on a periodic
+    /// tick just to discover nothing moved. Unions the same ids the reads above do, so a change under
+    /// either source is seen; nil when there is no store yet, which a caller treats as "cannot tell"
+    /// rather than as "unchanged". Twin of Kotlin's `hrFingerprintWindow`.
+    func hrFingerprint(from: Int, to: Int) async -> (count: Int, maxTs: Int)? {
+        guard let store = await ensureStore() else { return nil }
+        var count = 0
+        var maxTs = 0
+        for id in rawPhysiologyReadIds(store: store) {
+            guard let fp = try? await store.hrFingerprint(deviceId: id, from: from, to: to) else { continue }
+            count += fp.count
+            maxTs = max(maxTs, fp.maxTs)
+        }
+        return (count, maxTs)
+    }
+
     /// R-R beats across the active physical WHOOP and canonical history. Exact duplicates are removed
     /// active-first, while same-timestamp distinct beats remain intact.
     func rrIntervals(from: Int, to: Int, limit: Int = 8000) async -> [RRInterval] {

--- a/StrandTests/StressTraceTests.swift
+++ b/StrandTests/StressTraceTests.swift
@@ -1,0 +1,177 @@
+import XCTest
+import StrandAnalytics
+@testable import NOOP
+
+/// The stress widget's pure half, and the parity that keeps it honest.
+///
+/// Mirrors the Kotlin `StressTraceTest` case for case. The two that matter most pin where this departs
+/// from `HrTrace`: the domain is fixed rather than normalised, and an unscored hour is a hole rather
+/// than a point to draw through.
+final class StressTraceTests: XCTestCase {
+
+    private let hour: Int64 = 3_600
+    private func at(_ h: Int64, _ level: Double?, moving: Bool = false) -> StressPoint {
+        StressPoint(ts: h * hour, level: level, moving: moving)
+    }
+
+    // MARK: - the constant the extension cannot import
+
+    func testHighBandFloorStillMatchesTheAnalyticsConstant() {
+        // `StressTrace` restates this because the widget extension links no packages, so it cannot see
+        // `DaytimeStress`. This test is the only place that can compare them, and it exists so the copy
+        // cannot drift silently the day the band moves. If this fails, change the copy, not this line.
+        XCTAssertEqual(StressTrace.highBandFloor, DaytimeStress.highBandFloor)
+    }
+
+    func testDomainMaxMatchesTheScaleTheScoreIsOn() {
+        // The 0-3 proxy's top. A widget drawing against a different ceiling would misplace every hour.
+        XCTAssertEqual(StressTrace.domainMax, 3.0)
+    }
+
+    // MARK: - the fixed domain
+
+    func testACalmDayIsDrawnLowRatherThanStretchedAcrossTheBox() {
+        let calm = [at(0, 0.2), at(1, 0.3), at(2, 0.25)]
+        let pts = StressTrace.segments(calm, width: 100, height: 100)[0]
+        // Every point sits in the bottom tenth, because 0.3 of 3 IS low. Normalising to the day's own
+        // range would have spread these three across the full height and drawn a dramatic day.
+        XCTAssertTrue(pts.allSatisfy { $0.y >= 88 }, "calm day should hug the bottom, got \(pts)")
+    }
+
+    func testTheSameShapeAtAHigherLevelDrawsHigher() {
+        let calm = StressTrace.segments([at(0, 0.2), at(1, 0.4)], width: 100, height: 100)[0]
+        let tense = StressTrace.segments([at(0, 2.2), at(1, 2.4)], width: 100, height: 100)[0]
+        // Identical spread, different absolute level: under a normalising domain these would be drawn
+        // identically, which is the lie the fixed domain exists to prevent.
+        XCTAssertLessThan(tense[0].y, calm[0].y)
+    }
+
+    func testTheTopOfTheDomainIsTheTopOfTheBoxAndZeroIsTheBottom() {
+        let pts = StressTrace.segments([at(0, 3.0), at(1, 0.0)], width: 100, height: 100)[0]
+        XCTAssertEqual(pts[0].y, 0, accuracy: 0.001)
+        XCTAssertEqual(pts[1].y, 100, accuracy: 0.001)
+    }
+
+    // MARK: - gaps
+
+    func testAnUnscoredHourSplitsTheLineRatherThanBeingDrawnThrough() {
+        let day = [at(0, 1.0), at(1, 1.2), at(2, nil), at(3, 0.9), at(4, 1.1)]
+        let segs = StressTrace.segments(day, width: 100, height: 100)
+        XCTAssertEqual(segs.count, 2, "the hole must break the line in two")
+        XCTAssertEqual(segs[0].count, 2)
+        XCTAssertEqual(segs[1].count, 2)
+    }
+
+    func testTheGapKeepsItsWidthSoTheAfternoonDoesNotSlideLeft() {
+        let segs = StressTrace.segments([at(0, 1.0), at(1, nil), at(2, 1.0)], width: 100, height: 100)
+        XCTAssertEqual(segs[0][0].x, 0, accuracy: 0.001)
+        XCTAssertEqual(segs[1][0].x, 100, accuracy: 0.001)
+    }
+
+    func testADayWithNothingScoredDrawsNothing() {
+        let day = [at(0, nil), at(1, nil, moving: true)]
+        XCTAssertTrue(StressTrace.segments(day, width: 100, height: 100).isEmpty)
+        XCTAssertNil(StressTrace.stats(day))
+    }
+
+    // MARK: - movement
+
+    func testHoursMaskedAsMovementAreMarkedAndDoNotJoinTheLine() {
+        let day = [at(0, 1.0), at(1, nil, moving: true), at(2, 1.0)]
+        XCTAssertEqual(StressTrace.segments(day, width: 100, height: 100).count, 2)
+        let marks = StressTrace.movingMarks(day, width: 100)
+        XCTAssertEqual(marks.count, 1)
+        XCTAssertEqual(marks[0], 50, accuracy: 0.001)
+    }
+
+    // MARK: - the high band
+
+    func testOnlyHoursAtOrAboveTheHighBandGetADot() {
+        let day = [at(0, 1.0), at(1, 1.9), at(2, 2.0), at(3, 2.8), at(4, nil)]
+        // 2.0 is the floor itself, so it counts; 1.9 does not.
+        XCTAssertEqual(StressTrace.highPoints(day, width: 100, height: 100).count, 2)
+    }
+
+    func testADotLandsOnItsOwnVertex() {
+        let day = [at(0, 0.5), at(1, 2.5)]
+        let vertex = StressTrace.segments(day, width: 100, height: 100)[0][1]
+        let dot = StressTrace.highPoints(day, width: 100, height: 100)[0]
+        // Dot and line are placed by the same rule, so a nudge to one cannot leave the other behind.
+        // The view lifts the dot above the stroke; the geometry must agree exactly.
+        XCTAssertEqual(vertex.x, dot.x, accuracy: 0.001)
+        XCTAssertEqual(vertex.y, dot.y, accuracy: 0.001)
+    }
+
+    func testACalmDayGetsNoDotsAtAll() {
+        XCTAssertTrue(StressTrace.highPoints([at(0, 0.4), at(1, 1.2)], width: 100, height: 100).isEmpty)
+    }
+
+    // MARK: - stats
+
+    func testMeanCoversScoredHoursOnlyAndPeakIsTheHighestOfThem() throws {
+        let day = [at(0, 1.0), at(1, nil), at(2, 2.0), at(3, nil, moving: true)]
+        let stats = try XCTUnwrap(StressTrace.stats(day))
+        XCTAssertEqual(stats.mean, 1.5, accuracy: 0.0001)
+        XCTAssertEqual(stats.peak.level ?? 0, 2.0, accuracy: 0.0001)
+        XCTAssertEqual(stats.peak.ts, 2 * hour)
+        XCTAssertEqual(stats.scoredHours, 2)
+        XCTAssertEqual(stats.movingHours, 1)
+    }
+
+    // MARK: - axes
+
+    func testTheLevelScaleIsFixedSoTwoDaysCanBeCompared() {
+        XCTAssertEqual(StressTrace.levelTicks(), [3, 2, 1, 0])
+    }
+
+    func testTimeTicksAnchorToTheScoredHoursNotToTheDay() {
+        let day = [at(0, nil), at(8, 1.0), at(12, 1.5), at(16, 2.0), at(23, nil)]
+        // An evening-only day must not label its axis with a morning that was never sampled.
+        XCTAssertEqual(StressTrace.timeTicks(day), [8 * hour, 12 * hour, 16 * hour])
+    }
+
+    func testOneScoredHourNamesOneInstant() {
+        XCTAssertEqual(StressTrace.timeTicks([at(9, 1.0), at(10, nil)]), [9 * hour])
+    }
+
+    // MARK: - the snapshot's day guard
+
+    func testACurveScoredYesterdayIsNotDrawnToday() {
+        let now = Date()
+        var snap = WidgetSnapshot(recovery: nil, bpm: nil, batteryPct: nil, bonded: false, updated: now)
+        snap.stressSeries = [at(9, 1.5)]
+        snap.stressDay = WidgetSnapshot.localDayNumber(now) - 1
+        // Nothing runs at midnight to tidy the App Group, so the staleness check has to happen where the
+        // value is read. Otherwise the card shows yesterday's afternoon under today's date until the
+        // first scorable hour of the new day arrives.
+        XCTAssertTrue(snap.stressCurve(now: now).isEmpty)
+    }
+
+    func testTodaysCurveIsDrawn() {
+        let now = Date()
+        var snap = WidgetSnapshot(recovery: nil, bpm: nil, batteryPct: nil, bonded: false, updated: now)
+        snap.stressSeries = [at(9, 1.5)]
+        snap.stressDay = WidgetSnapshot.localDayNumber(now)
+        XCTAssertEqual(snap.stressCurve(now: now).count, 1)
+    }
+
+    func testAnOlderSnapshotWithNoCurveDecodesAndDrawsNothing() {
+        // Both fields are optional so a snapshot written before this existed still decodes; it simply
+        // has no curve to draw.
+        let snap = WidgetSnapshot(recovery: 50, bpm: 60, batteryPct: 80, bonded: true, updated: Date())
+        XCTAssertNil(snap.stressDay)
+        XCTAssertTrue(snap.stressCurve().isEmpty)
+    }
+
+    func testPublishingAFreshlyScoredHourIsNotDedupedAway() {
+        let now = Date()
+        var a = WidgetSnapshot(recovery: 50, bpm: 60, batteryPct: 80, bonded: true, updated: now)
+        a.stressDay = WidgetSnapshot.localDayNumber(now)
+        a.stressSeries = [at(9, 1.5)]
+        var b = a
+        b.stressSeries = [at(9, 1.5), at(10, 2.1)]
+        // Without the curve in the comparison, a publish that scored a fresh hour and changed nothing
+        // else would be dropped, and the widget would sit an hour behind until an unrelated field moved.
+        XCTAssertTrue(WidgetSnapshot.renderedContentChanged(from: a, to: b))
+    }
+}

--- a/StrandTests/StressTraceTests.swift
+++ b/StrandTests/StressTraceTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import StrandAnalytics
-@testable import NOOP
 
 /// The stress widget's pure half, and the parity that keeps it honest.
 ///

--- a/StrandiOS/Widgets/StressWidgetCurve.swift
+++ b/StrandiOS/Widgets/StressWidgetCurve.swift
@@ -65,14 +65,23 @@ enum StressWidgetCurve {
             // exactly as the screen does.
             let gravity = await repo.gravitySamplesUnion(from: from, to: to, limit: 200_000)
             let tz = TimeZone.current.secondsFromGMT(for: now)
-            points = DaytimeStress.analyze(hr: hr, rr: rr, gravity: gravity,
-                                           tzOffsetSeconds: tz, mode: .dayRelative)
-                .hours
-                .map {
-                    // `startTs` is the wall-clock bucket start with the local shift already undone, so
-                    // it is a true instant and formats correctly against the device's zone.
-                    StressPoint(ts: Int64($0.startTs), level: $0.level, moving: $0.maskedForActivity)
-                }
+            // Scored OFF the main actor. `Repository` is `@MainActor`, so without this hop a day's worth
+            // of hours would be bucketed and averaged on the main thread — and unlike the Stress screen,
+            // which does this because the user asked for it and is waiting, this runs unprompted when
+            // the app becomes active and after every Health sync, which is exactly when the UI is busy.
+            // The Kotlin twin gets this for free by living in a coroutine; here it has to be asked for.
+            // The samples are plain value structs, so the hop retains rather than copies them.
+            points = await Task.detached(priority: .utility) {
+                DaytimeStress.analyze(hr: hr, rr: rr, gravity: gravity,
+                                      tzOffsetSeconds: tz, mode: .dayRelative)
+                    .hours
+                    .map {
+                        // `startTs` is the wall-clock bucket start with the local shift already undone,
+                        // so it is a true instant and formats correctly against the device's zone.
+                        StressPoint(ts: Int64($0.startTs), level: $0.level,
+                                    moving: $0.maskedForActivity)
+                    }
+            }.value
         }
         // Too little signal leaves `points` empty, which is a real answer about today rather than a
         // refusal: the widget should drop yesterday's line rather than keep drawing it.

--- a/StrandiOS/Widgets/StressWidgetCurve.swift
+++ b/StrandiOS/Widgets/StressWidgetCurve.swift
@@ -1,0 +1,87 @@
+#if os(iOS)
+import Foundation
+import StrandAnalytics
+
+/// Scores today's hourly stress for the stress widget, and does it as rarely as it can get away with.
+///
+/// Swift twin of the Kotlin `StressWidgetProducer`, and the same reasoning governs both.
+///
+/// THE GATE IS THE POINT. Scoring a day means reading today's heart rate, R-R and gravity, three reads
+/// bounded at 200 000 rows each, which is the work the Stress screen does when you open it. The screen
+/// does that once, on a deliberate act. A widget producer runs on the publish path, which fires when
+/// the app becomes active and after every Health sync, so nothing is read until `Repository`'s cheap
+/// heart-rate fingerprint — a COUNT and a MAX over an indexed column — says today's heart rate actually
+/// moved. A publish that changed nothing costs that one query and reuses the previous curve.
+///
+/// SCORING MODE. Always the `.dayRelative` default, never the opt-in personal-baseline lens. Resolving
+/// that mode reads fourteen trailing days of heart rate to decide whether enough worn history exists,
+/// which the screen can afford on demand and a publish path cannot. Stated plainly because it is
+/// user-visible: with the personal-baseline toggle on, the widget shows the default lens while the
+/// screen shows the refined one, so the two can differ.
+enum StressWidgetCurve {
+
+    /// What the last scoring saw and produced, swapped in as ONE value.
+    ///
+    /// Separate fields could tear: a second publish arriving between two assignments would read one
+    /// call's fingerprint beside another's points and serve a curve for a day it was not scored
+    /// against. Both callers are `@MainActor` today, so the window is narrow, but an immutable holder
+    /// closes it for free.
+    private struct Memo {
+        let count: Int
+        let maxTs: Int
+        let day: Int
+        let points: [StressPoint]
+    }
+
+    @MainActor private static var memo: Memo?
+
+    /// Today's curve and the local day number it belongs to, or nil when it could not be scored.
+    ///
+    /// Nil is not "today scored nothing": it means "say nothing about stress in this publish", so the
+    /// caller must carry forward whatever the previous snapshot held rather than blanking the widget.
+    /// An empty ARRAY with a day is the real "nothing scored today" answer.
+    @MainActor
+    static func today(repo: Repository, now: Date = Date(),
+                      calendar: Calendar = .current) async -> (points: [StressPoint], day: Int)? {
+        let startOfDay = calendar.startOfDay(for: now)
+        let from = Int(startOfDay.timeIntervalSince1970)
+        let to = Int(now.timeIntervalSince1970)
+        let day = WidgetSnapshot.localDayNumber(now, calendar: calendar)
+
+        guard let fingerprint = await repo.hrFingerprint(from: from, to: to) else { return nil }
+        // Same day, same heart rate: nothing can have changed the score, so nothing is read. The day is
+        // part of the check because a fingerprint that happened to match across midnight would otherwise
+        // serve yesterday's curve as today's.
+        if let memo, memo.day == day, memo.count == fingerprint.count, memo.maxTs == fingerprint.maxTs {
+            return (memo.points, day)
+        }
+
+        let hr = await repo.hrSamples(from: from, to: to, limit: 200_000)
+        var points: [StressPoint] = []
+        if hr.count >= DaytimeStress.minHourHRSamples {
+            let rr = await repo.rrIntervals(from: from, to: to, limit: 200_000)
+            // Wrist accelerometer for the motion gate, so an ambulatory hour reads as exertion rather
+            // than as stress. Empty on hardware or imports without gravity, which degrades to no masking
+            // exactly as the screen does.
+            let gravity = await repo.gravitySamplesUnion(from: from, to: to, limit: 200_000)
+            let tz = TimeZone.current.secondsFromGMT(for: now)
+            points = DaytimeStress.analyze(hr: hr, rr: rr, gravity: gravity,
+                                           tzOffsetSeconds: tz, mode: .dayRelative)
+                .hours
+                .map {
+                    // `startTs` is the wall-clock bucket start with the local shift already undone, so
+                    // it is a true instant and formats correctly against the device's zone.
+                    StressPoint(ts: Int64($0.startTs), level: $0.level, moving: $0.maskedForActivity)
+                }
+        }
+        // Too little signal leaves `points` empty, which is a real answer about today rather than a
+        // refusal: the widget should drop yesterday's line rather than keep drawing it.
+        memo = Memo(count: fingerprint.count, maxTs: fingerprint.maxTs, day: day, points: points)
+        return (points, day)
+    }
+
+    /// Drops the memo so a test starts from a known state.
+    @MainActor
+    static func resetForTest() { memo = nil }
+}
+#endif

--- a/StrandiOS/Widgets/WidgetPublish.swift
+++ b/StrandiOS/Widgets/WidgetPublish.swift
@@ -60,6 +60,10 @@ extension WidgetSnapshot {
             }
             return "\(Int(stored.rounded()))"
         }
+        // #2040: today's stress curve. Self-gating on a cheap heart-rate fingerprint, so a publish that
+        // changed nothing costs one indexed COUNT and no rows. Only the FULL path scores it; the live
+        // fast path below reuses the previous snapshot and so carries the curve forward untouched.
+        let stress = await StressWidgetCurve.today(repo: model.repo)
         let snap = WidgetSnapshot(
             recovery: day?.recovery.map { Int($0.rounded()) },
             bpm: model.bpm ?? model.live.heartRate,
@@ -72,7 +76,11 @@ extension WidgetSnapshot {
             hrv: day?.avgHrv.map { Int($0.rounded()) },
             restingHr: day?.restingHr,
             effortDisplay: effortDisplay,
-            effortWhoop: effortScale == .whoop
+            effortWhoop: effortScale == .whoop,
+            // nil when the curve could not be scored at all, which must not blank a widget that already
+            // has one: carry the stored values forward instead of publishing an absence.
+            stressSeries: stress?.points ?? load()?.stressSeries,
+            stressDay: stress?.day ?? load()?.stressDay
         )
         saveAndReloadIfChanged(snap)
     }

--- a/StrandiOS/Widgets/WidgetPublish.swift
+++ b/StrandiOS/Widgets/WidgetPublish.swift
@@ -64,6 +64,10 @@ extension WidgetSnapshot {
         // changed nothing costs one indexed COUNT and no rows. Only the FULL path scores it; the live
         // fast path below reuses the previous snapshot and so carries the curve forward untouched.
         let stress = await StressWidgetCurve.today(repo: model.repo)
+        // Loaded ONCE for the carry-forward below. Reaching for `load()` in each of the two arguments
+        // would decode the App Group blob twice on any publish that could not score, and this file
+        // already went to the trouble of removing one such decode from the live path.
+        let storedStress: WidgetSnapshot? = stress == nil ? load() : nil
         let snap = WidgetSnapshot(
             recovery: day?.recovery.map { Int($0.rounded()) },
             bpm: model.bpm ?? model.live.heartRate,
@@ -79,8 +83,8 @@ extension WidgetSnapshot {
             effortWhoop: effortScale == .whoop,
             // nil when the curve could not be scored at all, which must not blank a widget that already
             // has one: carry the stored values forward instead of publishing an absence.
-            stressSeries: stress?.points ?? load()?.stressSeries,
-            stressDay: stress?.day ?? load()?.stressDay
+            stressSeries: stress?.points ?? storedStress?.stressSeries,
+            stressDay: stress?.day ?? storedStress?.stressDay
         )
         saveAndReloadIfChanged(snap)
     }

--- a/StrandiOSShared/StressTrace.swift
+++ b/StrandiOSShared/StressTrace.swift
@@ -1,0 +1,181 @@
+import Foundation
+
+/// One hour on the widget's stress trace.
+///
+/// `level` is the shared 0-3 proxy, nil when the hour was not scored. `moving` separates the two
+/// reasons it can be nil: the motion gate masked an AMBULATORY hour (exertion raises heart rate on its
+/// own, so it is deliberately not scored as stress), or there was not enough signal. Both break the
+/// line; only the first earns a mark along the base.
+///
+/// `Sendable` for the same reason `HrPoint` is: a SwiftUI `Shape` holding these is itself Sendable, and
+/// carrying a non-Sendable stored property there is an error in a future language mode. Three immutable
+/// value fields, so it is Sendable by inspection rather than by assertion.
+public struct StressPoint: Codable, Equatable, Sendable {
+    public let ts: Int64
+    public let level: Double?
+    public let moving: Bool
+    public init(ts: Int64, level: Double?, moving: Bool = false) {
+        self.ts = ts
+        self.level = level
+        self.moving = moving
+    }
+}
+
+/// The pure half of the stress widget: what the curve CONTAINS and where its ink goes.
+///
+/// Swift twin of the Kotlin `StressTrace`. The domain, the gap rule, the band threshold and the tick
+/// choices are the same decisions on both platforms and must not be made twice: a widget that scaled
+/// differently, or drew through a hole, would be a different reading of the same day.
+///
+/// TWO THINGS DIFFER FROM `HrTrace`, and both are deliberate.
+///
+/// The domain is FIXED at `domainMax`, not normalised to the day's own range. Heart rate has no
+/// absolute meaning at widget size, so its trace spreads whatever range it has across the full box. A
+/// stress score does have one: the bands are what the number means. Normalising here would redraw a
+/// flat calm day as a dramatic one, which is precisely the lie the fixed domain prevents.
+///
+/// And the series is REPLACED rather than appended to. The HR trace folds a live push into a rolling
+/// window; today's stress is a whole scored day that arrives complete each time it is scored, so there
+/// is no retention rule, no clock-jump guard and no cap. Yesterday is overwritten, not merged.
+///
+/// What deliberately does NOT port is Android's `encode`/`decode`: it packs the series into a
+/// SharedPreferences string because that is what it has, while the snapshot here is already `Codable`
+/// and carries `[StressPoint]` directly. Nor does the bitmap sizing, for the reason `HrTrace` gives:
+/// WidgetKit strokes a vector and has no payload budget to fit inside.
+public enum StressTrace {
+
+    /// Top of the scored range, the same 0-3 scale the gauge and the screen use.
+    public static let domainMax: Double = 3.0
+
+    /// Floor of the HIGH band, the level at which an hour earns a dot.
+    ///
+    /// This is `StrandAnalytics.DaytimeStress.highBandFloor`, RESTATED rather than referenced, because
+    /// the widget extension links no packages: everything it draws with has to live in shared sources
+    /// that import Foundation and nothing else. Android has no such wall and reads the analytics
+    /// constant directly, so this is the one place the two platforms express the same threshold
+    /// differently. `StressTraceTests` asserts the two are equal from the app target, which can see
+    /// both, so the copy cannot drift silently.
+    public static let highBandFloor: Double = 2.0
+
+    /// A point in the curve's box, origin top-left.
+    public struct Pt: Equatable, Sendable {
+        public let x: CGFloat
+        public let y: CGFloat
+        public init(x: CGFloat, y: CGFloat) {
+            self.x = x
+            self.y = y
+        }
+    }
+
+    /// The numbers the header shows. Nil when no hour was scored.
+    public struct Stats: Equatable, Sendable {
+        /// Mean across SCORED hours, the figure the screen prints as the day's average.
+        public let mean: Double
+        /// Highest scored hour.
+        public let peak: StressPoint
+        /// How many hours carry a score.
+        public let scoredHours: Int
+        /// How many were masked as movement rather than scored.
+        public let movingHours: Int
+    }
+
+    public static func stats(_ series: [StressPoint]) -> Stats? {
+        let scored = series.filter { $0.level != nil }
+        guard let first = scored.first else { return nil }
+        var peak = first
+        var sum = 0.0
+        for p in scored {
+            sum += p.level ?? 0
+            if (p.level ?? 0) > (peak.level ?? 0) { peak = p }
+        }
+        return Stats(mean: sum / Double(scored.count),
+                     peak: peak,
+                     scoredHours: scored.count,
+                     movingHours: series.filter(\.moving).count)
+    }
+
+    /// The one placement rule, shared so a dot and its vertex cannot land apart.
+    private static func place(ts: Int64, level: Double, t0: Int64, span: CGFloat,
+                              width: CGFloat, height: CGFloat) -> Pt {
+        let x = span <= 0 ? 0 : CGFloat(ts - t0) / span * width
+        let fraction = min(max(CGFloat(level / domainMax), 0), 1)
+        return Pt(x: x, y: height - fraction * height)
+    }
+
+    /// The curve as CONTIGUOUS RUNS of scored hours, each already in the box's coordinates.
+    ///
+    /// Runs rather than one list because an unscored hour is a hole in the day, and a line drawn
+    /// straight across it would invent a reading for an hour that has none. The screen's own caption
+    /// promises bare gaps, so the widget owes the same.
+    ///
+    /// X is placed on the hour's position in the day's SPAN, so an afternoon hole leaves a hole of the
+    /// right width rather than closing up. A single scored hour, or a day whose hours share one
+    /// timestamp, has no span to spread across and sits at the left edge.
+    ///
+    /// Y comes off the FIXED domain, so a calm day draws along the bottom where it belongs, and is
+    /// flipped on the way out: stress rises upward, points rise downward.
+    public static func segments(_ series: [StressPoint], width: CGFloat, height: CGFloat) -> [[Pt]] {
+        guard let firstPoint = series.first, let lastPoint = series.last,
+              width > 0, height > 0 else { return [] }
+        let t0 = firstPoint.ts
+        let span = CGFloat(lastPoint.ts - t0)
+        var out: [[Pt]] = []
+        var run: [Pt] = []
+        for p in series {
+            guard let level = p.level else {
+                if !run.isEmpty { out.append(run); run = [] }
+                continue
+            }
+            run.append(place(ts: p.ts, level: level, t0: t0, span: span, width: width, height: height))
+        }
+        if !run.isEmpty { out.append(run) }
+        return out
+    }
+
+    /// The scored hours sitting in the HIGH band, for the dots the screen puts above the line.
+    ///
+    /// Mapped through the same placement as `segments`, so a dot lands exactly on its own vertex.
+    public static func highPoints(_ series: [StressPoint], width: CGFloat, height: CGFloat) -> [Pt] {
+        guard let firstPoint = series.first, let lastPoint = series.last,
+              width > 0, height > 0 else { return [] }
+        let t0 = firstPoint.ts
+        let span = CGFloat(lastPoint.ts - t0)
+        return series.compactMap { p in
+            guard let level = p.level, level >= highBandFloor else { return nil }
+            return place(ts: p.ts, level: level, t0: t0, span: span, width: width, height: height)
+        }
+    }
+
+    /// X positions of the hours masked as movement, for the faint marks along the base.
+    ///
+    /// Bare X centres rather than spans: the mark's thickness is a drawing decision, while WHERE the
+    /// moving hours were is a fact about the day.
+    public static func movingMarks(_ series: [StressPoint], width: CGFloat) -> [CGFloat] {
+        guard let firstPoint = series.first, let lastPoint = series.last, width > 0 else { return [] }
+        let t0 = firstPoint.ts
+        let span = CGFloat(lastPoint.ts - t0)
+        return series.filter(\.moving).map { p in
+            span <= 0 ? 0 : CGFloat(p.ts - t0) / span * width
+        }
+    }
+
+    /// The labels up the left edge, top-down: the top of the domain down to zero.
+    ///
+    /// Fixed, not derived, for the same reason the domain is: these are the scale, and an axis that
+    /// moved with the day would make two days impossible to compare at a glance.
+    public static func levelTicks() -> [Int] { [3, 2, 1, 0] }
+
+    /// The three timestamps along the bottom: first, middle and last of the SCORED data, not of the day.
+    ///
+    /// Anchored to scored hours because a day with only an evening's signal would otherwise label its
+    /// axis with a morning that was never sampled, and the curve would sit crushed into the right-hand
+    /// end of a mostly empty chart. Fewer than three distinct instants returns what there is, so the
+    /// caller draws one label rather than three copies of it.
+    public static func timeTicks(_ series: [StressPoint]) -> [Int64] {
+        let scored = series.filter { $0.level != nil }
+        guard let first = scored.first?.ts, let last = scored.last?.ts else { return [] }
+        if first == last { return [first] }
+        let mid = first + (last - first) / 2
+        return (mid == first || mid == last) ? [first, last] : [first, mid, last]
+    }
+}

--- a/StrandiOSShared/WidgetSnapshot.swift
+++ b/StrandiOSShared/WidgetSnapshot.swift
@@ -27,11 +27,25 @@ public struct WidgetSnapshot: Codable, Equatable {
     /// Android store owning it: nothing that publishes had to learn the retention rule. Optional so a
     /// snapshot written by an older build still decodes.
     public var hrSeries: [HrPoint]?
+    /// Today's hourly stress curve for the stress widget (#2040), earliest to latest.
+    ///
+    /// Unlike `hrSeries` this is NOT folded by `save()`. It arrives complete from the publish that
+    /// scored the day, so a publish either carries a whole day or says nothing about stress at all, and
+    /// the live fast path simply carries the loaded value forward untouched. Optional so a snapshot
+    /// written by an older build still decodes.
+    public var stressSeries: [StressPoint]?
+    /// Local day number `stressSeries` was scored for, or nil when no curve has been published.
+    ///
+    /// Read back as the staleness check: a curve from any day but today is dropped rather than drawn,
+    /// so the widget cannot show yesterday's afternoon under today's date while waiting for the first
+    /// scorable hour after midnight.
+    public var stressDay: Int?
 
     public init(recovery: Int?, bpm: Int?, batteryPct: Int?, bonded: Bool, updated: Date,
                 effort: Int? = nil, rest: Int? = nil, hrv: Int? = nil, restingHr: Int? = nil,
                 effortDisplay: String? = nil, effortWhoop: Bool? = nil,
-                hrSeries: [HrPoint]? = nil) {
+                hrSeries: [HrPoint]? = nil, stressSeries: [StressPoint]? = nil,
+                stressDay: Int? = nil) {
         self.recovery = recovery
         self.bpm = bpm
         self.batteryPct = batteryPct
@@ -44,6 +58,27 @@ public struct WidgetSnapshot: Codable, Equatable {
         self.effortDisplay = effortDisplay
         self.effortWhoop = effortWhoop
         self.hrSeries = hrSeries
+        self.stressSeries = stressSeries
+        self.stressDay = stressDay
+    }
+
+    /// The curve to DRAW: what was published, unless it belongs to a day that is over.
+    ///
+    /// Resolved on read rather than cleared on write, the same discipline `HrTrace.prune` applies to
+    /// age: nothing runs at midnight to tidy the App Group, so the check has to happen where the value
+    /// is used. Calendar is injectable so a test can cross a rollover without waiting for one.
+    public func stressCurve(now: Date = Date(), calendar: Calendar = .current) -> [StressPoint] {
+        guard let stressDay, let stressSeries,
+              stressDay == WidgetSnapshot.localDayNumber(now, calendar: calendar) else { return [] }
+        return stressSeries
+    }
+
+    /// Days since a fixed epoch on the LOCAL calendar, the platform-neutral twin of Kotlin's
+    /// `LocalDate.toEpochDay()`. Both sides only ever compare it for equality against a value the same
+    /// side produced, so what matters is that it changes exactly at local midnight.
+    public static func localDayNumber(_ date: Date, calendar: Calendar = .current) -> Int {
+        let start = calendar.startOfDay(for: date)
+        return Int((start.timeIntervalSince1970 / 86_400).rounded(.down))
     }
 
     /// App Group suite the app and widget both use. Injected from the `APP_GROUP_ID` build setting
@@ -181,6 +216,12 @@ public struct WidgetSnapshot: Codable, Equatable {
             || previous.restingHr != next.restingHr
             || previous.effortDisplay != next.effortDisplay
             || previous.effortWhoop != next.effortWhoop
+            // The curve joins the comparison (#2040): a publish that scored a fresh hour and changed
+            // nothing else would otherwise be deduped away, and the widget would sit an hour behind
+            // until some unrelated field moved. The DAY joins it too, so the first publish after
+            // midnight still reaches WidgetKit even when the new day has no scored hour yet.
+            || previous.stressSeries != next.stressSeries
+            || previous.stressDay != next.stressDay
     }
 
     /// A live-only update may reuse score fields only within the same local calendar day. At rollover,

--- a/StrandiOSShared/WidgetSnapshot.swift
+++ b/StrandiOSShared/WidgetSnapshot.swift
@@ -73,12 +73,18 @@ public struct WidgetSnapshot: Codable, Equatable {
         return stressSeries
     }
 
-    /// Days since a fixed epoch on the LOCAL calendar, the platform-neutral twin of Kotlin's
-    /// `LocalDate.toEpochDay()`. Both sides only ever compare it for equality against a value the same
-    /// side produced, so what matters is that it changes exactly at local midnight.
+    /// Days since the epoch on the LOCAL calendar, the twin of Kotlin's `LocalDate.toEpochDay()`.
+    ///
+    /// Counted by the calendar rather than by dividing the day's start by 86 400. That arithmetic is
+    /// wrong on a DST day and measurably so: walking a year of local noons, `Europe/London` produces
+    /// ONE day whose number equals the previous day's, because its winter offset is UTC and a
+    /// 23-hour day then lands inside the same 86 400-second bucket. On that day the widget would have
+    /// read yesterday's curve as today's and drawn it, which is the one thing this number exists to
+    /// prevent. The calendar knows how long each local day actually was.
     public static func localDayNumber(_ date: Date, calendar: Calendar = .current) -> Int {
-        let start = calendar.startOfDay(for: date)
-        return Int((start.timeIntervalSince1970 / 86_400).rounded(.down))
+        let epoch = calendar.startOfDay(for: Date(timeIntervalSince1970: 0))
+        return calendar.dateComponents([.day], from: epoch,
+                                       to: calendar.startOfDay(for: date)).day ?? 0
     }
 
     /// App Group suite the app and widget both use. Injected from the `APP_GROUP_ID` build setting

--- a/StrandiOSWidgets/NOOPWidgetBundle.swift
+++ b/StrandiOSWidgets/NOOPWidgetBundle.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 /// The widget extension entry point. Bundles the glanceable widget, the live-HR Live Activity,
 /// the K10 Coach brief widget (stored morning brief on Lock Screen / Home Screen), and the
-/// heart-rate trace widget (#1957).
+/// heart-rate trace widget (#1957), and the stress curve widget (#2040).
 @main
 struct NOOPWidgetBundle: WidgetBundle {
     var body: some Widget {
@@ -11,5 +11,6 @@ struct NOOPWidgetBundle: WidgetBundle {
         NOOPLiveActivity()
         CoachBriefWidget()
         HeartRateWidget()
+        StressWidget()
     }
 }

--- a/StrandiOSWidgets/StressWidget.swift
+++ b/StrandiOSWidgets/StressWidget.swift
@@ -1,0 +1,298 @@
+import StrandDesign
+import SwiftUI
+import WidgetKit
+
+/// Home-screen widget: today's stress as the intraday curve the Stress screen draws (#2040).
+///
+/// Swift twin of the Android `StressGlanceWidget`, but the drawing is NOT a port. Glance compiles to
+/// RemoteViews and cannot draw, so Android renders the curve to a Bitmap under a payload budget and a
+/// reduced pixel depth, and has to composite every translucent colour by hand because 565 carries no
+/// alpha. WidgetKit is SwiftUI: stroked `Path`s, resolution-independent, with real opacity. What IS
+/// shared is `StressTrace` — the fixed domain, the gap rule, the band threshold and the tick choices —
+/// because those are the same reading of the same day.
+///
+/// Honest-blank throughout, matching the twin: an unscored hour is a GAP rather than an interpolation,
+/// an hour the motion gate masked gets a faint mark along the base instead of a score, and a day with
+/// nothing scored shows no chart at all rather than a flat line at zero.
+struct StressEntry: TimelineEntry {
+    let date: Date
+    let snap: WidgetSnapshot?
+}
+
+struct StressProvider: TimelineProvider {
+    func placeholder(in context: Context) -> StressEntry {
+        StressEntry(date: Date(), snap: nil)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (StressEntry) -> Void) {
+        completion(StressEntry(date: Date(), snap: WidgetSnapshot.load()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<StressEntry>) -> Void) {
+        let entry = StressEntry(date: Date(), snap: WidgetSnapshot.load())
+        // Half an hour, where the heart-rate widget takes fifteen minutes. This curve gains at most one
+        // point an hour, so a tighter net would spend budget on entries identical to the one before it.
+        // The app reloads timelines when it scores an hour, so this is only the safety net for when it
+        // is not running — and it also carries the card across midnight, when the day number changes and
+        // yesterday's curve stops being drawn.
+        let next = Calendar.current.date(byAdding: .minute, value: 30, to: Date())
+            ?? Date().addingTimeInterval(1_800)
+        completion(Timeline(entries: [entry], policy: .after(next)))
+    }
+}
+
+/// The curve: every contiguous run of scored hours as its own subpath.
+///
+/// Runs rather than one path because an unscored hour is a hole, and a line drawn across it would
+/// invent a reading. When `filled` each run is closed to the baseline SEPARATELY, so the area cannot
+/// spread under hours that were never scored, which would undo the gap the broken line exists to draw.
+private struct StressCurveShape: Shape {
+    let series: [StressPoint]
+    let filled: Bool
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        for run in StressTrace.segments(series, width: rect.width, height: rect.height) {
+            guard let first = run.first else { continue }
+            if run.count == 1 {
+                // A run of one hour is not a line. A dot says "one scored hour"; an empty box says
+                // "no data", and those are different things.
+                guard !filled else { continue }
+                let r: CGFloat = 2.5
+                path.addEllipse(in: CGRect(x: max(first.x, r) - r, y: first.y - r,
+                                           width: r * 2, height: r * 2))
+                continue
+            }
+            path.move(to: CGPoint(x: first.x, y: first.y))
+            for p in run.dropFirst() { path.addLine(to: CGPoint(x: p.x, y: p.y)) }
+            if filled {
+                path.addLine(to: CGPoint(x: run[run.count - 1].x, y: rect.maxY))
+                path.addLine(to: CGPoint(x: first.x, y: rect.maxY))
+                path.closeSubpath()
+            }
+        }
+        return path
+    }
+}
+
+/// The hours sitting in the HIGH band, dotted above the line as the screen marks them.
+private struct StressHighDotsShape: Shape {
+    let series: [StressPoint]
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let r: CGFloat = 2
+        for p in StressTrace.highPoints(series, width: rect.width, height: rect.height) {
+            // Lifted clear of the stroke so a dot is never half-hidden under the line it marks.
+            let y = max(p.y - 5, r)
+            path.addEllipse(in: CGRect(x: min(max(p.x, r), rect.maxX - r) - r, y: y - r,
+                                       width: r * 2, height: r * 2))
+        }
+        return path
+    }
+}
+
+/// The stretches the motion gate masked, marked along the base rather than scored.
+private struct StressMovingMarksShape: Shape {
+    let series: [StressPoint]
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let half: CGFloat = 3
+        for x in StressTrace.movingMarks(series, width: rect.width) {
+            path.addRoundedRect(
+                in: CGRect(x: max(x - half, 0), y: rect.minY,
+                           width: min(half * 2, rect.width), height: rect.height),
+                cornerSize: CGSize(width: half, height: half),
+            )
+        }
+        return path
+    }
+}
+
+struct StressWidgetView: View {
+    let entry: StressEntry
+
+    /// Resolved on read, so a curve scored for a day that is over is dropped rather than drawn. Measured
+    /// from `entry.date` rather than `Date()` because WidgetKit renders an entry at ITS date, which is
+    /// the same reasoning the heart-rate widget's prune follows.
+    private var series: [StressPoint] {
+        entry.snap?.stressCurve(now: entry.date) ?? []
+    }
+    private var stats: StressTrace.Stats? { StressTrace.stats(series) }
+    private var latest: Double? { series.last(where: { $0.level != nil })?.level }
+
+    // The ramp's band anchors, taken from the palette tokens the Stress screen's own ramp is built from,
+    // rather than the local hexes the Glance twin has to carry. Blue calm, green steady, amber tense.
+    private var calm: Color { StrandPalette.accent }
+    private var steady: Color { StrandPalette.statusPositive }
+    private var tense: Color { StrandPalette.statusWarning }
+
+    /// Vertical, because `StressTrace.segments` maps the score onto Y off a FIXED domain: height already
+    /// encodes level, so one top-to-bottom gradient paints every run the colour its own score deserves.
+    /// The screen's ramp read upward.
+    private var rampGradient: LinearGradient {
+        LinearGradient(colors: [tense, steady, calm], startPoint: .top, endPoint: .bottom)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Stress")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(StrandPalette.textPrimary)
+
+            HStack(alignment: .lastTextBaseline, spacing: 4) {
+                Text(latest.map { String(format: "%.1f", $0) } ?? "—")
+                    .font(.system(size: 30, weight: .bold, design: .rounded))
+                    .foregroundStyle(StrandPalette.textPrimary)
+                if latest != nil {
+                    Text("of 3")
+                        .font(.system(size: 12))
+                        .foregroundStyle(StrandPalette.textSecondary)
+                }
+                if let stats, let peak = stats.peak.level {
+                    Text("Peak \(String(format: "%.1f", peak)) · \(Date(timeIntervalSince1970: TimeInterval(stats.peak.ts)), format: .dateTime.hour().minute())")
+                        .font(.system(size: 11))
+                        .foregroundStyle(StrandPalette.textPrimary)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 3)
+                        .background(tense.opacity(0.18), in: Capsule())
+                        .padding(.leading, 6)
+                }
+            }
+
+            if stats != nil {
+                HStack(alignment: .top, spacing: 6) {
+                    // The scale sits on the LEFT, where the Stress screen puts it. (The heart-rate
+                    // widget puts its scale on the right, which is right for a trace whose numbers are
+                    // read off the end.) Fixed rather than derived, because that is what the domain is:
+                    // an axis that moved with the day would make two days impossible to compare.
+                    let ticks = StressTrace.levelTicks()
+                    VStack(alignment: .trailing) {
+                        ForEach(Array(ticks.enumerated()), id: \.offset) { index, tick in
+                            Text("\(tick)")
+                                .font(.system(size: 10))
+                                .foregroundStyle(StrandPalette.textSecondary)
+                            if index < ticks.count - 1 { Spacer(minLength: 0) }
+                        }
+                    }
+                    StressCurveChart(series: series, ramp: rampGradient,
+                                     fillTint: steady, dotTint: tense)
+                }
+                StressTimeAxis(series: series)
+            }
+
+            Spacer(minLength: 0)
+            if let updated = entry.snap?.updated, updated != .distantPast {
+                HStack {
+                    Spacer()
+                    if let stats {
+                        Text("avg \(String(format: "%.1f", stats.mean)) · Updated \(updated, format: .dateTime.hour().minute())")
+                            .font(.system(size: 10))
+                            .foregroundStyle(StrandPalette.textSecondary)
+                    } else {
+                        Text("Updated \(updated, format: .dateTime.hour().minute())")
+                            .font(.system(size: 10))
+                            .foregroundStyle(StrandPalette.textSecondary)
+                    }
+                    Spacer()
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityText)
+    }
+
+    /// One spoken sentence rather than a run of loose numbers, the same choice the heart-rate widget
+    /// makes. `String(localized:)` rather than bare literals: the audit matches a literal sitting
+    /// immediately after `.accessibilityLabel(`, and this is a computed property, so hardcoded English
+    /// here would ship to every locale with the gate green.
+    private var accessibilityText: String {
+        guard let latest else { return String(localized: "Stress, no reading today") }
+        let now = String(format: "%.1f", latest)
+        guard let stats, let peak = stats.peak.level else {
+            return String(localized: "Stress \(now) of 3")
+        }
+        let peakText = String(format: "%.1f", peak)
+        let meanText = String(format: "%.1f", stats.mean)
+        return String(localized: "Stress \(now) of 3, average \(meanText), peak \(peakText)")
+    }
+}
+
+/// The chart: fill, stroke, high-band dots, and the movement strip beneath them.
+///
+/// The marks get their OWN row rather than a reserved band inside the chart's coordinate space. The
+/// Glance twin has to carve the band out of one bitmap and normalise around it, which is exactly where
+/// that side went wrong once; here a `VStack` gives each part its own rect and the arithmetic
+/// disappears.
+private struct StressCurveChart: View {
+    let series: [StressPoint]
+    let ramp: LinearGradient
+    let fillTint: Color
+    let dotTint: Color
+
+    private var hasMarks: Bool { series.contains(where: \.moving) }
+
+    var body: some View {
+        VStack(spacing: 2) {
+            ZStack {
+                StressCurveShape(series: series, filled: true)
+                    .fill(LinearGradient(
+                        colors: [fillTint.opacity(0.3), fillTint.opacity(0)],
+                        startPoint: .top, endPoint: .bottom,
+                    ))
+                StressCurveShape(series: series, filled: false)
+                    .stroke(ramp, style: StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
+                StressHighDotsShape(series: series)
+                    .fill(dotTint)
+            }
+            if hasMarks {
+                StressMovingMarksShape(series: series)
+                    .fill(StrandPalette.textSecondary.opacity(0.45))
+                    .frame(height: 3)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+private struct StressTimeAxis: View {
+    let series: [StressPoint]
+
+    var body: some View {
+        let ticks = StressTrace.timeTicks(series)
+        // One instant pinned to the left edge reads as a stray rather than an axis, so it waits for a
+        // span to label, matching the twin.
+        if ticks.count >= 2 {
+            HStack {
+                ForEach(Array(ticks.enumerated()), id: \.offset) { i, ts in
+                    Text(Date(timeIntervalSince1970: TimeInterval(ts)),
+                         format: .dateTime.hour().minute())
+                        .font(.system(size: 9))
+                        .foregroundStyle(StrandPalette.textSecondary)
+                    if i < ticks.count - 1 { Spacer(minLength: 0) }
+                }
+            }
+        }
+    }
+}
+
+struct StressWidget: Widget {
+    static let kind = "StressWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: Self.kind, provider: StressProvider()) { entry in
+            if #available(iOS 17.0, *) {
+                StressWidgetView(entry: entry)
+                    .containerBackground(StrandPalette.surfaceBase, for: .widget)
+            } else {
+                StressWidgetView(entry: entry)
+                    .padding()
+                    .background(StrandPalette.surfaceBase)
+            }
+        }
+        .configurationDisplayName("Stress")
+        .description("Today's stress as an hour-by-hour curve.")
+        .supportedFamilies([.systemMedium])
+    }
+}

--- a/StrandiOSWidgets/StressWidget.swift
+++ b/StrandiOSWidgets/StressWidget.swift
@@ -151,13 +151,22 @@ struct StressWidgetView: View {
                         .foregroundStyle(StrandPalette.textSecondary)
                 }
                 if let stats, let peak = stats.peak.level {
-                    Text("Peak \(String(format: "%.1f", peak)) · \(Date(timeIntervalSince1970: TimeInterval(stats.peak.ts)), format: .dateTime.hour().minute())")
-                        .font(.system(size: 11))
-                        .foregroundStyle(StrandPalette.textPrimary)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 3)
-                        .background(tense.opacity(0.18), in: Capsule())
-                        .padding(.leading, 6)
+                    // "Peak" is a catalog key the app already carries in every locale; the value and the
+                    // time are DATA, so they are formatted into a plain String and shown verbatim. That
+                    // keeps a translator's job to the word that has one, and adds no catalog entry for a
+                    // string that is otherwise punctuation.
+                    let peakTime = Date(timeIntervalSince1970: TimeInterval(stats.peak.ts))
+                        .formatted(date: .omitted, time: .shortened)
+                    HStack(spacing: 4) {
+                        Text("Peak")
+                        Text(verbatim: String(format: "%.1f", peak) + " · " + peakTime)
+                    }
+                    .font(.system(size: 11))
+                    .foregroundStyle(StrandPalette.textPrimary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(tense.opacity(0.18), in: Capsule())
+                    .padding(.leading, 6)
                 }
             }
 
@@ -186,10 +195,17 @@ struct StressWidgetView: View {
             if let updated = entry.snap?.updated, updated != .distantPast {
                 HStack {
                     Spacer()
+                    // Both halves are catalog keys the app already carries, `avg %@` and `Updated %@`,
+                    // joined by a separator with nothing in it to translate. One composite key would have
+                    // needed a new entry in ten locales to say what these two already say.
                     if let stats {
-                        Text("avg \(String(format: "%.1f", stats.mean)) · Updated \(updated, format: .dateTime.hour().minute())")
-                            .font(.system(size: 10))
-                            .foregroundStyle(StrandPalette.textSecondary)
+                        HStack(spacing: 0) {
+                            Text("avg \(String(format: "%.1f", stats.mean))")
+                            Text(verbatim: " · ")
+                            Text("Updated \(updated, format: .dateTime.hour().minute())")
+                        }
+                        .font(.system(size: 10))
+                        .foregroundStyle(StrandPalette.textSecondary)
                     } else {
                         Text("Updated \(updated, format: .dateTime.hour().minute())")
                             .font(.system(size: 10))

--- a/project.yml
+++ b/project.yml
@@ -168,6 +168,11 @@ targets:
       # worth testing lives, and it is iOS/widget-only, so it is compiled into the test bundle rather
       # than added to the macOS app.
       - StrandiOSShared/HrTrace.swift
+      # And the stress curve's pure half, for the same reason (#2040) — plus one test this file is the
+      # only place that can run: the widget extension links no packages, so `StressTrace.highBandFloor`
+      # has to restate the analytics constant, and only the app target can see BOTH and assert they
+      # still agree.
+      - StrandiOSShared/StressTrace.swift
       # And the widget cost counters, for the same reason again: pure, iOS-only, and the arithmetic is
       # exactly the part that has been wrong twice on the Android side.
       - StrandiOSShared/WidgetTelemetry.swift


### PR DESCRIPTION
Addresses #2040, iOS side. Twin of #2044, and independent of it: no shared files, so the two can land
in either order.

The Swift half of the stress widget. Same reading of the same day as the Android one, drawn the way
WidgetKit draws.

### What ports, and what does not

`StressTrace` ports the DECISIONS: the fixed 0-3 domain, the rule that an unscored hour is a hole
rather than a point to draw through, the band threshold and the tick choices. Those are the same
reading of the same day and must not be made twice.

What does not port is everything Glance forced on the other side. Android renders to a Bitmap under a
payload budget at a reduced pixel depth, and has to composite every translucent colour by hand because
565 carries no alpha. Here the curve is a stroked `Path`, resolution-independent, with real opacity and
no box to predict. The SharedPreferences encoding does not port either, since the snapshot is already
`Codable` and carries the points directly.

### The one constant that had to be duplicated

The widget extension links no packages, so `StressTrace` cannot see `DaytimeStress.highBandFloor` the
way the Kotlin twin does. The threshold is restated, and `StressTraceTests` asserts the two are equal
from the app target, which can see both, so the copy cannot drift silently the day the band moves. That
test is why `StrandiOSShared/StressTrace.swift` joins the test target's explicit source list.

### The producer

Mirrors the Kotlin one, gate included, because the gate is the point: scoring a day means reading
today's heart rate, R-R and gravity. Nothing is read until `Repository.hrFingerprint` (twin of Kotlin's
`hrFingerprintWindow`, a COUNT and a MAX over an indexed column, unioned across the same ids the reads
use) says today's heart rate actually moved.

Only the FULL publish scores stress. The live fast path reuses the previous snapshot, so it carries the
curve forward untouched and a heart-rate tick never pays for scoring.

The curve carries the local day it was scored for and is resolved on READ, so a card rendered after
midnight drops yesterday's afternoon rather than drawing it under today's date. Nothing runs at
midnight to tidy the App Group, so that check has to live where the value is used.
`renderedContentChanged` learned about the curve and the day, otherwise a publish that scored a fresh
hour and changed nothing else would be deduped away and the card would sit an hour behind.

### Design

Matches the screen's chart the way #2044 now does: scale down the left, the ramp sampled by height
(the fixed domain makes vertical position the level), a filled area closed PER RUN so it cannot spread
under an unscored hour, dots on the hours in the high band, and faint marks along the base for the
stretches the motion gate masked. The marks get their own row here rather than a band carved out of the
chart's coordinate space, which is where the Glance side went wrong once.

### Verification

- `StressTrace.swift` imports only Foundation, so it was compiled standalone with `swiftc -O` and run
  against the Kotlin suite's own cases. It reproduces every expected value: the calm day's Ys
  (93.33 / 90.00 / 91.67, all inside the "bottom tenth" the Kotlin test asserts), the domain ends
  (0 / 100), the split runs and their widths, the mark at x=50, two high-band dots, dot-on-vertex,
  the stats (mean 1.5, peak ts 7200, 2 scored, 1 moving) and all three tick sets. That is the oracle
  the parity contract asks for rather than a read-through.
- 18 tests in `StressTraceTests`, including the threshold-parity assertion and the midnight guard.
- NOT verified locally: the app targets. `StrandiOSWidgets` cannot be built here. app-build is active
  and its path filter covers `Strand/**`, `StrandiOS/**`, `StrandiOSShared/**`, `StrandiOSWidgets/**`,
  `StrandTests/**` and `project.yml`, so this PR compiles both targets and runs StrandTests in CI.
- NOT verified: the widget on a real home screen.

### Scoring mode

Always the `.dayRelative` default, matching the Android twin and for the same reason: resolving the
opt-in personal-baseline lens reads fourteen trailing days of heart rate, which the screen can afford
on demand and a publish path cannot. With that toggle on, the widget shows the default lens and the
screen the refined one.
