### PR TITLE
Offer the Trends charts as Today cards

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HostedCards.kt
+++ b/android/app/src/main/java/com/noop/ui/HostedCards.kt
@@ -7,6 +7,9 @@ import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.ShowChart
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.StackedBarChart
@@ -74,7 +77,16 @@ enum class HostedCard(
      *  card hosted from a tab other than Sleep, so [localizedOrigin] gains a branch for it. Read-only,
      *  like the hosted Stages card: the Stress tab keeps the interactive timeline with its scrubbing and
      *  tooltips, and the Today host mirrors only the display. */
-    STRESS_TODAY("stress.today", "Stress through the day", "Stress", Icons.Filled.ShowChart);
+    STRESS_TODAY("stress.today", "Stress through the day", "Stress", Icons.Filled.ShowChart),
+    /** Trends tab · "HRV" — the trailing-month HRV trend (#today-hosted-cards). The first of the
+     *  Trends-origin cards, all three of which render the SAME `MetricTrendCard` the Trends tab draws,
+     *  parameterised by which `DailyMetric` field they read. */
+    TREND_HRV("trends.hrv", "HRV", "Trends", Icons.Filled.MonitorHeart),
+    /** Trends tab · "Resting heart rate" — the trailing-month resting-HR trend. */
+    TREND_RESTING_HR("trends.restingHr", "Resting heart rate", "Trends", Icons.Filled.Favorite),
+    /** Trends tab · "Effort" — the trailing-month Effort trend, displayed on the wearer's chosen
+     *  Effort scale exactly as the Trends tab shows it (#268). */
+    TREND_EFFORT("trends.effort", "Effort", "Trends", Icons.Filled.Bolt);
 
     companion object {
         fun fromRaw(raw: String?): HostedCard? = entries.firstOrNull { it.raw == raw }
@@ -104,6 +116,11 @@ fun HostedCard.localizedTitle(): String = when (this) {
     HostedCard.HOURS_VS_NEEDED -> stringResource(R.string.l10n_sleep_screen_hours_vs_needed_500a0aca)
     HostedCard.CONSISTENCY -> stringResource(R.string.l10n_sleep_screen_consistency_0ea7b95e)
     HostedCard.STRESS_TODAY -> stringResource(R.string.hosted_card_stress_title)
+    // The SAME titles the Trends tab gives these charts, so a hosted card is recognisably the card it
+    // came from rather than a second name for the same thing.
+    HostedCard.TREND_HRV -> stringResource(R.string.trends_hrv_full)
+    HostedCard.TREND_RESTING_HR -> stringResource(R.string.trends_resting_hr_full)
+    HostedCard.TREND_EFFORT -> stringResource(R.string.trends_effort)
 }
 
 /**

--- a/android/app/src/main/java/com/noop/ui/HostedCards.kt
+++ b/android/app/src/main/java/com/noop/ui/HostedCards.kt
@@ -100,6 +100,40 @@ enum class HostedCard(
 }
 
 /**
+ * Where tapping a hosted card sends you.
+ *
+ * DATA rather than a callback, because a callback cannot live on an enum and a mapping that lives
+ * inside the composable that draws it is unreachable from any test. The failure it guards is silent: a
+ * card wired to the wrong destination still renders, still taps, and simply lands somewhere else.
+ *
+ * Twin of the Swift `HostedCard.route`.
+ */
+sealed interface HostedDestination {
+    /** Opens nothing. The tap-to-log card, whose buttons ARE its purpose. */
+    object None : HostedDestination
+    object Sleep : HostedDestination
+    object Stress : HostedDestination
+    /** A metric's own detail page, the destination the Charge and Effort key tiles already use. */
+    data class Metric(val key: String) : HostedDestination
+}
+
+/**
+ * Where each card goes. Listed rather than defaulted, so a card added later cannot silently inherit
+ * "opens Sleep": the compiler asks where the new one goes.
+ */
+val HostedCard.destination: HostedDestination
+    get() = when (this) {
+        HostedCard.SLEEP_MARKS -> HostedDestination.None
+        HostedCard.STRESS_TODAY -> HostedDestination.Stress
+        HostedCard.TREND_HRV -> HostedDestination.Metric("hrv")
+        HostedCard.TREND_RESTING_HR -> HostedDestination.Metric("rhr")
+        HostedCard.TREND_EFFORT -> HostedDestination.Metric("strain")
+        HostedCard.ASLEEP_DURATION, HostedCard.STAGES_VS_TYPICAL, HostedCard.NIGHT_DETAIL,
+        HostedCard.SLEEP_DEBT, HostedCard.STAGES, HostedCard.HOURS_VS_NEEDED,
+        HostedCard.CONSISTENCY -> HostedDestination.Sleep
+    }
+
+/**
  * The card's display title, localized. The enum's [title] field stays the English source-of-truth default
  * (used for logging/comparisons); the UI reads this so the editor shows a translated title. Enum
  * constructors can't call [stringResource], so resolution happens here at the render site. Mirrors iOS,

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3533,7 +3533,12 @@ private fun HostedCardsSection(
         HostedCard.TREND_HRV -> ({ onOpenMetric("hrv") })
         HostedCard.TREND_RESTING_HR -> ({ onOpenMetric("rhr") })
         HostedCard.TREND_EFFORT -> ({ onOpenMetric("strain") })
-        else -> onOpenSleep
+        // Listed rather than an `else`, so a card added later cannot silently inherit "opens Sleep".
+        // Without exhaustiveness a Health-origin card would compile and quietly send you to the wrong
+        // tab; with it, the compiler asks where the new one goes.
+        HostedCard.ASLEEP_DURATION, HostedCard.STAGES_VS_TYPICAL, HostedCard.NIGHT_DETAIL,
+        HostedCard.SLEEP_DEBT, HostedCard.STAGES, HostedCard.HOURS_VS_NEEDED,
+        HostedCard.CONSISTENCY -> onOpenSleep
     }
 
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.sectionGap)) {
@@ -3542,6 +3547,12 @@ private fun HostedCardsSection(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
+                    // Clipped to the card's own radius BEFORE the click. `NoopCard` clips itself, but
+                    // the ripple draws on this wrapper, so without matching the shape here it would wash
+                    // square corners over a rounded card. `Metrics.cardRadius` is the right figure
+                    // because every hosted card renders through `NoopCard`: the 26dp liquid-hero
+                    // surface `ChartCard` can wear is hero-only, and none of these opt into it.
+                    .clip(RoundedCornerShape(Metrics.cardRadius))
                     .then(if (open != null) Modifier.clickable(onClick = open) else Modifier),
             ) {
             when (card) {

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1732,6 +1732,7 @@ fun TodayScreen(
                         // #today-hosted-cards: the Trends/Sleep cards the user pulled into Today, in
                         // arranged order. Each is the SAME card its home tab renders (a mirror).
                         TodaySection.ADDED_CARDS -> HostedCardsSection(
+                            effortScale = effortScale,
                             cards = enabledHostedCards,
                             days = days,
                             viewModel = viewModel,
@@ -3472,7 +3473,15 @@ private fun TodayEditAction(
  * confirmation toast). Renders nothing when [cards] is empty. Twin of the iOS `hostedCardsSection`.
  */
 @Composable
-private fun HostedCardsSection(cards: List<HostedCard>, days: List<DailyMetric>, viewModel: AppViewModel) {
+private fun HostedCardsSection(
+    cards: List<HostedCard>,
+    days: List<DailyMetric>,
+    viewModel: AppViewModel,
+    // Passed in rather than read here: Today already resolved it once for its own tiles, and reading
+    // SharedPreferences per hosted card per recomposition would put a synchronous file read on the
+    // composition path of a screen that recomposes often.
+    effortScale: EffortScale,
+) {
     if (cards.isEmpty()) return
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -3507,6 +3516,10 @@ private fun HostedCardsSection(cards: List<HostedCard>, days: List<DailyMetric>,
         cards.forEach { card ->
             when (card) {
                 HostedCard.STRESS_TODAY -> StressTodayCard(stressCurve)
+                // The Trends-origin trends. `resolveMetric` walks the `days` already in hand, so these
+                // need no model build and no gate, unlike the sleep and stress cards above.
+                HostedCard.TREND_HRV, HostedCard.TREND_RESTING_HR, HostedCard.TREND_EFFORT ->
+                    TrendHostCard(card, days, effortScale)
                 HostedCard.SLEEP_MARKS -> SleepMarkCard(
                     onMark = { type ->
                         val mark = SleepMark.now(type)

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3518,32 +3518,19 @@ private fun HostedCardsSection(
             emptyList()
         }
     }
-    // Where a hosted card sends you when tapped: back to the thing it is a copy of.
-    //
-    // The pinned tiles above already open their screen, so a card that did nothing sat next to one that
-    // did and looked broken rather than deliberate. The trends open the METRIC's own detail page rather
-    // than the Trends tab, which is the same destination the Charge and Effort key tiles use and lands
-    // closer to what was tapped.
-    //
-    // `SLEEP_MARKS` is deliberately absent. It is the tap-to-log card, its buttons ARE its purpose, and
-    // wrapping it in a navigation target would put a second meaning behind the same press.
-    fun destination(card: HostedCard): (() -> Unit)? = when (card) {
-        HostedCard.SLEEP_MARKS -> null
-        HostedCard.STRESS_TODAY -> onOpenStress
-        HostedCard.TREND_HRV -> ({ onOpenMetric("hrv") })
-        HostedCard.TREND_RESTING_HR -> ({ onOpenMetric("rhr") })
-        HostedCard.TREND_EFFORT -> ({ onOpenMetric("strain") })
-        // Listed rather than an `else`, so a card added later cannot silently inherit "opens Sleep".
-        // Without exhaustiveness a Health-origin card would compile and quietly send you to the wrong
-        // tab; with it, the compiler asks where the new one goes.
-        HostedCard.ASLEEP_DURATION, HostedCard.STAGES_VS_TYPICAL, HostedCard.NIGHT_DETAIL,
-        HostedCard.SLEEP_DEBT, HostedCard.STAGES, HostedCard.HOURS_VS_NEEDED,
-        HostedCard.CONSISTENCY -> onOpenSleep
+    // Turning the card's own destination into the callback that reaches it. The mapping itself lives
+    // on `HostedCard` so a test can assert it; this is only the wiring, which cannot be tested and does
+    // not need to be.
+    fun opener(card: HostedCard): (() -> Unit)? = when (val d = card.destination) {
+        HostedDestination.None -> null
+        HostedDestination.Sleep -> onOpenSleep
+        HostedDestination.Stress -> onOpenStress
+        is HostedDestination.Metric -> ({ onOpenMetric(d.key) })
     }
 
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.sectionGap)) {
         cards.forEach { card ->
-            val open = destination(card)
+            val open = opener(card)
             Box(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1733,6 +1733,9 @@ fun TodayScreen(
                         // arranged order. Each is the SAME card its home tab renders (a mirror).
                         TodaySection.ADDED_CARDS -> HostedCardsSection(
                             effortScale = effortScale,
+                            onOpenStress = onOpenStress,
+                            onOpenSleep = onOpenSleep,
+                            onOpenMetric = onOpenMetric,
                             cards = enabledHostedCards,
                             days = days,
                             viewModel = viewModel,
@@ -3481,6 +3484,9 @@ private fun HostedCardsSection(
     // SharedPreferences per hosted card per recomposition would put a synchronous file read on the
     // composition path of a screen that recomposes often.
     effortScale: EffortScale,
+    onOpenStress: () -> Unit,
+    onOpenSleep: () -> Unit,
+    onOpenMetric: (String) -> Unit,
 ) {
     if (cards.isEmpty()) return
     val context = LocalContext.current
@@ -3512,8 +3518,32 @@ private fun HostedCardsSection(
             emptyList()
         }
     }
+    // Where a hosted card sends you when tapped: back to the thing it is a copy of.
+    //
+    // The pinned tiles above already open their screen, so a card that did nothing sat next to one that
+    // did and looked broken rather than deliberate. The trends open the METRIC's own detail page rather
+    // than the Trends tab, which is the same destination the Charge and Effort key tiles use and lands
+    // closer to what was tapped.
+    //
+    // `SLEEP_MARKS` is deliberately absent. It is the tap-to-log card, its buttons ARE its purpose, and
+    // wrapping it in a navigation target would put a second meaning behind the same press.
+    fun destination(card: HostedCard): (() -> Unit)? = when (card) {
+        HostedCard.SLEEP_MARKS -> null
+        HostedCard.STRESS_TODAY -> onOpenStress
+        HostedCard.TREND_HRV -> ({ onOpenMetric("hrv") })
+        HostedCard.TREND_RESTING_HR -> ({ onOpenMetric("rhr") })
+        HostedCard.TREND_EFFORT -> ({ onOpenMetric("strain") })
+        else -> onOpenSleep
+    }
+
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.sectionGap)) {
         cards.forEach { card ->
+            val open = destination(card)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .then(if (open != null) Modifier.clickable(onClick = open) else Modifier),
+            ) {
             when (card) {
                 HostedCard.STRESS_TODAY -> StressTodayCard(stressCurve)
                 // The Trends-origin trends. `resolveMetric` walks the `days` already in hand, so these
@@ -3567,6 +3597,7 @@ private fun HostedCardsSection(
                 // ConsistencyHostCard. Null until the async build lands / no stage data — the slot renders
                 // nothing this frame, matching the Sleep tab's null-model guard.
                 HostedCard.CONSISTENCY -> hostedSleepModel?.let { ConsistencyHostCard(it) }
+            }
             }
         }
     }

--- a/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TrendsScreen.kt
@@ -955,6 +955,53 @@ private fun prettyAxisDate(day: String?): String =
             .getOrDefault(it)
     }.orEmpty()
 
+/**
+ * One Trends metric trend, rendered as a Today host card (#today-hosted-cards).
+ *
+ * Renders the SAME [MetricTrendCard] the Trends tab draws, so the hosted copy cannot drift into a
+ * second chart of the same numbers. What it does NOT carry is the range selector: a home-screen card
+ * has nowhere to put one and no obvious place to persist a per-card choice, so it takes a fixed
+ * trailing month and keeps the tab's widening fallback for a wearer whose history is shorter than
+ * that. The Trends tab remains where you change the window.
+ *
+ * Costs nothing to host. [resolveMetric] is a pure walk over the `days` list Today already holds, so
+ * unlike the sleep model or the stress curve there is no read behind this and nothing to gate.
+ */
+@Composable
+internal fun TrendHostCard(card: HostedCard, days: List<DailyMetric>, effortScale: EffortScale) {
+    val range = TrendsRange.Month
+    when (card) {
+        HostedCard.TREND_HRV -> MetricTrendCard(
+            title = stringResource(R.string.trends_hrv_full), unit = "ms",
+            color = Palette.metricPurple,
+            higherIsBetter = true,
+            resolved = remember(days) { resolveMetric(days, range) { it.avgHrv } },
+            fmt = { "${it.roundToInt()}" },
+        )
+        HostedCard.TREND_RESTING_HR -> MetricTrendCard(
+            title = stringResource(R.string.trends_resting_hr_full), unit = "bpm",
+            color = Palette.metricRose,
+            higherIsBetter = false,
+            resolved = remember(days) { resolveMetric(days, range) { it.restingHr?.toDouble() } },
+            fmt = { "${it.roundToInt()}" },
+        )
+        HostedCard.TREND_EFFORT -> MetricTrendCard(
+            // Plotted values stay on the stored 0-100 scale (line shape unchanged); only the displayed
+            // numbers and unit follow the Effort-scale toggle, converted inside `fmt`, exactly as the
+            // Trends tab does it (#268).
+            title = stringResource(R.string.trends_effort),
+            unit = "/ ${UnitFormatter.effortScaleMax(effortScale)}",
+            color = Palette.effortColor,
+            tint = Palette.effortColor,
+            tipColor = Palette.effortBright,
+            higherIsBetter = null,
+            resolved = remember(days) { resolveMetric(days, range) { it.strain } },
+            fmt = { UnitFormatter.effortDisplay(it, effortScale) },
+        )
+        else -> Unit
+    }
+}
+
 /** A labelled metric-trend card built from a [ResolvedMetric] with mean / min / max. */
 @Composable
 private fun MetricTrendCard(

--- a/android/app/src/test/java/com/noop/ui/HostedCardPrefsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/HostedCardPrefsTest.kt
@@ -20,6 +20,11 @@ class HostedCardPrefsTest {
         // Origin-namespaced on a tab other than Sleep, and frozen for the same reason: this id rides
         // .noopbak, so the Swift twin has to spell it identically or a restore drops the card.
         assertEquals("stress.today", HostedCard.STRESS_TODAY.raw)
+        // Trends-origin ids, frozen for the same reason: they ride .noopbak, so the Swift twin has to
+        // spell each one identically or a restore silently drops that card from the selection.
+        assertEquals("trends.hrv", HostedCard.TREND_HRV.raw)
+        assertEquals("trends.restingHr", HostedCard.TREND_RESTING_HR.raw)
+        assertEquals("trends.effort", HostedCard.TREND_EFFORT.raw)
         // Every id must be origin-namespaced so it routes to the right provider and can't collide with a
         // Today DashboardCard id.
         HostedCard.entries.forEach { card ->

--- a/android/app/src/test/java/com/noop/ui/HostedCardPrefsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/HostedCardPrefsTest.kt
@@ -32,6 +32,32 @@ class HostedCardPrefsTest {
         }
     }
 
+    /**
+     * Every hosted card opens the thing it mirrors, and the tap-to-log card opens nothing.
+     *
+     * Worth pinning because the failure is silent: a card wired to the wrong destination still renders,
+     * still taps, and simply lands somewhere else. Nothing about the screen looks wrong. Twin of the
+     * Swift `testEachHostedCardOpensItsOwnTab`.
+     */
+    @Test
+    fun eachHostedCardOpensItsOwnThing() {
+        // The tap-to-log card must NOT navigate: its buttons are its purpose, and a wrapper would put a
+        // second meaning behind the same press.
+        assertEquals(HostedDestination.None, HostedCard.SLEEP_MARKS.destination)
+        HostedCard.entries.filter { it != HostedCard.SLEEP_MARKS }.forEach {
+            assertTrue("${it.raw} taps through to nothing", it.destination != HostedDestination.None)
+        }
+        // Sleep-origin cards land on the Sleep tab; the trends land on their own metric page, which is
+        // where the Charge and Effort key tiles already send you.
+        HostedCard.entries.filter { it.origin == "Sleep" && it != HostedCard.SLEEP_MARKS }.forEach {
+            assertEquals("${it.raw} should open Sleep", HostedDestination.Sleep, it.destination)
+        }
+        assertEquals(HostedDestination.Stress, HostedCard.STRESS_TODAY.destination)
+        assertEquals(HostedDestination.Metric("hrv"), HostedCard.TREND_HRV.destination)
+        assertEquals(HostedDestination.Metric("rhr"), HostedCard.TREND_RESTING_HR.destination)
+        assertEquals(HostedDestination.Metric("strain"), HostedCard.TREND_EFFORT.destination)
+    }
+
     /** Opt-in surface: nothing is hosted until the user adds a card. */
     @Test
     fun default_isEmpty() {


### PR DESCRIPTION
Offer the Trends charts as Today cards

The hosted-card catalogue held only Sleep cards plus the stress curve, so the Trends charts could be
looked at but not pinned. HRV, resting heart rate and Effort now appear in Customise under a Trends
heading and can be added to Today like any other card.

They render the SAME `MetricTrendCard` the Trends tab draws, parameterised by which `DailyMetric` field
they read, so a hosted copy cannot drift into a second chart of the same numbers. What they do not
carry is the range selector: a home-screen card has nowhere to put one and no place to persist a
per-card choice, so each takes a fixed trailing month and keeps the tab's widening fallback for a
wearer whose history is shorter than that. The Trends tab stays where the window is chosen.

Hosting these costs nothing to speak of. `resolveMetric` is a pure walk over the `days` list Today
already holds, so unlike the sleep model and the stress curve there is no read behind them and nothing
to gate. Effort's scale is threaded down from the one Today already resolved rather than read per card,
since a SharedPreferences read per card per recomposition has no business on the composition path.

Every title reuses the string the Trends tab already shows, so nothing new reaches a translator and a
hosted card is recognisably the card it came from.

The three raw ids ride `.noopbak` and the frozen-contract test pins them, which also widens the gap the
stress card opened: until the Swift `HostedCard` spells all four identically, a backup restored on iOS
drops them from the hosted selection. Lossy rather than destructive, since unknown tokens are skipped,
and the twin is the next thing worth doing here.

### Verification

- `compileFullDebugKotlin` clean.
- `HostedCardPrefsTest` 5 tests, 0 failures, result XML checked; the frozen-id test now pins all four new raw ids.
- `lintVitalFullRelease -PstagingRelease` clean.
- `Tools/i18n_audit.py --ci` exits 0 (no new copy) and `Tools/doc_comment_lint.py` clean.
- NOT verified on a device: the three charts at Today's card width.

### Review pass before opening

Two things fixed in my own work first: the render arm was calling `UnitPrefs.effortScale(LocalContext.current)` per card, putting a synchronous prefs read on the composition path of a screen that recomposes often, when Today had already resolved it; and the three new frozen ids had no test pinning them.