### PR TITLE
Let a rejected API key be corrected without losing the conversation

### DIFF
--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -108,6 +108,16 @@ enum AIKeyStore {
 
 /// User-facing failure reasons mapped to clear, non-crashing messages.
 enum AICoachError: LocalizedError {
+
+    /// Whether an HTTP status means the stored key itself was turned away, as opposed to the provider
+    /// being busy, broken, or asked for something it does not have.
+    ///
+    /// Named rather than left as two literals in two switches because it is the hinge the key-repair
+    /// affordance hangs on, and it decides what the wearer is told to go and do. Widen it and a rate
+    /// limit starts demanding a new key; narrow it and the trap this exists to remove comes straight
+    /// back. Byte-identical twin of the Kotlin `AiCoach.isKeyRejection`.
+    static func isKeyRejection(_ status: Int) -> Bool { status == 401 || status == 403 }
+
     case noKey
     case emptyQuestion
     case badKey
@@ -162,6 +172,20 @@ final class AICoachEngine: ObservableObject {
     private var conversationDay: Int?
     @Published var sending = false
     @Published var errorText: String?
+
+    /// Whether the last failure was the provider turning the stored key away, as opposed to a rate
+    /// limit, a server fault or the network.
+    ///
+    /// It exists because the rejection message tells the wearer to check their key while the screen
+    /// offers no way to reach it: the coach shows the chat as soon as ANY key is stored, and a wrong
+    /// key is still a stored key, so the only route back was a Disconnect that also throws the
+    /// conversation away. This lets the error carry the field with it.
+    ///
+    /// It QUALIFIES `errorText` rather than standing on its own, and the view reads it only inside the
+    /// branch that renders one, so it cannot leave a key editor open under no error. Assigned on every
+    /// failure, so a rejection followed by a rate limit stops claiming to be a rejection. Twin of the
+    /// Kotlin `CoachViewModel.keyRejected`.
+    @Published var keyRejected = false
 
     /// #1862: a question handed over by the Today Coach launcher sheet, for `CoachView` to send on appear.
     ///
@@ -436,6 +460,10 @@ final class AICoachEngine: ObservableObject {
             return
         }
         errorText = nil
+        // A stored key is no longer the rejected one. Deliberately leaves the transcript alone:
+        // correcting a mistyped key is not a reason to lose the conversation, which is what routing
+        // this through `disconnect` used to cost. Twin of the Kotlin `saveKey`.
+        keyRejected = false
         objectWillChange.send() // `hasKey` is computed; nudge SwiftUI to re-read it.
         // #288: do NOT auto-fetch the provider's model list on key-save. For a cloud provider that GET
         // egresses to the provider the MOMENT a key is saved (IP + request timing + key-validity) — before
@@ -518,10 +546,21 @@ final class AICoachEngine: ObservableObject {
             var merged = builtin + discovered
             if !merged.contains(model) { merged.insert(model, at: 0) }
             availableModels = merged
-        } catch {
+        } catch let e as AICoachError {
             // A switch mid-flight makes any error moot for the old provider, so don't surface it.
             guard provider == capturedProvider else { return }
+            // Typed first, because this used to report EVERY failure as a network problem, including a
+            // key the provider had just turned away. Refresh is one of the two places a wrong key shows
+            // itself, and it was the one that blamed the wrong thing: the wearer read "Network problem"
+            // and went looking at their connection. It now says what happened and, for a rejection,
+            // opens the field to fix it.
+            errorText = e.errorDescription
+            if case .badKey = e { keyRejected = true } else { keyRejected = false }
+            return
+        } catch {
+            guard provider == capturedProvider else { return }
             errorText = AICoachError.network(error.localizedDescription).errorDescription
+            keyRejected = false
             return
         }
     }
@@ -699,6 +738,8 @@ final class AICoachEngine: ObservableObject {
                 messages.remove(at: lastIdx)
             }
             errorText = e.errorDescription
+            // Typed, never text-matched: the message is localized and the case is not.
+            if case .badKey = e { keyRejected = true } else { keyRejected = false }
         } catch {
             let partial = accumulated.trimmingCharacters(in: .whitespacesAndNewlines)
             if !partial.isEmpty, let lastIdx = messages.indices.last, messages[lastIdx].role == .assistant {
@@ -710,6 +751,7 @@ final class AICoachEngine: ObservableObject {
                 messages.remove(at: lastIdx)
             }
             errorText = AICoachError.network(error.localizedDescription).errorDescription
+            keyRejected = false
         }
     }
 
@@ -763,6 +805,8 @@ final class AICoachEngine: ObservableObject {
                 )
             }
             errorText = e.errorDescription
+            // Typed, never text-matched: the message is localized and the case is not.
+            if case .badKey = e { keyRejected = true } else { keyRejected = false }
         } catch {
             let partial = accumulated.trimmingCharacters(in: .whitespacesAndNewlines)
             if partial.isEmpty {
@@ -776,6 +820,7 @@ final class AICoachEngine: ObservableObject {
                 )
             }
             errorText = AICoachError.network(error.localizedDescription).errorDescription
+            keyRejected = false
         }
     }
 

