### PR TITLE
test: cover WHOOP 5 gap regressions on both platforms

### DIFF
--- a/StrandTests/IntelligenceRRSourceTests.swift
+++ b/StrandTests/IntelligenceRRSourceTests.swift
@@ -45,6 +45,87 @@ final class IntelligenceRRSourceTests: XCTestCase {
             sourceKind: .liveBLE, capabilities: [.hr, .hrv], status: .active, addedAt: 2, lastSeenAt: 2))
     }
 
+    private func seedBaseline(_ store: WhoopStore, before day: String) async throws {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let date = try XCTUnwrap(formatter.date(from: day))
+        let history = (1...8).map { offset in
+            DailyMetric(day: formatter.string(from: date.addingTimeInterval(-Double(offset) * 86_400)),
+                totalSleepMin: 480, efficiency: 0.9, deepMin: 90, remMin: 90, lightMin: 300,
+                disturbances: 0, restingHr: 60, avgHrv: 32 + Double(offset % 3), recovery: 60,
+                strain: nil, exerciseCount: nil)
+        }
+        _ = try await store.upsertDailyMetrics(history, deviceId: canonical)
+    }
+
+    // The same persisted row and store queries the Today explanation consumes.
+    private func showsLegacyGap(_ day: DailyMetric, store: WhoopStore, owner: String) async throws -> Bool {
+        func dayKey(_ ts: Int?) -> String? {
+            ts.map { Repository.localDayKey(Date(timeIntervalSince1970: TimeInterval($0))) }
+        }
+        let strict = try await store.isWhoop5RRSource(deviceId: owner)
+        let firstRecorded = try await store.firstRecordedRRTimestamp(deviceId: owner)
+        let firstScorable = try await store.firstScorableWhoop5RRTimestamp(deviceId: owner)
+        return day.recovery == nil && Whoop5RR.legacyUnscorableNight(
+            strictWhoop5: strict, day: day.day, firstRecordedDay: dayKey(firstRecorded),
+            firstScorableDay: dayKey(firstScorable), avgHrv: day.avgHrv, totalSleepMin: day.totalSleepMin)
+    }
+
+    func testLegacyGapAppearsForMissingScoresAndClearsAfterSourcePromotion() async throws {
+        try await withPreferences {
+            let store = try await WhoopStore.inMemory()
+            try register(DeviceRegistryStore(dbQueue: store.registryWriter), canonicalModel: "WHOOP")
+            let input = night()
+            try await seedBaseline(store, before: input.day)
+            _ = try await store.insert(Streams(hr: input.hr), deviceId: active)
+            let repo = Repository(deviceId: active)
+            repo.setStoreForTesting(store)
+            let engine = IntelligenceEngine(repo: repo, profile: ProfileStore(), deviceId: canonical)
+            func score() async throws -> DailyMetric {
+                await engine.analyzeRecent(maxDays: 2, force: true)
+                let rows = try await store.dailyMetrics(deviceId: canonical + "-noop", from: input.day, to: input.day)
+                return try XCTUnwrap(rows.first)
+            }
+
+            let noBeats = try await score()
+            XCTAssertGreaterThan(noBeats.totalSleepMin ?? 0, 0)
+            XCTAssertNil(noBeats.avgHrv)
+            XCTAssertNil(noBeats.recovery)
+            let noBeatsGap = try await showsLegacyGap(noBeats, store: store, owner: active)
+            XCTAssertFalse(noBeatsGap, "ordinary missing beats must not be blamed on legacy units")
+
+            _ = try await store.insert(Streams(rr: input.rr), deviceId: active)
+            let legacy = try await score()
+            XCTAssertNil(legacy.avgHrv)
+            XCTAssertNil(legacy.recovery, "a seeded baseline cannot supply the missing nightly HRV")
+            let legacyGap = try await showsLegacyGap(legacy, store: store, owner: active)
+            XCTAssertTrue(legacyGap, "the scored legacy night must reach the shipped explanation predicate")
+
+            // Keep the unlabelled-era bounds unchanged: valid displayed HRV alone must rule out this cause.
+            let calibrating = DailyMetric(day: legacy.day, totalSleepMin: legacy.totalSleepMin,
+                efficiency: legacy.efficiency, deepMin: legacy.deepMin, remMin: legacy.remMin,
+                lightMin: legacy.lightMin, disturbances: legacy.disturbances, restingHr: legacy.restingHr,
+                avgHrv: 40, recovery: nil, strain: legacy.strain, exerciseCount: legacy.exerciseCount)
+            let calibrationGap = try await showsLegacyGap(calibrating, store: store, owner: active)
+            XCTAssertFalse(calibrationGap, "valid HRV without Charge is ordinary calibration")
+
+            let tagged = input.rr.map { RRInterval(ts: $0.ts, rrMs: $0.rrMs, srcChannel: .whoop5Historical) }
+            let inserted = try await store.insert(Streams(rr: tagged), deviceId: active)
+            XCTAssertEqual(inserted.rr, 0, "re-offload changes only source provenance, not row count")
+            let restored = try await score()
+            XCTAssertGreaterThan(try XCTUnwrap(restored.avgHrv), 0)
+            XCTAssertNotNil(restored.recovery)
+            let restoredGap = try await showsLegacyGap(restored, store: store, owner: active)
+            XCTAssertFalse(restoredGap)
+            let idle = try await score()
+            XCTAssertEqual(idle.avgHrv, restored.avgHrv)
+            XCTAssertEqual(idle.recovery, restored.recovery)
+            let idleGap = try await showsLegacyGap(idle, store: store, owner: active)
+            XCTAssertFalse(idleGap, "a cache hit must not revive the explanation")
+
+        }
+    }
+
     // A completed night relative to the test's local day, using the established HR-only sleep fixture.
     private func night() -> (day: String, hr: [HRSample], rr: [RRInterval]) {
         let start = Int(Calendar.current.startOfDay(for: Date()).timeIntervalSince1970) - 86_400
@@ -110,14 +191,27 @@ final class IntelligenceRRSourceTests: XCTestCase {
             let registry = DeviceRegistryStore(dbQueue: store.registryWriter)
             try register(registry, canonicalModel: "4.0")
             let input = night()
-            _ = try await store.insert(Streams(hr: input.hr, rr: input.rr), deviceId: canonical)
+            try await seedBaseline(store, before: input.day)
+            _ = try await store.insert(Streams(hr: input.hr), deviceId: canonical)
             let repo = Repository(deviceId: active)
             repo.setStoreForTesting(store)
             let engine = IntelligenceEngine(repo: repo, profile: ProfileStore(), deviceId: canonical)
             await engine.analyzeRecent(maxDays: 2, force: true)
+            let emptyRows = try await store.dailyMetrics(deviceId: canonical + "-noop", from: input.day, to: input.day)
+            let empty = try XCTUnwrap(emptyRows.first)
+            XCTAssertNil(empty.avgHrv)
+            XCTAssertNil(empty.recovery)
+            let emptyGap = try await showsLegacyGap(empty, store: store, owner: canonical)
+            XCTAssertFalse(emptyGap)
+            _ = try await store.insert(Streams(rr: input.rr), deviceId: canonical)
+            await engine.analyzeRecent(maxDays: 2, force: true)
             let rows = try await store.dailyMetrics(deviceId: canonical + "-noop",
                 from: input.day, to: input.day)
-            XCTAssertGreaterThan(try XCTUnwrap(rows.first?.avgHrv), 0)
+            let scored = try XCTUnwrap(rows.first)
+            XCTAssertGreaterThan(try XCTUnwrap(scored.avgHrv), 0)
+            XCTAssertNotNil(scored.recovery)
+            let gap = try await showsLegacyGap(scored, store: store, owner: canonical)
+            XCTAssertFalse(gap, "WHOOP 4 legacy beats remain supported")
         }
     }
 

