### PR TITLE
Name the hosted stress card for what it is

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HostedCards.kt
+++ b/android/app/src/main/java/com/noop/ui/HostedCards.kt
@@ -74,7 +74,7 @@ enum class HostedCard(
      *  card hosted from a tab other than Sleep, so [localizedOrigin] gains a branch for it. Read-only,
      *  like the hosted Stages card: the Stress tab keeps the interactive timeline with its scrubbing and
      *  tooltips, and the Today host mirrors only the display. */
-    STRESS_TODAY("stress.today", "Stress", "Stress", Icons.Filled.ShowChart);
+    STRESS_TODAY("stress.today", "Stress through the day", "Stress", Icons.Filled.ShowChart);
 
     companion object {
         fun fromRaw(raw: String?): HostedCard? = entries.firstOrNull { it.raw == raw }
@@ -103,7 +103,7 @@ fun HostedCard.localizedTitle(): String = when (this) {
     HostedCard.STAGES -> stringResource(R.string.l10n_sleep_screen_stages_c1d33ad5)
     HostedCard.HOURS_VS_NEEDED -> stringResource(R.string.l10n_sleep_screen_hours_vs_needed_500a0aca)
     HostedCard.CONSISTENCY -> stringResource(R.string.l10n_sleep_screen_consistency_0ea7b95e)
-    HostedCard.STRESS_TODAY -> stringResource(R.string.l10n_stress_screen_stress_bad33342)
+    HostedCard.STRESS_TODAY -> stringResource(R.string.hosted_card_stress_title)
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -613,7 +613,10 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
     NoopCard(tint = Palette.stressColor, modifier = modifier) {
         Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Overline(uiString(R.string.l10n_stress_screen_stress_bad33342), modifier = Modifier.weight(1f))
+                // The SAME title the Customise list offers, so what you added and what appears are
+                // recognisably one thing. "Stress" alone collided with the pinned Your Cards tile,
+                // which shows a number rather than this curve.
+                Overline(uiString(R.string.hosted_card_stress_title), modifier = Modifier.weight(1f))
                 if (stats != null) {
                     val peakTenths = ((stats.peak.level ?: 0.0) * 10).roundToInt().coerceIn(0, 30)
                     Text(

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2757,6 +2757,7 @@
     <string name="widget_hr_name">NOOP Herzfrequenz</string>
     <string name="widget_hr_description">Live-Herzfrequenz mit den letzten drei Stunden als Verlauf.</string>
     <string name="widget_stress_name">NOOP Stress</string>
+    <string name="hosted_card_stress_title">Stress im Tagesverlauf</string>
     <string name="widget_stress_description">Der heutige Stress als Stundenverlauf.</string>
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Ladungs-Trend ansehen</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Jeder Tageswert im Zeitverlauf.</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2744,6 +2744,7 @@
     <string name="widget_hr_name">NOOP Frecuencia cardíaca</string>
     <string name="widget_hr_description">Frecuencia cardíaca en directo con las últimas tres horas como gráfico.</string>
     <string name="widget_stress_name">NOOP Estrés</string>
+    <string name="hosted_card_stress_title">Estrés a lo largo del día</string>
     <string name="widget_stress_description">El estrés de hoy como una curva hora a hora.</string>
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Ver la tendencia de Carga</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">La puntuación de cada día, a lo largo del tiempo.</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2743,6 +2743,7 @@
     <string name="widget_hr_name">NOOP Fréquence cardiaque</string>
     <string name="widget_hr_description">Fréquence cardiaque en direct avec les trois dernières heures en courbe.</string>
     <string name="widget_stress_name">NOOP Stress</string>
+    <string name="hosted_card_stress_title">Stress au fil de la journée</string>
     <string name="widget_stress_description">Le stress du jour en courbe, heure par heure.</string>
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Voir la tendance de la charge</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Le score de chaque jour, dans la durée.</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2748,6 +2748,7 @@
     <string name="widget_hr_name">NOOP Tętno</string>
     <string name="widget_hr_description">Tętno na żywo z ostatnimi trzema godzinami jako wykres.</string>
     <string name="widget_stress_name">NOOP Stres</string>
+    <string name="hosted_card_stress_title">Stres w ciągu dnia</string>
     <string name="widget_stress_description">Dzisiejszy stres jako wykres godzina po godzinie.</string>
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Zobacz trend Energii</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Wynik każdego dnia w czasie.</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2736,6 +2736,7 @@
     <string name="widget_hr_name">NOOP Frequência cardíaca</string>
     <string name="widget_hr_description">Frequência cardíaca em direto com as últimas três horas em gráfico.</string>
     <string name="widget_stress_name">NOOP Stress</string>
+    <string name="hosted_card_stress_title">Stress ao longo do dia</string>
     <string name="widget_stress_description">O stress de hoje como uma curva hora a hora.</string>
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Ver a tendência da Carga</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">A pontuação de cada dia, ao longo do tempo.</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -2627,6 +2627,7 @@
     <string name="widget_hr_name">NOOP Пульс</string>
     <string name="widget_hr_description">Пульс в реальном времени и график за последние три часа.</string>
     <string name="widget_stress_name">NOOP Стресс</string>
+    <string name="hosted_card_stress_title">Стресс в течение дня</string>
     <string name="widget_stress_description">Сегодняшний стресс в виде почасового графика.</string>
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Посмотреть динамику Заряда</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Оценка за каждый день во времени.</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2657,6 +2657,7 @@
     <string name="widget_hr_name">NOOP 心率</string>
     <string name="widget_hr_description">实时心率，并显示最近三小时的曲线。</string>
     <string name="widget_stress_name">NOOP 压力</string>
+    <string name="hosted_card_stress_title">全天压力变化</string>
     <string name="widget_stress_description">以逐小时曲线显示今天的压力。</string>
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">查看充能趋势</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">每天的分数，随时间变化。</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="widget_hr_name">NOOP Heart Rate</string>
     <string name="widget_hr_description">Live heart rate with the last three hours as a trace.</string>
     <string name="widget_stress_name">NOOP Stress</string>
+    <string name="hosted_card_stress_title">Stress through the day</string>
     <string name="widget_stress_description">Today\'s stress as an hour-by-hour curve.</string>
     <string name="widget_compact_name">NOOP Compact</string>
     <string name="widget_compact_description">Compact Rest, Charge and Effort widget, with live heart rate and strap battery.</string>


### PR DESCRIPTION
Name the hosted stress card for what it is

Customise has two lists. "Your Cards" holds the compact pinned tiles, one of which is a Stress tile
showing a single 0-3 number. "Added Cards" holds full-width cards hosted from another tab, and that is
where the curve lives.

Both offered an entry called "Stress". Someone looking for the graph found the tile, which is the
number they already had, and reasonably concluded the graph had not shipped. That is exactly what
happened on the 478 testing build.

The hosted card is now "Stress through the day", which is what the Stress tab's own card header calls
it, and the card's header uses the same string so what you added and what appears are recognisably one
thing. Translated in all eight locale directories.

Verified: compileFullDebugKotlin, HostedCardPrefsTest, lintVitalFullRelease, the i18n gate and the doc-comment lint all clean.