--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -204,6 +204,12 @@ final class AICoachEngine: ObservableObject {
             if !provider.modelOptions.contains(model) {
                 model = provider.defaultModel
             }
+            // The message names a provider ("That API key was rejected", after a request only THIS
+            // provider saw), so it cannot survive switching to a different one. Harmless while only the
+            // chat rendered it; wrong now that the setup card does too, which is where switching
+            // happens. Twin of the Kotlin `selectProvider`.
+            errorText = nil
+            keyRejected = false
         }
     }
     @Published var model: String {

--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -454,6 +454,13 @@ final class AICoachEngine: ObservableObject {
         // they were in the middle of disconnecting from.
         messages = []
         conversationDay = nil
+        // The error belongs to the connection being retired, so it goes with it. Kotlin has cleared it
+        // here since the method existed and this side never did: harmless while only the chat rendered
+        // an error, and a visible defect the moment the setup card does too, because the card this
+        // returns to would open carrying "That API key was rejected" above an empty key field, reading
+        // as a verdict on the key about to be typed.
+        errorText = nil
+        keyRejected = false
         objectWillChange.send()
     }
 
@@ -486,6 +493,13 @@ final class AICoachEngine: ObservableObject {
         // the credential and kept the conversation.
         messages = []
         conversationDay = nil
+        // The error belongs to the connection being retired, so it goes with it. Kotlin has cleared it
+        // here since the method existed and this side never did: harmless while only the chat rendered
+        // an error, and a visible defect the moment the setup card does too, because the card this
+        // returns to would open carrying "That API key was rejected" above an empty key field, reading
+        // as a verdict on the key about to be typed.
+        errorText = nil
+        keyRejected = false
         objectWillChange.send()
     }
 

--- a/Strand/AI/AIProvider.swift
+++ b/Strand/AI/AIProvider.swift
@@ -313,7 +313,7 @@ func performRequest(_ req: URLRequest, session: URLSession) async throws -> [Str
         }
 
         return obj
-    case 401, 403:
+    case let status where AICoachError.isKeyRejection(status):
         throw AICoachError.badKey
     case 429:
         throw AICoachError.rateLimited
@@ -374,7 +374,7 @@ func performStreamingRequest(
                 onLine(payload)
             }
         }
-    case 401, 403:
+    case let status where AICoachError.isKeyRejection(status):
         throw AICoachError.badKey
     case 429:
         throw AICoachError.rateLimited

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -210329,6 +210329,28 @@
         "ru": {"stringUnit": {"state": "translated", "value": "Эта ночь была записана до того, как NOOP начал отмечать, по какому каналу WHOOP 5 пришёл каждый удар, поэтому её интервалы смешивают две разные единицы, и ничего не сохранено, что позволило бы их различить. Ночь остаётся в вашей истории, а ночи, записанные с этого момента, оцениваются как обычно."}},
         "zh-Hans": {"stringUnit": {"state": "translated", "value": "这一夜是在 NOOP 标记每次心跳来自哪条 WHOOP 5 传输通道之前记录的，因此其间隔混合了两种不同的单位，而且没有保存任何可以区分它们的信息。该夜仍保留在你的历史记录中，从现在起记录的夜晚会正常评分。"}},
         "zh-Hant": {"stringUnit": {"state": "translated", "value": "這一夜是在 NOOP 標記每次心跳來自哪條 WHOOP 5 傳輸通道之前記錄的，因此其間隔混合了兩種不同的單位，而且沒有儲存任何可以區分它們的資訊。該夜仍保留在你的歷史記錄中，從現在起記錄的夜晚會正常評分。"}}
+    } },
+    "Paste the corrected key. Your conversation is kept." : { "localizations" : {
+        "de": {"stringUnit": {"state": "translated", "value": "Füge den korrigierten Schlüssel ein. Deine Unterhaltung bleibt erhalten."}},
+        "es": {"stringUnit": {"state": "translated", "value": "Pega la clave corregida. Tu conversación se conserva."}},
+        "fr": {"stringUnit": {"state": "translated", "value": "Collez la clé corrigée. Votre conversation est conservée."}},
+        "it": {"stringUnit": {"state": "translated", "value": "Incolla la chiave corretta. La tua conversazione viene mantenuta."}},
+        "pl": {"stringUnit": {"state": "translated", "value": "Wklej poprawiony klucz. Twoja rozmowa zostanie zachowana."}},
+        "pt-PT": {"stringUnit": {"state": "translated", "value": "Cola a chave corrigida. A tua conversa é mantida."}},
+        "ru": {"stringUnit": {"state": "translated", "value": "Вставьте исправленный ключ. Ваш разговор сохранится."}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "粘贴更正后的密钥。你的对话会保留。"}},
+        "zh-Hant": {"stringUnit": {"state": "translated", "value": "貼上更正後的密鑰。你的對話會保留。"}}
+    } },
+    "Corrected API key" : { "localizations" : {
+        "de": {"stringUnit": {"state": "translated", "value": "Korrigierter API-Schlüssel"}},
+        "es": {"stringUnit": {"state": "translated", "value": "Clave de API corregida"}},
+        "fr": {"stringUnit": {"state": "translated", "value": "Clé d'API corrigée"}},
+        "it": {"stringUnit": {"state": "translated", "value": "Chiave API corretta"}},
+        "pl": {"stringUnit": {"state": "translated", "value": "Poprawiony klucz API"}},
+        "pt-PT": {"stringUnit": {"state": "translated", "value": "Chave de API corrigida"}},
+        "ru": {"stringUnit": {"state": "translated", "value": "Исправленный ключ API"}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "更正后的 API 密钥"}},
+        "zh-Hant": {"stringUnit": {"state": "translated", "value": "更正後的 API 密鑰"}}
     } }
   },
   "version": "1.0"

