### PR TITLE
Host today's stress curve on the Today screen (Android)

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HostedCards.kt
+++ b/android/app/src/main/java/com/noop/ui/HostedCards.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.filled.ShowChart
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.StackedBarChart
 import androidx.compose.material.icons.filled.Timeline
@@ -68,7 +69,12 @@ enum class HostedCard(
      *  honouring the imported-consistency preference) from the wearer's SleepModel (#today-hosted-cards). The
      *  Sleep tab surfaces this metric only as a StatTile in the Night-detail grid; the Today host gives it a
      *  standalone card (ConsistencyHostCard) reading the SAME metric, so the value can't diverge. */
-    CONSISTENCY("sleep.consistency", "Consistency", "Sleep", Icons.Filled.Repeat);
+    CONSISTENCY("sleep.consistency", "Consistency", "Sleep", Icons.Filled.Repeat),
+    /** Stress tab · "Stress" — today's hour-by-hour autonomic-load curve (#2040 follow-up). The FIRST
+     *  card hosted from a tab other than Sleep, so [localizedOrigin] gains a branch for it. Read-only,
+     *  like the hosted Stages card: the Stress tab keeps the interactive timeline with its scrubbing and
+     *  tooltips, and the Today host mirrors only the display. */
+    STRESS_TODAY("stress.today", "Stress", "Stress", Icons.Filled.ShowChart);
 
     companion object {
         fun fromRaw(raw: String?): HostedCard? = entries.firstOrNull { it.raw == raw }
@@ -97,6 +103,7 @@ fun HostedCard.localizedTitle(): String = when (this) {
     HostedCard.STAGES -> stringResource(R.string.l10n_sleep_screen_stages_c1d33ad5)
     HostedCard.HOURS_VS_NEEDED -> stringResource(R.string.l10n_sleep_screen_hours_vs_needed_500a0aca)
     HostedCard.CONSISTENCY -> stringResource(R.string.l10n_sleep_screen_consistency_0ea7b95e)
+    HostedCard.STRESS_TODAY -> stringResource(R.string.l10n_stress_screen_stress_bad33342)
 }
 
 /**
@@ -107,6 +114,7 @@ fun HostedCard.localizedTitle(): String = when (this) {
 @Composable
 fun HostedCard.localizedOrigin(): String = when (origin) {
     "Trends" -> stringResource(R.string.nav_trends)
+    "Stress" -> stringResource(R.string.nav_stress)
     else -> stringResource(R.string.nav_sleep)
 }
 

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -61,6 +61,8 @@ import com.noop.analytics.DaytimeStress
 import com.noop.analytics.HrvFreqDomain
 import com.noop.analytics.StressIndex
 import com.noop.data.DailyMetric
+import com.noop.widget.StressPoint
+import com.noop.widget.StressTrace
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -584,6 +586,148 @@ private fun StressDaytimeSection(
         if (day.sustainedHigh) SustainedBreatheCard(day, onBreathe)
     }
 }
+
+// MARK: - Today host: the intraday curve as a compact card (#2040 follow-up)
+
+/**
+ * The stress curve as a card for the Today screen, mirroring the home-screen widget.
+ *
+ * READ-ONLY on purpose. The Stress tab's own timeline is the interactive one, with scrubbing, a
+ * crosshair and per-hour tooltips; hosting that here would put two live charts on two screens fighting
+ * over the same gestures. This is the same rule the Sleep tab's hosted "Stages" card follows, where the
+ * Today host mirrors only the display.
+ *
+ * Geometry comes from [StressTrace], the same pure helper the widget draws through, so the card and the
+ * widget cannot disagree about where an hour sits, where the line breaks or which hours are high. Only
+ * the drawing differs, because Glance has to render to a Bitmap and Compose does not.
+ */
+@Composable
+internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Modifier) {
+    val stats = remember(points) { StressTrace.stats(points) }
+    val ticks = remember(points) { StressTrace.timeTicks(points) }
+    val textTertiary = Palette.textTertiary
+    val calm = StressRamp.CALM
+    val steady = StressRamp.STEADY
+    val tense = StressRamp.TENSE
+
+    NoopCard(tint = Palette.stressColor, modifier = modifier) {
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Overline(uiString(R.string.l10n_stress_screen_stress_bad33342), modifier = Modifier.weight(1f))
+                if (stats != null) {
+                    val peakTenths = ((stats.peak.level ?: 0.0) * 10).roundToInt().coerceIn(0, 30)
+                    Text(
+                        uiString(R.string.trends_peak) +
+                            " ${peakTenths / 10}.${peakTenths % 10} · ${hourLabel(peakHourOf(stats.peak))}",
+                        style = NoopType.footnote,
+                        color = Palette.textSecondary,
+                    )
+                }
+            }
+
+            if (stats == null) {
+                // The SAME "Calibrating" placeholder the pinned Today stress card already shows with no
+                // usable signal, so the two never disagree about what an unscored day looks like. Honest
+                // blank rather than a flat line at zero: only waking hours score, so this is every day's
+                // early morning as well as a day with too little signal.
+                Text(
+                    uiString(R.string.l10n_today_screen_calibrating_37c2c9bd),
+                    style = NoopType.footnote,
+                    color = textTertiary,
+                )
+            } else {
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    // The FIXED 0-3 scale down the left, as the screen and the widget both draw it. An
+                    // axis that moved with the day would make two days impossible to compare.
+                    Column(
+                        modifier = Modifier.height(Metrics.chartHeight),
+                        horizontalAlignment = Alignment.End,
+                        verticalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        StressTrace.levelTicks().forEach {
+                            Text(it.toString(), style = NoopType.footnote, color = textTertiary)
+                        }
+                    }
+                    Spacer(Modifier.width(6.dp))
+                    Canvas(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(Metrics.chartHeight),
+                    ) {
+                        val w = size.width
+                        val h = size.height
+                        if (w <= 0f || h <= 0f) return@Canvas
+                        val strokeW = 2.dp.toPx()
+                        // Amber at the top through green to blue at the bottom: because the domain is
+                        // fixed, vertical position IS the level, so one shader colours every run by the
+                        // score it actually carries.
+                        val gradient = Brush.verticalGradient(listOf(tense, steady, calm))
+
+                        StressTrace.segments(points, w, h).forEach { run ->
+                            if (run.isEmpty()) return@forEach
+                            if (run.size == 1) {
+                                drawCircle(color = steady, radius = strokeW,
+                                           center = Offset(run[0].x.coerceAtLeast(strokeW), run[0].y))
+                                return@forEach
+                            }
+                            val line = Path().apply {
+                                moveTo(run[0].x, run[0].y)
+                                run.drop(1).forEach { lineTo(it.x, it.y) }
+                            }
+                            // Closed PER RUN, so the fill cannot spread under an hour that was never
+                            // scored and undo the gap the broken line exists to draw.
+                            val fill = Path().apply {
+                                addPath(line)
+                                lineTo(run.last().x, h)
+                                lineTo(run[0].x, h)
+                                close()
+                            }
+                            drawPath(fill, brush = gradient, alpha = StrandAlpha.chartFillSoft)
+                            drawPath(line, brush = gradient,
+                                     style = Stroke(width = strokeW, cap = StrokeCap.Round,
+                                                    join = StrokeJoin.Round))
+                        }
+                        // Hours in the HIGH band, dotted above the line exactly as the screen marks them.
+                        StressTrace.highPoints(points, w, h).forEach {
+                            drawCircle(color = tense, radius = strokeW,
+                                       center = Offset(it.x, (it.y - strokeW * 2f).coerceAtLeast(strokeW)))
+                        }
+                        // The stretches the motion gate masked: exertion raises heart rate on its own, so
+                        // the hour is marked rather than scored.
+                        StressTrace.movingMarks(points, w).forEach {
+                            drawCircle(color = textTertiary, radius = strokeW * 0.6f,
+                                       center = Offset(it, h - strokeW))
+                        }
+                    }
+                }
+
+                if (ticks.size >= 2) {
+                    Row(modifier = Modifier.fillMaxWidth()) {
+                        ticks.forEachIndexed { i, ts ->
+                            Text(hourLabel(hourOfEpoch(ts)), style = NoopType.footnote, color = textTertiary)
+                            if (i < ticks.size - 1) Spacer(Modifier.weight(1f))
+                        }
+                    }
+                }
+
+                val avgTenths = (stats.mean * 10).roundToInt().coerceIn(0, 30)
+                Text(
+                    uiString(R.string.l10n_stress_screen_avg_a178769d) +
+                        " ${avgTenths / 10}.${avgTenths % 10}",
+                    style = NoopType.footnote,
+                    color = textTertiary,
+                )
+            }
+        }
+    }
+}
+
+/** Local hour-of-day for an epoch second, so the axis reads in the device's own clock. */
+private fun hourOfEpoch(ts: Long): Int =
+    java.time.Instant.ofEpochSecond(ts).atZone(java.time.ZoneId.systemDefault()).hour
+
+/** The peak's hour-of-day, resolved the same way. */
+private fun peakHourOf(p: StressPoint): Int = hourOfEpoch(p.ts)
 
 // MARK: - Daytime autonomic-load line (gradient, same scale as the gauge)
 //

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -640,7 +640,13 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
                     // The FIXED 0-3 scale down the left, as the screen and the widget both draw it. An
                     // axis that moved with the day would make two days impossible to compare.
                     Column(
-                        modifier = Modifier.height(Metrics.chartHeight),
+                        // Marked decorative: read aloud, "3 2 1 0" is four bare numbers with nothing to
+                        // say what they measure. The peak and average beside the chart carry the reading,
+                        // and the axis is only meaningful to someone who can see what it annotates.
+                        // Glance could not do this for the widget; Compose can.
+                        modifier = Modifier
+                            .height(Metrics.chartHeight)
+                            .clearAndSetSemantics { },
                         horizontalAlignment = Alignment.End,
                         verticalArrangement = Arrangement.SpaceBetween,
                     ) {
@@ -658,15 +664,27 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
                         val h = size.height
                         if (w <= 0f || h <= 0f) return@Canvas
                         val strokeW = 2.dp.toPx()
+                        // Reserve the bottom strip for the movement marks, and build the geometry AT the
+                        // reduced height rather than scaling it afterwards. A calm hour sits at the very
+                        // bottom of a fixed domain, so without the strip its line and the marks share a
+                        // row and read as one thing. (The widget carves the same band out of its bitmap;
+                        // computing against `chartH` here is the same idea without the second mapping
+                        // that had to be got right there.)
+                        val hasMarks = points.any { it.moving }
+                        val markBand = if (hasMarks) (strokeW * 2.5f).coerceAtMost(h / 6f) else 0f
+                        val chartH = (h - markBand).coerceAtLeast(1f)
                         // Amber at the top through green to blue at the bottom: because the domain is
                         // fixed, vertical position IS the level, so one shader colours every run by the
                         // score it actually carries.
-                        val gradient = Brush.verticalGradient(listOf(tense, steady, calm))
+                        val gradient = Brush.verticalGradient(listOf(tense, steady, calm),
+                                                              startY = 0f, endY = chartH)
 
-                        StressTrace.segments(points, w, h).forEach { run ->
+                        StressTrace.segments(points, w, chartH).forEach { run ->
                             if (run.isEmpty()) return@forEach
                             if (run.size == 1) {
-                                drawCircle(color = steady, radius = strokeW,
+                                // Brushed, not a flat colour: the dot has to carry the level the same way
+                                // the line does, or a lone HIGH hour would draw the calm-day green.
+                                drawCircle(brush = gradient, radius = strokeW,
                                            center = Offset(run[0].x.coerceAtLeast(strokeW), run[0].y))
                                 return@forEach
                             }
@@ -678,8 +696,8 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
                             // scored and undo the gap the broken line exists to draw.
                             val fill = Path().apply {
                                 addPath(line)
-                                lineTo(run.last().x, h)
-                                lineTo(run[0].x, h)
+                                lineTo(run.last().x, chartH)
+                                lineTo(run[0].x, chartH)
                                 close()
                             }
                             drawPath(fill, brush = gradient, alpha = StrandAlpha.chartFillSoft)
@@ -688,7 +706,7 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
                                                     join = StrokeJoin.Round))
                         }
                         // Hours in the HIGH band, dotted above the line exactly as the screen marks them.
-                        StressTrace.highPoints(points, w, h).forEach {
+                        StressTrace.highPoints(points, w, chartH).forEach {
                             drawCircle(color = tense, radius = strokeW,
                                        center = Offset(it.x, (it.y - strokeW * 2f).coerceAtLeast(strokeW)))
                         }
@@ -696,7 +714,7 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
                         // the hour is marked rather than scored.
                         StressTrace.movingMarks(points, w).forEach {
                             drawCircle(color = textTertiary, radius = strokeW * 0.6f,
-                                       center = Offset(it, h - strokeW))
+                                       center = Offset(it, h - markBand / 2f))
                         }
                     }
                 }

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -618,7 +618,7 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
                     val peakTenths = ((stats.peak.level ?: 0.0) * 10).roundToInt().coerceIn(0, 30)
                     Text(
                         uiString(R.string.trends_peak) +
-                            " ${peakTenths / 10}.${peakTenths % 10} · ${hourLabel(peakHourOf(stats.peak))}",
+                            " ${peakTenths / 10}.${peakTenths % 10} · ${pointTimeLabel(stats.peak.ts)}",
                         style = NoopType.footnote,
                         color = Palette.textSecondary,
                     )
