### PR TITLE
Host the stress curve on Apple's Today

### DIFF
--- a/Strand/Data/StressDayCurve.swift
+++ b/Strand/Data/StressDayCurve.swift
@@ -21,8 +21,8 @@ enum StressDayCurve {
 
     /// What the last scoring saw and produced, swapped in as ONE value.
     ///
-    /// Separate fields could tear: a second publish arriving between two assignments would read one
-    /// call's fingerprint beside another's points and serve a curve for a day it was not scored
+    /// Separate fields could tear: a second call arriving between two assignments would read one
+    /// call's fingerprint beside another's result and serve a curve for a day it was not scored
     /// against. Both callers are `@MainActor` today, so the window is narrow, but an immutable holder
     /// closes it for free.
     private struct Memo {

--- a/Strand/Data/StressDayCurve.swift
+++ b/Strand/Data/StressDayCurve.swift
@@ -50,7 +50,7 @@ enum StressDayCurve {
         let startOfDay = calendar.startOfDay(for: now)
         let from = Int(startOfDay.timeIntervalSince1970)
         let to = Int(now.timeIntervalSince1970)
-        let day = WidgetSnapshot.localDayNumber(now, calendar: calendar)
+        let day = localDayNumber(now, calendar: calendar)
 
         guard let fingerprint = await repo.hrFingerprint(from: from, to: to) else { return nil }
         // Same day, same heart rate: nothing can have changed the score, so nothing is read. The day is
@@ -87,6 +87,25 @@ enum StressDayCurve {
         // refusal: a reader should drop yesterday's line rather than keep drawing it.
         memo = Memo(count: fingerprint.count, maxTs: fingerprint.maxTs, day: day, result: scored)
         return (scored, day)
+    }
+
+    /// Days since the epoch on the LOCAL calendar.
+    ///
+    /// RESTATED from `WidgetSnapshot.localDayNumber` rather than shared, because there is no module
+    /// both readers can see: `WidgetSnapshot` lives in the iOS/widget sources, which the macOS app does
+    /// not compile, and the widget extension links no packages, so it cannot reach this file either.
+    ///
+    /// The two MUST agree. The widget stores the day this returns and later compares it against
+    /// `WidgetSnapshot.localDayNumber` to decide whether the stored curve is still today's, so a
+    /// divergence would silently drop a valid curve. `HostedCardPrefsTests` pins them equal from the
+    /// app target, which can see both.
+    ///
+    /// Counted by the calendar rather than by dividing by 86 400, because that arithmetic is wrong on a
+    /// DST day: `Europe/London` produces one day a year whose number would equal the previous day's.
+    static func localDayNumber(_ date: Date, calendar: Calendar = .current) -> Int {
+        let epoch = calendar.startOfDay(for: Date(timeIntervalSince1970: 0))
+        return calendar.dateComponents([.day], from: epoch,
+                                       to: calendar.startOfDay(for: date)).day ?? 0
     }
 
     /// Drops the memo so a test starts from a known state.

--- a/Strand/Data/StressDayCurve.swift
+++ b/Strand/Data/StressDayCurve.swift
@@ -1,8 +1,7 @@
-#if os(iOS)
 import Foundation
 import StrandAnalytics
 
-/// Scores today's hourly stress for the stress widget, and does it as rarely as it can get away with.
+/// Scores today's stress for the surfaces that draw it, and does it as rarely as it can get away with.
 ///
 /// Swift twin of the Kotlin `StressWidgetProducer`, and the same reasoning governs both.
 ///
@@ -18,7 +17,7 @@ import StrandAnalytics
 /// which the screen can afford on demand and a publish path cannot. Stated plainly because it is
 /// user-visible: with the personal-baseline toggle on, the widget shows the default lens while the
 /// screen shows the refined one, so the two can differ.
-enum StressWidgetCurve {
+enum StressDayCurve {
 
     /// What the last scoring saw and produced, swapped in as ONE value.
     ///
@@ -30,19 +29,24 @@ enum StressWidgetCurve {
         let count: Int
         let maxTs: Int
         let day: Int
-        let points: [StressPoint]
+        let result: DaytimeStress.Result
     }
 
     @MainActor private static var memo: Memo?
 
     /// Today's curve and the local day number it belongs to, or nil when it could not be scored.
     ///
-    /// Nil is not "today scored nothing": it means "say nothing about stress in this publish", so the
-    /// caller must carry forward whatever the previous snapshot held rather than blanking the widget.
-    /// An empty ARRAY with a day is the real "nothing scored today" answer.
+    /// Nil is not "today scored nothing": it means "say nothing about stress right now", so a caller
+    /// that persists this must carry forward what it already had rather than blanking. An EMPTY result
+    /// with a day is the real "nothing scored today" answer.
+    ///
+    /// Returns the analytics `Result` rather than any one drawing's point type, because two surfaces
+    /// read it: the iOS widget, which maps it into its own `StressPoint`, and the Today host card,
+    /// which hands `timeline` straight to `DaytimeLoadLine`. Keeping the widget's type here would have
+    /// kept this file iOS-only, and the Today card is shared with macOS.
     @MainActor
     static func today(repo: Repository, now: Date = Date(),
-                      calendar: Calendar = .current) async -> (points: [StressPoint], day: Int)? {
+                      calendar: Calendar = .current) async -> (result: DaytimeStress.Result, day: Int)? {
         let startOfDay = calendar.startOfDay(for: now)
         let from = Int(startOfDay.timeIntervalSince1970)
         let to = Int(now.timeIntervalSince1970)
@@ -53,11 +57,11 @@ enum StressWidgetCurve {
         // part of the check because a fingerprint that happened to match across midnight would otherwise
         // serve yesterday's curve as today's.
         if let memo, memo.day == day, memo.count == fingerprint.count, memo.maxTs == fingerprint.maxTs {
-            return (memo.points, day)
+            return (memo.result, day)
         }
 
         let hr = await repo.hrSamples(from: from, to: to, limit: 200_000)
-        var points: [StressPoint] = []
+        var scored: DaytimeStress.Result = .empty
         if hr.count >= DaytimeStress.minHourHRSamples {
             let rr = await repo.rrIntervals(from: from, to: to, limit: 200_000)
             // Wrist accelerometer for the motion gate, so an ambulatory hour reads as exertion rather
@@ -71,30 +75,21 @@ enum StressWidgetCurve {
             // the app becomes active and after every Health sync, which is exactly when the UI is busy.
             // The Kotlin twin gets this for free by living in a coroutine; here it has to be asked for.
             // The samples are plain value structs, so the hop retains rather than copies them.
-            points = await Task.detached(priority: .utility) {
+            // The half-step display series is asked for here (`includeTimeline`), because both readers
+            // draw a curve. Nothing downstream of this counts hours, so the overlap is free.
+            scored = await Task.detached(priority: .utility) {
                 DaytimeStress.analyze(hr: hr, rr: rr, gravity: gravity,
                                       tzOffsetSeconds: tz, mode: .dayRelative,
                                       includeTimeline: true)
-                    // The half-step display series rather than the bare hours: same scored window,
-                    // same reference, read twice as often, so the curve tracks the day instead of
-                    // stepping through it. Nothing here counts hours, so the overlap is free.
-                    .timeline
-                    .map {
-                        // `startTs` is the wall-clock bucket start with the local shift already undone,
-                        // so it is a true instant and formats correctly against the device's zone.
-                        StressPoint(ts: Int64($0.startTs), level: $0.level,
-                                    moving: $0.maskedForActivity)
-                    }
             }.value
         }
-        // Too little signal leaves `points` empty, which is a real answer about today rather than a
-        // refusal: the widget should drop yesterday's line rather than keep drawing it.
-        memo = Memo(count: fingerprint.count, maxTs: fingerprint.maxTs, day: day, points: points)
-        return (points, day)
+        // Too little signal leaves an EMPTY result, which is a real answer about today rather than a
+        // refusal: a reader should drop yesterday's line rather than keep drawing it.
+        memo = Memo(count: fingerprint.count, maxTs: fingerprint.maxTs, day: day, result: scored)
+        return (scored, day)
     }
 
     /// Drops the memo so a test starts from a known state.
     @MainActor
     static func resetForTest() { memo = nil }
 }
-#endif

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -72,6 +72,12 @@ struct LiquidTodayView: View {
     /// hosted sleep card pays none of the extra Repository work. nil until (and unless) it's built.
     @State private var hostedSleepModel: SleepModel? = nil
 
+    // #2040: today's scored stress for the hosted curve card. Loaded only when that card is hosted, the
+    // same "hosting none pays nothing" rule the sleep model follows. `StressDayCurve` self-gates on a
+    // cheap heart-rate fingerprint and memoises, so the widget, this shell and the other Today view all
+    // share one computation rather than scoring the day three times.
+    @State private var hostedStressHours: [DaytimeStress.HourPoint] = []
+
     // sheets / expanders
     @State private var guideSection: ScoreSection?
     @State private var customizationDestination: TodayCustomizationDestination?
@@ -771,6 +777,25 @@ struct LiquidTodayView: View {
     private func hostedCard(for card: HostedCard) -> some View {
         switch card {
         case .sleepMarks: SleepMarkCard()
+        case .stressToday:
+            // READ-ONLY, like `stages`: the Stress tab keeps the interactive timeline and this mirrors
+            // only the display. `DaytimeLoadLine` is the tab's OWN line, so the host cannot drift into
+            // a second drawing of the same day.
+            NoopCard(tint: StressRamp.calm) {
+                VStack(alignment: .leading, spacing: 14) {
+                    Text("Stress through the day").strandOverline()
+                    if hostedStressHours.contains(where: { $0.level != nil }) {
+                        DaytimeLoadLine(hours: hostedStressHours)
+                    } else {
+                        // The honest blank: only waking hours score and an hour needs enough heart
+                        // rate, so early morning is empty by construction rather than by failure.
+                        Text("Calibrating")
+                            .font(StrandFont.subhead)
+                            .foregroundStyle(StrandPalette.textTertiary)
+                            .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+                    }
+                }
+            }
         case .asleepDuration: AsleepDurationCard(data: AsleepDurationData.build(days: repo.days))
         case .stagesVsTypical:
             // Renders from the shared SleepModel built in load() (same inputs as the Sleep tab). Until that
@@ -1756,6 +1781,11 @@ struct LiquidTodayView: View {
         } else {
             hostedSleepModel = nil
         }
+
+        // #2040: and today's stress, on the same "only when hosted" rule.
+        hostedStressHours = HostedCardPrefs.decodeEnabled(hostedCardsRaw).contains(.stressToday)
+            ? (await StressDayCurve.today(repo: repo)?.result.timeline ?? [])
+            : []
 
         // First load done — bring the hero gauges + sky to life now the launch churn has settled.
         if !dataLoaded { withAnimation(.easeIn(duration: 0.4)) { dataLoaded = true } }

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -153044,6 +153044,70 @@
         }
       }
     },
+    "Stress through the day": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stress im Tagesverlauf"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stress through the day"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Estrés a lo largo del día"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stress au fil de la journée"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stress durante la giornata"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stres w ciągu dnia"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stress ao longo do dia"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Стресс в течение дня"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全天压力变化"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全天壓力變化"
+          }
+        }
+      }
+    },
     "Stress %@ of 3, %@": {
       "localizations": {
         "de": {

--- a/Strand/Screens/HostedCards.swift
+++ b/Strand/Screens/HostedCards.swift
@@ -48,6 +48,13 @@ enum HostedCard: String, CaseIterable, Identifiable {
     /// grid; the Today host gives it a standalone card (`ConsistencyCard`) reading the SAME `consistency`
     /// metric, so the value can't diverge.
     case consistency = "sleep.consistency"
+    /// Stress tab · "Stress through the day" — today's autonomic-load curve (#2040 follow-up). The
+    /// first card hosted from a tab other than Sleep. Read-only like `stages`: the Stress tab keeps the
+    /// interactive timeline, and the Today host mirrors only the display.
+    ///
+    /// The rawValue rides `.noopbak` under `today.hostedCards`, so it is byte-identical to the Android
+    /// `HostedCard.STRESS_TODAY`.
+    case stressToday = "stress.today"
 
     var id: String { rawValue }
 
@@ -62,6 +69,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
         case .stages: return String(localized: "Stages")
         case .hoursVsNeeded: return String(localized: "Hours vs Needed")
         case .consistency: return String(localized: "Consistency")
+        case .stressToday: return String(localized: "Stress through the day")
         }
     }
 
@@ -70,6 +78,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
     var origin: String {
         switch self {
         case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages, .hoursVsNeeded, .consistency: return String(localized: "Sleep")
+        case .stressToday: return String(localized: "Stress")
         }
     }
 
@@ -89,6 +98,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
         case .sleepMarks: return nil
         case .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages,
              .hoursVsNeeded, .consistency: return .sleep
+        case .stressToday: return .stress
         }
     }
 
@@ -103,6 +113,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
         case .stages: return "chart.bar.fill"
         case .hoursVsNeeded: return "gauge.medium"
         case .consistency: return "repeat"
+        case .stressToday: return "chart.xyaxis.line"
         }
     }
 
@@ -110,6 +121,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
     var customizationTint: Color {
         switch self {
         case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages, .hoursVsNeeded, .consistency: return StrandPalette.restColor
+        case .stressToday: return StrandPalette.stressColor
         }
     }
 

--- a/Strand/Screens/StressView.swift
+++ b/Strand/Screens/StressView.swift
@@ -964,15 +964,14 @@ struct DaytimeLoadLine: View {
         GeometryReader { geo in
             let w = geo.size.width
             let h = geo.size.height
-            let n = max(hours.count, 1)
-            // x for an hour index; y maps a 0–3 level into the chart (0 at bottom).
-            // (closures, not `func` — a `@ViewBuilder` closure can't contain declarations)
-            let x: (Int) -> CGFloat = { i in n <= 1 ? w / 2 : w * CGFloat(i) / CGFloat(n - 1) }
+            // y maps a 0–3 level into the chart (0 at bottom), for the baseline rule below. The x
+            // placement moved into `scoredRuns`, which needs it per point anyway.
+            // (a closure, not a `func` — a `@ViewBuilder` closure can't contain declarations)
             let y: (Double) -> CGFloat = { level in h - h * CGFloat(min(max(level / 3.0, 0), 1)) }
 
-            let pts: [(CGFloat, CGFloat)] = hours.enumerated().compactMap { i, p in
-                p.level.map { (x(i), y($0)) }
-            }
+            // Contiguous runs of scored hours. Built in a method, not here: this is a
+            // `@ViewBuilder` closure and cannot hold statements.
+            let runs = scoredRuns(width: w, height: h)
 
             ZStack {
                 // Baseline (1.5 of 3) reference line.
@@ -983,31 +982,44 @@ struct DaytimeLoadLine: View {
                 }
                 .stroke(StrandPalette.hairline, style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
 
-                if pts.count >= 2 {
-                    // Soft area fill under the curve — a calm WHOOP-blue wash (no gold).
-                    areaPath(pts, width: w, height: h)
-                        .fill(
-                            LinearGradient(
-                                gradient: Gradient(colors: [
-                                    StressRamp.calm.opacity(0.22),
-                                    StressRamp.calm.opacity(0.02),
-                                ]),
-                                startPoint: .top, endPoint: .bottom
+                // The ramp runs DOWN the chart, not across the day.
+                //
+                // It used to be `.leading` to `.trailing`, which painted the stress band colours along
+                // the x-axis: a calm 9pm hour rendered amber and a tense 7am one blue, so the colour
+                // said nothing about the score while looking exactly as though it did. Because y maps
+                // the 0-3 level onto the chart, a vertical ramp makes vertical position the level, which
+                // is what the Kotlin twin does and what the legend claims. Amber at the top, blue at the
+                // bottom: `StressRamp.gradient` runs calm-first, so it is reversed here.
+                let levelRamp = LinearGradient(
+                    gradient: Gradient(colors: Array(StressRamp.stops.map(\.color).reversed())),
+                    startPoint: .top, endPoint: .bottom
+                )
+                ForEach(Array(runs.enumerated()), id: \.offset) { _, seg in
+                    if seg.count >= 2 {
+                        // Closed PER RUN, so the wash cannot spread under an hour that was never scored
+                        // and undo the gap the broken line just drew.
+                        areaPath(seg, width: w, height: h)
+                            .fill(
+                                LinearGradient(
+                                    gradient: Gradient(colors: [
+                                        StressRamp.calm.opacity(0.22),
+                                        StressRamp.calm.opacity(0.02),
+                                    ]),
+                                    startPoint: .top, endPoint: .bottom
+                                )
                             )
-                        )
-                    // The gradient line itself (blue→green→amber, left→right).
-                    linePath(pts)
-                        .stroke(
-                            LinearGradient(gradient: StressRamp.gradient,
-                                           startPoint: .leading, endPoint: .trailing),
-                            style: StrokeStyle(lineWidth: 2.5, lineCap: .round, lineJoin: .round)
-                        )
-                } else if let only = pts.first {
-                    // A single scored hour: a lone dot rather than a line.
-                    Circle()
-                        .fill(StressRamp.color(1.5))
-                        .frame(width: 6, height: 6)
-                        .position(x: only.0, y: only.1)
+                        linePath(seg)
+                            .stroke(levelRamp,
+                                    style: StrokeStyle(lineWidth: 2.5, lineCap: .round, lineJoin: .round))
+                    } else if let only = seg.first {
+                        // A run of one scored hour: a dot rather than a line. Coloured by the level it
+                        // actually carries — it used to be hardcoded to the mid colour, so a lone HIGH
+                        // hour drew as an ordinary one.
+                        Circle()
+                            .fill(StressRamp.color(level(at: only.1, height: h)))
+                            .frame(width: 6, height: 6)
+                            .position(x: only.0, y: only.1)
+                    }
                 }
             }
         }
@@ -1015,6 +1027,36 @@ struct DaytimeLoadLine: View {
         .frame(maxWidth: .infinity)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(accessibilitySummary)
+    }
+
+    /// CONTIGUOUS RUNS of scored hours, in chart coordinates.
+    ///
+    /// The old path `compactMap`-ed the unscored hours away and stroked a smooth curve through whatever
+    /// was left, which draws a reading straight across an hour that has none — the one thing the caption
+    /// promises it will not do. Splitting into runs lets each be stroked and filled separately, so a
+    /// hole in the day stays a hole. The Kotlin twin has always broken the line here.
+    private func scoredRuns(width w: CGFloat, height h: CGFloat) -> [[(CGFloat, CGFloat)]] {
+        let n = max(hours.count, 1)
+        var out: [[(CGFloat, CGFloat)]] = []
+        var run: [(CGFloat, CGFloat)] = []
+        for (i, p) in hours.enumerated() {
+            guard let level = p.level else {
+                if !run.isEmpty { out.append(run); run = [] }
+                continue
+            }
+            let px = n <= 1 ? w / 2 : w * CGFloat(i) / CGFloat(n - 1)
+            let py = h - h * CGFloat(min(max(level / 3.0, 0), 1))
+            run.append((px, py))
+        }
+        if !run.isEmpty { out.append(run) }
+        return out
+    }
+
+    /// The 0-3 level a chart y-position represents: the inverse of the `y` mapping above, so a lone
+    /// point can be coloured by what it actually reads rather than by a fixed guess.
+    private func level(at yPos: CGFloat, height: CGFloat) -> Double {
+        guard height > 0 else { return 0 }
+        return Double((height - yPos) / height) * 3.0
     }
 
     /// A smooth (Catmull-Rom-ish) stroke through the scored points.

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -367,6 +367,12 @@ struct TodayView: View {
     // when a sleep-origin card is hosted. Twin of the LiquidTodayView `hostedSleepModel`.
     @State private var hostedSleepModel: SleepModel? = nil
 
+    // #2040: today's scored stress for the hosted curve card. Loaded only when that card is hosted, the
+    // same "hosting none pays nothing" rule the sleep model follows. `StressDayCurve` self-gates on a
+    // cheap heart-rate fingerprint, so a refresh that changed nothing costs one indexed COUNT and no
+    // rows, and the iOS widget shares the same computation rather than scoring the day twice.
+    @State private var hostedStressHours: [DaytimeStress.HourPoint] = []
+
     // TODAY's in-progress Effort (NOOP 0–100 axis), recomputed over the day's HR (local-midnight→now)
     // each load so the gauge tracks today as it accumulates rather than waiting on the heavy daily pass
     // to persist, which early in the day would otherwise surface yesterday's completed Effort or a stale
@@ -2477,6 +2483,25 @@ struct TodayView: View {
     private func hostedCard(for card: HostedCard) -> some View {
         switch card {
         case .sleepMarks: SleepMarkCard()
+        case .stressToday:
+            // READ-ONLY, like `stages`: the Stress tab keeps the interactive timeline and this mirrors
+            // only the display. `DaytimeLoadLine` is the tab's OWN line, so the host cannot drift into
+            // a second drawing of the same day.
+            NoopCard(tint: StressRamp.calm) {
+                VStack(alignment: .leading, spacing: 14) {
+                    Text("Stress through the day").strandOverline()
+                    if hostedStressHours.contains(where: { $0.level != nil }) {
+                        DaytimeLoadLine(hours: hostedStressHours)
+                    } else {
+                        // The honest blank: only waking hours score and an hour needs enough heart
+                        // rate, so early morning is empty by construction rather than by failure.
+                        Text("Calibrating")
+                            .font(StrandFont.subhead)
+                            .foregroundStyle(StrandPalette.textTertiary)
+                            .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+                    }
+                }
+            }
         case .asleepDuration: AsleepDurationCard(data: AsleepDurationData.build(days: repo.days))
         case .stagesVsTypical:
             // Renders from the shared SleepModel built in loadAll() (same inputs as the Sleep tab). Until the
@@ -4464,6 +4489,7 @@ struct TodayView: View {
         // (before the cache-restore short-circuit below), so the card survives a tab-away/return; the gate
         // inside makes it a no-op unless a sleep card is actually hosted.
         await loadHostedSleepModel()
+        await loadHostedStress()
         // #849: a bare Today RE-MOUNT (tab-away + return, or an Apple-Health import that recreates the view)
         // re-fires this task with TodayView's `@State` reset, so the heavy history-wide pass re-ran in full
         // every time even when NOTHING in the data had changed: hundreds of redundant reads (incl. the
@@ -4509,6 +4535,22 @@ struct TodayView: View {
     /// SleepView does (`allSleepSessions` / `habitualMidsleepSec` / `sessionMotions`) and hands them to the
     /// SAME pure `SleepModel.build`, so a hosted card's numbers match the Sleep tab. Twin of the
     /// LiquidTodayView hostedSleepModel build.
+    /// #2040: today's scored stress for the hosted curve card, ONLY when that card is hosted.
+    ///
+    /// The same "hosting none pays nothing" rule the sleep model above follows. `StressDayCurve` does
+    /// the gating: it reads nothing until a cheap heart-rate fingerprint says today's heart rate moved,
+    /// and it memoises, so the iOS widget publishing from the same producer shares this computation
+    /// rather than scoring the day a second time.
+    private func loadHostedStress() async {
+        guard HostedCardPrefs.decodeEnabled(hostedCardsRaw).contains(.stressToday) else {
+            hostedStressHours = []
+            return
+        }
+        // `timeline`, not `hours`: the half-step display series, so the curve tracks the day rather
+        // than stepping through it, matching the widget and the Android card.
+        hostedStressHours = await StressDayCurve.today(repo: repo)?.result.timeline ?? []
+    }
+
     private func loadHostedSleepModel() async {
         let sleepOrigin = String(localized: "Sleep")
         guard HostedCardPrefs.decodeEnabled(hostedCardsRaw).contains(where: { $0.origin == sleepOrigin }) else {

--- a/StrandTests/HostedCardPrefsTests.swift
+++ b/StrandTests/HostedCardPrefsTests.swift
@@ -11,6 +11,9 @@ final class HostedCardPrefsTests: XCTestCase {
     func testRawValuesAreTheFrozenNamespacedContract() {
         XCTAssertEqual(HostedCard.sleepMarks.rawValue, "sleep.sleepMarks")
         XCTAssertEqual(HostedCard.asleepDuration.rawValue, "sleep.asleepDuration")
+        // Byte-identical to the Kotlin `HostedCard.STRESS_TODAY`. This id rides .noopbak, so a
+        // difference of one character means an Android backup restored here silently drops the card.
+        XCTAssertEqual(HostedCard.stressToday.rawValue, "stress.today")
         // Every id must be origin-namespaced so it routes to the right provider and can't collide with a
         // Today DashboardCard id.
         for card in HostedCard.allCases {

--- a/StrandTests/HostedCardPrefsTests.swift
+++ b/StrandTests/HostedCardPrefsTests.swift
@@ -14,6 +14,26 @@ final class HostedCardPrefsTests: XCTestCase {
         // Byte-identical to the Kotlin `HostedCard.STRESS_TODAY`. This id rides .noopbak, so a
         // difference of one character means an Android backup restored here silently drops the card.
         XCTAssertEqual(HostedCard.stressToday.rawValue, "stress.today")
+    }
+
+    /// The two local-day counters have to agree, and nothing but this test can check them.
+    ///
+    /// `StressDayCurve` returns the day the widget then STORES, and the widget's read path compares
+    /// that against `WidgetSnapshot.localDayNumber` to decide whether the stored curve is still today's.
+    /// They are separate copies because no module sees both: the macOS app does not compile the widget
+    /// sources, and the widget extension links no packages. This target sees both, so it is the only
+    /// place a divergence can be caught, and a divergence would silently drop a valid curve.
+    func testTheTwoLocalDayCountersAgree() {
+        var cal = Calendar(identifier: .gregorian)
+        for zone in ["Europe/London", "America/New_York", "Australia/Lord_Howe", "UTC"] {
+            cal.timeZone = TimeZone(identifier: zone)!
+            for offset in stride(from: 0, to: 400, by: 7) {
+                let d = Date(timeIntervalSince1970: 1_735_732_800 + Double(offset) * 86_400 + 43_200)
+                XCTAssertEqual(StressDayCurve.localDayNumber(d, calendar: cal),
+                               WidgetSnapshot.localDayNumber(d, calendar: cal),
+                               "\(zone) at \(d)")
+            }
+        }
         // Every id must be origin-namespaced so it routes to the right provider and can't collide with a
         // Today DashboardCard id.
         for card in HostedCard.allCases {

--- a/StrandTests/HostedCardPrefsTests.swift
+++ b/StrandTests/HostedCardPrefsTests.swift
@@ -57,6 +57,9 @@ final class HostedCardPrefsTests: XCTestCase {
         for card in HostedCard.allCases where card.origin == sleepOrigin && card != .sleepMarks {
             XCTAssertEqual(card.route, .sleep, "\(card.rawValue) should open Sleep")
         }
+        // Named explicitly, as the Kotlin twin names it: the generic checks above would still pass if
+        // this card were quietly pointed at the wrong tab.
+        XCTAssertEqual(HostedCard.stressToday.route, .stress)
     }
 
     /// Opt-in surface: nothing is hosted until the user adds a card.

--- a/StrandiOS/Widgets/WidgetPublish.swift
+++ b/StrandiOS/Widgets/WidgetPublish.swift
@@ -63,7 +63,17 @@ extension WidgetSnapshot {
         // #2040: today's stress curve. Self-gating on a cheap heart-rate fingerprint, so a publish that
         // changed nothing costs one indexed COUNT and no rows. Only the FULL path scores it; the live
         // fast path below reuses the previous snapshot and so carries the curve forward untouched.
-        let stress = await StressWidgetCurve.today(repo: model.repo)
+        let stress = await StressDayCurve.today(repo: model.repo)
+        // The widget's own point type is built HERE, at the one place that needs it: `StressPoint`
+        // lives in the iOS/widget shared sources, and the producer is now also read by the Today card,
+        // which is compiled for macOS too.
+        let stressPoints: [StressPoint]? = stress.map { scored in
+            scored.result.timeline.map {
+                // `startTs` is the wall-clock bucket start with the local shift already undone, so it
+                // is a true instant and formats correctly against the device's zone.
+                StressPoint(ts: Int64($0.startTs), level: $0.level, moving: $0.maskedForActivity)
+            }
+        }
         // Loaded ONCE for the carry-forward below. Reaching for `load()` in each of the two arguments
         // would decode the App Group blob twice on any publish that could not score, and this file
         // already went to the trouble of removing one such decode from the live path.
@@ -83,7 +93,7 @@ extension WidgetSnapshot {
             effortWhoop: effortScale == .whoop,
             // nil when the curve could not be scored at all, which must not blank a widget that already
             // has one: carry the stored values forward instead of publishing an absence.
-            stressSeries: stress?.points ?? storedStress?.stressSeries,
+            stressSeries: stressPoints ?? storedStress?.stressSeries,
             stressDay: stress?.day ?? storedStress?.stressDay
         )
         saveAndReloadIfChanged(snap)


### PR DESCRIPTION
Host the stress curve on Apple's Today

The Swift twin of the Android card. Same id, same data, drawn by the Stress tab's own line.

`stress.today` now exists on both platforms. That id rides `.noopbak`, so until now an Android backup
restored on iOS silently dropped the card from the hosted selection: the decoder skips tokens it does
not recognise. The Apple contract test pins the spelling beside the sleep ids.

The card renders `DaytimeLoadLine`, which is the Stress tab's OWN line rather than a second drawing of
the same day, so the host cannot drift from the tab it mirrors. Read-only, like the hosted Stages card.
It reads `timeline`, the half-step series, matching the widget and the Android card, and shows the same
honest "Calibrating" blank when no waking hour has scored yet.

The producer moved out of the widget folder to make that possible. `StressWidgetCurve` was iOS-only and
returned the widget's own `StressPoint`, while `TodayView` is compiled for macOS too. It is now
`Strand/Data/StressDayCurve.swift`, platform-neutral, returning the analytics `Result`; the widget
publish maps that into `StressPoint` at the one place that needs it. The gate, the memo and the
off-main-actor scoring are unchanged, so the widget and the card share one computation rather than
scoring the day twice.

Loaded only when the card is hosted, the same rule the sleep model beside it follows.

**Stacked on #2052** — it needs `hostedRoute` to give the card its tap-through. Merge that first, or this shows its commit too.

### Verification

- `swiftc -parse` clean on every touched file; `Tools/doc_comment_lint.py` clean.
- The app targets do not build here (CSQLite), so the compile and `StrandTests` are app-build's job. Its path filter covers `Strand/**`, `StrandiOS/**` and `StrandTests/**`.
- NOT verified on a device.

### Parity after this

| | Kotlin | Swift |
| --- | --- | --- |
| hosted cards navigate | yes | yes (#2052) |
| `stress.today` | yes | **yes (this PR)** |
| `trends.*` (3 ids) | yes | still missing |

The three Trends cards remain. Apple has no `MetricTrendCard` equivalent — `TrendsView.metricChart` is a private method whose data comes from a private `resolve` using instance state — so those need the resolver extracting rather than hosting, which is why they are not in this change.