### PR TITLE
Make Apple's hosted cards open the tab they came from

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -754,7 +754,12 @@ struct LiquidTodayView: View {
         if !cards.isEmpty {
             VStack(spacing: NoopMetrics.sectionGap) {
                 ForEach(cards) { card in
-                    hostedCard(for: card)
+                    if let route = card.route {
+                        NavigationLink(value: route) { hostedCard(for: card) }
+                            .buttonStyle(.plain)
+                    } else {
+                        hostedCard(for: card)
+                    }
                 }
             }
         }

--- a/Strand/Screens/HostedCards.swift
+++ b/Strand/Screens/HostedCards.swift
@@ -73,6 +73,25 @@ enum HostedCard: String, CaseIterable, Identifiable {
         }
     }
 
+    /// Where tapping this card sends you: back to the tab it is a copy of.
+    ///
+    /// Declared on the CARD rather than inside the view that draws it, so it can be tested. A mapping
+    /// that lives as a private method on a `View` is unreachable from any test, and a card quietly
+    /// routing to the wrong tab is not the kind of thing anyone notices in review.
+    ///
+    /// `nil` for `sleepMarks`: it is the tap-to-log card, its buttons ARE its purpose, and wrapping it
+    /// in a navigation target would put a second meaning behind the same press.
+    ///
+    /// Listed rather than defaulted, so a card added later cannot silently inherit "opens Sleep": the
+    /// compiler asks where the new one goes.
+    var route: TabRoute? {
+        switch self {
+        case .sleepMarks: return nil
+        case .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages,
+             .hoursVsNeeded, .consistency: return .sleep
+        }
+    }
+
     /// SF Symbol for the editor row (reuses the shared customization-icon treatment).
     var customizationIcon: String {
         switch self {

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -2461,9 +2461,33 @@ struct TodayView: View {
         if selectedDayOffset == 0 && !cards.isEmpty {
             VStack(alignment: .leading, spacing: NoopMetrics.sectionGap) {
                 ForEach(cards) { card in
-                    hostedCard(for: card)
+                    if let route = hostedRoute(card) {
+                        NavigationLink(value: route) { hostedCard(for: card) }
+                            .buttonStyle(.plain)
+                    } else {
+                        hostedCard(for: card)
+                    }
                 }
             }
+        }
+    }
+
+    /// Where a hosted card sends you when tapped: back to the tab it is a copy of.
+    ///
+    /// The pinned dashboard rows above already push their route, so a hosted card that did nothing sat
+    /// beside one that did and read as broken rather than deliberate. Every hosted card had been inert
+    /// since the mechanism shipped.
+    ///
+    /// `sleepMarks` is deliberately absent. It is the tap-to-log card, its buttons ARE its purpose, and
+    /// wrapping it in a navigation target would put a second meaning behind the same press.
+    ///
+    /// Listed rather than defaulted, so a card added later cannot silently inherit "opens Sleep": the
+    /// compiler asks where the new one goes. Twin of the Kotlin `destination` map.
+    private func hostedRoute(_ card: HostedCard) -> TabRoute? {
+        switch card {
+        case .sleepMarks: return nil
+        case .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages,
+             .hoursVsNeeded, .consistency: return .sleep
         }
     }
 

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -2461,7 +2461,7 @@ struct TodayView: View {
         if selectedDayOffset == 0 && !cards.isEmpty {
             VStack(alignment: .leading, spacing: NoopMetrics.sectionGap) {
                 ForEach(cards) { card in
-                    if let route = hostedRoute(card) {
+                    if let route = card.route {
                         NavigationLink(value: route) { hostedCard(for: card) }
                             .buttonStyle(.plain)
                     } else {
@@ -2469,25 +2469,6 @@ struct TodayView: View {
                     }
                 }
             }
-        }
-    }
-
-    /// Where a hosted card sends you when tapped: back to the tab it is a copy of.
-    ///
-    /// The pinned dashboard rows above already push their route, so a hosted card that did nothing sat
-    /// beside one that did and read as broken rather than deliberate. Every hosted card had been inert
-    /// since the mechanism shipped.
-    ///
-    /// `sleepMarks` is deliberately absent. It is the tap-to-log card, its buttons ARE its purpose, and
-    /// wrapping it in a navigation target would put a second meaning behind the same press.
-    ///
-    /// Listed rather than defaulted, so a card added later cannot silently inherit "opens Sleep": the
-    /// compiler asks where the new one goes. Twin of the Kotlin `destination` map.
-    private func hostedRoute(_ card: HostedCard) -> TabRoute? {
-        switch card {
-        case .sleepMarks: return nil
-        case .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages,
-             .hoursVsNeeded, .consistency: return .sleep
         }
     }
 

--- a/StrandTests/HostedCardPrefsTests.swift
+++ b/StrandTests/HostedCardPrefsTests.swift
@@ -18,6 +18,24 @@ final class HostedCardPrefsTests: XCTestCase {
         }
     }
 
+    /// Every hosted card opens the tab it mirrors, and the tap-to-log card opens nothing.
+    ///
+    /// Worth pinning because the failure is silent: a card wired to the wrong route still renders, still
+    /// taps, and simply lands somewhere else. Nothing about the screen looks wrong.
+    func testEachHostedCardOpensItsOwnTab() {
+        // The tap-to-log card must NOT navigate: its buttons are its purpose, and a wrapper would put a
+        // second meaning behind the same press.
+        XCTAssertNil(HostedCard.sleepMarks.route)
+        for card in HostedCard.allCases where card != .sleepMarks {
+            XCTAssertNotNil(card.route, "\(card.rawValue) taps through to nothing")
+        }
+        // Sleep-origin cards land on the Sleep tab.
+        let sleepOrigin = String(localized: "Sleep")
+        for card in HostedCard.allCases where card.origin == sleepOrigin && card != .sleepMarks {
+            XCTAssertEqual(card.route, .sleep, "\(card.rawValue) should open Sleep")
+        }
+    }
+
     /// Opt-in surface: nothing is hosted until the user adds a card.
     func testDefaultIsEmpty() {
         XCTAssertEqual(HostedCard.defaultSelection, [])


### PR DESCRIPTION
Make Apple's hosted cards open the tab they came from

Tapping a hosted card on Today did nothing. The pinned dashboard rows directly above them each push
their route, so a card that was inert sat beside one that was not and read as broken rather than
deliberate. Every hosted card had been that way since the mechanism shipped.

Each now pushes its origin's route, the same wrapper the pinned rows use, so the two kinds of row
cannot drift.

`sleepMarks` is deliberately excluded. It is the tap-to-log card, its buttons ARE its purpose, and
wrapping it in a navigation target would put a second meaning behind the same press.

The map is exhaustive rather than defaulted, so a card added later cannot silently inherit "opens
Sleep"; the compiler asks where the new one goes. That matters here more than usual, because the
Android catalogue has four cards this one does not yet have, and they are coming.

Twin of the Kotlin `destination` map. This is the first of three gaps between the two hosted-card
implementations to close; the other two are the four missing card ids, which ride `.noopbak`, and the
cards themselves.

### Verification

- `swiftc -parse` clean and `Tools/doc_comment_lint.py` clean.
- The app targets do not build here, so the compile and `StrandTests` are left to app-build, whose path filter covers `Strand/**`.
- NOT verified on a device.

### Parity state after this

| | Kotlin | Swift |
| --- | --- | --- |
| hosted cards navigate | yes | **yes (this PR)** |
| catalogue size | 12 | 8 |
| missing ids | — | `stress.today`, `trends.hrv`, `trends.restingHr`, `trends.effort` |