--- a/android/app/src/test/java/com/noop/data/Whoop5RRSqliteTest.kt
+++ b/android/app/src/test/java/com/noop/data/Whoop5RRSqliteTest.kt
@@ -1,5 +1,6 @@
 package com.noop.data
 
+import com.noop.protocol.Whoop5RR
 import com.noop.protocol.RrSourceChannel
 import com.noop.ingest.RawSensorExport
 import com.noop.analytics.AnalyticsEngine
@@ -176,6 +177,91 @@ class Whoop5RRSqliteTest {
     }
     private suspend fun read(from: Long = 0, to: Long = 1000, limit: Int = 100) =
         repo.rrIntervalsForDevice(id, from, to, limit)
+
+    private fun seedBaseline(before: String) {
+        for (offset in 1L..8L) {
+            val day = java.time.LocalDate.parse(before).minusDays(offset).toString()
+            days[id to day] = DailyMetric(deviceId = id, day = day, totalSleepMin = 480.0,
+                efficiency = 0.9, restingHr = 60, avgHrv = 40.0 + offset % 3, recovery = 60.0)
+        }
+    }
+
+    // The same persisted row and production SQL inputs consumed by the Today explanation.
+    private suspend fun showsLegacyGap(row: DailyMetric, owner: String): Boolean {
+        fun dayKey(ts: Long?) = ts?.let {
+            java.time.LocalDate.ofInstant(java.time.Instant.ofEpochSecond(it),
+                java.time.ZoneId.systemDefault()).toString()
+        }
+        return row.recovery == null && Whoop5RR.legacyUnscorableNight(
+            strictWhoop5 = repo.isWhoop5RrSource(owner), day = row.day,
+            firstRecordedDay = dayKey(repo.firstRecordedRrTs(owner)),
+            firstScorableDay = dayKey(repo.firstScorableWhoop5RrTs(owner)),
+            avgHrv = row.avgHrv, totalSleepMin = row.totalSleepMin,
+        )
+    }
+
+    private suspend fun assertLegacyGapScoringLifecycle(model: String, expectsLegacyGap: Boolean) {
+        val owner = "physical-strap"
+        registry(model, owner = owner)
+        activate(owner)
+        val now = 1_780_272_000L
+        val offset = java.util.TimeZone.getDefault().getOffset(now * 1000L) / 1000L
+        val end = now - Math.floorMod(now + offset, 86_400L)
+        val start = end - 3_600L
+        seedBaseline(AnalyticsEngine.dayString(end, offset))
+        repo.insert(StreamBatch(hr = (start until end).map { HrRow(it, 60) }), owner)
+        repo.upsertSleepSessions(listOf(SleepSession(deviceId = owner, startTs = start, endTs = end,
+            efficiency = 1.0, stagesJSON = AnalyticsEngine.encodeStages(listOf(StageSegment(start, end, "light"))))))
+        val registry = DeviceRegistry(dao, object : DeviceRegistry.Transactor {
+            override suspend fun <R> run(block: suspend () -> R): R = block()
+        })
+        suspend fun score(): DailyMetric {
+            val computed = IntelligenceEngine.analyzeRecent(repo, maxDays = 1, importedDeviceId = id,
+                nowSeconds = now, ownerSource = RegistryDayOwnerSource(registry), dayCycleMode = DayCycleMode.MIDNIGHT).single()
+            return days.getValue("$id-noop" to computed.day)
+        }
+
+        val noBeats = score()
+        assertTrue((noBeats.totalSleepMin ?: 0.0) > 0.0)
+        assertNull(noBeats.avgHrv)
+        assertNull(noBeats.recovery)
+        assertFalse("ordinary missing beats are not legacy units", showsLegacyGap(noBeats, owner))
+
+        val legacyRr = (start until end).map { RrRow(it, if (it % 2L == 0L) 980 else 1020) }
+        repo.insert(StreamBatch(rr = legacyRr), owner)
+        val legacy = score()
+        assertEquals(expectsLegacyGap, showsLegacyGap(legacy, owner))
+        if (expectsLegacyGap) {
+            assertNull(legacy.avgHrv)
+            assertNull("a seeded baseline cannot supply missing nightly HRV", legacy.recovery)
+            // Keep the same unlabelled-era bounds: valid HRV alone must rule out this cause.
+            assertFalse("valid HRV without Charge is ordinary calibration",
+                showsLegacyGap(legacy.copy(avgHrv = 40.0), owner))
+            assertEquals(0, repo.insert(StreamBatch(rr = legacyRr.map {
+                it.copy(srcChannel = RrSourceChannel.WHOOP5_HISTORICAL)
+            }), owner).rr)
+        } else {
+            assertEquals(40.0, legacy.avgHrv!!, 0.001)
+            assertNotNull(legacy.recovery)
+        }
+
+        val restored = score()
+        assertEquals(40.0, restored.avgHrv!!, 0.001)
+        assertNotNull(restored.recovery)
+        assertFalse(showsLegacyGap(restored, owner))
+        val idle = score()
+        assertEquals(restored.avgHrv, idle.avgHrv)
+        assertEquals(restored.recovery, idle.recovery)
+        assertFalse("a cache hit must not revive the explanation", showsLegacyGap(idle, owner))
+    }
+
+    @Test fun actualWhoop5GapClearsAfterSourcePromotion() = runBlocking {
+        assertLegacyGapScoringLifecycle("5.0 MG", expectsLegacyGap = true)
+    }
+
+    @Test fun actualWhoop4LegacyNightKeepsScoresWithoutExplanation() = runBlocking {
+        assertLegacyGapScoringLifecycle("4.0", expectsLegacyGap = false)
+    }
 
     /** The date the "this night cannot be scored" explanation names comes from this query, so it has to
      *  agree with what scoring actually accepts: labelled transports only, suspect stamps excluded, and


### PR DESCRIPTION
## What this PR does

Add regression coverage for the WHOOP 5 missing-score explanation introduced in `dfb69e67`. The Swift and Kotlin tests run nightly scoring against stored data, then feed the persisted daily row and the real first-recorded/first-scorable queries into the same `Whoop5RR.legacyUnscorableNight` predicate used by Today.

The final diff changes two test files. Production code, UI copy, and the historical date bounds match `main`.

## Type of change

- [x] Bug fix regression coverage
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

The new lifecycle coverage pins three cases:

1. A staged WHOOP 5 night containing only unlabelled beats has neither HRV nor Charge despite a seeded baseline, and qualifies for the explanation.
2. Re-offloading identical interval keys with canonical source labels inserts zero rows, restores HRV and Charge, and clears the explanation through the next cached scoring pass.
3. WHOOP 4 legacy beats remain scoreable. Ordinary missing beats and valid HRV with missing Charge do not qualify for the explanation. The calibration control retains the positive legacy case's date bounds and changes only displayed HRV, so it cannot pass merely because the first-scorable date suppresses the note.

Existing re-pairing/alias, transport-window and restaging regressions remain intact. These are scorer/store/predicate tests; they do not render the UI.

- macOS app build and all 5 `IntelligenceRRSourceTests` passed locally. The [Apple CI run](https://github.com/ryanbr/noop/actions/runs/34451779470) also passed its full macOS test run and iOS simulator build.
- All 27 focused Android R-R, SQLite and JaCoCo-budget tests passed. The [full Android CI run](https://github.com/ryanbr/noop/actions/runs/34451779374) also passed.
- Removing the HRV guard deliberately made the new WHOOP 5 test fail on both platforms; the original production files were restored byte-for-byte before the final passing runs.
- Full Android local suite: 5,847 tests, 6 skipped, with only the two previously reproduced exact half-tie failures in unchanged `RecoveryDriversTest` on JetBrains JDK 21.0.8 (`-0.5` versus `-0.4999999999999929`).
- Source-comment lint and whitespace checks passed.

## Checklist

- [x] Swift app tests pass locally and the full macOS test job passes in CI
- [x] Focused Android tests pass
- [x] Full Android suite passes in CI — the local JVM-specific rounding assertions are described above
- [x] No production, UI, protocol or schema changes
- [x] Follows `docs/CONTRIBUTING.md`
- [x] No generated Xcode project, credentials, or private captures committed

## Related issues

Follow-up to #2046 and the gap explanation in `dfb69e67`. Related to #1505.