@@ -704,7 +704,7 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
                 if (ticks.size >= 2) {
                     Row(modifier = Modifier.fillMaxWidth()) {
                         ticks.forEachIndexed { i, ts ->
-                            Text(hourLabel(hourOfEpoch(ts)), style = NoopType.footnote, color = textTertiary)
+                            Text(pointTimeLabel(ts), style = NoopType.footnote, color = textTertiary)
                             if (i < ticks.size - 1) Spacer(Modifier.weight(1f))
                         }
                     }
@@ -722,12 +722,18 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
     }
 }
 
-/** Local hour-of-day for an epoch second, so the axis reads in the device's own clock. */
-private fun hourOfEpoch(ts: Long): Int =
-    java.time.Instant.ofEpochSecond(ts).atZone(java.time.ZoneId.systemDefault()).hour
-
-/** The peak's hour-of-day, resolved the same way. */
-private fun peakHourOf(p: StressPoint): Int = hourOfEpoch(p.ts)
+/**
+ * A point's clock time, in the device's own short format.
+ *
+ * NOT [hourLabel]: that renders an hour-of-day and nothing finer, which was correct while every point
+ * sat on the hour. The timeline now reads its window every half hour, so a peak at 09:30 would have
+ * been labelled "9 am" and an axis tick at 06:30 "6 am" — wrong by up to half an hour, and silently,
+ * since the number beside it would still be the right one. The widget formats the timestamp for the
+ * same reason.
+ */
+private fun pointTimeLabel(ts: Long): String =
+    java.text.DateFormat.getTimeInstance(java.text.DateFormat.SHORT)
+        .format(java.util.Date(ts * 1_000L))
 
 // MARK: - Daytime autonomic-load line (gradient, same scale as the gauge)
 //

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -164,6 +164,8 @@ import com.noop.analytics.StepsEstimateEngine
 import com.noop.analytics.StrainScorer
 import com.noop.ble.WhoopModel
 import com.noop.data.DailyMetric