--- a/Strand/Screens/CoachView.swift
+++ b/Strand/Screens/CoachView.swift
@@ -25,6 +25,10 @@ struct CoachView: View {
     @State private var draft: String = UserDefaults.standard.string(forKey: "coach.composerDraft") ?? ""
     /// Pending key text in the setup card (never persisted here, handed to `setKey`).
     @State private var keyDraft: String = ""
+    /// The corrected key, typed into the editor a rejection opens. Separate from `keyDraft` so the
+    /// setup card's own field is untouched, and cleared on save so a secret does not sit in view state
+    /// after it has been stored. Twin of the Kotlin `keyFix`.
+    @State private var keyFix: String = ""
     /// Whether the model selector is in free-text "Custom…" mode.
     @State private var customModel: Bool = false
     /// The id typed in the "Custom…" field.
@@ -78,6 +82,11 @@ struct CoachView: View {
                 transcript
                 if let error = coach.errorText, !error.isEmpty {
                     errorBanner(error)
+                    // A rejected key is the one failure the wearer can act on from here, and the
+                    // message already tells them to: "Check the key and the provider you selected".
+                    // Until this, the screen offered nowhere to check it. Rendered INSIDE the error
+                    // branch, never on its own flag, so it cannot outlive the message justifying it.
+                    if coach.keyRejected { keyRepairPanel }
                 }
                 // K7: show follow-up chips after each assistant reply (when the transcript is
                 // non-empty and the last message is from the assistant and not mid-send);
@@ -749,6 +758,48 @@ struct CoachView: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Error: \(message)")
+    }
+
+    /// The inline "your key was turned away, here is the field" repair, shown under a rejection.
+    ///
+    /// Saving goes through `setKey`, which replaces the stored key and leaves the transcript alone. The
+    /// existing route was the Disconnect button, which also wipes the conversation and un-commits a
+    /// custom provider: far more than correcting a typo asks for, and named for an outcome the wearer
+    /// is trying to avoid. Twin of the Kotlin editor in `CoachChat`.
+    private var keyRepairPanel: some View {
+        StrandCard(padding: 14) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Paste the corrected key. Your conversation is kept.")
+                    .font(StrandFont.footnote)
+                    .foregroundStyle(StrandPalette.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                SecureField("Paste your \(coach.provider.displayName) API key", text: $keyFix)
+                    .textFieldStyle(.plain)
+                    .font(StrandFont.body)
+                    .foregroundStyle(StrandPalette.textPrimary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 9)
+                    .background(StrandPalette.surfaceInset, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+                    .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .strokeBorder(StrandPalette.hairline, lineWidth: 1))
+                    .onSubmit(saveRepairedKey)
+                    .accessibilityLabel("Corrected API key")
+                HStack {
+                    NoopButton("Update key", systemImage: "key.fill", kind: .primary, action: saveRepairedKey)
+                        .disabled(keyFix.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    Spacer()
+                }
+            }
+        }
+    }
+
+    /// Store the corrected key and drop it from view state. `setKey` clears the error and the rejection
+    /// flag, which is what closes this panel.
+    private func saveRepairedKey() {
+        let trimmed = keyFix.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        coach.setKey(trimmed)
+        keyFix = ""
     }
 
     private var suggestionChips: some View {

--- a/Strand/Screens/CoachView.swift
+++ b/Strand/Screens/CoachView.swift
@@ -517,6 +517,15 @@ struct CoachView: View {
                     Spacer()
                 }
 
+                // Whatever the last attempt from THIS card ran into. The setup card had no error line
+                // at all, so every way it can fail before a key is committed failed silently: a Refresh
+                // the provider turned away, a Connect to a server that wants auth. The wearer saw a
+                // button do nothing. No repair affordance beside it, unlike the chat: the key field is
+                // already on screen, which is the whole point of the card.
+                if let error = coach.errorText, !error.isEmpty {
+                    errorBanner(error)
+                }
+
                 Divider().overlay(StrandPalette.hairline)
                 privacyFootnote
             }

--- a/StrandTests/AIKeyRejectionTests.swift
+++ b/StrandTests/AIKeyRejectionTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import Strand
+
+/// The coach shows the chat as soon as ANY key is stored, and a wrong key is still a stored key, so a
+/// rejection is the one failure whose repair the wearer cannot reach on their own. The view opens a key
+/// field on exactly this classification, which makes it load-bearing rather than cosmetic: widen it and
+/// a rate limit starts demanding a new key, narrow it and the trap comes back.
+///
+/// The same table is asserted in Kotlin `AiKeyRejectionTest`, so the two platforms cannot start
+/// disagreeing about which failures are the wearer's to fix. Pure logic, no network.
+final class AIKeyRejectionTests: XCTestCase {
+
+    func testIsKeyRejection() {
+        let cases: [(Int, Bool)] = [
+            // Unauthorized and Forbidden are the two the providers use for a bad or revoked key.
+            (401, true),
+            (403, true),
+            // Success is not a failure at all.
+            (200, false),
+            // The request's problem, not the key's: a model that does not exist reaches here.
+            (400, false),
+            // Payment and quota read like an account problem, and a new key does not answer either.
+            (402, false),
+            (404, false),
+            (408, false),
+            (429, false),
+            // The provider's problem. Retyping a key would send the wearer chasing the wrong thing.
+            (500, false),
+            (502, false),
+            (503, false),
+            (599, false),
+            // Nothing outside the range gets a free pass either.
+            (0, false),
+            (-1, false),
+        ]
+        for (status, want) in cases {
+            XCTAssertEqual(AICoachError.isKeyRejection(status), want, "HTTP \(status)")
+        }
+    }
+}

--- a/android/app/src/main/java/com/noop/ai/AiCoach.kt
+++ b/android/app/src/main/java/com/noop/ai/AiCoach.kt
@@ -994,7 +994,12 @@ class AiCoach(
         }
     }
 
