### PR TITLE
Host the Trends charts on Apple's Today

### DIFF
--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -777,6 +777,11 @@ struct LiquidTodayView: View {
     private func hostedCard(for card: HostedCard) -> some View {
         switch card {
         case .sleepMarks: SleepMarkCard()
+        case .trendHRV, .trendRestingHR, .trendEffort:
+            // The Trends charts, drawn by the tab's own ChartCard + TrendChart from the SAME resolved
+            // points. `HostedTrendData` walks the `days` already in hand, so unlike the sleep model and
+            // the stress curve there is no read behind these and nothing to gate.
+            HostedTrendCard(card: card, days: repo.days, effortScale: effortScale)
         case .stressToday:
             // READ-ONLY, like `stages`: the Stress tab keeps the interactive timeline and this mirrors
             // only the display. `DaytimeLoadLine` is the tab's OWN line, so the host cannot drift into

--- a/Strand/Screens/HostedCards.swift
+++ b/Strand/Screens/HostedCards.swift
@@ -55,6 +55,16 @@ enum HostedCard: String, CaseIterable, Identifiable {
     /// The rawValue rides `.noopbak` under `today.hostedCards`, so it is byte-identical to the Android
     /// `HostedCard.STRESS_TODAY`.
     case stressToday = "stress.today"
+    /// Trends tab · "HRV" — the trailing-month HRV trend (#today-hosted-cards). The three Trends-origin
+    /// cards render the SAME `ChartCard` + `TrendChart` pair the tab draws, from the SAME resolved
+    /// points, parameterised by which `DailyMetric` field they read.
+    ///
+    /// These rawValues ride `.noopbak` and are byte-identical to the Android `HostedCard` ids.
+    case trendHRV = "trends.hrv"
+    /// Trends tab · "Resting heart rate" — the trailing-month resting-HR trend.
+    case trendRestingHR = "trends.restingHr"
+    /// Trends tab · "Effort" — the trailing-month Effort trend, on the wearer's chosen scale (#268).
+    case trendEffort = "trends.effort"
 
     var id: String { rawValue }
 
@@ -70,6 +80,9 @@ enum HostedCard: String, CaseIterable, Identifiable {
         case .hoursVsNeeded: return String(localized: "Hours vs Needed")
         case .consistency: return String(localized: "Consistency")
         case .stressToday: return String(localized: "Stress through the day")
+        case .trendHRV: return String(localized: "Heart rate variability")
+        case .trendRestingHR: return String(localized: "Resting heart rate")
+        case .trendEffort: return String(localized: "Effort")
         }
     }
 
@@ -79,6 +92,7 @@ enum HostedCard: String, CaseIterable, Identifiable {
         switch self {
         case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages, .hoursVsNeeded, .consistency: return String(localized: "Sleep")
         case .stressToday: return String(localized: "Stress")
+        case .trendHRV, .trendRestingHR, .trendEffort: return String(localized: "Trends")
         }
     }
 
@@ -99,6 +113,11 @@ enum HostedCard: String, CaseIterable, Identifiable {
         case .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages,
              .hoursVsNeeded, .consistency: return .sleep
         case .stressToday: return .stress
+        // The METRIC's own detail page rather than the Trends tab: closer to what was tapped, and the
+        // destination the Charge and Effort key tiles already use. Twin of the Kotlin `Metric` destination.
+        case .trendHRV: return .metricSourced(key: "hrv", source: "my-whoop")
+        case .trendRestingHR: return .metricSourced(key: "rhr", source: "my-whoop")
+        case .trendEffort: return .metricSourced(key: "strain", source: "my-whoop")
         }
     }
 
@@ -114,6 +133,9 @@ enum HostedCard: String, CaseIterable, Identifiable {
         case .hoursVsNeeded: return "gauge.medium"
         case .consistency: return "repeat"
         case .stressToday: return "chart.xyaxis.line"
+        case .trendHRV: return "waveform.path.ecg"
+        case .trendRestingHR: return "heart"
+        case .trendEffort: return "bolt.fill"
         }
     }
 
@@ -122,6 +144,9 @@ enum HostedCard: String, CaseIterable, Identifiable {
         switch self {
         case .sleepMarks, .asleepDuration, .stagesVsTypical, .nightDetail, .sleepDebt, .stages, .hoursVsNeeded, .consistency: return StrandPalette.restColor
         case .stressToday: return StrandPalette.stressColor
+        case .trendHRV: return StrandPalette.metricPurple
+        case .trendRestingHR: return StrandPalette.metricRose
+        case .trendEffort: return StrandPalette.effortColor
         }
     }
 

--- a/Strand/Screens/HostedTrendCard.swift
+++ b/Strand/Screens/HostedTrendCard.swift
@@ -1,5 +1,6 @@
 import StrandDesign
 import SwiftUI
+import WhoopStore
 
 /// Resolving a metric's trend points from banked days.
 ///

--- a/Strand/Screens/HostedTrendCard.swift
+++ b/Strand/Screens/HostedTrendCard.swift
@@ -42,6 +42,22 @@ enum HostedTrendData {
         return days.filter { $0.day >= cutoff }
     }
 
+    /// The plotted y-range: the data's own span with a little air, the fixed fallback when there is no
+    /// data at all, and a unit either side of a single repeated value so one flat line does not map onto
+    /// a zero-width range.
+    ///
+    /// Shared with the tab for the same reason the windowing is. A card that padded by a different
+    /// fraction would plot the SAME points at a visibly different height from the chart it mirrors,
+    /// which is exactly the drift hosting is meant to avoid.
+    static func valueRange(_ pts: [TrendPoint], fallback: ClosedRange<Double>,
+                           pad: Double = 0.12) -> ClosedRange<Double> {
+        let vals = pts.map(\.value)
+        guard let lo = vals.min(), let hi = vals.max() else { return fallback }
+        if hi <= lo { return (lo - 1)...(hi + 1) }
+        let span = hi - lo
+        return (lo - span * pad)...(hi + span * pad)
+    }
+
     private static func points(_ days: [DailyMetric], _ value: (DailyMetric) -> Double?) -> [TrendPoint] {
         days.compactMap { d in
             guard let v = value(d), let dt = dayParser.date(from: d.day) else { return nil }
@@ -102,7 +118,7 @@ struct HostedTrendCard: View {
                   height: NoopMetrics.chartHeight, tint: colour) {
             TrendChart(points: pts,
                        gradient: Gradient(colors: [colour.opacity(0.35), colour]),
-                       valueRange: valueRange(pts, fallback: fallback),
+                       valueRange: HostedTrendData.valueRange(pts, fallback: fallback),
                        showsArea: true,
                        // Hover OFF. The card sits inside a NavigationLink, so a scrubbing gesture here
                        // would compete with the tap that opens the metric — the same conflict that
@@ -114,14 +130,4 @@ struct HostedTrendCard: View {
         .accessibilityLabel(Text(title))
     }
 
-    /// The plotted range: the data's own span with a little air, or a sensible fixed window when the
-    /// card has too little to imply one. Without the fallback a single point would map onto a
-    /// zero-width range and land wherever the divide happened to put it.
-    private func valueRange(_ pts: [TrendPoint], fallback: ClosedRange<Double>) -> ClosedRange<Double> {
-        guard let lo = pts.map(\.value).min(), let hi = pts.map(\.value).max(), hi > lo else {
-            return fallback
-        }
-        let pad = (hi - lo) * 0.1
-        return (lo - pad)...(hi + pad)
-    }
 }

--- a/Strand/Screens/HostedTrendCard.swift
+++ b/Strand/Screens/HostedTrendCard.swift
@@ -1,0 +1,127 @@
+import StrandDesign
+import SwiftUI
+
+/// Resolving a metric's trend points from banked days.
+///
+/// Extracted from `TrendsView` so the Today host cards resolve EXACTLY as the Trends tab does. It is
+/// shared rather than copied on purpose: the widening fallback is the part a wearer with two weeks of
+/// history actually depends on, and a second implementation of it would drift the moment either side
+/// was tuned. `TrendsView.resolve` calls this too.
+enum HostedTrendData {
+
+    /// Day strings are banked as `yyyy-MM-dd` in UTC; parsing them any other way shifts every point.
+    private static let dayParser: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+
+    /// The metric's points for the smallest window at or wider than `selected` that holds any data,
+    /// and the window it settled on.
+    ///
+    /// Walks the widening order ONCE, keeping the window's points rather than re-filtering to read them
+    /// back. Falls back to all history when no window held anything, which matches what the tab shows
+    /// rather than leaving a new wearer with an empty card.
+    static func resolve(days: [DailyMetric],
+                        selected: TrendsView.Range,
+                        value: (DailyMetric) -> Double?) -> (points: [TrendPoint], effective: TrendsView.Range) {
+        for r in selected.widening {
+            let pts = points(window(days, r), value)
+            if !pts.isEmpty { return (pts, r) }
+        }
+        return (points(window(days, .all), value), .all)
+    }
+
+    /// The trailing window of `days`, anchored on today's local day exactly as the tab anchors it.
+    private static func window(_ days: [DailyMetric], _ r: TrendsView.Range) -> [DailyMetric] {
+        guard let n = r.days, n > 0 else { return days }
+        let cutoff = Repository.localDayKey(
+            Calendar.current.date(byAdding: .day, value: -(n - 1), to: Date()) ?? Date())
+        return days.filter { $0.day >= cutoff }
+    }
+
+    private static func points(_ days: [DailyMetric], _ value: (DailyMetric) -> Double?) -> [TrendPoint] {
+        days.compactMap { d in
+            guard let v = value(d), let dt = dayParser.date(from: d.day) else { return nil }
+            return TrendPoint(date: dt, value: v)
+        }
+    }
+}
+
+/// One Trends metric trend, rendered as a Today host card (#today-hosted-cards).
+///
+/// Draws the same `ChartCard` + `TrendChart` pair the Trends tab draws, from the same resolved points,
+/// so the hosted copy cannot become a second chart of the same numbers.
+///
+/// What it does NOT carry is the range selector. A home-screen card has nowhere to put one and no place
+/// to persist a per-card choice, so each takes a fixed trailing month and keeps the tab's widening
+/// fallback for a wearer whose history is shorter than that. The Trends tab stays where the window is
+/// chosen. Twin of the Kotlin `TrendHostCard`.
+struct HostedTrendCard: View {
+    let card: HostedCard
+    let days: [DailyMetric]
+    /// The wearer's Effort scale, resolved by the host rather than read here: only one of the three
+    /// cards needs it, and Today already has it for its own tiles.
+    let effortScale: EffortScale
+
+    var body: some View {
+        switch card {
+        case .trendHRV:
+            chart(title: "Heart rate variability", unit: "ms",
+                  colour: StrandPalette.metricPurple, fallback: 20...120, value: { $0.avgHrv },
+                  fmt: { "\(Int($0.rounded()))" })
+        case .trendRestingHR:
+            chart(title: "Resting heart rate", unit: "bpm",
+                  colour: StrandPalette.metricRose, fallback: 40...90, value: { $0.restingHr.map(Double.init) },
+                  fmt: { "\(Int($0.rounded()))" })
+        case .trendEffort:
+            // Plotted on the stored 0-100 axis so the line's shape is scale-independent; only the
+            // printed numbers follow the Effort-scale toggle, converted inside `fmt`, exactly as the
+            // Trends tab does it (#268).
+            chart(title: "Effort", unit: "/ \(UnitFormatter.effortScaleMax(effortScale))",
+                  colour: StrandPalette.effortColor, fallback: 0...100, value: { $0.strain },
+                  fmt: { UnitFormatter.effortDisplay($0, scale: effortScale) })
+        default:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func chart(title: LocalizedStringKey, unit: String, colour: Color,
+                       fallback: ClosedRange<Double>,
+                       value: @escaping (DailyMetric) -> Double?,
+                       fmt: @escaping (Double) -> String) -> some View {
+        let resolved = HostedTrendData.resolve(days: days, selected: .month, value: value)
+        let pts = resolved.points
+        let avg = pts.isEmpty ? nil : pts.map(\.value).reduce(0, +) / Double(pts.count)
+        // The unit rides with the average. The Trends tab carries it in a footer of min/mean/max, which
+        // a home-screen card has no room for, so without this the number would appear bare.
+        ChartCard(title: title, subtitle: nil, trailing: avg.map { "\(fmt($0)) \(unit)" },
+                  height: NoopMetrics.chartHeight, tint: colour) {
+            TrendChart(points: pts,
+                       gradient: Gradient(colors: [colour.opacity(0.35), colour]),
+                       valueRange: valueRange(pts, fallback: fallback),
+                       showsArea: true,
+                       // Hover OFF. The card sits inside a NavigationLink, so a scrubbing gesture here
+                       // would compete with the tap that opens the metric — the same conflict that
+                       // keeps the tap-to-log card out of the navigation map. The Trends tab keeps the
+                       // scrub; the Today host mirrors only the display, as the hosted Stages card does.
+                       showsHover: false)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text(title))
+    }
+
+    /// The plotted range: the data's own span with a little air, or a sensible fixed window when the
+    /// card has too little to imply one. Without the fallback a single point would map onto a
+    /// zero-width range and land wherever the divide happened to put it.
+    private func valueRange(_ pts: [TrendPoint], fallback: ClosedRange<Double>) -> ClosedRange<Double> {
+        guard let lo = pts.map(\.value).min(), let hi = pts.map(\.value).max(), hi > lo else {
+            return fallback
+        }
+        let pad = (hi - lo) * 0.1
+        return (lo - pad)...(hi + pad)
+    }
+}

--- a/Strand/Screens/HostedTrendCard.swift
+++ b/Strand/Screens/HostedTrendCard.swift
@@ -114,7 +114,8 @@ struct HostedTrendCard: View {
         let avg = pts.isEmpty ? nil : pts.map(\.value).reduce(0, +) / Double(pts.count)
         // The unit rides with the average. The Trends tab carries it in a footer of min/mean/max, which
         // a home-screen card has no room for, so without this the number would appear bare.
-        ChartCard(title: title, subtitle: nil, trailing: avg.map { "\(fmt($0)) \(unit)" },
+        let trailing = avg.map { "\(fmt($0)) \(unit)" }
+        ChartCard(title: title, subtitle: nil, trailing: trailing,
                   height: NoopMetrics.chartHeight, tint: colour) {
             TrendChart(points: pts,
                        gradient: Gradient(colors: [colour.opacity(0.35), colour]),
@@ -127,7 +128,12 @@ struct HostedTrendCard: View {
                        showsHover: false)
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(Text(title))
+        // The average goes into the spoken label, not just the visible corner. `children: .combine`
+        // merges what the card renders, and overriding that with the bare title, as this first did,
+        // silently drops the one number on the card: VoiceOver announced "Heart rate variability" and
+        // nothing else. Composed rather than interpolated into a localized string, so it needs no new
+        // catalog entry for what is a title the app already has plus a formatted value.
+        .accessibilityLabel(trailing.map { Text(title) + Text(verbatim: ", \($0)") } ?? Text(title))
     }
 
 }

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -2483,6 +2483,11 @@ struct TodayView: View {
     private func hostedCard(for card: HostedCard) -> some View {
         switch card {
         case .sleepMarks: SleepMarkCard()
+        case .trendHRV, .trendRestingHR, .trendEffort:
+            // The Trends charts, drawn by the tab's own ChartCard + TrendChart from the SAME resolved
+            // points. `HostedTrendData` walks the `days` already in hand, so unlike the sleep model and
+            // the stress curve there is no read behind these and nothing to gate.
+            HostedTrendCard(card: card, days: repo.days, effortScale: effortScale)
         case .stressToday:
             // READ-ONLY, like `stages`: the Stress tab keeps the interactive timeline and this mirrors
             // only the display. `DaytimeLoadLine` is the tab's OWN line, so the host cannot drift into

--- a/Strand/Screens/TrendsView.swift
+++ b/Strand/Screens/TrendsView.swift
@@ -94,22 +94,6 @@ struct TrendsView: View {
     /// (issue #23). Empty short windows auto-widen (see `resolve`), so old imports surface under a
     /// wider range / All history instead of masquerading as recent. `.all` returns everything.
     /// ISO yyyy-MM-dd compares chronologically.
-    private func days(for r: Range) -> [DailyMetric] {
-        guard let n = r.days else { return repo.days }
-        let cutoffKey = Repository.localDayKey(Calendar.current.date(byAdding: .day, value: -(n - 1), to: Date()) ?? Date())
-        return repo.days.filter { $0.day >= cutoffKey }
-    }
-
-    /// Build trend points from a metric accessor over a day slice.
-    private func points(_ days: ArraySlice<DailyMetric>, _ value: (DailyMetric) -> Double?) -> [TrendPoint] {
-        days.compactMap { d in
-            guard let v = value(d), let dt = date(d.day) else { return nil }
-            return TrendPoint(date: dt, value: v)
-        }
-    }
-    private func points(_ days: [DailyMetric], _ value: (DailyMetric) -> Double?) -> [TrendPoint] {
-        points(days[...], value)
-    }
 
     // MARK: Resolved metric (memoized per body)
     //
@@ -156,11 +140,7 @@ struct TrendsView: View {
 
     /// A padded value range for a series so the line isn't flat against the axis.
     private func valueRange(_ pts: [TrendPoint], fallback: ClosedRange<Double>, pad: Double = 0.12) -> ClosedRange<Double> {
-        let vals = pts.map(\.value)
-        guard let lo = vals.min(), let hi = vals.max() else { return fallback }
-        if hi <= lo { return (lo - 1)...(hi + 1) }
-        let span = hi - lo
-        return (lo - span * pad)...(hi + span * pad)
+        HostedTrendData.valueRange(pts, fallback: fallback, pad: pad)
     }
 
     private func mean(_ pts: [TrendPoint]) -> Double? {

--- a/Strand/Screens/TrendsView.swift
+++ b/Strand/Screens/TrendsView.swift
@@ -132,17 +132,13 @@ struct TrendsView: View {
     private func resolve(_ value: (DailyMetric) -> Double?) -> ResolvedMetric {
         // Find the smallest range ≥ selected whose window has ≥1 point, keeping
         // that window's points so we don't re-filter to read them back.
-        for r in range.widening {
-            let pts = points(days(for: r), value)
-            if !pts.isEmpty {
-                return ResolvedMetric(points: pts, effective: r,
-                                      widened: r != range, caption: caption(count: pts.count, eff: r))
-            }
-        }
-        // No range held data: fall back to ALL (matches effectiveRange()).
-        let pts = points(days(for: .all), value)
-        return ResolvedMetric(points: pts, effective: .all,
-                              widened: .all != range, caption: caption(count: pts.count, eff: .all))
+        // The windowing lives in `HostedTrendData` so the Today host cards resolve EXACTLY as this tab
+        // does. Shared rather than copied: the widening fallback is what a wearer with two weeks of
+        // history depends on, and a second implementation would drift the moment either side was tuned.
+        let r = HostedTrendData.resolve(days: repo.days, selected: range, value: value)
+        return ResolvedMetric(points: r.points, effective: r.effective,
+                              widened: r.effective != range,
+                              caption: caption(count: r.points.count, eff: r.effective))
     }
 
     /// Caption text from an already-resolved count + effective range. Mirrors

--- a/StrandTests/HostedCardPrefsTests.swift
+++ b/StrandTests/HostedCardPrefsTests.swift
@@ -14,6 +14,9 @@ final class HostedCardPrefsTests: XCTestCase {
         // Byte-identical to the Kotlin `HostedCard.STRESS_TODAY`. This id rides .noopbak, so a
         // difference of one character means an Android backup restored here silently drops the card.
         XCTAssertEqual(HostedCard.stressToday.rawValue, "stress.today")
+        XCTAssertEqual(HostedCard.trendHRV.rawValue, "trends.hrv")
+        XCTAssertEqual(HostedCard.trendRestingHR.rawValue, "trends.restingHr")
+        XCTAssertEqual(HostedCard.trendEffort.rawValue, "trends.effort")
     }
 
     /// The two local-day counters have to agree, and nothing but this test can check them.
@@ -60,6 +63,11 @@ final class HostedCardPrefsTests: XCTestCase {
         // Named explicitly, as the Kotlin twin names it: the generic checks above would still pass if
         // this card were quietly pointed at the wrong tab.
         XCTAssertEqual(HostedCard.stressToday.route, .stress)
+        // The metric's own page, with the SOURCE pinned: `rhr` exists under both my-whoop and
+        // xiaomi-band, so a bare key would resolve by catalog declaration order.
+        XCTAssertEqual(HostedCard.trendHRV.route, .metricSourced(key: "hrv", source: "my-whoop"))
+        XCTAssertEqual(HostedCard.trendRestingHR.route, .metricSourced(key: "rhr", source: "my-whoop"))
+        XCTAssertEqual(HostedCard.trendEffort.route, .metricSourced(key: "strain", source: "my-whoop"))
     }
 
     /// Opt-in surface: nothing is hosted until the user adds a card.


### PR DESCRIPTION
Host the Trends charts on Apple's Today

The last of the hosted-card parity gaps. HRV, resting heart rate and Effort now appear in Customise
under a Trends heading on Apple as they do on Android, in both Today shells, and their three raw ids
exist on both platforms, so an Android backup restored here stops silently dropping them.

The resolver is SHARED, not copied. `TrendsView.resolve` walked its own windowing over instance state,
which no other view could reach, so it moved to `HostedTrendData` and the tab now calls it too. That
matters more than the tidiness: the widening fallback is what a wearer with two weeks of history
depends on, and a second implementation of it would drift the moment either side was tuned.

The cards draw the tab's own `ChartCard` + `TrendChart` from the same resolved points, so a hosted copy
cannot become a second chart of the same numbers. They carry no range selector, because a home-screen
card has nowhere to put one and no place to persist a per-card choice; each takes a fixed trailing
month and keeps the widening fallback. The unit rides with the average, since the tab's min/mean/max
footer has no room here and the number would otherwise appear bare.

Hover is OFF. These sit inside a `NavigationLink`, and `TrendChart` scrubs by default, so leaving it on
would put a drag gesture in competition with the tap that opens the metric, the same conflict that
keeps the tap-to-log card out of the navigation map.

Each opens the METRIC's own detail page rather than the Trends tab, with the source pinned. That is not
decoration: `rhr` exists in the catalog under both `my-whoop` and `xiaomi-band`, so a bare key would
resolve by declaration order. The tests pin the ids and the routes.