+import com.noop.widget.StressPoint
+import com.noop.widget.StressWidgetProducer
 import com.noop.data.HrBucket
 import com.noop.data.SleepSession
 import com.noop.data.WhoopRepository
@@ -3488,9 +3490,23 @@ private fun HostedCardsSection(cards: List<HostedCard>, days: List<DailyMetric>,
             null
         }
     }
+    // Today's stress curve, loaded only when the card is actually hosted — the same "hosting none pays
+    // nothing" rule the sleep model above follows. Routed through the SAME gated producer the stress
+    // widget publishes from, so hosting this card costs one indexed COUNT on an unchanged day and the
+    // card and the widget can never show different curves.
+    val needsStressCurve = cards.contains(HostedCard.STRESS_TODAY)
+    var stressCurve by remember { mutableStateOf<List<StressPoint>>(emptyList()) }
+    LaunchedEffect(needsStressCurve, days, viewModel.activeStrapId) {
+        stressCurve = if (needsStressCurve) {
+            StressWidgetProducer.todayCurve(viewModel.repo, viewModel.activeStrapId)?.points ?: emptyList()
+        } else {
+            emptyList()
+        }
+    }
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.sectionGap)) {
         cards.forEach { card ->
             when (card) {
+                HostedCard.STRESS_TODAY -> StressTodayCard(stressCurve)
                 HostedCard.SLEEP_MARKS -> SleepMarkCard(
                     onMark = { type ->
                         val mark = SleepMark.now(type)

--- a/android/app/src/test/java/com/noop/ui/HostedCardPrefsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/HostedCardPrefsTest.kt
@@ -17,6 +17,9 @@ class HostedCardPrefsTest {
     fun rawValues_areTheFrozenNamespacedContract() {
         assertEquals("sleep.sleepMarks", HostedCard.SLEEP_MARKS.raw)
         assertEquals("sleep.asleepDuration", HostedCard.ASLEEP_DURATION.raw)
+        // Origin-namespaced on a tab other than Sleep, and frozen for the same reason: this id rides
+        // .noopbak, so the Swift twin has to spell it identically or a restore drops the card.
+        assertEquals("stress.today", HostedCard.STRESS_TODAY.raw)
         // Every id must be origin-namespaced so it routes to the right provider and can't collide with a
         // Today DashboardCard id.
         HostedCard.entries.forEach { card ->


### PR DESCRIPTION
Follow-up to #2044 / #2045: the stress curve existed in two places and neither was the home screen. The
Stress tab draws it, the new widget draws it, and Today showed stress as a single number on a pinned
tile.

### Shape

A hosted card, the mechanism that already exists for surfacing another tab's card on Today. Read-only,
the same rule the hosted Stages card follows: the Stress tab keeps the interactive timeline with its
scrubbing, crosshair and per-hour tooltips, and the Today host mirrors only the display. Two live charts
on two screens fighting over the same gestures is not an improvement.

Geometry comes from `StressTrace`, the pure helper the widget already draws through, so the card and the
widget cannot disagree about where an hour sits, where the line breaks or which hours sit in the high
band. Only the drawing differs, because Glance renders to a Bitmap and Compose does not.

### Cost

The data comes from the SAME gated producer the widget publishes from. Hosting the card costs one
indexed COUNT on a day whose heart rate has not moved, and the two surfaces share one computation
instead of scoring the day twice. It loads only when the card is actually hosted, matching the sleep
model beside it, so a Today hosting none pays nothing.

### Copy

Every string reuses a key the app already carries, so nothing new reaches a translator: `Stress`,
`Peak`, `avg`, and the `Calibrating` placeholder the pinned stress tile already shows when there is no
usable signal. The two now agree about what an unscored day looks like, which matters because only
waking hours score, so early morning is blank by construction rather than by failure.

### The frozen id

`STRESS_TODAY` is the first card hosted from a tab other than Sleep, so `localizedOrigin` gains a
branch. Its raw id rides `.noopbak` under `today.hostedCards`, and the existing frozen-contract test now
pins `stress.today` alongside the sleep ids.

### Not in this change

The Apple twin. The raw id must be spelled identically in the Swift `HostedCard` or a backup restored on
iOS drops this one card from the hosted selection: lossy rather than destructive, since the decoder
skips unknown tokens. Doing it properly means a case in the shared enum, switch arms in BOTH Apple Today
views, an iOS-only card and an iOS-only loader inside shared files, none of which builds here. I started
it and backed it out rather than ship a Swift change I could not compile. It lands better as its own PR
against app-build, the way the widget's twin did.

### Verification

- `./gradlew compileFullDebugKotlin` clean.
- `./gradlew testFullDebugUnitTest --tests "com.noop.ui.HostedCardPrefsTest"`: 5 tests, 0 failures,
  result XML checked.
- `./gradlew lintVitalFullRelease -PstagingRelease` clean.
- `Tools/i18n_audit.py --ci` exits 0, no new copy.
- `Tools/doc_comment_lint.py` clean.
- NOT verified on a device: the card's layout at real width. The chart is a plain Compose Canvas rather
  than the widget's budgeted bitmap, so the failure modes that bit the widget do not apply, but it has
  not been seen on a screen.
