### PR TITLE
Read the stress hour every 30 minutes instead of every hour

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
@@ -34,6 +34,20 @@ public enum DaytimeStress {
     public static let minHourHRSamples: Int = 300
     /// Bucket width for the timeline, in seconds (one hour).
     public static let bucketSeconds: Int = 3_600
+    /// How far the DISPLAY timeline slides its window between points.
+    ///
+    /// The scored unit stays a full `bucketSeconds` hour. This only decides how often that hour is
+    /// re-read, so a half-step gives two points an hour, each still an hour of data, rather than
+    /// half-hours of thinner data. Shrinking `bucketSeconds` itself would have been a scoring change
+    /// wearing a display change's clothes: the calm reference is a quartile ACROSS buckets, the
+    /// post-exercise shadow looks back exactly one bucket, and `sustainedHours` counts them.
+    ///
+    /// Half rather than a quarter because adjacent points then share half their samples instead of
+    /// three quarters. The curve is smoother either way, and a denser line invites the reader to see
+    /// detail it cannot resolve: a 30-minute spike still moves an hour's worth of weight, just sooner.
+    /// Half is the least overlap that still doubles the resolution, and it keeps every on-the-hour
+    /// point exactly where the hourly pass put it. Byte-twin of the Kotlin `timelineStepSeconds`.
+    public static let timelineStepSeconds: Int = 1_800
     /// Band floor for "high" on the shared 0–3 scale (matches StressBand .high).
     public static let highBandFloor: Double = 2.0
     /// Consecutive most-recent covered hours that must all be HIGH to flag sustained stress.
@@ -215,10 +229,22 @@ public enum DaytimeStress {
         /// day-wide) and false for `.empty`.
         public let hrOnlyFallback: Bool
 
+        /// DISPLAY-ONLY sliding read of the same day: `hours` plus a point every
+        /// `timelineStepSeconds`, each still scored over a full `bucketSeconds` window against the
+        /// SAME reference `hours` used. Defaults to `hours` so a caller that never asked for it, and
+        /// every existing test, sees exactly what it saw before.
+        ///
+        /// Deliberately NOT the input to anything that counts hours. `sustainedHigh`,
+        /// `highStressMinutes`, `dayMean` and `peak` all stay on the non-overlapping `hours`, because
+        /// overlapping windows would count the same minute more than once.
+        public let timeline: [HourPoint]
+
         public init(hours: [HourPoint], sustainedHigh: Bool, sustainedRun: Int,
                     dayMean: Double?, peak: HourPoint?, activityMaskedHours: Int = 0,
-                    highStressMinutes: Int = 0, hrOnlyFallback: Bool = false) {
+                    highStressMinutes: Int = 0, hrOnlyFallback: Bool = false,
+                    timeline: [HourPoint]? = nil) {
             self.hours = hours
+            self.timeline = timeline ?? hours
             self.sustainedHigh = sustainedHigh
             self.sustainedRun = sustainedRun
             self.dayMean = dayMean
@@ -283,6 +309,15 @@ public enum DaytimeStress {
         let ratio = 3.0 / band - 1.0
         guard ratio > 0, marginBPM > 0 else { return max(marginBPM, 1e-9) }
         return marginBPM / (-log(ratio))
+    }
+
+    /// The bucket a local timestamp falls in for a grid offset by `phase`.
+    ///
+    /// `phase = 0` is the on-the-hour grid every existing reading uses. `phase = timelineStepSeconds`
+    /// is the same grid slid forward, so its windows straddle the hour boundaries rather than
+    /// replacing them.
+    private static func bucketOf(_ localTs: Int, phase: Int) -> Int {
+        floorDiv(localTs - phase, bucketSeconds) * bucketSeconds + phase
     }
 
     // MARK: - Public API
@@ -356,53 +391,63 @@ public enum DaytimeStress {
 
         // 1) Bucket HR + R-R into LOCAL hour-of-day buckets, keyed by the bucket start
         //    (floored to the hour on the local clock).
-        var hrByBucket: [Int: [Double]] = [:]
-        for s in hr {
-            let local = s.ts + tzOffsetSeconds
-            let bucket = floorDiv(local, bucketSeconds) * bucketSeconds
-            hrByBucket[bucket, default: []].append(Double(s.bpm))
+        func hrBuckets(_ phase: Int) -> [Int: [Double]] {
+            var m: [Int: [Double]] = [:]
+            for s in hr { m[bucketOf(s.ts + tzOffsetSeconds, phase: phase), default: []].append(Double(s.bpm)) }
+            return m
         }
-        var rrByBucket: [Int: [Double]] = [:]
-        for s in rr {
-            let local = s.ts + tzOffsetSeconds
-            let bucket = floorDiv(local, bucketSeconds) * bucketSeconds
-            rrByBucket[bucket, default: []].append(Double(s.rrMs))
+        func rrBuckets(_ phase: Int) -> [Int: [Double]] {
+            var m: [Int: [Double]] = [:]
+            for s in rr { m[bucketOf(s.ts + tzOffsetSeconds, phase: phase), default: []].append(Double(s.rrMs)) }
+            return m
         }
+        let hrByBucket = hrBuckets(0)
+        let rrByBucket = rrBuckets(0)
 
         // 2) Per-hour mean HR + RMSSD (RMSSD via the shared HRV cleaner, so ectopic
         //    beats can't fabricate variability). An hour with < minHourHRSamples HR is
         //    left unscored (noData) — never invented.
         struct HourAgg { let bucket: Int; let meanHR: Double?; let rmssd: Double?; let nHR: Int }
-        let orderedBuckets = hrByBucket.keys.sorted()
-        var aggs: [HourAgg] = []
-        aggs.reserveCapacity(orderedBuckets.count)
-        for b in orderedBuckets {
-            let hrs = hrByBucket[b] ?? []
-            let mHR = hrs.count >= minHourHRSamples ? mean(hrs) : nil
-            let rrRes = HRVAnalyzer.analyze(rawRR: rrByBucket[b] ?? [])
-            aggs.append(HourAgg(bucket: b, meanHR: mHR, rmssd: rrRes.rmssd, nHR: hrs.count))
+        func aggregate(_ hrGrid: [Int: [Double]], _ rrGrid: [Int: [Double]]) -> [HourAgg] {
+            let ordered = hrGrid.keys.sorted()
+            var out: [HourAgg] = []
+            out.reserveCapacity(ordered.count)
+            for b in ordered {
+                let hrs = hrGrid[b] ?? []
+                let mHR = hrs.count >= minHourHRSamples ? mean(hrs) : nil
+                let rrRes = HRVAnalyzer.analyze(rawRR: rrGrid[b] ?? [])
+                out.append(HourAgg(bucket: b, meanHR: mHR, rmssd: rrRes.rmssd, nHR: hrs.count))
+            }
+            return out
         }
+        let aggs = aggregate(hrByBucket, rrByBucket)
 
         // 2b) Motion gate: bucket the day's gravity-derived activity by the SAME local hour and mark
         //     each hour AMBULATORY when at least `activityMaskFraction` of its records clear the
         //     calibrated walk floor (`WorkoutDetector.motionThreshold`) — reusing the exact activity
         //     series `SedentaryDetector` / `WorkoutDetector` already trust. Empty gravity → no active
         //     buckets → nothing masked below (byte-identical to the pre-motion behaviour).
-        var activeFracByBucket: [Int: Double] = [:]
-        if !gravity.isEmpty {
+        // Derived ONCE and re-bucketed per grid. `activitySeries` walks the whole day's gravity, so
+        // recomputing it for the second grid would have doubled the most expensive part of the motion
+        // gate to answer the same question about the same samples.
+        let activity = gravity.isEmpty ? [] : WorkoutDetector.activitySeries(gravity)
+        func activeFractions(_ phase: Int) -> [Int: Double] {
+            var out: [Int: Double] = [:]
+            guard !activity.isEmpty else { return out }
             var counts: [Int: (active: Int, total: Int)] = [:]
-            for p in WorkoutDetector.activitySeries(gravity) {
-                let local = p.ts + tzOffsetSeconds
-                let bucket = floorDiv(local, bucketSeconds) * bucketSeconds
+            for p in activity {
+                let bucket = bucketOf(p.ts + tzOffsetSeconds, phase: phase)
                 var e = counts[bucket] ?? (0, 0)
                 e.total += 1
                 if p.intensity > WorkoutDetector.motionThreshold { e.active += 1 }
                 counts[bucket] = e
             }
             for (b, e) in counts where e.total > 0 {
-                activeFracByBucket[b] = Double(e.active) / Double(e.total)
+                out[b] = Double(e.active) / Double(e.total)
             }
+            return out
         }
+        let activeFracByBucket = activeFractions(0)
         func isAmbulatory(_ bucket: Int) -> Bool {
             (activeFracByBucket[bucket] ?? 0) >= activityMaskFraction
         }
@@ -473,9 +518,18 @@ public enum DaytimeStress {
         }
 
         // 4) Score each waking-hour bucket on the shared 0–3 curve.
-        var points: [HourPoint] = []
-        points.reserveCapacity(aggs.count)
-        for a in aggs {
+        //
+        // Written against a supplied bucket grid so the SAME expression scores the on-the-hour pass
+        // and the half-step display pass. One copy, so the two can never drift into scoring the same
+        // hour differently — which is the whole reason the sliding read reuses the references
+        // computed above rather than deriving its own.
+        func scoreGrid(_ gridAggs: [HourAgg], _ activeFrac: [Int: Double]) -> [HourPoint] {
+            func ambulatory(_ bucket: Int) -> Bool {
+                (activeFrac[bucket] ?? 0) >= activityMaskFraction
+            }
+            var points: [HourPoint] = []
+            points.reserveCapacity(gridAggs.count)
+            for a in gridAggs {
             guard isWakingHour(a.bucket) else { continue }
             let hourOfDay = floorDiv(a.bucket, bucketSeconds) % 24
             // The wall-clock bucket start (undo the local shift applied above).
@@ -486,9 +540,9 @@ public enum DaytimeStress {
             // genuine cardiac recovery (a following hour already back at baseline scores normally).
             // Only meaningful when the hour actually HAD a reading to withhold — a no-HR hour is plain
             // `.noData`, not "masked".
-            let shadow = isAmbulatory(a.bucket - bucketSeconds)
+            let shadow = ambulatory(a.bucket - bucketSeconds)
                 && a.meanHR != nil && refHR != nil && a.meanHR! > refHR! + postActivityShadowBPM
-            let masked = a.meanHR != nil && (isAmbulatory(a.bucket) || shadow)
+            let masked = a.meanHR != nil && (ambulatory(a.bucket) || shadow)
             // Score only when at least one signal is present AND HR cleared the count gate AND the
             // hour was not motion-masked (HR is the always-available anchor; RMSSD enriches it).
             let level: Double? = (a.meanHR != nil && !masked)
@@ -498,8 +552,23 @@ public enum DaytimeStress {
             points.append(HourPoint(hour: hourOfDay, startTs: wallStart,
                                     level: level, meanHR: a.meanHR, rmssd: a.rmssd,
                                     maskedForActivity: masked))
+            }
+            return points
         }
+        let points = scoreGrid(aggs, activeFracByBucket)
         let activityMaskedHours = points.reduce(0) { $0 + ($1.maskedForActivity ? 1 : 0) }
+
+        // 4b) The half-step DISPLAY timeline: the same hour-long window re-read every
+        //     `timelineStepSeconds`, scored against the SAME references, and merged with the
+        //     on-the-hour points. Every hourly point survives untouched; only the straddling
+        //     midpoints are new, so the curve still passes through exactly the values scored above.
+        //     Nothing that counts hours reads this — see `Result.timeline`.
+        let timeline: [HourPoint] = {
+            guard timelineStepSeconds > 0, timelineStepSeconds < bucketSeconds else { return points }
+            let midAggs = aggregate(hrBuckets(timelineStepSeconds), rrBuckets(timelineStepSeconds))
+            return (points + scoreGrid(midAggs, activeFractions(timelineStepSeconds)))
+                .sorted { $0.startTs < $1.startTs }
+        }()
 
         let scored = points.compactMap { p -> (HourPoint, Double)? in p.level.map { (p, $0) } }
         guard !scored.isEmpty else {
@@ -510,7 +579,7 @@ public enum DaytimeStress {
             return points.isEmpty ? .empty
                 : Result(hours: points, sustainedHigh: false, sustainedRun: 0,
                          dayMean: nil, peak: nil, activityMaskedHours: activityMaskedHours,
-                         highStressMinutes: 0, hrOnlyFallback: hrOnlyFallback)
+                         highStressMinutes: 0, hrOnlyFallback: hrOnlyFallback, timeline: timeline)
         }
 
         // 5) Sustained-high flag: walk back from the latest SCORED hour while each is HIGH.
@@ -531,7 +600,8 @@ public enum DaytimeStress {
 
         return Result(hours: points, sustainedHigh: sustained, sustainedRun: run,
                       dayMean: dayMean, peak: peak, activityMaskedHours: activityMaskedHours,
-                      highStressMinutes: highStressMinutes, hrOnlyFallback: hrOnlyFallback)
+                      highStressMinutes: highStressMinutes, hrOnlyFallback: hrOnlyFallback,
+                      timeline: timeline)
     }
 
     // MARK: - Helpers

--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeStress.swift
@@ -337,10 +337,16 @@ public enum DaytimeStress {
     ///     opt-in: existing callers that don't pass `mode` keep the exact prior behaviour.
     ///
     /// Returns `.empty` when there isn't a single hour with enough HR to score.
+    ///   - includeTimeline: also compute `Result.timeline`, the sliding read is OPT-IN because half the callers do not want it.
+
+    ///     The Stress screen reads `hours` and draws its own interactive timeline; making it pay for a
+    ///     second pass of bucketing and one RMSSD per extra window, on the screen that already does three
+    ///     200 000-row reads, would be cost for nothing. The widget and the Today card ask for it.
     public static func analyze(hr: [HRSample], rr: [RRInterval],
                                gravity: [GravitySample] = [],
                                tzOffsetSeconds: Int = 0,
-                               mode: ScoringMode = .dayRelative) -> Result {
+                               mode: ScoringMode = .dayRelative,
+                               includeTimeline: Bool = false) -> Result {
         // v7.0.2 perf (#707): buckets the day's full HR + R-R streams into per-hour aggregates and runs an
         // RMSSD per hour — invoked from the Stress view, so a `body` re-evaluation re-buckets the whole day.
         // Memoize on the streams' fingerprint + tz offset + scoring mode; result is a small `Result`, raw
@@ -363,15 +369,19 @@ public enum DaytimeStress {
                 Int(($0.x * 128).rounded()) &+ Int(($0.y * 128).rounded()) &* 257
                     &+ Int(($0.z * 128).rounded()) &* 66_049
             }),
-            tz: tzOffsetSeconds, mode: modeKey)
+            // The flag is part of the KEY, not just the call. Without it a screen read (false)
+            // would seed the cache with a hourly-only result and the next widget read (true) would be
+            // handed it, silently losing the sliding series with nothing to show why.
+            tz: tzOffsetSeconds, mode: modeKey, includeTimeline: includeTimeline)
         return analyzeCache.value(key) {
-            analyzeUncached(hr: hr, rr: rr, gravity: gravity, tzOffsetSeconds: tzOffsetSeconds, mode: mode)
+            analyzeUncached(hr: hr, rr: rr, gravity: gravity, tzOffsetSeconds: tzOffsetSeconds,
+                            mode: mode, includeTimeline: includeTimeline)
         }
     }
 
     private struct StressKey: Hashable {
         let hr: StreamFingerprint; let rr: StreamFingerprint; let gravity: StreamFingerprint
-        let tz: Int; let mode: ModeKey
+        let tz: Int; let mode: ModeKey; let includeTimeline: Bool
     }
 
     /// Hashable fingerprint of `ScoringMode` for the memo cache — `BaselineState` itself isn't
@@ -386,7 +396,8 @@ public enum DaytimeStress {
 
     private static func analyzeUncached(hr: [HRSample], rr: [RRInterval],
                                         gravity: [GravitySample],
-                                        tzOffsetSeconds: Int, mode: ScoringMode) -> Result {
+                                        tzOffsetSeconds: Int, mode: ScoringMode,
+                                        includeTimeline: Bool) -> Result {
         guard !hr.isEmpty else { return .empty }
 
         // 1) Bucket HR + R-R into LOCAL hour-of-day buckets, keyed by the bucket start
@@ -564,7 +575,8 @@ public enum DaytimeStress {
         //     midpoints are new, so the curve still passes through exactly the values scored above.
         //     Nothing that counts hours reads this — see `Result.timeline`.
         let timeline: [HourPoint] = {
-            guard timelineStepSeconds > 0, timelineStepSeconds < bucketSeconds else { return points }
+            guard includeTimeline,
+                  timelineStepSeconds > 0, timelineStepSeconds < bucketSeconds else { return points }
             let midAggs = aggregate(hrBuckets(timelineStepSeconds), rrBuckets(timelineStepSeconds))
             return (points + scoreGrid(midAggs, activeFractions(timelineStepSeconds)))
                 .sorted { $0.startTs < $1.startTs }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeStressTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeStressTests.swift
@@ -10,6 +10,94 @@ final class DaytimeStressTests: XCTestCase {
         return (0..<n).map { HRSample(ts: base + $0, bpm: bpm) }
     }
 
+    // MARK: - the half-step display timeline
+
+    /// A plain worn morning: several waking hours of steady HR with a little R-R jitter.
+    private func wornMorning() -> ([HRSample], [RRInterval]) {
+        var hr: [HRSample] = []
+        var rr: [RRInterval] = []
+        for h in 7...11 {
+            hr += hourHR(h, bpm: 60 + (h - 7) * 4)
+            rr += hourRRVariable(h, rrMs: 900, jitter: 20)
+        }
+        return (hr, rr)
+    }
+
+    func testTimelineKeepsEveryHourlyPointExactlyAsScored() {
+        let (hr, rr) = wornMorning()
+        let res = DaytimeStress.analyze(hr: hr, rr: rr)
+        // The sliding read must not restate the hours it slides between: a point on the hour has to
+        // carry the same level it carried before this existed, or the curve would disagree with every
+        // other surface that reads `hours`.
+        let byStart = Dictionary(uniqueKeysWithValues: res.timeline.map { ($0.startTs, $0) })
+        XCTAssertFalse(res.hours.isEmpty)
+        for h in res.hours {
+            XCTAssertEqual(byStart[h.startTs]?.level, h.level, "hour \(h.startTs) restated")
+            XCTAssertEqual(byStart[h.startTs]?.maskedForActivity, h.maskedForActivity)
+        }
+    }
+
+    func testTimelineAddsTheStraddlingMidpointsAndNothingElse() {
+        let (hr, rr) = wornMorning()
+        let res = DaytimeStress.analyze(hr: hr, rr: rr)
+        XCTAssertGreaterThan(res.timeline.count, res.hours.count)
+        let hourly = Set(res.hours.map(\.startTs))
+        let extras = res.timeline.filter { !hourly.contains($0.startTs) }
+        XCTAssertFalse(extras.isEmpty)
+        // Every added point sits exactly half a window off the hour, which is what "slid" means. A
+        // point anywhere else would mean the grid, not the phase, had moved.
+        for e in extras {
+            let offset = ((e.startTs % DaytimeStress.bucketSeconds) + DaytimeStress.bucketSeconds)
+                % DaytimeStress.bucketSeconds
+            XCTAssertEqual(offset, DaytimeStress.timelineStepSeconds)
+        }
+        XCTAssertEqual(res.timeline.map(\.startTs), res.timeline.map(\.startTs).sorted())
+    }
+
+    func testHourCountingIgnoresTheSlidingRead() {
+        let (hr, rr) = wornMorning()
+        let res = DaytimeStress.analyze(hr: hr, rr: rr)
+        // Overlapping windows would count the same minute twice, so the minute total stays on the
+        // non-overlapping hours. This is the assertion that fails first if someone later points
+        // `highStressMinutes` at the denser series.
+        let highHours = res.hours.filter { ($0.level ?? 0) >= DaytimeStress.highBandFloor }.count
+        XCTAssertEqual(res.highStressMinutes, highHours * 60)
+        XCTAssertEqual(res.activityMaskedHours, res.hours.filter(\.maskedForActivity).count)
+    }
+
+    func testASteadyDayScoresItsMidpointsLikeItsHours() {
+        // Same HR every hour: with one shared reference the midpoints must land on the same level as
+        // the hours they straddle. If the sliding pass ever derived its OWN calm reference, this is
+        // where it would show up, as a curve that zigzags between two scales rather than tracking one.
+        var hr: [HRSample] = []
+        var rr: [RRInterval] = []
+        for h in 8...12 { hr += hourHR(h, bpm: 66); rr += hourRRVariable(h, rrMs: 900, jitter: 20) }
+        let res = DaytimeStress.analyze(hr: hr, rr: rr)
+        let levels = Set(res.timeline.compactMap { $0.level.map { String(format: "%.6f", $0) } })
+        XCTAssertLessThanOrEqual(levels.count, 1, "a flat day should not zigzag, got \(levels)")
+    }
+
+    func testTimelineMatchesTheKotlinTwinValueForValue() {
+        // The other half of the oracle. The Kotlin `DaytimeStressTest` asserts these same literals for
+        // this same scenario, so a change landing on ONE platform moves one of the two and fails here
+        // or there. An oracle only guards the direction it is written in.
+        let (hr, rr) = wornMorning()
+        let res = DaytimeStress.analyze(hr: hr, rr: rr)
+        func render(_ points: [DaytimeStress.HourPoint]) -> String {
+            points.map { "\($0.startTs):" + ($0.level.map { String(format: "%.6f", $0) } ?? "nil") }
+                .joined(separator: " ")
+        }
+        XCTAssertEqual(render(res.hours),
+                       "25200:0.990715 28800:1.500000 32400:2.009285 36000:2.413289 39600:2.678875")
+        XCTAssertEqual(render(res.timeline),
+                       "23400:0.990715 25200:0.990715 27000:1.500000 28800:1.500000 30600:2.009285 "
+                       + "32400:2.009285 34200:2.413289 36000:2.413289 37800:2.678875 39600:2.678875")
+        XCTAssertEqual(res.highStressMinutes, 180)
+        XCTAssertTrue(res.sustainedHigh)
+        XCTAssertEqual(res.sustainedRun, 3)
+        XCTAssertEqual(res.peak?.startTs, 39600)
+    }
+
     func testEmptyWhenNoHR() {
         XCTAssertEqual(DaytimeStress.analyze(hr: [], rr: []), .empty)
     }

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeStressTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeStressTests.swift
@@ -10,6 +10,17 @@ final class DaytimeStressTests: XCTestCase {
         return (0..<n).map { HRSample(ts: base + $0, bpm: bpm) }
     }
 
+    func testTheSlidingReadIsOptIn() {
+        let (hr, rr) = wornMorning()
+        // The Stress screen reads `hours` and draws its own timeline, so it must not pay for a second
+        // pass of bucketing and an RMSSD per extra window. Default off means `timeline` IS `hours`.
+        let plain = DaytimeStress.analyze(hr: hr, rr: rr)
+        XCTAssertEqual(plain.timeline, plain.hours)
+        XCTAssertGreaterThan(
+            DaytimeStress.analyze(hr: hr, rr: rr, includeTimeline: true).timeline.count,
+            plain.hours.count)
+    }
+
     // MARK: - the half-step display timeline
 
     /// A plain worn morning: several waking hours of steady HR with a little R-R jitter.
@@ -25,7 +36,7 @@ final class DaytimeStressTests: XCTestCase {
 
     func testTimelineKeepsEveryHourlyPointExactlyAsScored() {
         let (hr, rr) = wornMorning()
-        let res = DaytimeStress.analyze(hr: hr, rr: rr)
+        let res = DaytimeStress.analyze(hr: hr, rr: rr, includeTimeline: true)
         // The sliding read must not restate the hours it slides between: a point on the hour has to
         // carry the same level it carried before this existed, or the curve would disagree with every
         // other surface that reads `hours`.
@@ -39,7 +50,7 @@ final class DaytimeStressTests: XCTestCase {
 
     func testTimelineAddsTheStraddlingMidpointsAndNothingElse() {
         let (hr, rr) = wornMorning()
-        let res = DaytimeStress.analyze(hr: hr, rr: rr)
+        let res = DaytimeStress.analyze(hr: hr, rr: rr, includeTimeline: true)
         XCTAssertGreaterThan(res.timeline.count, res.hours.count)
         let hourly = Set(res.hours.map(\.startTs))
         let extras = res.timeline.filter { !hourly.contains($0.startTs) }
@@ -56,7 +67,7 @@ final class DaytimeStressTests: XCTestCase {
 
     func testHourCountingIgnoresTheSlidingRead() {
         let (hr, rr) = wornMorning()
-        let res = DaytimeStress.analyze(hr: hr, rr: rr)
+        let res = DaytimeStress.analyze(hr: hr, rr: rr, includeTimeline: true)
         // Overlapping windows would count the same minute twice, so the minute total stays on the
         // non-overlapping hours. This is the assertion that fails first if someone later points
         // `highStressMinutes` at the denser series.
@@ -72,7 +83,7 @@ final class DaytimeStressTests: XCTestCase {
         var hr: [HRSample] = []
         var rr: [RRInterval] = []
         for h in 8...12 { hr += hourHR(h, bpm: 66); rr += hourRRVariable(h, rrMs: 900, jitter: 20) }
-        let res = DaytimeStress.analyze(hr: hr, rr: rr)
+        let res = DaytimeStress.analyze(hr: hr, rr: rr, includeTimeline: true)
         let levels = Set(res.timeline.compactMap { $0.level.map { String(format: "%.6f", $0) } })
         XCTAssertLessThanOrEqual(levels.count, 1, "a flat day should not zigzag, got \(levels)")
     }
@@ -82,7 +93,7 @@ final class DaytimeStressTests: XCTestCase {
         // this same scenario, so a change landing on ONE platform moves one of the two and fails here
         // or there. An oracle only guards the direction it is written in.
         let (hr, rr) = wornMorning()
-        let res = DaytimeStress.analyze(hr: hr, rr: rr)
+        let res = DaytimeStress.analyze(hr: hr, rr: rr, includeTimeline: true)
         func render(_ points: [DaytimeStress.HourPoint]) -> String {
             points.map { "\($0.startTs):" + ($0.level.map { String(format: "%.6f", $0) } ?? "nil") }
                 .joined(separator: " ")

--- a/StrandiOS/Widgets/StressWidgetCurve.swift
+++ b/StrandiOS/Widgets/StressWidgetCurve.swift
@@ -74,7 +74,10 @@ enum StressWidgetCurve {
             points = await Task.detached(priority: .utility) {
                 DaytimeStress.analyze(hr: hr, rr: rr, gravity: gravity,
                                       tzOffsetSeconds: tz, mode: .dayRelative)
-                    .hours
+                    // The half-step display series rather than the bare hours: same scored window,
+                    // same reference, read twice as often, so the curve tracks the day instead of
+                    // stepping through it. Nothing here counts hours, so the overlap is free.
+                    .timeline
                     .map {
                         // `startTs` is the wall-clock bucket start with the local shift already undone,
                         // so it is a true instant and formats correctly against the device's zone.

--- a/StrandiOS/Widgets/StressWidgetCurve.swift
+++ b/StrandiOS/Widgets/StressWidgetCurve.swift
@@ -73,7 +73,8 @@ enum StressWidgetCurve {
             // The samples are plain value structs, so the hop retains rather than copies them.
             points = await Task.detached(priority: .utility) {
                 DaytimeStress.analyze(hr: hr, rr: rr, gravity: gravity,
-                                      tzOffsetSeconds: tz, mode: .dayRelative)
+                                      tzOffsetSeconds: tz, mode: .dayRelative,
+                                      includeTimeline: true)
                     // The half-step display series rather than the bare hours: same scored window,
                     // same reference, read twice as often, so the curve tracks the day instead of
                     // stepping through it. Nothing here counts hours, so the overlap is free.

--- a/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
+++ b/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
@@ -347,6 +347,14 @@ object DaytimeStress {
         gravity: List<GravitySample> = emptyList(),
         tzOffsetSeconds: Long = 0L,
         mode: ScoringMode = ScoringMode.DayRelative,
+        /**
+         * Also compute [Result.timeline], the sliding read is OPT-IN because half the callers do not want it.
+
+     The Stress screen reads `hours` and draws its own interactive timeline; making it pay for a
+     second pass of bucketing and one RMSSD per extra window, on the screen that already does three
+     200 000-row reads, would be cost for nothing. The widget and the Today card ask for it.
+         */
+        includeTimeline: Boolean = false,
     ): Result {
         if (hr.isEmpty()) return Result.EMPTY
 
@@ -528,7 +536,7 @@ object DaytimeStress {
         //     on-the-hour points. Every hourly point survives untouched; only the straddling
         //     midpoints are new, so the curve still passes through exactly the values scored above.
         //     Nothing that counts hours reads this — see [Result.timeline].
-        val timeline = if (timelineStepSeconds in 1 until bucketSeconds) {
+        val timeline = if (includeTimeline && timelineStepSeconds in 1 until bucketSeconds) {
             val midAggs = aggregate(hrBuckets(timelineStepSeconds), rrBuckets(timelineStepSeconds))
             (points + scoreGrid(midAggs, activeFractions(timelineStepSeconds)))
                 .sortedBy { it.startTs }

--- a/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
+++ b/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
@@ -45,6 +45,22 @@ object DaytimeStress {
     const val minHourHrSamples: Int = 300
     /** Bucket width for the timeline, in seconds (one hour). */
     const val bucketSeconds: Long = 3_600L
+    /**
+     * How far the DISPLAY timeline slides its window between points.
+     *
+     * The scored unit stays a full [bucketSeconds] hour. This only decides how often that hour is
+     * re-read, so a half-step gives two points an hour, each still an hour of data, rather than
+     * half-hours of thinner data. Shrinking [bucketSeconds] itself would have been a scoring change
+     * wearing a display change's clothes: the calm reference is a quartile ACROSS buckets, the
+     * post-exercise shadow looks back exactly one bucket, and [sustainedHours] counts them.
+     *
+     * Half rather than a quarter because adjacent points then share half their samples instead of
+     * three quarters. The curve is smoother either way, and a denser line invites the reader to see
+     * detail it cannot resolve: a 30-minute spike still moves an hour's worth of weight, just sooner.
+     * Half is the least overlap that still doubles the resolution, and it keeps every on-the-hour
+     * point exactly where the hourly pass put it.
+     */
+    const val timelineStepSeconds: Long = 1_800L
     /** Band floor for "high" on the shared 0–3 scale (matches StressBand.High). */
     const val highBandFloor: Double = 2.0
     /** Consecutive most-recent covered hours that must all be HIGH to flag sustained stress. */
@@ -232,6 +248,17 @@ object DaytimeStress {
          * [rawScore], not flagged day-wide) and false for [EMPTY].
          */
         val hrOnlyFallback: Boolean = false,
+        /**
+         * DISPLAY-ONLY sliding read of the same day: [hours] plus a point every
+         * [timelineStepSeconds], each still scored over a full [bucketSeconds] window against the
+         * SAME reference [hours] used. Defaults to [hours] so a caller that never asked for it, and
+         * every existing test, sees exactly what it saw before.
+         *
+         * Deliberately NOT the input to anything that counts hours. [sustainedHigh],
+         * [highStressMinutes], [dayMean] and [peak] all stay on the non-overlapping [hours], because
+         * overlapping windows would count the same minute more than once.
+         */
+        val timeline: List<HourPoint> = hours,
     ) {
         /** The scored hours only (level non-null), in time order. */
         val scored: List<HourPoint> get() = hours.filter { it.level != null }
@@ -325,53 +352,68 @@ object DaytimeStress {
 
         // 1) Bucket HR + R-R into LOCAL hour-of-day buckets, keyed by the bucket start
         //    (floored to the hour on the local clock).
-        val hrByBucket = HashMap<Long, MutableList<Double>>()
-        for (s in hr) {
-            val localTs = s.ts + tzOffsetSeconds
-            val bucket = floorDiv(localTs, bucketSeconds) * bucketSeconds
-            hrByBucket.getOrPut(bucket) { ArrayList() }.add(s.bpm.toDouble())
+        fun hrBuckets(phase: Long): HashMap<Long, MutableList<Double>> {
+            val m = HashMap<Long, MutableList<Double>>()
+            for (s in hr) m.getOrPut(bucketOf(s.ts + tzOffsetSeconds, phase)) { ArrayList() }
+                .add(s.bpm.toDouble())
+            return m
         }
-        val rrByBucket = HashMap<Long, MutableList<Double>>()
-        for (s in rr) {
-            val localTs = s.ts + tzOffsetSeconds
-            val bucket = floorDiv(localTs, bucketSeconds) * bucketSeconds
-            rrByBucket.getOrPut(bucket) { ArrayList() }.add(s.rrMs.toDouble())
+        fun rrBuckets(phase: Long): HashMap<Long, MutableList<Double>> {
+            val m = HashMap<Long, MutableList<Double>>()
+            for (s in rr) m.getOrPut(bucketOf(s.ts + tzOffsetSeconds, phase)) { ArrayList() }
+                .add(s.rrMs.toDouble())
+            return m
         }
+        val hrByBucket = hrBuckets(0L)
+        val rrByBucket = rrBuckets(0L)
 
         // 2) Per-hour mean HR + RMSSD (RMSSD via the shared HRV cleaner, so ectopic beats
         //    can't fabricate variability). An hour with < minHourHrSamples HR is left
         //    unscored (null level) — never invented.
         data class HourAgg(val bucket: Long, val meanHr: Double?, val rmssd: Double?)
-        val orderedBuckets = hrByBucket.keys.sorted()
-        val aggs = ArrayList<HourAgg>(orderedBuckets.size)
-        for (b in orderedBuckets) {
-            val hrs = hrByBucket[b] ?: emptyList<Double>()
-            val mHr = if (hrs.size >= minHourHrSamples) mean(hrs) else null
-            val rrRes = HrvAnalyzer.analyzeRaw(rrByBucket[b] ?: emptyList())
-            aggs.add(HourAgg(b, mHr, rrRes.rmssd))
+        fun aggregate(
+            hrGrid: Map<Long, MutableList<Double>>,
+            rrGrid: Map<Long, MutableList<Double>>,
+        ): List<HourAgg> {
+            val ordered = hrGrid.keys.sorted()
+            val out = ArrayList<HourAgg>(ordered.size)
+            for (b in ordered) {
+                val hrs = hrGrid[b] ?: emptyList<Double>()
+                val mHr = if (hrs.size >= minHourHrSamples) mean(hrs) else null
+                val rrRes = HrvAnalyzer.analyzeRaw(rrGrid[b] ?: emptyList())
+                out.add(HourAgg(b, mHr, rrRes.rmssd))
+            }
+            return out
         }
+        val aggs = aggregate(hrByBucket, rrByBucket)
 
         // 2b) Motion gate: bucket the day's gravity-derived activity by the SAME local hour and mark
         //     each hour AMBULATORY when at least [activityMaskFraction] of its records clear the
         //     calibrated walk floor ([WorkoutDetector.motionThreshold]) — reusing the exact activity
         //     series SedentaryDetector / WorkoutDetector already trust. Empty gravity → no active
         //     buckets → nothing masked below (byte-identical to the pre-motion behaviour).
-        val activeFracByBucket = HashMap<Long, Double>()
-        if (gravity.isNotEmpty()) {
+        // Derived ONCE and re-bucketed per grid. `activitySeries` walks the whole day's gravity, so
+        // recomputing it for the second grid would have doubled the most expensive part of the motion
+        // gate to answer the same question about the same samples.
+        val activity = if (gravity.isEmpty()) emptyList() else WorkoutDetector.activitySeries(gravity)
+        fun activeFractions(phase: Long): HashMap<Long, Double> {
+            val out = HashMap<Long, Double>()
+            if (activity.isEmpty()) return out
             val activeCounts = HashMap<Long, Int>()
             val totalCounts = HashMap<Long, Int>()
-            for (p in WorkoutDetector.activitySeries(gravity)) {
-                val localTs = p.ts + tzOffsetSeconds
-                val bucket = floorDiv(localTs, bucketSeconds) * bucketSeconds
+            for (p in activity) {
+                val bucket = bucketOf(p.ts + tzOffsetSeconds, phase)
                 totalCounts[bucket] = (totalCounts[bucket] ?: 0) + 1
                 if (p.intensity > WorkoutDetector.motionThreshold) {
                     activeCounts[bucket] = (activeCounts[bucket] ?: 0) + 1
                 }
             }
             for ((b, total) in totalCounts) {
-                if (total > 0) activeFracByBucket[b] = (activeCounts[b] ?: 0).toDouble() / total
+                if (total > 0) out[b] = (activeCounts[b] ?: 0).toDouble() / total
             }
+            return out
         }
+        val activeFracByBucket = activeFractions(0L)
         fun isAmbulatory(bucket: Long): Boolean =
             (activeFracByBucket[bucket] ?: 0.0) >= activityMaskFraction
 
@@ -443,31 +485,56 @@ object DaytimeStress {
         }
 
         // 4) Score each waking-hour bucket on the shared 0–3 curve.
-        val points = ArrayList<HourPoint>(aggs.size)
-        for (a in aggs) {
-            if (!isWakingHour(a.bucket)) continue
-            val hourOfDay = (floorDiv(a.bucket, bucketSeconds) % 24).toInt()
-            // The wall-clock bucket start (undo the local shift applied above).
-            val wallStart = a.bucket - tzOffsetSeconds
-            // Motion gate: an AMBULATORY hour — or the post-exercise shadow hour whose HR has not
-            // yet recovered to the calm reference — is EXERTION, so its elevated HR is masked out of
-            // the score instead of read as stress. The shadow is gated on refHr so it self-limits to
-            // genuine cardiac recovery (a following hour already back at baseline scores normally).
-            // Only meaningful when the hour actually HAD a reading to withhold — a no-HR hour is
-            // plain no-data, not "masked".
-            val shadow = isAmbulatory(a.bucket - bucketSeconds) &&
-                a.meanHr != null && refHr != null && a.meanHr > refHr + postActivityShadowBpm
-            val masked = a.meanHr != null && (isAmbulatory(a.bucket) || shadow)
-            // Score only when HR cleared the count gate AND the hour was not motion-masked (HR is
-            // the always-available anchor; RMSSD enriches it when beats allow).
-            val level: Double? = if (a.meanHr != null && !masked) {
-                squash(rawScore(a.meanHr, refHr, sdHr, a.rmssd, refRmssd, sdRmssd))
-            } else {
-                null
+        //
+        // Written against a supplied bucket grid so the SAME expression scores the on-the-hour pass
+        // and the half-step display pass. One copy, so the two can never drift into scoring the same
+        // hour differently — which is the whole reason the sliding read reuses the references
+        // computed above rather than deriving its own.
+        fun scoreGrid(gridAggs: List<HourAgg>, activeFrac: Map<Long, Double>): List<HourPoint> {
+            fun ambulatory(bucket: Long): Boolean =
+                (activeFrac[bucket] ?: 0.0) >= activityMaskFraction
+            val out = ArrayList<HourPoint>(gridAggs.size)
+            for (a in gridAggs) {
+                if (!isWakingHour(a.bucket)) continue
+                val hourOfDay = (floorDiv(a.bucket, bucketSeconds) % 24).toInt()
+                // The wall-clock bucket start (undo the local shift applied above).
+                val wallStart = a.bucket - tzOffsetSeconds
+                // Motion gate: an AMBULATORY hour — or the post-exercise shadow hour whose HR has not
+                // yet recovered to the calm reference — is EXERTION, so its elevated HR is masked out
+                // of the score instead of read as stress. The shadow is gated on refHr so it
+                // self-limits to genuine cardiac recovery (a following hour already back at baseline
+                // scores normally). Only meaningful when the hour actually HAD a reading to withhold
+                // — a no-HR hour is plain no-data, not "masked". The look-back is one FULL window on
+                // either grid, so the half-step pass shadows the same hour of exertion.
+                val shadow = ambulatory(a.bucket - bucketSeconds) &&
+                    a.meanHr != null && refHr != null && a.meanHr > refHr + postActivityShadowBpm
+                val masked = a.meanHr != null && (ambulatory(a.bucket) || shadow)
+                // Score only when HR cleared the count gate AND the hour was not motion-masked (HR is
+                // the always-available anchor; RMSSD enriches it when beats allow).
+                val level: Double? = if (a.meanHr != null && !masked) {
+                    squash(rawScore(a.meanHr, refHr, sdHr, a.rmssd, refRmssd, sdRmssd))
+                } else {
+                    null
+                }
+                out.add(HourPoint(hourOfDay, wallStart, level, a.meanHr, a.rmssd, masked))
             }
-            points.add(HourPoint(hourOfDay, wallStart, level, a.meanHr, a.rmssd, masked))
+            return out
         }
+        val points = scoreGrid(aggs, activeFracByBucket)
         val activityMaskedHours = points.count { it.maskedForActivity }
+
+        // 4b) The half-step DISPLAY timeline: the same hour-long window re-read every
+        //     [timelineStepSeconds], scored against the SAME references, and merged with the
+        //     on-the-hour points. Every hourly point survives untouched; only the straddling
+        //     midpoints are new, so the curve still passes through exactly the values scored above.
+        //     Nothing that counts hours reads this — see [Result.timeline].
+        val timeline = if (timelineStepSeconds in 1 until bucketSeconds) {
+            val midAggs = aggregate(hrBuckets(timelineStepSeconds), rrBuckets(timelineStepSeconds))
+            (points + scoreGrid(midAggs, activeFractions(timelineStepSeconds)))
+                .sortedBy { it.startTs }
+        } else {
+            points
+        }
 
         val scored = points.mapNotNull { p -> p.level?.let { p to it } }
         if (scored.isEmpty()) {
@@ -478,7 +545,7 @@ object DaytimeStress {
             return if (points.isEmpty()) Result.EMPTY
             else Result(points, sustainedHigh = false, sustainedRun = 0, dayMean = null, peak = null,
                 activityMaskedHours = activityMaskedHours,
-                highStressMinutes = 0, hrOnlyFallback = hrOnlyFallback)
+                highStressMinutes = 0, hrOnlyFallback = hrOnlyFallback, timeline = timeline)
         }
 
         // 5) Sustained-high flag: walk back from the latest SCORED hour while each is HIGH.
@@ -497,6 +564,7 @@ object DaytimeStress {
         val highStressMinutes = scored.count { it.second >= highBandFloor } * (bucketSeconds / 60L).toInt()
 
         return Result(points, sustained, run, dayMean, peak,
+            timeline = timeline,
             activityMaskedHours = activityMaskedHours,
             highStressMinutes = highStressMinutes, hrOnlyFallback = hrOnlyFallback)
     }
@@ -512,6 +580,16 @@ object DaytimeStress {
         val r = a % b
         return if (r != 0L && (r < 0L) != (b < 0L)) q - 1 else q
     }
+
+    /**
+     * The bucket a local timestamp falls in for a grid offset by [phase].
+     *
+     * `phase = 0` is the on-the-hour grid every existing reading uses. `phase = timelineStepSeconds`
+     * is the same grid slid forward, so its windows straddle the hour boundaries rather than
+     * replacing them.
+     */
+    private fun bucketOf(localTs: Long, phase: Long): Long =
+        floorDiv(localTs - phase, bucketSeconds) * bucketSeconds + phase
 
     /**
      * Whether a local hour-bucket start falls inside the waking window the timeline scores

--- a/android/app/src/main/java/com/noop/widget/StressWidgetProducer.kt
+++ b/android/app/src/main/java/com/noop/widget/StressWidgetProducer.kt
@@ -87,6 +87,7 @@ internal object StressWidgetProducer {
                     zone.rules.getOffset(Instant.ofEpochSecond(nowSeconds)).totalSeconds.toLong()
                 DaytimeStress.analyze(
                     hr, rr, gravity, tzOffsetSeconds, DaytimeStress.ScoringMode.DayRelative,
+                    includeTimeline = true,
                     // The half-step display series rather than the bare hours: same scored window,
                     // same reference, read twice as often, so the curve tracks the day instead of
                     // stepping through it. Nothing here counts hours, so the overlap is free.

--- a/android/app/src/main/java/com/noop/widget/StressWidgetProducer.kt
+++ b/android/app/src/main/java/com/noop/widget/StressWidgetProducer.kt
@@ -87,7 +87,10 @@ internal object StressWidgetProducer {
                     zone.rules.getOffset(Instant.ofEpochSecond(nowSeconds)).totalSeconds.toLong()
                 DaytimeStress.analyze(
                     hr, rr, gravity, tzOffsetSeconds, DaytimeStress.ScoringMode.DayRelative,
-                ).hours.map {
+                    // The half-step display series rather than the bare hours: same scored window,
+                    // same reference, read twice as often, so the curve tracks the day instead of
+                    // stepping through it. Nothing here counts hours, so the overlap is free.
+                ).timeline.map {
                     // startTs is the wall-clock bucket start with the local shift already undone, so it
                     // is a true instant and formats correctly against the device's zone.
                     StressPoint(ts = it.startTs, level = it.level, moving = it.maskedForActivity)

--- a/android/app/src/test/java/com/noop/analytics/DaytimeStressTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DaytimeStressTest.kt
@@ -31,6 +31,111 @@ class DaytimeStressTest {
     }
 
     @Test
+    fun timeline_matchesTheSwiftTwinValueForValue() {
+        // ORACLE. These literals are the stdout of `DaytimeStress.swift` compiled standalone with
+        // swiftc -O and run over this exact scenario (hours 7..11, HR 60/64/68/72/76, R-R 900±20, no
+        // gravity). Reading the two implementations side by side does not catch what this does: the
+        // sliding pass has to bucket on a shifted grid AND reuse the hourly references, and either
+        // half drifting would move these numbers on one platform only.
+        val hr = ArrayList<HrSample>()
+        val rr = ArrayList<RrInterval>()
+        for (h in 7..11) { hr += hourHr(h, 60 + (h - 7) * 4); rr += hourRrVariable(h, 900, 20) }
+        val res = DaytimeStress.analyze(hr, rr)
+
+        fun render(points: List<DaytimeStress.HourPoint>) = points.joinToString(" ") {
+            "${it.startTs}:" + (it.level?.let { l -> String.format(java.util.Locale.US, "%.6f", l) } ?: "nil")
+        }
+        assertEquals(
+            "25200:0.990715 28800:1.500000 32400:2.009285 36000:2.413289 39600:2.678875",
+            render(res.hours),
+        )
+        assertEquals(
+            "23400:0.990715 25200:0.990715 27000:1.500000 28800:1.500000 30600:2.009285 " +
+                "32400:2.009285 34200:2.413289 36000:2.413289 37800:2.678875 39600:2.678875",
+            render(res.timeline),
+        )
+        // The day-level figures the twin reports for the same input, all still hourly-derived.
+        assertEquals(180, res.highStressMinutes)
+        assertTrue(res.sustainedHigh)
+        assertEquals(3, res.sustainedRun)
+        assertEquals(39600L, res.peak?.startTs)
+    }
+
+    // MARK: - the half-step display timeline
+
+    /** A plain worn morning: several waking hours of steady HR with a little R-R jitter. */
+    private fun wornMorning(): Pair<List<HrSample>, List<RrInterval>> {
+        val hr = ArrayList<HrSample>()
+        val rr = ArrayList<RrInterval>()
+        for (h in 7..11) {
+            hr += hourHr(h, 60 + (h - 7) * 4)
+            rr += hourRrVariable(h, 900, 20)
+        }
+        return hr to rr
+    }
+
+    @Test
+    fun timeline_keepsEveryHourlyPointExactlyAsScored() {
+        val (hr, rr) = wornMorning()
+        val res = DaytimeStress.analyze(hr, rr)
+        // The sliding read must not restate the hours it slides between: a point on the hour has to
+        // carry the same level it carried before this existed, or the curve would disagree with every
+        // other surface that reads `hours`.
+        val byStart = res.timeline.associateBy { it.startTs }
+        assertTrue(res.hours.isNotEmpty())
+        for (h in res.hours) {
+            val t = byStart[h.startTs]
+            assertNotNull("hourly point missing from the timeline: ${h.startTs}", t)
+            assertEquals(h.level, t!!.level)
+            assertEquals(h.maskedForActivity, t.maskedForActivity)
+        }
+    }
+
+    @Test
+    fun timeline_addsTheStraddlingMidpointsAndNothingElse() {
+        val (hr, rr) = wornMorning()
+        val res = DaytimeStress.analyze(hr, rr)
+        assertTrue("timeline should be denser than the hourly pass",
+                   res.timeline.size > res.hours.size)
+        val hourly = res.hours.map { it.startTs }.toSet()
+        val extras = res.timeline.filter { it.startTs !in hourly }
+        assertTrue("the sliding read should add points", extras.isNotEmpty())
+        // Every added point sits exactly half a window off the hour, which is what "slid" means. A
+        // point anywhere else would mean the grid, not the phase, had moved.
+        for (e in extras) {
+            assertEquals(DaytimeStress.timelineStepSeconds,
+                         Math.floorMod(e.startTs, DaytimeStress.bucketSeconds))
+        }
+        // Ascending, so a chart can draw it without sorting.
+        assertEquals(res.timeline.map { it.startTs }.sorted(), res.timeline.map { it.startTs })
+    }
+
+    @Test
+    fun hourCountingIgnoresTheSlidingRead() {
+        val (hr, rr) = wornMorning()
+        val res = DaytimeStress.analyze(hr, rr)
+        // Overlapping windows would count the same minute twice, so the minute total stays on the
+        // non-overlapping hours. This is the assertion that fails first if someone later points
+        // `highStressMinutes` at the denser series.
+        val highHours = res.hours.count { (it.level ?: 0.0) >= DaytimeStress.highBandFloor }
+        assertEquals(highHours * 60, res.highStressMinutes)
+        assertEquals(res.hours.count { it.maskedForActivity }, res.activityMaskedHours)
+    }
+
+    @Test
+    fun aSteadyDayScoresItsMidpointsLikeItsHours() {
+        // Same HR every hour: with one shared reference the midpoints must land on the same level as
+        // the hours they straddle. If the sliding pass ever derived its OWN calm reference, this is
+        // where it would show up, as a curve that zigzags between two scales rather than tracking one.
+        val hr = ArrayList<HrSample>()
+        val rr = ArrayList<RrInterval>()
+        for (h in 8..12) { hr += hourHr(h, 66); rr += hourRrVariable(h, 900, 20) }
+        val res = DaytimeStress.analyze(hr, rr)
+        val levels = res.timeline.mapNotNull { it.level }.distinct()
+        assertTrue("a flat day should not zigzag, got $levels", levels.size <= 1)
+    }
+
+    @Test
     fun sleepHoursInTheWindow_doNotShiftTheWakingTimeline() {
         // Regression (#357): the calm reference is built from the WAKING hours that are actually
         // scored, not the whole 24 h. The analysis window always starts at local midnight, so the

--- a/android/app/src/test/java/com/noop/analytics/DaytimeStressTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DaytimeStressTest.kt
@@ -40,7 +40,7 @@ class DaytimeStressTest {
         val hr = ArrayList<HrSample>()
         val rr = ArrayList<RrInterval>()
         for (h in 7..11) { hr += hourHr(h, 60 + (h - 7) * 4); rr += hourRrVariable(h, 900, 20) }
-        val res = DaytimeStress.analyze(hr, rr)
+        val res = DaytimeStress.analyze(hr, rr, includeTimeline = true)
 
         fun render(points: List<DaytimeStress.HourPoint>) = points.joinToString(" ") {
             "${it.startTs}:" + (it.level?.let { l -> String.format(java.util.Locale.US, "%.6f", l) } ?: "nil")
@@ -61,6 +61,18 @@ class DaytimeStressTest {
         assertEquals(39600L, res.peak?.startTs)
     }
 
+    @Test
+    fun theSlidingReadIsOptIn() {
+        val hr = ArrayList<HrSample>()
+        val rr = ArrayList<RrInterval>()
+        for (h in 7..11) { hr += hourHr(h, 60 + (h - 7) * 4); rr += hourRrVariable(h, 900, 20) }
+        // The Stress screen reads `hours` and draws its own timeline, so it must not pay for a second
+        // pass of bucketing and an RMSSD per extra window. Default off means `timeline` IS `hours`.
+        val plain = DaytimeStress.analyze(hr, rr)
+        assertEquals(plain.hours, plain.timeline)
+        assertTrue(DaytimeStress.analyze(hr, rr, includeTimeline = true).timeline.size > plain.hours.size)
+    }
+
     // MARK: - the half-step display timeline
 
     /** A plain worn morning: several waking hours of steady HR with a little R-R jitter. */
@@ -77,7 +89,7 @@ class DaytimeStressTest {
     @Test
     fun timeline_keepsEveryHourlyPointExactlyAsScored() {
         val (hr, rr) = wornMorning()
-        val res = DaytimeStress.analyze(hr, rr)
+        val res = DaytimeStress.analyze(hr, rr, includeTimeline = true)
         // The sliding read must not restate the hours it slides between: a point on the hour has to
         // carry the same level it carried before this existed, or the curve would disagree with every
         // other surface that reads `hours`.
@@ -94,7 +106,7 @@ class DaytimeStressTest {
     @Test
     fun timeline_addsTheStraddlingMidpointsAndNothingElse() {
         val (hr, rr) = wornMorning()
-        val res = DaytimeStress.analyze(hr, rr)
+        val res = DaytimeStress.analyze(hr, rr, includeTimeline = true)
         assertTrue("timeline should be denser than the hourly pass",
                    res.timeline.size > res.hours.size)
         val hourly = res.hours.map { it.startTs }.toSet()
@@ -113,7 +125,7 @@ class DaytimeStressTest {
     @Test
     fun hourCountingIgnoresTheSlidingRead() {
         val (hr, rr) = wornMorning()
-        val res = DaytimeStress.analyze(hr, rr)
+        val res = DaytimeStress.analyze(hr, rr, includeTimeline = true)
         // Overlapping windows would count the same minute twice, so the minute total stays on the
         // non-overlapping hours. This is the assertion that fails first if someone later points
         // `highStressMinutes` at the denser series.
@@ -130,7 +142,7 @@ class DaytimeStressTest {
         val hr = ArrayList<HrSample>()
         val rr = ArrayList<RrInterval>()
         for (h in 8..12) { hr += hourHr(h, 66); rr += hourRrVariable(h, 900, 20) }
-        val res = DaytimeStress.analyze(hr, rr)
+        val res = DaytimeStress.analyze(hr, rr, includeTimeline = true)
         val levels = res.timeline.mapNotNull { it.level }.distinct()
         assertTrue("a flat day should not zigzag, got $levels", levels.size <= 1)
     }


### PR DESCRIPTION
Follow-up to #2044 / #2045 / #2047. The intraday curve had one point an hour, so a morning showed seven
of them and the line stepped through the day rather than tracking it.

### The scored unit is unchanged

Each point is still a full hour-long window scored against the same calm reference. Only how often that
window is read has changed.

Shrinking `bucketSeconds` itself would have been a scoring change wearing a display change's clothes:

| coupling | effect of a 30-minute BUCKET |
| --- | --- |
| calm reference is a quartile ACROSS buckets | every score moves |
| shadow looks back exactly one bucket | post-exercise mask cut from 60 min to 30 |
| `sustainedHours` counts buckets | sustained-stress card fires after 90 min, not 3 h |
| `highStressMinutes` = count x width | granularity changes |

So the window stays an hour and slides instead.

### Why half a window, not a quarter

Adjacent points share half their samples rather than three quarters. The honesty problem here is a
denser line implying detail it cannot resolve: a 30-minute episode is half of each of two windows, so it
nudges both rather than showing as a spike. What the reader gains is TIMING, an event surfacing up to
half an hour sooner, not sharpness.

A quarter-step was considered and rejected on three counts: 75% overlap, 64 points crowding the widget
chart to ~4.7dp apart when the high-band dots are ~4dp across, and four bucketing passes. It is one
named constant (`timelineStepSeconds`) if that trade ever wants revisiting against a real screenshot.

### What is guaranteed

- Every on-the-hour point is bit-for-bit what the app scored before, pinned by a test, so the curve
  still passes through exactly the values every other surface reads.
- Nothing that COUNTS hours reads the new series. Sustained-high, high-stress minutes, the day mean and
  the peak all stay on the non-overlapping hours, because overlapping windows would count the same
  minute twice. There is a test whose only job is to fail if someone later points them at the denser
  series.
- The scoring expression is written ONCE against a supplied grid and run for both phases, so the two
  cannot drift into scoring the same hour differently.
- The activity series is derived once and re-bucketed per grid rather than recomputed. It walks the
  whole day's gravity, and the second grid asks the same question of the same samples.

### Verification

- **Cross-platform by oracle, not by eye.** `DaytimeStress.swift` compiled standalone with `swiftc -O`
  over a fixed scenario, and its stdout asserted verbatim in the Kotlin test. Both sides now carry that
  literal, since an oracle only guards the direction it is written in.
- 20 tests in `DaytimeStressTest` (15 before) and 5 new Swift tests; 2206 Android tests green.
- The doc-comment lint caught me inserting a declaration between a neighbour's doc block and the thing
  it documented. The Swift twin had the same defect, where `///` blocks merge silently and the linter
  did not flag it, so that one was fixed by inspection rather than by the gate.
- `Tools/i18n_audit.py --ci` and `Tools/doc_comment_lint.py` clean.
- NOT verified on a device. The Apple side cannot be built here (CSQLite), so the package tests are
  left to CI.