-    /** Map a non-2xx response to a clear, user-facing message (key, rate-limit, server). */
+    /** Map a non-2xx response to a clear, user-facing message (key, rate-limit, server).
+     *
+     *  A key rejection returns [AiKeyRejectedException] rather than a bare one, so the UI can offer the
+     *  wearer the field the message tells them to check. The message alone cannot carry that: matching
+     *  on its text would break the moment the copy is localized, which is every locale but English.
+     *  The status-to-type decision itself lives in [isKeyRejection], where a test can pin it. */
     private fun httpError(provider: AiProvider, code: Int, body: String): Exception {
         val detail = extractApiErrorMessage(body)
         val base = when (code) {
@@ -1004,7 +1009,8 @@ class AiCoach(
             400 -> "The request was rejected by ${provider.displayName} (HTTP 400)."
             else -> "${provider.displayName} returned an error (HTTP $code)."
         }
-        return Exception(if (detail != null) "$base ($detail)" else base)
+        val message = if (detail != null) "$base ($detail)" else base
+        return if (isKeyRejection(code)) AiKeyRejectedException(message) else Exception(message)
     }
 
     /** Pull the provider's error message out of an error JSON body, if present. */
@@ -1065,6 +1071,18 @@ class AiCoach(
 
     companion object {
         private val JSON = "application/json; charset=utf-8".toMediaType()
+
+        /**
+         * Whether an HTTP status means the stored key itself was turned away, as opposed to the
+         * provider being busy, broken, or asked for something it does not have.
+         *
+         * Named rather than left as two literals because it is the hinge the key-repair affordance
+         * hangs on, and it decides what the wearer is told to go and do. Widen it and a rate limit
+         * starts demanding a new key; narrow it and the trap this exists to remove comes straight
+         * back. Byte-identical twin of Swift `AICoachError.isKeyRejection`, which the two response
+         * switches in `AIProvider.swift` read.
+         */
+        internal fun isKeyRejection(code: Int): Boolean = code == 401 || code == 403
 
         /**
          * Normalise a user-entered Custom base URL: trim, drop a trailing slash, and tolerate a pasted

--- a/android/app/src/main/java/com/noop/ai/AiKeyStore.kt
+++ b/android/app/src/main/java/com/noop/ai/AiKeyStore.kt
@@ -5,6 +5,16 @@ import android.content.SharedPreferences
 import com.noop.data.SecurePrefs
 
 /**
+ * The provider turned the stored key away (HTTP 401 or 403).
+ *
+ * Typed rather than left as a bare exception because the message it carries tells the wearer to check
+ * the key, and until the UI can recognise this case it has nowhere to send them: the coach shows the
+ * chat once ANY key is stored, and a wrong key is still a stored key. The alternative, matching on the
+ * message text, stops working in every locale but English. Twin of Swift `AICoachError.badKey`.
+ */
+class AiKeyRejectedException(message: String) : Exception(message)
+
+/**
  * Secure, at-rest-encrypted storage for the user's AI Coach API key.
  *
  * Backed by Jetpack Security `EncryptedSharedPreferences` — values are encrypted with a

--- a/android/app/src/main/java/com/noop/ui/CoachScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachScreen.kt
@@ -123,6 +123,11 @@ private fun CoachSetup(vm: CoachViewModel) {
     val refreshingModels by vm.refreshingModels.collectAsStateWithLifecycle()
     val customBaseUrl by vm.customBaseUrl.collectAsStateWithLifecycle()
     val customAuthHeader by vm.customAuthHeader.collectAsStateWithLifecycle()
+    // The setup card had no error line at all, so every way this screen can fail before a key is
+    // committed failed silently: a Refresh the provider turned away, a Connect to a server that wants
+    // auth. The wearer saw a button do nothing. The chat has had one since the beginning; this is the
+    // half that was missing.
+    val error by vm.error.collectAsStateWithLifecycle()
     var keyInput by remember { mutableStateOf("") }
     val isCustom = provider == AiProvider.CUSTOM
 
@@ -233,6 +238,20 @@ private fun CoachSetup(vm: CoachViewModel) {
                     label = uiString(R.string.l10n_coach_screen_save_key_f5216b3a),
                     enabled = keyInput.isNotBlank(),
                     onClick = { vm.saveKey(context, keyInput) },
+                )
+            }
+
+            // Whatever the last attempt from THIS card ran into. No repair affordance beside it:
+            // unlike the chat, the key field is already on screen, which is the whole point of the card.
+            val errorMsg = error
+            if (errorMsg != null) {
+                Text(
+                    errorMsg,
+                    style = NoopType.subhead,
+                    color = Palette.statusCritical,
+                    modifier = Modifier.semantics {
+                        contentDescription = uiString(R.string.l10n_coach_screen_coach_error_error_ad9c8c46, errorMsg)
+                    },
                 )
             }
 

--- a/android/app/src/main/java/com/noop/ui/CoachScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachScreen.kt
@@ -250,6 +250,8 @@ private fun CoachChat(vm: CoachViewModel) {
     val messages by vm.messages.collectAsStateWithLifecycle()
     val sending by vm.sending.collectAsStateWithLifecycle()
     val error by vm.error.collectAsStateWithLifecycle()
+    // Only ever read inside the error branch below — see CoachViewModel.keyRejected.
+    val keyRejected by vm.keyRejected.collectAsStateWithLifecycle()
     val provider by vm.provider.collectAsStateWithLifecycle()
     val model by vm.model.collectAsStateWithLifecycle()
     val suggestions by vm.suggestions.collectAsStateWithLifecycle()
@@ -259,6 +261,10 @@ private fun CoachChat(vm: CoachViewModel) {
     var input by remember { mutableStateOf(draftPrefs.getString("draft", "") ?: "") }
     // K2: confirmation gate for the destructive "Clear conversation" action.
     var showClearConfirm by remember { mutableStateOf(false) }
+    // The corrected key, typed into the editor the rejection message opens. Separate from `input` so a
+    // half-typed question is not lost while fixing the key, and cleared on save so a secret does not
+    // sit in composition state after it has been stored.
+    var keyFix by remember { mutableStateOf("") }
 
     // Refresh the contextual chips whenever the chat empties (so a fresh sync updates them) and
     // once on first show. Best-effort; the VM falls back to the generic set on any failure.
@@ -401,6 +407,32 @@ private fun CoachChat(vm: CoachViewModel) {
                 color = Palette.statusCritical,
                 modifier = Modifier.semantics { contentDescription = uiString(R.string.l10n_coach_screen_coach_error_error_ad9c8c46, errorMsg) },
             )
+            // A rejected key is the one failure the wearer can act on from here, and the message
+            // already tells them to: "Check the key and try again". Until this, the screen offered
+            // nowhere to check it. The field is rendered INSIDE the error branch, never on its own
+            // flag, so it cannot outlive the message that justifies it.
+            if (keyRejected) {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        uiString(R.string.coach_key_rejected_hint),
+                        style = NoopType.footnote,
+                        color = Palette.textSecondary,
+                    )
+                    CoachKeyField(
+                        value = keyFix,
+                        onValueChange = { keyFix = it },
+                        placeholder = uiString(R.string.coach_key_rejected_placeholder, provider.displayName),
+                    )
+                    CoachPrimaryButton(
+                        label = uiString(R.string.coach_key_rejected_action),
+                        enabled = keyFix.isNotBlank(),
+                        onClick = {
+                            vm.saveKey(context, keyFix)
+                            keyFix = ""
+                        },
+                    )
+                }
+            }
         }
 
         // Input row + Send, a frosted overlay surface so the composer reads as a docked input bar.

--- a/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.noop.NoopApplication
 import com.noop.ai.AiCoach
+import com.noop.ai.AiKeyRejectedException
 import com.noop.ai.AiKeyStore
 import com.noop.ai.AiProvider
 import com.noop.ai.ChatMsg
@@ -264,8 +265,16 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
                         selectModel(appCtx, merged.first())
                     }
                 }
-            } catch (_: Exception) {
-                // Best-effort, keep whatever list we already have.
+            } catch (e: Exception) {
+                // Best-effort about the LIST: whatever we already have stays. But a key the provider
+                // turned away is not a list problem, and swallowing it left Refresh looking like it
+                // simply did nothing. Refresh is one of the two places a wrong key shows itself, so it
+                // now says so and opens the field to fix it. Every other failure stays quiet, which is
+                // what "best-effort" was protecting. Mirrors the typed catch in Swift refreshModels.
+                if (e is AiKeyRejectedException) {
+                    _error.value = e.message
+                    _keyRejected.value = true
+                }
             } finally {
                 _refreshingModels.value = false
             }
@@ -287,10 +296,32 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
 
     // MARK: - Key management
 
-    /** Save the user's API key (encrypted at rest). Blank input clears the key instead. */
+    /**
+     * Whether the last failure was the provider turning the stored key away, as opposed to a rate
+     * limit, a server fault or the network.
+     *
+     * It exists because the rejection message tells the wearer to check their key while the screen
+     * offers no way to reach it: the coach shows the chat as soon as ANY key is stored, and a wrong key
+     * is still a stored key, so the only route back was a Disconnect that also throws the conversation
+     * away. This lets the error carry the field with it.
+     *
+     * It QUALIFIES the error rather than standing on its own, and the UI reads it only inside the
+     * branch that renders one. That is deliberate: six separate paths clear the error, and a parallel
+     * flag each of them also had to reset would be one forgotten line away from leaving a key editor
+     * open under no error at all, with the seventh such path bound to forget. Assigned unconditionally
+     * on every failure, so a rejection followed by a rate limit stops claiming to be a rejection.
+     */
+    private val _keyRejected = MutableStateFlow(false)
+    val keyRejected: StateFlow<Boolean> = _keyRejected
+
+    /** Save the user's API key (encrypted at rest). Blank input clears the key instead.
+     *
+     *  Deliberately leaves the transcript alone. Correcting a mistyped key is not a reason to lose the
+     *  conversation, which is what routing this through `disconnect` used to cost. */
     fun saveKey(ctx: Context, key: String) {
         AiKeyStore.save(ctx, key)
         _error.value = null
+        _keyRejected.value = false
         _keyVersion.value += 1
         // #288: do NOT auto-fetch the provider's model list on key-save. For a cloud provider that GET hits
         // the provider the MOMENT a key is saved (leaking IP + request timing + key-validity) — before the
@@ -413,6 +444,8 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
                     _messages.value = _messages.value.filterNot { it.id == placeholderId }
                 }
                 _error.value = e.message ?: "Something went wrong. Please try again."
+                // Typed, never text-matched: the message is localized and the type is not.
+                _keyRejected.value = e is AiKeyRejectedException
             } finally {
                 _sending.value = false
                 // K2: persist once the turn is fully settled (success, mid-stream error, or empty-

--- a/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
@@ -219,6 +219,11 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
      */
     fun selectProvider(ctx: Context, p: AiProvider) {
         if (p == _provider.value) return
+        // The message names a provider ("Your OpenAI API key was rejected"), so it cannot survive
+        // switching to a different one: it would be attributing a failure to a provider that never saw
+        // the request. Harmless while nothing rendered it on this card; wrong now that something does.
+        _error.value = null
+        _keyRejected.value = false
         _provider.value = p
         AiKeyStore.saveProvider(ctx, p)
         val resolved = AiKeyStore.readModel(ctx, p)
@@ -253,6 +258,10 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
         val appCtx = ctx.applicationContext
         val p = _provider.value
         val url = _customBaseUrl.value
+        // Clear before trying, not only on success. The setup card renders this now, so without it a
+        // stale message from the previous attempt would sit under a refresh that has just succeeded.
+        _error.value = null
+        _keyRejected.value = false
         _refreshingModels.value = true
         viewModelScope.launch {
             try {

--- a/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
@@ -347,6 +347,7 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
         // clears an already-empty list) but it would be a field claiming something untrue.
         conversationDay = null
         _error.value = null
+        _keyRejected.value = false
         _keyVersion.value += 1
     }
 
@@ -361,6 +362,7 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
         _messages.value = emptyList()
         conversationDay = null
         _error.value = null
+        _keyRejected.value = false
         _keyVersion.value += 1
     }
 

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2764,4 +2764,7 @@
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Ein Coach, der den Faden behält, deine Herzfrequenz auf dem Homescreen und Diagramme, die weniger behaupten</string>
     <string name="charge_legacy_rr_gap_title">Frühere Herzschläge nicht auswertbar</string>
     <string name="charge_legacy_rr_gap_detail">Diese Nacht wurde aufgezeichnet, bevor NOOP festhielt, über welchen WHOOP-5-Übertragungsweg jeder Herzschlag kam. Ihre Intervalle mischen deshalb zwei verschiedene Einheiten, und es ist nichts gespeichert, was sie unterscheidbar macht. Die Nacht bleibt in deinem Verlauf, und ab jetzt aufgezeichnete Nächte werden normal bewertet.</string>
+    <string name="coach_key_rejected_hint">Füge den korrigierten Schlüssel ein. Deine Unterhaltung bleibt erhalten.</string>
+    <string name="coach_key_rejected_placeholder">%1$s-Schlüssel einfügen</string>
+    <string name="coach_key_rejected_action">Schlüssel aktualisieren</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2751,4 +2751,7 @@
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Un coach que mantiene el hilo, tu frecuencia cardíaca en la pantalla de inicio y gráficos que afirman menos</string>
     <string name="charge_legacy_rr_gap_title">Los latidos anteriores no se pueden puntuar</string>
     <string name="charge_legacy_rr_gap_detail">Esta noche se registró antes de que NOOP etiquetara de qué transporte de WHOOP 5 procedía cada latido, así que sus intervalos mezclan dos unidades distintas y no hay nada guardado que permita distinguirlas. La noche permanece en tu historial y las noches registradas a partir de ahora se puntúan con normalidad.</string>
+    <string name="coach_key_rejected_hint">Pega la clave corregida. Tu conversación se conserva.</string>
+    <string name="coach_key_rejected_placeholder">Pega tu clave de %1$s</string>
+    <string name="coach_key_rejected_action">Actualizar clave</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2750,4 +2750,7 @@
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Un coach qui garde le fil, votre fréquence cardiaque sur l\'écran d\'accueil, et des graphiques qui affirment moins</string>
     <string name="charge_legacy_rr_gap_title">Battements antérieurs non évaluables</string>
     <string name="charge_legacy_rr_gap_detail">Cette nuit a été enregistrée avant que NOOP n\'indique de quel transport WHOOP 5 provenait chaque battement. Ses intervalles mêlent donc deux unités différentes, sans rien d\'enregistré pour les distinguer. La nuit reste dans votre historique, et les nuits enregistrées à partir de maintenant sont évaluées normalement.</string>
+    <string name="coach_key_rejected_hint">Collez la clé corrigée. Votre conversation est conservée.</string>
+    <string name="coach_key_rejected_placeholder">Collez votre clé %1$s</string>
+    <string name="coach_key_rejected_action">Mettre à jour la clé</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2755,4 +2755,7 @@
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Trener, który nie gubi wątku, tętno na ekranie głównym i wykresy, które mniej zakładają</string>
     <string name="charge_legacy_rr_gap_title">Wcześniejszych uderzeń nie można ocenić</string>
     <string name="charge_legacy_rr_gap_detail">Ta noc została zarejestrowana, zanim NOOP zaczął oznaczać, z którego kanału WHOOP 5 pochodzi każde uderzenie, więc jej odstępy mieszają dwie różne jednostki i nic zapisanego nie pozwala ich rozróżnić. Noc pozostaje w Twojej historii, a noce zarejestrowane od teraz są oceniane normalnie.</string>
+    <string name="coach_key_rejected_hint">Wklej poprawiony klucz. Twoja rozmowa zostanie zachowana.</string>
+    <string name="coach_key_rejected_placeholder">Wklej swój klucz %1$s</string>
+    <string name="coach_key_rejected_action">Zaktualizuj klucz</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2743,4 +2743,7 @@
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Um treinador que mantém o fio, a sua frequência cardíaca no ecrã principal e gráficos que afirmam menos</string>
     <string name="charge_legacy_rr_gap_title">Batimentos anteriores não podem ser pontuados</string>
     <string name="charge_legacy_rr_gap_detail">Esta noite foi registada antes de o NOOP identificar de que transporte WHOOP 5 vinha cada batimento, por isso os seus intervalos misturam duas unidades diferentes e não há nada guardado que permita distingui-las. A noite mantém-se no teu histórico e as noites registadas a partir de agora são pontuadas normalmente.</string>
+    <string name="coach_key_rejected_hint">Cola a chave corrigida. A tua conversa é mantida.</string>
+    <string name="coach_key_rejected_placeholder">Cola a tua chave %1$s</string>
+    <string name="coach_key_rejected_action">Atualizar chave</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -2634,4 +2634,7 @@
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">Тренер, который не теряет нить, ваш пульс на главном экране и графики, которые меньше домысливают</string>
     <string name="charge_legacy_rr_gap_title">Ранние удары невозможно оценить</string>
     <string name="charge_legacy_rr_gap_detail">Эта ночь была записана до того, как NOOP начал отмечать, по какому каналу WHOOP 5 пришёл каждый удар, поэтому её интервалы смешивают две разные единицы, и ничего не сохранено, что позволило бы их различить. Ночь остаётся в вашей истории, а ночи, записанные с этого момента, оцениваются как обычно.</string>
+    <string name="coach_key_rejected_hint">Вставьте исправленный ключ. Ваш разговор сохранится.</string>
+    <string name="coach_key_rejected_placeholder">Вставьте ключ %1$s</string>
+    <string name="coach_key_rejected_action">Обновить ключ</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2664,4 +2664,7 @@
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">能接住话头的教练、主屏幕上的心率，以及不再过度断言的图表</string>
     <string name="charge_legacy_rr_gap_title">早期心跳无法评分</string>
     <string name="charge_legacy_rr_gap_detail">这一夜是在 NOOP 标记每次心跳来自哪条 WHOOP 5 传输通道之前记录的，因此其间隔混合了两种不同的单位，而且没有保存任何可以区分它们的信息。该夜仍保留在你的历史记录中，从现在起记录的夜晚会正常评分。</string>
+    <string name="coach_key_rejected_hint">粘贴更正后的密钥。你的对话会保留。</string>
+    <string name="coach_key_rejected_placeholder">粘贴你的 %1$s 密钥</string>
+    <string name="coach_key_rejected_action">更新密钥</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2780,4 +2780,7 @@
     <string name="l10n_app_changelog_a_coach_that_keeps_the_thread_2ee52e0c">A coach that keeps the thread, your heart rate on the home screen, and charts that claim less</string>
     <string name="charge_legacy_rr_gap_title">Earlier beats cannot be scored</string>
     <string name="charge_legacy_rr_gap_detail">This night was recorded before NOOP labelled which WHOOP 5 transport each heartbeat came from, so its intervals mix two different units with nothing stored to tell them apart. The night stays in your history, and nights recorded from now on score normally.</string>
+    <string name="coach_key_rejected_hint">Paste the corrected key. Your conversation is kept.</string>
+    <string name="coach_key_rejected_placeholder">Paste your %1$s key</string>
+    <string name="coach_key_rejected_action">Update key</string>
 </resources>

--- a/android/app/src/test/java/com/noop/ai/AiKeyRejectionTest.kt
+++ b/android/app/src/test/java/com/noop/ai/AiKeyRejectionTest.kt
@@ -1,0 +1,47 @@
+package com.noop.ai
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The coach shows the chat as soon as ANY key is stored, and a wrong key is still a stored key, so a
+ * rejection is the one failure whose repair the wearer cannot reach on their own. The UI opens a key
+ * field on exactly this classification, which makes it load-bearing rather than cosmetic: widen it and
+ * a rate limit starts demanding a new key, narrow it and the trap comes back.
+ *
+ * The same table is asserted in Swift `AICoachErrorTests.testIsKeyRejection`, so the two platforms
+ * cannot start disagreeing about which failures are the wearer's to fix.
+ */
+class AiKeyRejectionTest {
+
+    @Test fun isKeyRejectionMatchesTheSharedTable() {
+        for ((code, want) in CASES) {
+            assertEquals("HTTP $code", want, AiCoach.isKeyRejection(code))
+        }
+    }
+
+    private companion object {
+        val CASES = listOf(
+            // Unauthorized and Forbidden are the two the providers use for a bad or revoked key.
+            401 to true,
+            403 to true,
+            // Success is not a failure at all.
+            200 to false,
+            // The request's problem, not the key's: a model that does not exist reaches here.
+            400 to false,
+            // Payment and quota read like an account problem, and a new key does not answer either.
+            402 to false,
+            404 to false,
+            408 to false,
+            429 to false,
+            // The provider's problem. Retyping a key would send the wearer chasing the wrong thing.
+            500 to false,
+            502 to false,
+            503 to false,
+            599 to false,
+            // Nothing outside the range gets a free pass either.
+            0 to false,
+            -1 to false,
+        )
+    }
+}


### PR DESCRIPTION
## What this PR does

Two wearers reported entering the wrong API key for the AI coach and being unable to change it. They
were right that there was no way to, short of an action named for something else.

The coach shows the chat as soon as ANY key is stored, and a wrong key is still a stored key. So a
rejection leaves the wearer on the chat screen reading `Your <provider> API key was rejected. Check
the key and try again` with nowhere to check it: the setup card that owns the key field only renders
when no key is stored at all. The only route back was a small secondary caption labelled **Disconnect**,
named for the outcome someone trying to keep using the feature is avoiding, which also wipes the
transcript and un-commits a custom server. Correcting a typo cost the conversation.

A rejection now carries the field with it: a hint, a masked input and **Update key**, inline under the
error, on both platforms. It saves through the existing key path, so the key is replaced and the
transcript is left alone.

## The classification is the hinge, so it is named and pinned

Which HTTP statuses mean "your key is wrong" decides what the wearer is told to go and do. Widen it and
a rate limit starts demanding a new key; narrow it and the trap comes back. It was two loose literals
in two Swift switches and one Kotlin `when`. It is now `AICoachError.isKeyRejection` and
`AiCoach.isKeyRejection`, read by every site, and both are asserted against the same table of fourteen
statuses so the platforms cannot start disagreeing about which failures are the wearer's to fix.

The UI reads a type, never the message text, because the message is localized and the type is not.

## A second place the wrong key showed itself, and said nothing at all

Refresh Models is the other surface a rejection reaches, and it was misreporting on one platform and
silent on both.

- **Apple**: the catch was untyped, so every failure was reported as `AICoachError.network`, including
  a key the provider had just turned away.
- **Android**: it was swallowed entirely, so Refresh looked like it simply did nothing.

Correcting that alone would have changed nothing on screen, which re-review caught before this was
ready: Refresh lives only on the setup card, and **the setup card had no error line at all**. The chat
has had one since the beginning; this was the half that was missing. So every way the card can fail
before a key is committed failed silently, a Connect to a server that wants auth included. It now says
what went wrong, with no repair affordance beside it, because there the key field is already on screen.

Making that state visible exposed two places it was already stale, both harmless while nothing drew
it. A refresh cleared the error only by succeeding, so the previous attempt's message sat under one
that had just worked. And switching provider kept the old message, which names a provider, so the card
could tell a wearer their Anthropic key was rejected on a request only OpenAI ever saw, right beside
the field for the wrong key. Both are cleared at the point they stop applying.

## Design note

The rejection flag QUALIFIES the error rather than standing beside it, and both views read it only
inside the branch that renders one. Six separate paths clear the error; a parallel flag each of them
also had to reset would be one forgotten line from leaving a key editor open under no error at all,
with the seventh such path bound to forget.

## How it was tested

- Android: `compileFullDebugKotlin`, then the full suite on the pinned JDK 17. **5849 tests, 6 skipped,
  0 failures**, including the new `AiKeyRejectionTest`.
- `Tools/doc_comment_lint.py` clean. It caught one real defect during the work: the new exception had
  been inserted between `AiKeyStore`'s doc block and the object it documents.
- `Tools/i18n_audit.py --ci` clean, and `lintVitalFullRelease -PstagingRelease` passes.
- Nine locales on each platform, hand-written rather than echoed English.
- App targets: not covered by default CI, so this PR's own build is the gate.

## Checklist

- [x] Swift package tests pass for any package I touched, no packages changed
- [x] Full Android unit suite passes
- [x] No new build warnings introduced by the changed code
- [x] UI changes use only design-system tokens
- [x] No hardcoded hex frame bytes; no protocol changes
- [x] Both platforms changed together
- [x] No generated Xcode project, credentials or private captures committed

Relates to the reports above; no issue was filed for them.

