### PR TITLE
fix: explain unavailable WHOOP 5 recovery history

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/Whoop5RRReadPolicy.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Whoop5RRReadPolicy.swift
@@ -2,6 +2,18 @@ import GRDB
 import WhoopProtocol
 
 extension WhoopStore {
+    /// Whether a sleep interval contains legacy beats whose units cannot be recovered. Callers
+    /// must establish the owner's WHOOP 5 policy before using this as a reason for missing HRV.
+    public func hasUnlabelledRR(deviceId: String, from: Int, to: Int) async throws -> Bool {
+        try syncRead { db in
+            try Bool.fetchOne(db, sql: """
+                SELECT EXISTS(SELECT 1 FROM rrInterval
+                WHERE deviceId = ? AND ts >= ? AND ts < ? AND srcChannel IS NULL
+                  AND (tsSuspect IS NULL OR tsSuspect <> 1))
+                """, arguments: [deviceId, from, to]) ?? false
+        }
+    }
+
     /// Shared by RR reads and consumers whose cached/union reads must obey the same owner policy.
     public func isWhoop5RRSource(deviceId: String, unlabelledAliasOfWhoop5: Bool = false) async throws -> Bool {
         try syncRead { try Self.isWhoop5RRSource(db: $0, deviceId: deviceId,

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/Whoop5RRStoreTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/Whoop5RRStoreTests.swift
@@ -4,6 +4,27 @@ import WhoopProtocol
 @testable import WhoopStore
 
 final class Whoop5RRStoreTests: XCTestCase {
+    func testLegacyGapEvidenceExcludesSuspectTimestampsAndTheSleepEnd() async throws {
+        let store = try await WhoopStore.inMemory()
+        _ = try await store.insert(Streams(rr: [
+            RRInterval(ts: 100, rrMs: 900),
+            RRInterval(ts: 200, rrMs: 900),
+            RRInterval(ts: 300, rrMs: 900),
+            RRInterval(ts: 400, rrMs: 900, srcChannel: .whoop5Historical)
+        ]), deviceId: "five")
+        try await store.registryWriter.write { db in
+            try db.execute(sql: "UPDATE rrInterval SET tsSuspect = 1 WHERE ts = 200")
+        }
+        let inside = try await store.hasUnlabelledRR(deviceId: "five", from: 100, to: 200)
+        let suspectOnly = try await store.hasUnlabelledRR(deviceId: "five", from: 101, to: 300)
+        let labelled = try await store.hasUnlabelledRR(deviceId: "five", from: 400, to: 500)
+        let otherOwner = try await store.hasUnlabelledRR(deviceId: "other", from: 0, to: 500)
+        XCTAssertTrue(inside)
+        XCTAssertFalse(suspectOnly)
+        XCTAssertFalse(labelled)
+        XCTAssertFalse(otherOwner)
+    }
+
     private let id = "my-whoop"
     private func registry(_ store: WhoopStore, model: String, brand: String = "WHOOP") throws {
         try store.registryWriter.write { db in

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -197,6 +197,8 @@ final class IntelligenceEngine: ObservableObject {
         /// Persisted to metricSeries as "hrv_rr_overcount" (1/0) in pass 2 so the HRV card can flag the
         /// reading "unverified" until the de-dup fix lands. Same verdict the always-on `hrv diag` logs.
         let hrvOverCounted: Bool?
+        /// No selected in-sleep beats survived the WHOOP 5 legacy-unit exclusion.
+        let legacyRRExcluded: Bool
         /// #1169 SHADOW METRIC: the primary-session MEAN resting HR (PrimarySessionRestingHR, #1174) for this
         /// day, computed off the main actor beside the shipped nightly HR FLOOR (`daily.restingHr`). nil when
         /// no session clears the coverage gate. Written to metricSeries as "rhr_primary_session" in pass 2 —
@@ -1336,6 +1338,16 @@ final class IntelligenceEngine: ObservableObject {
                 // Byte-identical to the Kotlin line.
                 let sleepRrRows = rr.filter { r in res.cachedSleep.contains { r.ts >= $0.startTs && r.ts < $0.endTs } }
                 let sleepRr = sleepRrRows.map { Double($0.rrMs) }
+                var legacyRRExcluded = false
+                if strictWhoop5RR && sleepRr.isEmpty && res.daily.avgHrv == nil {
+                    for session in res.cachedSleep {
+                        if (try? await store.hasUnlabelledRR(deviceId: owner,
+                            from: session.startTs, to: session.endTs)) == true {
+                            legacyRRExcluded = true
+                            break
+                        }
+                    }
+                }
                 let hrvDiag: String?
                 let hrvOverCounted: Bool?   // #1118: nil = no in-sleep R-R (no HRV to caveat)
                 // #1331: the RSA gate's inputs, carried to the resp diagnostic below. Declared out here because
@@ -1589,6 +1601,7 @@ final class IntelligenceEngine: ObservableObject {
                                    hrvDiag: Self.mergedDayDiag(hrvDiag, strainDiagLines),
                                    spo2Candidate: spo2CandidateMean,
                                    hrvOverCounted: hrvOverCounted,
+                                   legacyRRExcluded: legacyRRExcluded,
                                    primarySessionRHR: primarySessionRHR,
                                    primarySessionRHRCoverage: primarySessionRHRCoverage)
                 // #1005: cache this freshly-scored scan under its per-day key (only when the day was
@@ -1669,6 +1682,7 @@ final class IntelligenceEngine: ObservableObject {
         // #1118: per-day HRV over-count flag, carried from pass 1 for metricSeries persistence. nil (absent)
         // for a night with no in-sleep R-R; otherwise true/false, so a re-score always overwrites the row.
         var hrvOverCountByDay: [String: Bool] = [:]
+        var legacyRRExcludedByDay: [String: Bool] = [:]
         // #1169: primary-session mean RHR shadow metric per day, carried from pass 1 for metricSeries persistence.
         var primarySessionRHRByDay: [String: Double] = [:]
         // #1169: its coverage inputs (valid-sample count + primary-session duration), same lifetime as the mean.
@@ -1679,6 +1693,7 @@ final class IntelligenceEngine: ObservableObject {
         // main actor was free during the heavy enumeration above.
         for scan in scanned {
             let res = scan.result
+            legacyRRExcludedByDay[res.daily.day] = scan.legacyRRExcluded
             readOwnerByDay[res.daily.day] = (scan.readOwner, scan.hrRows)
             resolvedScoreOwnerByDay[res.daily.day] = scan.readOwner
             nightlyHrvByDay[res.daily.day] = res.daily.avgHrv
@@ -2064,6 +2079,9 @@ final class IntelligenceEngine: ObservableObject {
             if let oc = hrvOverCountByDay[daily.day] {
                 restPoints.append(MetricPoint(day: daily.day, key: "hrv_rr_overcount", value: oc ? 1.0 : 0.0))
             }
+            // Write zero as well: a re-sync must clear an earlier explanation, including on cache hits.
+            restPoints.append(MetricPoint(day: daily.day, key: "hrv_rr_legacy_excluded",
+                value: legacyRRExcludedByDay[daily.day] == true && daily.avgHrv == nil ? 1.0 : 0.0))
             // #1169 shadow metric: the primary-session mean RHR, stored beside the shipped floor
             // (daily.restingHr) under the "-noop" computed ID. Instrumentation only — never shown, never
             // scored — so the mean-vs-floor comparison the issue needs can be evaluated from exports later.
@@ -2236,6 +2254,16 @@ final class IntelligenceEngine: ObservableObject {
         // resting HR, which the engine's computed-only `dailies` never carries). Captured here so the
         // Fitness Age gate can't be undercut by this pass's own scoring/eviction. Windowed to the range.
         let faPriorDaily = await repo.dailyMetrics(fromDay: oldestDay, toDay: newestDay)
+
+        // Clear skipped days in this computed source, without duplicating fresh scored evidence.
+        // The existing persistence transaction retains its guard for an entirely empty pass.
+        let legacyFlagDays = Set(restPoints.filter { $0.key == "hrv_rr_legacy_excluded" }.map(\.day))
+        for offset in 0..<maxDays {
+            let day = AnalyticsEngine.dayString(nowLocalMidnight - offset * 86_400, offsetSec: tzOffset)
+            if !legacyFlagDays.contains(day) {
+                restPoints.append(MetricPoint(day: day, key: "hrv_rr_legacy_excluded", value: 0))
+            }
+        }
 
         // Score provenance is metric-specific and lives outside dayOwnership (which remains solely a
         // resolver override). Persist scores + provenance atomically so a failed write can never label an

--- a/Strand/Data/Repository.swift
+++ b/Strand/Data/Repository.swift
@@ -195,6 +195,8 @@ final class Repository: ObservableObject {
     /// Daily metric rows with source provenance, used by vital-sign surfaces that need honest
     /// "WHOOP import / NOOP computed / Apple Health" captions instead of a silent merged row.
     @Published private(set) var vitalRows: [SourcedDailyMetric] = []
+    /// Scored nights missing HRV because their WHOOP 5 beats have unproven legacy units.
+    @Published private(set) var legacyRRExcludedDays: Set<String> = []
     /// Monotonic counter bumped on every successful `refresh()`. Intraday-updating views key their
     /// data load on this so they reload when fresh strap data lands , `today?.day` alone is a stable
     /// date string within a day and would freeze e.g. the Today HR trend until the date rolls over.
@@ -905,6 +907,14 @@ final class Repository: ObservableObject {
         let activityFile = (try? await store.dailyMetrics(deviceId: Self.activityFileSource, from: fromDay, to: toDay)) ?? []
         let impSleep = await unionSleepSessions(store: store, from: lo, to: hi)
         let compSleep = await unionComputedSleepSessions(store: store, from: lo, to: hi)
+        var legacyRRFlags: [String: Double] = [:]
+        for id in computedReadIds.reversed() {
+            for point in (try? await store.metricSeries(deviceId: id, key: "hrv_rr_legacy_excluded",
+                from: fromDay, to: toDay)) ?? [] {
+                legacyRRFlags[point.day] = point.value
+            }
+        }
+        let legacyRRDays = Set(legacyRRFlags.filter { $0.value == 1 }.map(\.key))
 
         // Export-verbatim sleep figures (long-format metricSeries rows from WhoopImporter).
         // SleepView prefers these per day over its APPROXIMATE recomputations.
@@ -953,6 +963,7 @@ final class Repository: ObservableObject {
             && merged.importedSleep == importedSleep
             && merged.vitalRows == vitalRows
             && merged.freshness == freshness
+            && legacyRRDays == legacyRRExcludedDays
         guard !unchanged else { return }
 
         // One consistent publish per refresh: assign every cache, flip `loaded`, then bump `refreshSeq` so
@@ -961,6 +972,7 @@ final class Repository: ObservableObject {
         self.days = merged.days
         self.sleeps = merged.sleeps
         self.vitalRows = merged.vitalRows
+        self.legacyRRExcludedDays = legacyRRDays
         self.freshness = merged.freshness
         self.loaded = true
         // Drop the Explorer's cross-catalog memo rather than leaving it to be evicted lazily by a key

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -337,7 +337,11 @@ struct LiquidTodayView: View {
                     // nothing and keeps its slot in the saved order.
                     ForEach(sectionOrder) { section in
                         switch section {
-                        case .hero: heroCard
+                        case .hero:
+                            VStack(alignment: .leading, spacing: NoopMetrics.space3) {
+                                heroCard
+                                if let rrGapMessage { Whoop5RRGapNotice(message: rrGapMessage) }
+                            }
                         case .liveSession: if liveSessionsBeta { liveSessionStartRow }
                         case .synthesis: synthesisSection
                         case .keyMetrics: keyMetricsSection
@@ -656,6 +660,10 @@ struct LiquidTodayView: View {
         }
         .buttonStyle(LiquidPressStyle())
         .accessibilityLabel("Start a live session. Beta. Silent strap coaching against today's Charge.")
+    }
+
+    private var rrGapMessage: String? {
+        Whoop5RRGap.message(day: displayDay, excludedDays: repo.legacyRRExcludedDays)
     }
 
     private var heroCard: some View {
@@ -1145,12 +1153,12 @@ struct LiquidTodayView: View {
                         // readiness one-liner here — the same swap classic makes (`calibrationDetail ??
                         // synthesisCardDetail`), so the count the short greeting pill can't carry lands in
                         // the card and both Today screens read identically.
-                        Text(chargeDisplay.calibrationDetail ?? synthLine)
+                        Text(rrGapMessage ?? chargeDisplay.calibrationDetail ?? synthLine)
                             .font(StrandFont.body).foregroundStyle(StrandPalette.textPrimary)
                             .fixedSize(horizontal: false, vertical: true)
                         // The reason the count is not moving, when nights are arriving empty. Sits under
                         // the progress rather than replacing it: the wearer needs both the number and why.
-                        if let why = chargeDisplay.calibrationReason(
+                        if rrGapMessage == nil, let why = chargeDisplay.calibrationReason(
                             dayKeys: repo.days.map(\.day), nightlyHrv: repo.days.map(\.avgHrv),
                             today: Repository.logicalDayKey(Date())) {
                             Text(why).font(StrandFont.caption)

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -1,6 +1,70 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "Earlier WHOOP 5 beats cannot be scored for HRV or Charge. Re-sync your strap to recover available history.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Earlier WHOOP 5 beats cannot be scored for HRV or Charge. Re-sync your strap to recover available history."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frühere WHOOP 5-Herzschläge können nicht für HRV oder Charge ausgewertet werden. Synchronisiere dein Band erneut, um verfügbare Verlaufsdaten wiederherzustellen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los latidos anteriores de WHOOP 5 no se pueden usar para calcular HRV o Charge. Vuelve a sincronizar tu pulsera para recuperar el historial disponible."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les anciens battements WHOOP 5 ne peuvent pas servir au calcul de HRV ou de Charge. Resynchronisez votre bracelet pour récupérer les données historiques disponibles."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I battiti precedenti di WHOOP 5 non possono essere usati per calcolare HRV o Charge. Sincronizza di nuovo il bracciale per recuperare la cronologia disponibile."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Os batimentos anteriores do WHOOP 5 não podem ser usados para calcular HRV ou Charge. Volta a sincronizar a pulseira para recuperar o histórico disponível."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wcześniejsze uderzenia serca z WHOOP 5 nie mogą służyć do obliczania HRV ani Charge. Zsynchronizuj ponownie opaskę, aby odzyskać dostępną historię."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Прежние данные об ударах сердца WHOOP 5 нельзя использовать для расчёта HRV или Charge. Синхронизируйте браслет заново, чтобы восстановить доступную историю."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "早期的 WHOOP 5 心搏数据无法用于计算 HRV 或 Charge。请重新同步手环，以恢复仍可获取的历史数据。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "早期的 WHOOP 5 心搏資料無法用於計算 HRV 或 Charge。請重新同步手環，以恢復仍可取得的歷史資料。"
+          }
+        }
+      }
+    },
     "Heart rate, no reading": { "localizations": {
       "de": { "stringUnit": { "state": "translated", "value": "Herzfrequenz, keine Messung" } }, "en": { "stringUnit": { "state": "translated", "value": "Heart rate, no reading" } }, "es": { "stringUnit": { "state": "translated", "value": "Frecuencia cardíaca, sin lectura" } }, "fr": { "stringUnit": { "state": "translated", "value": "Fréquence cardiaque, aucune mesure" } }, "it": { "stringUnit": { "state": "translated", "value": "Frequenza cardiaca, nessuna lettura" } }, "pl": { "stringUnit": { "state": "translated", "value": "Tętno, brak odczytu" } }, "pt-PT": { "stringUnit": { "state": "translated", "value": "Frequência cardíaca, sem leitura" } }, "ru": { "stringUnit": { "state": "translated", "value": "Пульс, нет данных" } }, "zh-Hans": { "stringUnit": { "state": "translated", "value": "心率，无读数" } }, "zh-Hant": { "stringUnit": { "state": "translated", "value": "心率，無讀數" } }
     } },

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -2031,6 +2031,7 @@ struct TodayView: View {
     private var heroSection: some View {
         let d = displayDay
         let score = d?.recovery
+        let rrGapMessage = Whoop5RRGap.message(day: d, excludedDays: repo.legacyRRExcludedDays)
         VStack(alignment: .leading, spacing: NoopMetrics.gap) {
             // Recording status now lives as a colour-coded light in the header icon row, not a full-width
             // banner sandwiched above the rings. The three clean rings lead the screen directly.
@@ -2041,7 +2042,9 @@ struct TodayView: View {
             // BEFORE the generic Component-2 note (and on every day, not just today): unlike an ordinary
             // "missing data" gap, here the exact cause and the fix are known, so a past day gets the same
             // honest explanation rather than the usual silent bare ring.
-            if chargeDeepWindowGap {
+            if let rrGapMessage {
+                Whoop5RRGapNotice(message: rrGapMessage)
+            } else if chargeDeepWindowGap {
                 chargeDeepWindowGapNote
             } else if selectedDayOffset == 0 && !chargeScoreState.isCalibrating {
                 // Component 2, when Charge has no real today value, an explained state with its detail +
@@ -2061,7 +2064,7 @@ struct TodayView: View {
             // TODAY (a past day with no Charge is missing data, not mid-calibration).
             // #827: this repeats nightly through the calibration window, so it's dismissible into the inbox
             // (restorable) instead of nagging a returning user every day. Hidden once dismissed.
-            if selectedDayOffset == 0, !calibratingDismissed, let banked = recoveryCalibration {
+            if rrGapMessage == nil, selectedDayOffset == 0, !calibratingDismissed, let banked = recoveryCalibration {
                 chargeCalibrationCountdown(banked: banked)
                     // A small × tucks the calibration note into the Updates inbox (restorable from there).
                     .overlay(alignment: .topTrailing) {

--- a/Strand/Screens/Whoop5RRGap.swift
+++ b/Strand/Screens/Whoop5RRGap.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftUI
+import StrandDesign
+import WhoopStore
+
+/// The selected day's explanation, derived from the scored evidence and the values the UI displays.
+enum Whoop5RRGap {
+    static func message(day: DailyMetric?, excludedDays: Set<String>) -> String? {
+        guard let day, day.avgHrv == nil, day.recovery == nil,
+              excludedDays.contains(day.day) else { return nil }
+        return String(localized: "Earlier WHOOP 5 beats cannot be scored for HRV or Charge. Re-sync your strap to recover available history.")
+    }
+}
+
+/// Shared by both Apple Today layouts so the explanation has the same visible and accessible copy.
+struct Whoop5RRGapNotice: View {
+    let message: String
+
+    var body: some View {
+        NoopCard(padding: NoopMetrics.space3, tint: StrandPalette.chargeColor) {
+            Text(message)
+                .font(StrandFont.subhead)
+                .foregroundStyle(StrandPalette.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityIdentifier("whoop5RRGapNotice")
+    }
+}

--- a/StrandTests/IntelligenceRRSourceTests.swift
+++ b/StrandTests/IntelligenceRRSourceTests.swift
@@ -45,6 +45,19 @@ final class IntelligenceRRSourceTests: XCTestCase {
             sourceKind: .liveBLE, capabilities: [.hr, .hrv], status: .active, addedAt: 2, lastSeenAt: 2))
     }
 
+    private func seedBaseline(_ store: WhoopStore, before day: String) async throws {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let date = try XCTUnwrap(formatter.date(from: day))
+        let history = (1...8).map { offset in
+            DailyMetric(day: formatter.string(from: date.addingTimeInterval(-Double(offset) * 86_400)),
+                totalSleepMin: 480, efficiency: 0.9, deepMin: 90, remMin: 90, lightMin: 300,
+                disturbances: 0, restingHr: 60, avgHrv: 32 + Double(offset % 3), recovery: 60,
+                strain: nil, exerciseCount: nil)
+        }
+        _ = try await store.upsertDailyMetrics(history, deviceId: canonical)
+    }
+
     // A completed night relative to the test's local day, using the established HR-only sleep fixture.
     private func night() -> (day: String, hr: [HRSample], rr: [RRInterval]) {
         let start = Int(Calendar.current.startOfDay(for: Date()).timeIntervalSince1970) - 86_400
@@ -69,6 +82,7 @@ final class IntelligenceRRSourceTests: XCTestCase {
             let registry = DeviceRegistryStore(dbQueue: store.registryWriter)
             try register(registry, canonicalModel: "WHOOP")
             let input = night()
+            try await seedBaseline(store, before: input.day)
             _ = try await store.insert(Streams(hr: input.hr, rr: input.rr), deviceId: canonical)
             let repo = Repository(deviceId: canonical)
             repo.setStoreForTesting(store)
@@ -83,6 +97,17 @@ final class IntelligenceRRSourceTests: XCTestCase {
             let first = try XCTUnwrap(before.first)
             XCTAssertGreaterThan(first.totalSleepMin ?? 0, 0, "the fixture must actually score a night")
             XCTAssertNil(first.avgHrv, "legacy alias R-R has unproven units after WHOOP 5 re-pairing")
+            XCTAssertNil(first.recovery, "an established baseline cannot score Charge without nightly HRV")
+            await repo.refresh()
+            XCTAssertNotNil(Whoop5RRGap.message(day: repo.days.first { $0.day == input.day },
+                                              excludedDays: repo.legacyRRExcludedDays),
+                            "the persisted cause must reach the same helper Today renders")
+
+            // A second repository represents a cold app launch; the explanation must survive it.
+            let reopened = Repository(deviceId: active)
+            reopened.setStoreForTesting(store)
+            await reopened.refresh()
+            XCTAssertNotNil(Whoop5RRGap.message(day: first, excludedDays: reopened.legacyRRExcludedDays))
 
             let tagged = input.rr.map { RRInterval(ts: $0.ts, rrMs: $0.rrMs, srcChannel: .whoop5Historical) }
             let inserted = try await store.insert(Streams(rr: tagged), deviceId: canonical)
@@ -93,12 +118,19 @@ final class IntelligenceRRSourceTests: XCTestCase {
                 from: input.day, to: input.day)
             let promoted = try XCTUnwrap(after.first?.avgHrv)
             XCTAssertGreaterThan(promoted, 0, "the same engine must replace its cached R-R-less result")
+            XCTAssertNotNil(after.first?.recovery, "Charge returns once valid HRV and its baseline are available")
+            await repo.refresh()
+            XCTAssertFalse(repo.legacyRRExcludedDays.contains(input.day), "re-sync must clear the persisted flag")
+            XCTAssertNil(Whoop5RRGap.message(day: after.first, excludedDays: repo.legacyRRExcludedDays))
 
             log.removeAll()
             await engine.analyzeRecent(maxDays: 2, force: true)
             let idle = try await store.dailyMetrics(deviceId: canonical + "-noop",
                 from: input.day, to: input.day)
             XCTAssertEqual(idle.first?.avgHrv, promoted)
+            XCTAssertEqual(idle.first?.recovery, after.first?.recovery)
+            await repo.refresh()
+            XCTAssertFalse(repo.legacyRRExcludedDays.contains(input.day), "a cache hit must not revive the notice")
             XCTAssertTrue(log.contains { $0.contains("dayCache reused=2/2") },
                           "an unchanged pass should reuse both previously scored windows: \(log)")
         }
@@ -110,14 +142,94 @@ final class IntelligenceRRSourceTests: XCTestCase {
             let registry = DeviceRegistryStore(dbQueue: store.registryWriter)
             try register(registry, canonicalModel: "4.0")
             let input = night()
-            _ = try await store.insert(Streams(hr: input.hr, rr: input.rr), deviceId: canonical)
+            try await seedBaseline(store, before: input.day)
+            _ = try await store.insert(Streams(hr: input.hr), deviceId: canonical)
             let repo = Repository(deviceId: active)
             repo.setStoreForTesting(store)
             let engine = IntelligenceEngine(repo: repo, profile: ProfileStore(), deviceId: canonical)
             await engine.analyzeRecent(maxDays: 2, force: true)
+            let empty = try await store.dailyMetrics(deviceId: canonical + "-noop",
+                from: input.day, to: input.day).first
+            XCTAssertNotNil(empty)
+            XCTAssertNil(empty?.avgHrv)
+            XCTAssertNil(empty?.recovery)
+            await repo.refresh()
+            XCTAssertNil(Whoop5RRGap.message(day: empty, excludedDays: repo.legacyRRExcludedDays))
+            _ = try await store.insert(Streams(rr: input.rr), deviceId: canonical)
+            await engine.analyzeRecent(maxDays: 2, force: true)
             let rows = try await store.dailyMetrics(deviceId: canonical + "-noop",
                 from: input.day, to: input.day)
             XCTAssertGreaterThan(try XCTUnwrap(rows.first?.avgHrv), 0)
+            XCTAssertNotNil(rows.first?.recovery)
+            await repo.refresh()
+            XCTAssertFalse(repo.legacyRRExcludedDays.contains(input.day), "WHOOP 4 legacy beats remain supported")
+            XCTAssertNil(Whoop5RRGap.message(day: rows.first, excludedDays: repo.legacyRRExcludedDays))
+        }
+    }
+
+    func testLegacyGapDoesNotExplainOrdinaryCalibrationOrAnotherDaysValues() {
+        func row(hrv: Double? = nil, recovery: Double? = nil) -> DailyMetric {
+            DailyMetric(day: "2026-09-09", totalSleepMin: 480, efficiency: nil,
+                deepMin: nil, remMin: nil, lightMin: nil, disturbances: nil, restingHr: 60,
+                avgHrv: hrv, recovery: recovery, strain: nil, exerciseCount: nil)
+        }
+        let empty = row()
+        XCTAssertNil(Whoop5RRGap.message(day: nil, excludedDays: [empty.day]))
+        XCTAssertNil(Whoop5RRGap.message(day: empty, excludedDays: []), "no legacy evidence, no warning")
+        XCTAssertNil(Whoop5RRGap.message(day: empty, excludedDays: ["2026-09-08"]))
+        XCTAssertNil(Whoop5RRGap.message(day: row(recovery: 60), excludedDays: [empty.day]),
+                     "an imported Charge value must not be described as missing")
+        XCTAssertNil(Whoop5RRGap.message(day: row(hrv: 40), excludedDays: [empty.day]),
+                     "valid HRV with an unseeded baseline is ordinary calibration")
+    }
+
+    func testLegacyExplanationRefreshesWhenOnlyItsPersistedFlagChanges() async throws {
+        let store = try await WhoopStore.inMemory()
+        let repo = Repository(deviceId: canonical)
+        repo.setStoreForTesting(store)
+        let day = Repository.localDayKey(Date())
+        await repo.refresh()
+        _ = try await store.upsertMetricSeries([
+            MetricPoint(day: day, key: "hrv_rr_legacy_excluded", value: 1)
+        ], deviceId: canonical + "-noop")
+        await repo.refresh()
+        XCTAssertEqual(repo.legacyRRExcludedDays, [day])
+        let flaggedSeq = repo.refreshSeq
+        _ = try await store.upsertMetricSeries([
+            MetricPoint(day: day, key: "hrv_rr_legacy_excluded", value: 0)
+        ], deviceId: canonical + "-noop")
+        await repo.refresh()
+        XCTAssertTrue(repo.legacyRRExcludedDays.isEmpty)
+        XCTAssertGreaterThan(repo.refreshSeq, flaggedSeq, "unchanged daily metrics cannot hide a cleared notice")
+    }
+
+    func testSkippedDayClearsItsOldExplanationWithoutTouchingOtherSources() async throws {
+        try await withPreferences {
+            let store = try await WhoopStore.inMemory()
+            let now = Int(Date().timeIntervalSince1970)
+            let previousDay = Repository.localDayKey(Date().addingTimeInterval(-2 * 86_400))
+            let flag = MetricPoint(day: previousDay, key: "hrv_rr_legacy_excluded", value: 1)
+            _ = try await store.upsertMetricSeries([flag], deviceId: canonical + "-noop")
+            _ = try await store.upsertMetricSeries([flag], deviceId: "other-noop")
+            let repo = Repository(deviceId: canonical)
+            repo.setStoreForTesting(store)
+            let engine = IntelligenceEngine(repo: repo, profile: ProfileStore(), deviceId: canonical)
+
+            // An entirely empty pass must preserve existing state, just like the scores it accompanies.
+            await engine.analyzeRecent(maxDays: 3, force: true)
+            let emptyPass = try await store.metricSeries(deviceId: canonical + "-noop",
+                key: flag.key, from: previousDay, to: previousDay)
+            XCTAssertEqual(emptyPass.first?.value, 1)
+
+            _ = try await store.insert(Streams(hr: (now - 400..<now).map { HRSample(ts: $0, bpm: 60) }),
+                deviceId: canonical)
+            await engine.analyzeRecent(maxDays: 3, force: true)
+            let skipped = try await store.metricSeries(deviceId: canonical + "-noop",
+                key: flag.key, from: previousDay, to: previousDay)
+            let other = try await store.metricSeries(deviceId: "other-noop",
+                key: flag.key, from: previousDay, to: previousDay)
+            XCTAssertEqual(skipped.first?.value, 0, "a nonempty replacement clears evidence for a skipped day")
+            XCTAssertEqual(other.first?.value, 1, "another computed source retains its history")
         }
     }
 

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -129,6 +129,7 @@ object IntelligenceEngine {
         val primaryRhrCoverage: PrimarySessionRestingHR.Coverage?,
         val spo2Candidate: Int?,
         val hrvOverCount: Boolean?,
+        val legacyRRExcluded: Boolean,
         val diagLines: List<String>,
         /** #1575: the per-day trace lines for each channel, replayed on a hit so an active trace no
          *  longer forces a full re-read + re-score of every night on every pass. Empty when those modes
@@ -726,6 +727,7 @@ object IntelligenceEngine {
         // #1118: per-day HRV over-count flag, carried for metricSeries persistence. Absent for a night with
         // no in-sleep R-R (no HRV to caveat); otherwise true/false, so a re-score always overwrites the row.
         val hrvOverCountByDay = LinkedHashMap<String, Boolean>()
+        val legacyRRExcludedByDay = LinkedHashMap<String, Boolean>()
         // #1169: primary-session mean RHR shadow metric per day, carried from pass 1 for persistence.
         val primarySessionRHRByDay = LinkedHashMap<String, Double>()
         // #1169: its coverage inputs (valid-sample count + primary-session duration), same lifetime as the mean.
@@ -949,6 +951,7 @@ object IntelligenceEngine {
                     // matching the loop's own guard).
                     if (universalSink != null) readOwnerByDay[day] = OwnerRead(cached.owner, cached.hrRows)
                     cached.hrvOverCount?.let { hrvOverCountByDay[day] = it }
+                    legacyRRExcludedByDay[day] = cached.legacyRRExcluded
                     nightlyHrvByDay[day] = cached.res.daily.avgHrv
                     nightlyRhrByDay[day] = cached.res.daily.restingHr?.toDouble()
                     nightlySkinByDay[day] = cached.res.nightlySkinTempC
@@ -1382,15 +1385,10 @@ object IntelligenceEngine {
             // choice. null on a WHOOP 4.0 (no v18 aux stream) with no candidate decode, an Oura night with
             // no in-window plausible sample, or when the toggle is OFF. Persisted to metricSeries as
             // "spo2_candidate" in pass 2, never to `spo2Pct`.
-            if (spo2CandidateDisplay) {
-                // Lifted into [spo2CandidateMean] rather than inlined: `analyzeRecentOnCpu` sits within ~100
-                // bytes of the JVM's 64 KB per-method ceiling, and this block plus the #1575 trace recorders
-                // put the JaCoCo-instrumented size 30 bytes OVER the budget #1524 guards. Neither change
-                // exceeded it alone — only together, which no single PR's CI could see.
-                spo2CandidateMean(repo, owner, res.sleepSessions, spo2, from, to)?.let {
-                    spo2CandidateByDay[res.daily.day] = it
-                }
-            }
+            val auxiliary = nightAuxiliaryInputs(repo, owner, res, sleepRr.isEmpty(),
+                activeWhoop5RR, spo2CandidateDisplay, spo2, from, to)
+            legacyRRExcludedByDay[day] = auxiliary.legacyRRExcluded
+            auxiliary.spo2Candidate?.let { spo2CandidateByDay[res.daily.day] = it }
             // #1169 SHADOW METRIC (instrumentation only): the primary-session MEAN resting HR, recorded
             // beside the shipped nightly HR FLOOR (daily.restingHr = min per session) so the mean-vs-floor
             // comparison the issue asks for accrues on real devices. NEVER shown and NEVER fed to any score;
@@ -1414,7 +1412,8 @@ object IntelligenceEngine {
                 dayScanCache[day] = CachedDayScan(
                     key = key, res = res, owner = owner, hrRows = hr.size,
                     primaryRhr = primaryRhr, primaryRhrCoverage = primaryRhrCoverage,
-                    spo2Candidate = spo2CandidateByDay[day], hrvOverCount = hrvOverCountByDay[day],
+                    spo2Candidate = auxiliary.spo2Candidate, hrvOverCount = hrvOverCountByDay[day],
+                    legacyRRExcluded = auxiliary.legacyRRExcluded,
                     diagLines = dayDiagLines.toList(),
                     traces = dayTraces,
                 )
@@ -1635,33 +1634,10 @@ object IntelligenceEngine {
                 for (line in recoveryTraceLines(daily, baselines2)) recoveryTraceSink(line)
             }
             val skinTempDevC = recomputeSkinTempDev(res.nightlySkinTempC, baselines2.skinTemp)
-            RestScorer.restFromDaily(daily)?.let { rest ->
-                restRows.add(MetricSeriesRow(deviceId = computedId, day = daily.day, key = "sleep_performance", value = rest))
-            }
-            // #103: persist the SpO₂ candidate @82 nightly mean to metricSeries as "spo2_candidate" so the
-            // Blood Oxygen tile can surface it as a "strap estimate (unverified)" fallback when the toggle
-            // is ON. Written under the "-noop" computed device ID, never to `spo2Pct`.
-            spo2CandidateByDay[daily.day]?.let { cand ->
-                restRows.add(MetricSeriesRow(deviceId = computedId, day = daily.day, key = "spo2_candidate", value = cand.toDouble()))
-            }
-            // #1118: persist the HRV over-count flag (1/0) so the HRV card can mark an over-counted 4.0
-            // night's reading "unverified" until the two-channel de-dup lands. 0 written on a clean night
-            // (not just absent) so a night that flips clean on re-score clears its prior flag.
-            hrvOverCountByDay[daily.day]?.let { oc ->
-                restRows.add(MetricSeriesRow(deviceId = computedId, day = daily.day, key = "hrv_rr_overcount", value = if (oc) 1.0 else 0.0))
-            }
-            // #1169 shadow metric: the primary-session mean RHR, stored beside the shipped floor
-            // (daily.restingHr) under the "-noop" computed ID. Instrumentation only — never shown, never
-            // scored — for later mean-vs-floor evaluation from exports.
-            primarySessionRHRByDay[daily.day]?.let { v ->
-                restRows.add(MetricSeriesRow(deviceId = computedId, day = daily.day, key = "rhr_primary_session", value = v))
-            }
-            // #1169: its coverage inputs beside the mean — valid-sample count + primary-session duration (s)
-            // — so a thin-coverage night can be down-weighted in the later holdout. Raw inputs, not a fraction.
-            primarySessionRHRCoverageByDay[daily.day]?.let { cov ->
-                restRows.add(MetricSeriesRow(deviceId = computedId, day = daily.day, key = "rhr_primary_session_valid_samples", value = cov.validSamples.toDouble()))
-                restRows.add(MetricSeriesRow(deviceId = computedId, day = daily.day, key = "rhr_primary_session_duration_s", value = cov.durationSec))
-            }
+            appendNightlyMetricRows(restRows, computedId, daily,
+                spo2CandidateByDay[daily.day], hrvOverCountByDay[daily.day],
+                legacyRRExcludedByDay[daily.day] == true, primarySessionRHRByDay[daily.day],
+                primarySessionRHRCoverageByDay[daily.day])
 
             out.add(
                 Computed(
@@ -1907,6 +1883,7 @@ object IntelligenceEngine {
         // this only fills the days the strap collected but no import covered.
         // Persist metric-level input provenance in the SAME Room transaction. dayOwnership remains
         // exclusively a resolver override, and a failed write can never relabel an older score.
+        restRows.addAll(legacyGapDefaults(computedId, nowLocalMidnight, tzOffsetSeconds, maxDays, restRows))
         val computedWindow = IntelligencePersistence.prepareComputedWindow(
             repo, importedDeviceId, computedId, oldestDay, newestDay, dailies, restRows, physiologicalSteps,
             candidatePriorities, resolvedScoreOwnerByDay,
@@ -2860,6 +2837,67 @@ object IntelligenceEngine {
     private suspend fun activeWhoop5RrPolicy(
         repo: com.noop.data.WhoopRepository, candidates: List<Pair<String, Int>>, fallback: String,
     ): Boolean = repo.isWhoop5RrSource(candidates.firstOrNull { it.second == 0 }?.first ?: fallback)
+
+    /** Clear skipped days only. The persistence planner keeps the first row for each key, so defaults
+     * must never duplicate fresh scored evidence. The existing transaction guards an entirely empty pass. */
+    private fun legacyGapDefaults(
+        computedId: String, midnight: Long, offset: Long, maxDays: Int, rows: List<MetricSeriesRow>,
+    ): List<MetricSeriesRow> {
+        val scored = rows.filter { it.key == "hrv_rr_legacy_excluded" }.map { it.day }.toSet()
+        return (0 until maxDays).map { dayOffset ->
+            MetricSeriesRow(deviceId = computedId,
+                day = AnalyticsEngine.dayString(midnight - dayOffset * SECONDS_PER_DAY, offset),
+                key = "hrv_rr_legacy_excluded", value = 0.0)
+        }.filter { it.day !in scored }
+    }
+
+    /** Persist nightly auxiliary values outside the scoring coroutine's instrumentation budget.
+     * Zero flags overwrite earlier notices; shadow measurements never feed Charge. */
+    private fun appendNightlyMetricRows(
+        rows: MutableList<MetricSeriesRow>, computedId: String, daily: DailyMetric,
+        spo2Candidate: Int?, hrvOverCount: Boolean?, legacyRRExcluded: Boolean,
+        primaryRhr: Double?, primaryCoverage: PrimarySessionRestingHR.Coverage?,
+    ) {
+        fun append(key: String, value: Double) {
+            rows.add(MetricSeriesRow(deviceId = computedId, day = daily.day, key = key, value = value))
+        }
+        RestScorer.restFromDaily(daily)?.let { append("sleep_performance", it) }
+        spo2Candidate?.let { append("spo2_candidate", it.toDouble()) }
+        hrvOverCount?.let { append("hrv_rr_overcount", if (it) 1.0 else 0.0) }
+        append("hrv_rr_legacy_excluded", if (legacyRRExcluded && daily.avgHrv == null) 1.0 else 0.0)
+        primaryRhr?.let { append("rhr_primary_session", it) }
+        primaryCoverage?.let {
+            append("rhr_primary_session_valid_samples", it.validSamples.toDouble())
+            append("rhr_primary_session_duration_s", it.durationSec)
+        }
+    }
+
+    private data class NightAuxiliary(val legacyRRExcluded: Boolean, val spo2Candidate: Int?)
+
+    /** Keep the nightly evidence reads in one coroutine call, preserving the scoring method's budget.
+     * The optional SpO2 capture remains gated; neither value feeds the recovery formula. */
+    private suspend fun nightAuxiliaryInputs(
+        repo: WhoopRepository, owner: String, result: DayResult, noSleepRr: Boolean,
+        activeWhoop5RR: Boolean, spo2CandidateDisplay: Boolean,
+        spo2: List<com.noop.data.Spo2Sample>, from: Long, to: Long,
+    ): NightAuxiliary = NightAuxiliary(
+        legacyRRExcluded(repo, owner, result, noSleepRr,
+            activeWhoop5RR && owner == WhoopRepository.WHOOP_SOURCE),
+        if (spo2CandidateDisplay) spo2CandidateMean(repo, owner, result.sleepSessions, spo2, from, to) else null,
+    )
+
+    /** Attribute an empty HRV window only to legacy beats actually present in its scored sleep. */
+    private suspend fun legacyRRExcluded(
+        repo: com.noop.data.WhoopRepository, owner: String, result: DayResult,
+        noSleepRr: Boolean, unlabelledAliasOfWhoop5: Boolean,
+    ): Boolean {
+        if (!noSleepRr || result.daily.avgHrv != null ||
+            !repo.isWhoop5RrSource(owner, unlabelledAliasOfWhoop5)) return false
+        for (session in result.sleepSessions) {
+            if (repo.hasUnlabelledRr(owner, session.start, session.end)) return true
+        }
+        return false
+    }
 
     /** Keep both stream witnesses and the R-R alias policy in the nightly cache key (#29).
      * The two database awaits live here to preserve the scoring method's instrumentation budget. */

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -101,6 +101,10 @@ internal const val WHOOP5_RR_INTERVALS_SQL =
 internal const val HAS_WHOOP5_RR_SOURCE_SQL =
     "SELECT EXISTS(SELECT 1 FROM rrInterval WHERE deviceId = :deviceId AND srcChannel IN (5, 6, 7))"
 
+internal const val HAS_UNLABELLED_RR_SQL =
+    "SELECT EXISTS(SELECT 1 FROM rrInterval WHERE deviceId = :deviceId AND ts >= :from AND ts < :to " +
+    "AND srcChannel IS NULL AND (tsSuspect IS NULL OR tsSuspect <> 1))"
+
 internal const val PROMOTE_WHOOP5_RR_SOURCE_SQL =
     "UPDATE rrInterval SET srcChannel = :source, ord = :ord " +
     "WHERE deviceId = :deviceId AND ts = :ts AND rrMs = :rrMs AND seq = :seq " +
@@ -560,6 +564,10 @@ interface WhoopDao : DeviceRegistryDao {
 
     @Query(HAS_WHOOP5_RR_SOURCE_SQL)
     suspend fun hasWhoop5RrSource(deviceId: String): Boolean
+
+    /** Legacy beats inside one sleep interval; suspect timestamps cannot explain a score gap. */
+    @Query(HAS_UNLABELLED_RR_SQL)
+    suspend fun hasUnlabelledRr(deviceId: String, from: Long, to: Long): Boolean
 
     /** Newly observed canonical source wins exact-key collisions: history > standard > native/legacy. */
     @Query(PROMOTE_WHOOP5_RR_SOURCE_SQL)

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -1308,6 +1308,10 @@ class WhoopRepository(
         return com.noop.protocol.Whoop5RR.usesCanonicalSource(owner?.model, owner?.brand, tagged || unlabelledAliasOfWhoop5)
     }
 
+    /** The caller resolves WHOOP 5 ownership before using these legacy beats to explain missing HRV. */
+    suspend fun hasUnlabelledRr(deviceId: String, from: Long, to: Long): Boolean =
+        dao.hasUnlabelledRr(deviceId, from, to)
+
     /** Diagnostic export keeps all WHOOP transports and legacy values without scoring selection.
      * Existing quarantine and Oura SpO2-IBI exclusions still apply. */
     suspend fun rawRrIntervalsForDevice(deviceId: String, from: Long, to: Long,

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -782,6 +782,18 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         }.flowOn(Dispatchers.IO)
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
 
+    /** Observe the persisted explanation itself: its flag can clear while daily values stay null. */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val legacyRRExcludedDays: StateFlow<Set<String>> = activeStrapIdFlow
+        .map { effectiveActiveStrapId(it, deviceId) }
+        .distinctUntilChanged()
+        .flatMapLatest { activeId ->
+            repository.metricSeriesComputedUnionFlow(activeId, "hrv_rr_legacy_excluded", "0000-01-01", "9999-12-31")
+                .map { rows -> rows.filter { it.value == 1.0 }.map { it.day }.toSet() }
+        }
+        .flowOn(Dispatchers.IO)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptySet())
+
     /**
      * #386 self-heal: a "kick" the app-resume hook sends to wake the 15-min analyze loop early, so an
      * OEM-killed overnight re-score tick catches up the moment the user opens NOOP instead of showing a

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -983,6 +983,8 @@ fun TodayScreen(
     // Recovery cold-start: recovery is null until the HRV baseline crosses the seed gate
     // (Baselines.minNightsSeed valid nights). Show honest "calibrating, N of 4 nights" progress
     // instead of a bare "No Data" so a new BLE-only user knows scores are coming, not broken. (PR #85)
+    val legacyRRExcludedDays by viewModel.legacyRRExcludedDays.collectAsStateWithLifecycle()
+    val rrGapMessage = Whoop5RRGap.message(displayMetric, legacyRRExcludedDays)
     val recoveryCalibration: Int? = if (selectedDayOffset == 0) {
         // Thread the persisted "Recalibrate HRV baseline" epoch (0 = none) so N folds the SAME
         // epoch-aware history the recovery engine folds — otherwise a post-recalibration user's pre-epoch
@@ -1362,7 +1364,7 @@ fun TodayScreen(
             // matching iOS explainedScoreNote. Today only; never a fabricated value.
             //
             // #827: NeedsStrap ALWAYS shows (a today-blocking state, not a recurring nag).
-            if (selectedDayOffset == 0 && scoreState is ScoreState.NeedsStrap) {
+            if (rrGapMessage == null && selectedDayOffset == 0 && scoreState is ScoreState.NeedsStrap) {
                 ScoreStateNote(scoreState)
             }
             // The carried "Latest sleep · <date>" / "Last night · <date>" note. iOS has NOTHING in this slot,
@@ -1394,7 +1396,7 @@ fun TodayScreen(
             }
             // #827: the dismissible calibrating note. Hidden once dismissed into the inbox; a "Restore to
             // Today" tap there flips calibratingDismissed back via the shared restore path above.
-            if (selectedDayOffset == 0 && scoreState is ScoreState.Calibrating && !calibratingDismissed) {
+            if (rrGapMessage == null && selectedDayOffset == 0 && scoreState is ScoreState.Calibrating && !calibratingDismissed) {
                 Box(modifier = Modifier.fillMaxWidth()) {
                     ScoreStateNote(
                         scoreState,
@@ -1534,6 +1536,11 @@ fun TodayScreen(
                                     ),
                                     onOpenMetric = onOpenMetric,
                                 )
+                            }
+                            rrGapMessage?.let { message ->
+                                Text(stringResource(message), style = NoopType.subhead,
+                                    color = Palette.textSecondary,
+                                    modifier = Modifier.fillMaxWidth().padding(horizontal = Metrics.space12))
                             }
                             // Honest "why is Effort 0?" caption — only when today's Effort is a real
                             // near-zero (HR present but never crossed the cardio zone). Effort accrues over

--- a/android/app/src/main/java/com/noop/ui/Whoop5RRGap.kt
+++ b/android/app/src/main/java/com/noop/ui/Whoop5RRGap.kt
@@ -1,0 +1,11 @@
+package com.noop.ui
+
+import com.noop.R
+import com.noop.data.DailyMetric
+
+/** The selected day's explanation uses scored evidence and the values actually displayed. */
+internal object Whoop5RRGap {
+    fun message(day: DailyMetric?, excludedDays: Set<String>): Int? =
+        if (day != null && day.avgHrv == null && day.recovery == null && day.day in excludedDays)
+            R.string.whoop5_rr_legacy_gap else null
+}

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2762,4 +2762,5 @@
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Ladungs-Trend ansehen</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Jeder Tageswert im Zeitverlauf.</string>
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Ein Coach, der den Faden behält, deine Herzfrequenz auf dem Homescreen und Diagramme, die weniger behaupten</string>
+    <string name="whoop5_rr_legacy_gap">Frühere WHOOP 5-Herzschläge können nicht für HRV oder Charge ausgewertet werden. Synchronisiere dein Band erneut, um verfügbare Verlaufsdaten wiederherzustellen.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2749,4 +2749,5 @@
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Ver la tendencia de Carga</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">La puntuación de cada día, a lo largo del tiempo.</string>
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Un coach que mantiene el hilo, tu frecuencia cardíaca en la pantalla de inicio y gráficos que afirman menos</string>
+    <string name="whoop5_rr_legacy_gap">Los latidos anteriores de WHOOP 5 no se pueden usar para calcular HRV o Charge. Vuelve a sincronizar tu pulsera para recuperar el historial disponible.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2748,4 +2748,5 @@
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Voir la tendance de la charge</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Le score de chaque jour, dans la durée.</string>
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Un coach qui garde le fil, votre fréquence cardiaque sur l\'écran d\'accueil, et des graphiques qui affirment moins</string>
+    <string name="whoop5_rr_legacy_gap">Les anciens battements WHOOP 5 ne peuvent pas servir au calcul de HRV ou de Charge. Resynchronisez votre bracelet pour récupérer les données historiques disponibles.</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2753,4 +2753,5 @@
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Zobacz trend Energii</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Wynik każdego dnia w czasie.</string>
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Trener, który nie gubi wątku, tętno na ekranie głównym i wykresy, które mniej zakładają</string>
+    <string name="whoop5_rr_legacy_gap">Wcześniejsze uderzenia serca z WHOOP 5 nie mogą służyć do obliczania HRV ani Charge. Zsynchronizuj ponownie opaskę, aby odzyskać dostępną historię.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2741,4 +2741,5 @@
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Ver a tendência da Carga</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">A pontuação de cada dia, ao longo do tempo.</string>
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Um treinador que mantém o fio, a sua frequência cardíaca no ecrã principal e gráficos que afirmam menos</string>
+    <string name="whoop5_rr_legacy_gap">Os batimentos anteriores do WHOOP 5 não podem ser usados para calcular HRV ou Charge. Volta a sincronizar a pulseira para recuperar o histórico disponível.</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -2632,4 +2632,5 @@
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">Посмотреть динамику Заряда</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Оценка за каждый день во времени.</string>
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Тренер, который не теряет нить, ваш пульс на главном экране и графики, которые меньше домысливают</string>
+    <string name="whoop5_rr_legacy_gap">Прежние данные об ударах сердца WHOOP 5 нельзя использовать для расчёта HRV или Charge. Синхронизируйте браслет заново, чтобы восстановить доступную историю.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2662,4 +2662,5 @@
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">查看充能趋势</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">每天的分数，随时间变化。</string>
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">能接住话头的教练、主屏幕上的心率，以及不再过度断言的图表</string>
+    <string name="whoop5_rr_legacy_gap">早期的 WHOOP 5 心搏数据无法用于计算 HRV 或 Charge。请重新同步手环，以恢复仍可获取的历史数据。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2778,4 +2778,5 @@
     <string name="l10n_today_screen_see_the_charge_trend_9dcbcff7">See the Charge trend</string>
     <string name="l10n_today_screen_every_day_s_score_over_time_a00ea7c7">Every day\'s score, over time.</string>
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">A coach that keeps the thread, your heart rate on the home screen, and charts that claim less</string>
+    <string name="whoop5_rr_legacy_gap">Earlier WHOOP 5 beats cannot be scored for HRV or Charge. Re-sync your strap to recover available history.</string>
 </resources>

--- a/android/app/src/test/java/com/noop/data/Whoop5RRSqliteTest.kt
+++ b/android/app/src/test/java/com/noop/data/Whoop5RRSqliteTest.kt
@@ -8,6 +8,8 @@ import com.noop.analytics.IntelligenceEngine
 import com.noop.analytics.RegistryDayOwnerSource
 import com.noop.analytics.SleepStageHealer
 import com.noop.analytics.StageSegment
+import com.noop.ui.Whoop5RRGap
+import com.noop.R
 import java.io.StringWriter
 import java.lang.reflect.Proxy
 import java.sql.Connection
@@ -29,6 +31,7 @@ class Whoop5RRSqliteTest {
     private val owners = linkedMapOf<String, PairedDeviceRow>()
     private val sleeps = linkedMapOf<Pair<String, Long>, SleepSession>()
     private val days = linkedMapOf<Pair<String, String>, DailyMetric>()
+    private val metrics = linkedMapOf<Triple<String, String, String>, MetricSeriesRow>()
     private val gravity = mutableListOf<GravitySample>()
     private val id = "my-whoop"
 
@@ -82,7 +85,14 @@ class Whoop5RRSqliteTest {
                     if (sleeps.putIfAbsent(row.deviceId to row.startTs, row) == null) 1L else -1L
                 }
                 "replaceComputedScoreWindow" -> {
-                    (args[3] as List<*>).filterIsInstance<DailyMetric>().forEach { days[it.deviceId to it.day] = it }
+                    val freshDays = (args[3] as List<*>).filterIsInstance<DailyMetric>()
+                    if (freshDays.isNotEmpty()) {
+                        days.entries.removeIf { (key, _) -> key.first == args[0] && key.second in (args[1] as String)..(args[2] as String) }
+                        freshDays.forEach { days[it.deviceId to it.day] = it }
+                        (args[4] as List<*>).filterIsInstance<MetricSeriesRow>().forEach {
+                            metrics[Triple(it.deviceId, it.day, it.key)] = it
+                        }
+                    }
                     Unit
                 }
                 "upsertMetricSeries", "upsertMetricSeriesWithProvenance", "deleteWorkoutsBySport" -> Unit
@@ -111,6 +121,8 @@ class Whoop5RRSqliteTest {
                     RrInterval(r.getString("deviceId"), r.getLong("ts"), r.getInt("rrMs"), r.getInt("seq"),
                         r.getInt("synced"), optional("ord"), optional("srcChannel"), optional("tsSuspect"))
                 }
+                "hasUnlabelledRr" -> query(HAS_UNLABELLED_RR_SQL,
+                    listOf("deviceId", "from", "to").zip(args.take(3)).toMap()) { it.getInt(1) != 0 }.single()
                 "hasWhoop5RrSource" -> query(HAS_WHOOP5_RR_SOURCE_SQL, mapOf("deviceId" to args[0])) {
                     it.getBoolean(1)
                 }.single()
@@ -172,10 +184,31 @@ class Whoop5RRSqliteTest {
     private suspend fun read(from: Long = 0, to: Long = 1000, limit: Int = 100) =
         repo.rrIntervalsForDevice(id, from, to, limit)
 
+    private fun excludedDays(): Set<String> = metrics.values
+        .filter { it.key == "hrv_rr_legacy_excluded" && it.value == 1.0 }.map { it.day }.toSet()
+
+    private fun seedBaseline(before: String, owner: String = id) {
+        for (offset in 1L..8L) {
+            val day = java.time.LocalDate.parse(before).minusDays(offset).toString()
+            days[owner to day] = DailyMetric(deviceId = owner, day = day, totalSleepMin = 480.0,
+                efficiency = 0.9, restingHr = 60, avgHrv = 40.0 + offset % 3, recovery = 60.0)
+        }
+    }
+
     @Test fun sourceFingerprintQueriesUseCoveringIndex() {
         val plan = query("EXPLAIN QUERY PLAN $ANALYSIS_FINGERPRINT_SQL") { it.getString("detail") }
         assertEquals(3, plan.count { it.contains("USING COVERING INDEX rrInterval_source_suspect") })
         assertFalse(plan.any { it.contains("SCAN rrInterval") })
+    }
+
+    @Test fun legacyGapEvidenceExcludesSuspectTimestampsAndTheSleepEnd() = runBlocking {
+        repo.insert(StreamBatch(rr = listOf(RrRow(100, 900), RrRow(200, 900), RrRow(300, 900),
+            RrRow(400, 900, RrSourceChannel.WHOOP5_HISTORICAL))), id)
+        sql("UPDATE rrInterval SET tsSuspect = 1 WHERE ts = 200")
+        assertTrue(repo.hasUnlabelledRr(id, 100, 200))
+        assertFalse(repo.hasUnlabelledRr(id, 101, 300))
+        assertFalse(repo.hasUnlabelledRr(id, 400, 500))
+        assertFalse(repo.hasUnlabelledRr("other", 0, 500))
     }
 
     @Test fun actualNightlyScorerGuardsCanonicalHistoryAfterRePairing() = runBlocking {
@@ -186,6 +219,7 @@ class Whoop5RRSqliteTest {
         val offset = java.util.TimeZone.getDefault().getOffset(now * 1000L) / 1000L
         val end = now - Math.floorMod(now + offset, 86_400L)
         val start = end - 3_600L
+        seedBaseline(AnalyticsEngine.dayString(end, offset), owner = "new-five")
         repo.insert(StreamBatch(
             hr = (start until end).map { HrRow(it, 60) },
             rr = (start until end).map { RrRow(it, if (it % 2L == 0L) 980 else 1020) },
@@ -204,6 +238,9 @@ class Whoop5RRSqliteTest {
         assertEquals(60, first.rhr)
         assertNull("unlabelled canonical history must not supply HRV after re-pairing", first.hrv)
         assertNull(days.getValue("new-five-noop" to first.day).avgHrv)
+        assertNull("an established baseline cannot score Charge without HRV", first.recovery)
+        assertEquals(R.string.whoop5_rr_legacy_gap,
+            Whoop5RRGap.message(days.getValue("new-five-noop" to first.day), excludedDays()))
 
         // Same rows, same timestamps, same engine cache: only source provenance changes.
         assertEquals(0, repo.insert(StreamBatch(rr = (start until end).map {
@@ -212,7 +249,70 @@ class Whoop5RRSqliteTest {
         val promoted = score().single()
         assertEquals(40.0, promoted.hrv!!, 0.001)
         assertEquals(promoted.hrv, days.getValue("new-five-noop" to first.day).avgHrv)
+        assertNotNull("Charge returns with valid HRV and its seeded baseline", promoted.recovery)
+        assertFalse("source promotion must clear the persisted notice", first.day in excludedDays())
+        assertNull(Whoop5RRGap.message(days.getValue("new-five-noop" to first.day), excludedDays()))
         assertEquals(promoted.hrv, score().single().hrv)
+        assertFalse("a cache hit must not revive the notice", first.day in excludedDays())
+    }
+
+    @Test fun legacyGapDoesNotExplainUnaffectedDaysOrImportedValues() {
+        val empty = DailyMetric(deviceId = id, day = "2026-09-09", totalSleepMin = 480.0, restingHr = 60)
+        assertNull(Whoop5RRGap.message(null, setOf(empty.day)))
+        assertNull("ordinary calibration has no legacy evidence", Whoop5RRGap.message(empty, emptySet()))
+        assertNull(Whoop5RRGap.message(empty, setOf("2026-09-08")))
+        assertNull(Whoop5RRGap.message(empty.copy(recovery = 60.0), setOf(empty.day)))
+        assertNull("valid HRV with an unseeded baseline is ordinary calibration",
+            Whoop5RRGap.message(empty.copy(avgHrv = 40.0), setOf(empty.day)))
+    }
+
+    @Test fun skippedDayClearsItsOldExplanationWithoutTouchingOtherSources() = runBlocking {
+        val now = 1_780_272_000L
+        val offset = java.util.TimeZone.getDefault().getOffset(now * 1000L) / 1000L
+        val previousDay = AnalyticsEngine.dayString(now - 2 * 86_400L, offset)
+        val key = "hrv_rr_legacy_excluded"
+        for (source in listOf("$id-noop", "other-noop")) {
+            metrics[Triple(source, previousDay, key)] = MetricSeriesRow(source, previousDay, key, 1.0)
+        }
+        suspend fun score() = IntelligenceEngine.analyzeRecent(repo, maxDays = 3, importedDeviceId = id,
+            nowSeconds = now, dayCycleMode = DayCycleMode.MIDNIGHT)
+        score()
+        assertEquals(1.0, metrics.getValue(Triple("$id-noop", previousDay, key)).value, 0.0)
+        repo.insert(StreamBatch(hr = (now - 400 until now).map { HrRow(it, 60) }), id)
+        score()
+        assertEquals(0.0, metrics.getValue(Triple("$id-noop", previousDay, key)).value, 0.0)
+        assertEquals(1.0, metrics.getValue(Triple("other-noop", previousDay, key)).value, 0.0)
+    }
+
+    @Test fun actualWhoop4LegacyNightKeepsScoresWithoutExplanation() = runBlocking {
+        val owner = "four"
+        registry("4.0", owner = owner)
+        activate(owner)
+        val now = 1_780_272_000L
+        val offset = java.util.TimeZone.getDefault().getOffset(now * 1000L) / 1000L
+        val end = now - Math.floorMod(now + offset, 86_400L)
+        val start = end - 3_600L
+        seedBaseline(AnalyticsEngine.dayString(end, offset))
+        repo.insert(StreamBatch(hr = (start until end).map { HrRow(it, 60) }), owner)
+        repo.upsertSleepSessions(listOf(SleepSession(deviceId = owner, startTs = start, endTs = end,
+            efficiency = 1.0, stagesJSON = AnalyticsEngine.encodeStages(listOf(StageSegment(start, end, "light"))))))
+        val registry = DeviceRegistry(dao, object : DeviceRegistry.Transactor {
+            override suspend fun <R> run(block: suspend () -> R): R = block()
+        })
+        suspend fun score() = IntelligenceEngine.analyzeRecent(repo, maxDays = 1, importedDeviceId = id,
+            nowSeconds = now, ownerSource = RegistryDayOwnerSource(registry), dayCycleMode = DayCycleMode.MIDNIGHT).single()
+        val empty = score()
+        assertNull(empty.hrv)
+        assertNull(empty.recovery)
+        assertNull(Whoop5RRGap.message(days.getValue("$id-noop" to empty.day), excludedDays()))
+        repo.insert(StreamBatch(rr = (start until end).map {
+            RrRow(it, if (it % 2L == 0L) 980 else 1020)
+        }), owner)
+        val scored = score()
+        assertEquals(40.0, scored.hrv!!, 0.001)
+        assertNotNull(scored.recovery)
+        assertTrue(excludedDays().isEmpty())
+        assertNull(Whoop5RRGap.message(days.getValue("$id-noop" to scored.day), excludedDays()))
     }
 
     @Test fun ordinaryRrReadsAndFingerprintsFollowActiveAliasPolicy() = runBlocking {


### PR DESCRIPTION
Superseded by #2056, which adds the requested regression tests on top of the explanation now in `main`.

## What this PR does

WHOOP 5 legacy R-R rows are excluded after #2046 because their units are unknown. When that leaves a scored night without HRV or Charge, both Apple Today layouts and Android now explain the gap: “Earlier WHOOP 5 beats cannot be scored for HRV or Charge. Re-sync your strap to recover available history.”

Persist the reason with the computed night, carry it through cached scoring, and clear it when labelled history restores valid input or the day is removed from a nonempty scoring pass. The notice follows the selected day and stays hidden for WHOOP 4, ordinary calibration, and displayed imported values. Copy is included in the existing Apple and Android locales.

Android keeps the existing 55,700-byte JaCoCo limit by grouping nightly auxiliary reads and metric writes. The sleep fallback and score formulas are unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

`IntelligenceRRSourceTests` (Swift) and `Whoop5RRSqliteTest` (Kotlin) exercise the actual nightly scoring and persisted notice through three cases:

1. Legacy WHOOP 5 history produces no HRV/Charge and a visible explanation, even with a seeded baseline.
2. Zero-insert source promotion restores valid HRV/Charge, clears the explanation, and remains clear on a cache hit.
3. WHOOP 4 and ordinary calibration gaps do not acquire the warning.

Additional checks cover sleep boundaries, suspect timestamps, cold repository reload, flag-only refresh, skipped-day cleanup, and isolation between computed sources. Temporarily forcing the persisted flag to always zero or always one made the relevant new tests fail on both platforms; the final implementation was restored before validation.

- macOS app build and 65 targeted app tests passed, including the nightly pipeline, paired R-R captures, Liquid Charge carry, and Today explainability.
- iOS simulator build passed for both architectures.
- All 541 WhoopStore tests passed.
- Android: all 27 R-R/store/budget tests passed. Full local suite: 5,847 tests, 6 skipped; the only failures were the two previously reproduced `RecoveryDriversTest` exact half-tie assertions on JetBrains JDK 21.0.8 (`-0.5` versus `-0.4999999999999929`).
- Translation audit, source-comment lint, and whitespace checks passed.

## Checklist

- [x] Swift package tests pass for the package touched
- [ ] Android full unit suite passes locally — JVM-specific rounding assertions described above
- [x] UI changes use design tokens for colors, fonts, and spacing
- [x] No hardcoded hex frame bytes; protocol decoders are unchanged
- [x] Follows `docs/CONTRIBUTING.md`
- [x] No generated Xcode project, credentials, or private captures committed

## Related issues

Follow-up to #2046 and its review. Related to #1505.
