### PR TITLE
Android: keep workout actions readable over the daytime scene

### DIFF
--- a/android/app/src/main/java/com/noop/ui/WorkoutStart.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutStart.kt
@@ -265,25 +265,19 @@ fun WorkoutStartSection(vm: AppViewModel, onAdd: () -> Unit) {
         }
     } else if (live.bonded) {
         // Start + Add as an equal-width action row (EXP-018 parity with the iOS workoutActionRow).
-        //
-        // #1602: CENTRED, not top-aligned. A Row defaults to `Alignment.Top`, so any height difference
-        // between the two children showed as one button riding higher than the other — which is how this
-        // was reported. The heights are now matched in `AddWorkoutButton`, so this is belt-and-braces:
-        // it keeps a future divergence looking like a size difference rather than a broken layout.
-        // SwiftUI's HStack centres by default, which is why the iOS twin never showed it.
+        // Both actions use the shared opaque button surfaces: unlike the old accent-muted/translucent
+        // pair, their fills and labels keep their contrast over the full-bleed daytime scene (#1625).
         Row(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth(),
         ) {
-            Button(
+            NoopButton(
+                text = uiString(R.string.l10n_workout_start_start_workout_d0f3f2cd),
+                kind = NoopButtonKind.Primary,
                 onClick = { showSportPicker = true },
                 modifier = Modifier.weight(1f),
-                contentPadding = PaddingValues(horizontal = 10.dp, vertical = 10.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = Palette.accent, contentColor = Palette.surfaceBase,
-                ),
-            ) { Text(uiString(R.string.l10n_workout_start_start_workout_d0f3f2cd), style = NoopType.captionNumber) }
+            )
             AddWorkoutButton(onAdd, Modifier.weight(1f))
         }
     } else {

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -110,8 +110,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Size
@@ -438,50 +436,16 @@ private fun PostLogNoteBanner(text: String) {
     }
 }
 
-/**
- * The "Add workout" pill — opens the manual add dialog. Shown on both the populated screen
- * (in the range bar) and the empty state, so a user with no imports can still log a session.
- *
- * #1602: this sits beside a Material3 [Button] in the Workouts action row, and the two are built by
- * different mechanisms — so their metrics have to be matched deliberately or they drift. A `Button`
- * carries `defaultMinSize(minHeight = ButtonDefaults.MinHeight)`; a bare `Row` has no minimum at all,
- * so its height was whatever the content happened to be plus its padding, and the pair rendered at
- * different heights with different label sizes.
- *
- * Both are pinned here: the same minimum height as a `Button`, and the same [NoopType.captionNumber]
- * the Start button uses. iOS has never had this because both of its buttons come from ONE primitive
- * (`NoopButton`, differing only by `kind`) — the real fix is an Android equivalent, and until that
- * exists this is the seam that has to be held by hand.
- */
+/** The secondary workout action, kept on an opaque design-system surface so the daytime scene
+ * cannot wash out its fill or label (#1625). */
 @Composable
 internal fun AddWorkoutButton(onAdd: () -> Unit, modifier: Modifier = Modifier) {
-    Row(
+    NoopButton(
+        text = uiString(R.string.l10n_workouts_screen_add_workout_a196a2cc),
+        leadingIcon = Icons.Filled.Add,
+        kind = NoopButtonKind.Secondary,
         modifier = modifier
-            // Material's constant, not a NOOP token: the goal is not "be 40.dp", it is "be whatever the
-            // Button beside me is". Android has no control-height token to reach for (iOS keeps one,
-            // `NoopMetrics.controlHeight` = 48), and minting one at today's value would match by
-            // coincidence and drift the moment Material changed its default.
-            .defaultMinSize(minHeight = ButtonDefaults.MinHeight)
-            .clip(RoundedCornerShape(50))
-            .background(Palette.accentMuted)
-            .clickable(onClick = onAdd)
-            // 10.dp matches the Start button's contentPadding; this used to carry 14.dp. Invisible in
-            // English — width is fixed by `weight(1f)` — but this button already gives up 22.dp to an
-            // icon and spacer that Start has not, and the long translations are comparable in length
-            // ("Ajouter un entraînement" against "Démarrer l'entraînement"), so the extra 8.dp only
-            // decided which label ellipsized first.
-            .padding(horizontal = 10.dp, vertical = 10.dp),
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Icon(Icons.Filled.Add, contentDescription = null, tint = Palette.accent, modifier = Modifier.size(16.dp))
-        Spacer(Modifier.width(6.dp))
-        Text(
-            uiString(R.string.l10n_workouts_screen_add_workout_a196a2cc),
-            style = NoopType.captionNumber,
-            color = Palette.accent,
-        )
-    }
+    ) { onAdd() }
 }
 
 // MARK: - Range control


### PR DESCRIPTION
## What this PR does

Replaces the Workouts screen's mixed Material/hand-built action buttons with the shared `NoopButton` primary and secondary variants. Their opaque design-system surfaces and explicit foreground colours keep both actions legible over the full-bleed daytime sky, while preserving the equal-width primary/secondary hierarchy.

The shared component also keeps the two controls on the same 48 dp geometry instead of manually matching a Material button to a custom row.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- `./gradlew compileFullDebugKotlin`
- `./gradlew assembleFullDebug testFullDebugUnitTest`
- `python3 Tools/i18n_audit.py --ci upstream/main`
- `python3 Tools/doc_comment_lint.py`
- `git diff --check`

No Android device or emulator was connected, so the change was not visually exercised on-device. The affected variants use the existing opaque `NoopButton` surfaces; no new colours or geometry were introduced.

## Checklist

- [x] Swift package tests pass for any package I touched (`swift test` in `Packages/<name>`) — not applicable; no Swift package changed
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens — no hardcoded colors, fonts, or spacing
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Relates to #1625
