### PR TITLE
Let a hero ring on the classic Today open its own detail

### DIFF
--- a/Strand/App/TabRoute.swift
+++ b/Strand/App/TabRoute.swift
@@ -75,3 +75,23 @@ extension View {
         }
     }
 }
+
+/// The metric keys the three hero rings route to, named rather than repeated as literals.
+///
+/// Both Apple Today shells render those rings and both used their own copies of the strings, so the
+/// pairing lived in three places at once including the test that was meant to guard it. `TabRoute.metric`
+/// falls back to the Health screen on a key it does not recognise, which is the reason this is worth
+/// pinning: a rename leaves the ring tappable, animating, and landing on the wrong screen with nothing
+/// logged and nothing to notice.
+///
+/// Twin of Android's `HERO_CHARGE_METRIC_KEY` and friends, with ONE deliberate difference: Rest routes on
+/// `sleep_performance` here and on `rest` there, because the two platforms' detail screens resolve
+/// different key spaces. Making them agree would break the Android side, not fix anything here.
+enum HeroRingMetric {
+    static let charge = "recovery"
+    static let effort = "strain"
+    static let rest = "sleep_performance"
+
+    /// Charge, Effort, Rest, in the order the hero row renders them.
+    static let all = [charge, effort, rest]
+}

--- a/Strand/App/TabRoute.swift
+++ b/Strand/App/TabRoute.swift
@@ -76,10 +76,16 @@ extension View {
     }
 }
 
-/// The metric keys the three hero rings route to, named rather than repeated as literals.
+/// The metric keys the hero rings and their Key-Metrics tiles route to, named rather than repeated as
+/// literals.
 ///
 /// Both Apple Today shells render those rings and both used their own copies of the strings, so the
-/// pairing lived in three places at once including the test that was meant to guard it. `TabRoute.metric`
+/// pairing lived in three places at once including the test that was meant to guard it.
+///
+/// Not every ring uses one. A ring opens the RICHEST explanation its shell has, so Charge keeps its
+/// breakdown sheet wherever that sheet exists (the classic Today, and Android) and takes a route only on
+/// the Liquid Today, which has no breakdown to offer. Effort and Rest have no breakdown anywhere, so a
+/// route is the richest thing they have and every surface uses one. `TabRoute.metric`
 /// falls back to the Health screen on a key it does not recognise, which is the reason this is worth
 /// pinning: a rename leaves the ring tappable, animating, and landing on the wrong screen with nothing
 /// logged and nothing to notice.

--- a/Strand/App/TabRoute.swift
+++ b/Strand/App/TabRoute.swift
@@ -87,6 +87,14 @@ extension View {
 /// Twin of Android's `HERO_CHARGE_METRIC_KEY` and friends, with ONE deliberate difference: Rest routes on
 /// `sleep_performance` here and on `rest` there, because the two platforms' detail screens resolve
 /// different key spaces. Making them agree would break the Android side, not fix anything here.
+///
+/// SCOPE, since the same three strings appear elsewhere meaning something else. These are CATALOG keys,
+/// resolved through `MetricCatalog`. The Liquid Key-Metrics tiles take them too, because that parameter
+/// resolves the tile's destination through the same catalog, which is the pairing the hero-ring test
+/// exists to guard. What does NOT belong here is the series key space: `exploreSeries(key:)`,
+/// `resolvedSeries(key:)`, `sparks[...]` and the classic hero's `provenanceKey` happen to spell two of
+/// these the same way while asking a different question. Android's `rest` against `sleep_performance` is
+/// the standing proof that two key spaces looking alike is not the same as being one.
 enum HeroRingMetric {
     static let charge = "recovery"
     static let effort = "strain"

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -666,7 +666,7 @@ struct LiquidTodayView: View {
             // today's own accumulation, so yesterday's number would be a false statement, not a stale one.
             HeroScoreCell(label: String(localized: "Charge"), score: chargeDisplay.pct, tint: StrandPalette.chargeColor,
                           animated: dataLoaded, onGuide: { guideSection = .charge },
-                          detailRoute: .metric("recovery"))
+                          detailRoute: .metric(HeroRingMetric.charge))
             // #45: the hero Effort must honour the user's Effort scale like every other Effort read-out.
             // Show the value on the chosen scale (0–100 or WHOOP 0–21) with the matching vessel max, and
             // one decimal on the compressed 0–21 axis to match the app-wide `effortDisplay` convention
@@ -677,10 +677,10 @@ struct LiquidTodayView: View {
                           onGuide: { guideSection = .effort },
                           maxValue: effortScale == .whoop ? 21 : 100,
                           decimals: effortScale == .whoop ? 1 : 0,
-                          detailRoute: .metric("strain"))
+                          detailRoute: .metric(HeroRingMetric.effort))
             HeroScoreCell(label: String(localized: "Rest"), score: restScore, tint: StrandPalette.restColor,
                           animated: dataLoaded, onGuide: { guideSection = .rest },
-                          detailRoute: .metric("sleep_performance"))
+                          detailRoute: .metric(HeroRingMetric.rest))
                 .overlay(alignment: .top) {
                     if let sourceLabel = heroSourceLabel {
                         SourceBadge("\(sourceLabel)", tint: StrandPalette.textSecondary)

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -1328,16 +1328,16 @@ struct LiquidTodayView: View {
             // hero are the same number, so a carry that reached only one of them would put two answers for
             // Charge on one screen. (#543: one prior row feeds every recovery-derived read-out.) Strain below
             // stays raw, matching the Effort hero, which correctly does not carry.
-            ktile(String(localized: "Recovery"), icon: keyMetricIcon(metric), intText(chargeDisplay.pct), "%", StrandPalette.chargeColor, frac(chargeDisplay.pct), key: "recovery")
+            ktile(String(localized: "Recovery"), icon: keyMetricIcon(metric), intText(chargeDisplay.pct), "%", StrandPalette.chargeColor, frac(chargeDisplay.pct), key: HeroRingMetric.charge)
         case .effort:
             // #492: Effort is a load index (0–100 NOOP / 0–21 WHOOP), NOT a percentage, and the unit was
             // wrong on either axis. Fixed on Android and in `TodayView` at the time; THIS view kept the old
             // form, so the tile also ignored the scale toggle — the hero ring above it read ~8 on the WHOOP
             // axis while this read 38. `effortText` is the same shared formatter the ring and the workout
             // rows use, so all three now agree by construction.
-            ktile(String(localized: "Strain"), icon: keyMetricIcon(metric), effortText(effortStrain(displayDay)), "", StrandPalette.effortColor, frac(effortStrain(displayDay)), key: "strain")
+            ktile(String(localized: "Strain"), icon: keyMetricIcon(metric), effortText(effortStrain(displayDay)), "", StrandPalette.effortColor, frac(effortStrain(displayDay)), key: HeroRingMetric.effort)
         case .rest:
-            ktile(String(localized: "Rest"), icon: keyMetricIcon(metric), intText(restScore), "%", StrandPalette.restColor, frac(restScore), key: "sleep_performance")
+            ktile(String(localized: "Rest"), icon: keyMetricIcon(metric), intText(restScore), "%", StrandPalette.restColor, frac(restScore), key: HeroRingMetric.rest)
         case .hrv:
             ktile("HRV", icon: keyMetricIcon(metric), intText(hrv), "ms", StrandPalette.metricCyan, fracOver(hrv, 120), key: "hrv")
         case .restingHr:

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -210286,6 +210286,54 @@
         "ru": {"stringUnit": {"state": "translated", "value": "Исправленный ключ API"}},
         "zh-Hans": {"stringUnit": {"state": "translated", "value": "更正后的 API 密钥"}},
         "zh-Hant": {"stringUnit": {"state": "translated", "value": "更正後的 API 密鑰"}}
+    } },
+    "Open your Charge detail" : { "localizations" : {
+        "de": {"stringUnit": {"state": "translated", "value": "Ladung im Detail öffnen"}},
+        "en": {"stringUnit": {"state": "translated", "value": "Open your Charge detail"}},
+        "es": {"stringUnit": {"state": "translated", "value": "Abre el detalle de Carga"}},
+        "fr": {"stringUnit": {"state": "translated", "value": "Ouvrir le détail de la charge"}},
+        "it": {"stringUnit": {"state": "translated", "value": "Apri il dettaglio della carica"}},
+        "pl": {"stringUnit": {"state": "translated", "value": "Otwórz szczegóły Ładunku"}},
+        "pt-PT": {"stringUnit": {"state": "translated", "value": "Abrir o detalhe da carga"}},
+        "ru": {"stringUnit": {"state": "translated", "value": "Открыть подробности заряда"}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "打开充能详情"}},
+        "zh-Hant": {"stringUnit": {"state": "translated", "value": "開啟充能詳情"}}
+    } },
+    "Open your Effort detail" : { "localizations" : {
+        "de": {"stringUnit": {"state": "translated", "value": "Belastung im Detail öffnen"}},
+        "en": {"stringUnit": {"state": "translated", "value": "Open your Effort detail"}},
+        "es": {"stringUnit": {"state": "translated", "value": "Abre el detalle de Esfuerzo"}},
+        "fr": {"stringUnit": {"state": "translated", "value": "Ouvrir le détail de l'effort"}},
+        "it": {"stringUnit": {"state": "translated", "value": "Apri il dettaglio dello sforzo"}},
+        "pl": {"stringUnit": {"state": "translated", "value": "Otwórz szczegóły Wysiłku"}},
+        "pt-PT": {"stringUnit": {"state": "translated", "value": "Abrir o detalhe do esforço"}},
+        "ru": {"stringUnit": {"state": "translated", "value": "Открыть подробности усилия"}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "打开消耗详情"}},
+        "zh-Hant": {"stringUnit": {"state": "translated", "value": "開啟消耗詳情"}}
+    } },
+    "Open your Rest detail" : { "localizations" : {
+        "de": {"stringUnit": {"state": "translated", "value": "Erholung im Detail öffnen"}},
+        "en": {"stringUnit": {"state": "translated", "value": "Open your Rest detail"}},
+        "es": {"stringUnit": {"state": "translated", "value": "Abre el detalle de Descanso"}},
+        "fr": {"stringUnit": {"state": "translated", "value": "Ouvrir le détail du repos"}},
+        "it": {"stringUnit": {"state": "translated", "value": "Apri il dettaglio del riposo"}},
+        "pl": {"stringUnit": {"state": "translated", "value": "Otwórz szczegóły Odpoczynku"}},
+        "pt-PT": {"stringUnit": {"state": "translated", "value": "Abrir o detalhe do descanso"}},
+        "ru": {"stringUnit": {"state": "translated", "value": "Открыть подробности отдыха"}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "打开休息详情"}},
+        "zh-Hant": {"stringUnit": {"state": "translated", "value": "開啟休息詳情"}}
+    } },
+    "Open your Stress detail" : { "localizations" : {
+        "de": {"stringUnit": {"state": "translated", "value": "Stress im Detail öffnen"}},
+        "en": {"stringUnit": {"state": "translated", "value": "Open your Stress detail"}},
+        "es": {"stringUnit": {"state": "translated", "value": "Abre el detalle de Estrés"}},
+        "fr": {"stringUnit": {"state": "translated", "value": "Ouvrir le détail du stress"}},
+        "it": {"stringUnit": {"state": "translated", "value": "Apri il dettaglio dello stress"}},
+        "pl": {"stringUnit": {"state": "translated", "value": "Otwórz szczegóły Stresu"}},
+        "pt-PT": {"stringUnit": {"state": "translated", "value": "Abrir o detalhe do stress"}},
+        "ru": {"stringUnit": {"state": "translated", "value": "Открыть подробности стресса"}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "打开压力详情"}},
+        "zh-Hant": {"stringUnit": {"state": "translated", "value": "開啟壓力詳情"}}
     } }
   },
   "version": "1.0"

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -3247,13 +3247,19 @@ struct TodayView: View {
             // edge, INSIDE the ring frame so it adds no stacked height, keeping the #762 self-sizing row
             // untouched). It opens the Charge breakdown sheet (the existing ChargeBreakdownSection), built
             // lazily on tap. No new badge/dot/tier sits under the ring (that would re-load the #762 stack).
-            // The three keys are the ones `HeroRingDetailRouteTests` pins against `MetricCatalog`, and
-            // the same three the Liquid hero and the Key-Metrics tiles below already use. `TabRoute.metric`
-            // falls back to the Health screen on an unknown key rather than failing, which is exactly why
-            // they are pinned rather than trusted.
+            // A ring opens the RICHEST explanation this shell has for its score, which is the rule
+            // Android states outright: "Charge keeps its breakdown sheet, which is richer than a trend and
+            // has no twin on the iOS liquid Today". That clause is why the three surfaces differ, and it
+            // is not an oversight. The Liquid Today sends Charge to the trend because it has no breakdown
+            // to offer; THIS shell has one, so its Charge ring keeps it and matches Android.
+            //
+            // Effort and Rest have no breakdown on any platform, so the trend is the richest thing they
+            // have and both rings open it, exactly as Android's do. The keys are the ones
+            // `HeroRingDetailRouteTests` pins against `MetricCatalog`; `TabRoute.metric` falls back to the
+            // Health screen on an unknown key rather than failing, which is why they are pinned.
             heroRingColumn(section: .charge, domain: .charge, provenanceKey: "recovery",
-                           onChevronTap: { showChargeBreakdown = true },
-                           detailRoute: .metric(HeroRingMetric.charge)) {
+                           onRingTap: { showChargeBreakdown = true },
+                           onChevronTap: { showChargeBreakdown = true }) {
                 chargeRing(score: score, d: d, diameter: ring)
             }
             heroRingColumn(section: .effort, domain: .effort,
@@ -3324,7 +3330,8 @@ struct TodayView: View {
     /// ring's edge. Mirrors Android's `HeroRingColumn(caption:)`.
     private func heroRingColumn<RingBody: View>(
         section: ScoreSection, domain: DomainTheme, provenanceKey: String? = nil,
-        onChevronTap: (() -> Void)? = nil, detailRoute: TabRoute? = nil, caption: String? = nil,
+        onRingTap: (() -> Void)? = nil, onChevronTap: (() -> Void)? = nil,
+        detailRoute: TabRoute? = nil, caption: String? = nil,
         captionWidth: CGFloat = 98,
         @ViewBuilder ring: () -> RingBody
     ) -> some View {
@@ -3338,14 +3345,23 @@ struct TodayView: View {
             // A1: the body is the ring plus a contentShape so the whole disc is hittable, and the ring
             // carries NO in-ring cue. `.plain` is load-bearing: a bare NavigationLink applies the default
             // link chrome and would tint the ring, the same reason `metricRow` carries a button style.
-            // Every column passes a route, so there is no untappable branch; a nil route would render a
-            // plain ring, which is what a future domain without a detail screen should get.
+            // A column supplies EITHER a route (Effort, Rest) or an action (Charge, whose breakdown is a
+            // sheet rather than a destination), never both. A column with neither renders a plain ring,
+            // which is what a future domain with nothing richer to open should get.
             if let detailRoute {
                 NavigationLink(value: detailRoute) {
                     ring().contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(Self.domainDetailAccessibilityLabel(domain))
+                .accessibilityAddTraits(.isButton)
+            } else if let onRingTap {
+                Button(action: onRingTap) {
+                    ring().contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Self.domainLabel(domain))
+                .accessibilityHint("See what shaped your Charge")
                 .accessibilityAddTraits(.isButton)
             } else {
                 ring()

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -3252,7 +3252,7 @@ struct TodayView: View {
             // falls back to the Health screen on an unknown key rather than failing, which is exactly why
             // they are pinned rather than trusted.
             heroRingColumn(section: .charge, domain: .charge, provenanceKey: "recovery",
-                           onRingTap: { showChargeBreakdown = true },
+                           onChevronTap: { showChargeBreakdown = true },
                            detailRoute: .metric(HeroRingMetric.charge)) {
                 chargeRing(score: score, d: d, diameter: ring)
             }
@@ -3324,34 +3324,28 @@ struct TodayView: View {
     /// ring's edge. Mirrors Android's `HeroRingColumn(caption:)`.
     private func heroRingColumn<RingBody: View>(
         section: ScoreSection, domain: DomainTheme, provenanceKey: String? = nil,
-        onRingTap: (() -> Void)? = nil, detailRoute: TabRoute? = nil, caption: String? = nil,
+        onChevronTap: (() -> Void)? = nil, detailRoute: TabRoute? = nil, caption: String? = nil,
         captionWidth: CGFloat = 98,
         @ViewBuilder ring: () -> RingBody
     ) -> some View {
         VStack(spacing: 8) {
-            // A1: when the column is tappable (Charge), wrap the ring in a button (the body is just the ring
-            // with a contentShape so the whole disc is hittable). The tappable ring carries NO in-ring cue:
-            // the single affordance is the label chevron below it (see the comment near the Button below).
-            // The non-tappable rings render unchanged.
+            // The RING opens this score's own detail, which is what the Liquid Today has done since
+            // #1995 and what Android does through its own hero keys. Here it used to be Charge alone,
+            // wired to the breakdown sheet, while Effort and Rest were not tappable at all: two of the
+            // three rings did nothing and the third went somewhere else. The chevron below keeps whatever
+            // it already opened, so this adds a destination rather than moving one.
+            //
+            // A1: the body is the ring plus a contentShape so the whole disc is hittable, and the ring
+            // carries NO in-ring cue. `.plain` is load-bearing: a bare NavigationLink applies the default
+            // link chrome and would tint the ring, the same reason `metricRow` carries a button style.
+            // Every column passes a route, so there is no untappable branch; a nil route would render a
+            // plain ring, which is what a future domain without a detail screen should get.
             if let detailRoute {
-                // The RING opens this score's own detail, which is what the Liquid Today has done since
-                // #1995 and what Android does. Here it was Charge only, wired to the breakdown sheet,
-                // while Effort and Rest were not tappable at all: two of the three rings did nothing, and
-                // the third went somewhere else. The chevron below keeps whatever it already opened, so
-                // this adds a destination rather than moving one.
                 NavigationLink(value: detailRoute) {
                     ring().contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(Self.domainDetailAccessibilityLabel(domain))
-                .accessibilityAddTraits(.isButton)
-            } else if let onRingTap {
-                Button(action: onRingTap) {
-                    ring().contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(Self.domainLabel(domain))
-                .accessibilityHint("See what shaped your Charge")
                 .accessibilityAddTraits(.isButton)
             } else {
                 ring()
@@ -3359,7 +3353,7 @@ struct TodayView: View {
             // ONE chevron affordance under every ring, so the row reads uniformly (no second cue on the
             // Charge ring). Charge's chevron opens the "what shaped it" breakdown (its richest explanation);
             // Effort / Rest open their scoring-guide section.
-            Button { if let onRingTap { onRingTap() } else { guideSection = section } } label: {
+            Button { if let onChevronTap { onChevronTap() } else { guideSection = section } } label: {
                 HStack(spacing: 3) {
                     // #937: an invisible LEADING twin of the trailing chevron. The word + chevron used to
                     // centre as ONE block, which pushed the word visibly off the ring's axis (worst on short
@@ -3387,8 +3381,8 @@ struct TodayView: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel(onRingTap == nil ? Self.domainGuideAccessibilityLabel(domain)
-                                                  : "See what shaped your Charge")
+            .accessibilityLabel(onChevronTap == nil ? Self.domainGuideAccessibilityLabel(domain)
+                                                     : "See what shaped your Charge")
             // Component 4, the real per-day source under the ring (only when this score has a value for
             // the day AND we resolved its winner; a calibrating / empty ring shows no provenance badge).
             // Apple Watch (M1): a watch-sourced score reads "Apple Watch" with its confidence bound to the

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -3258,12 +3258,13 @@ struct TodayView: View {
             // `HeroRingDetailRouteTests` pins against `MetricCatalog`; `TabRoute.metric` falls back to the
             // Health screen on an unknown key rather than failing, which is why they are pinned.
             heroRingColumn(section: .charge, domain: .charge, provenanceKey: "recovery",
-                           onRingTap: { showChargeBreakdown = true },
-                           onChevronTap: { showChargeBreakdown = true }) {
+                           onOpenBreakdown: { showChargeBreakdown = true }) {
                 chargeRing(score: score, d: d, diameter: ring)
             }
             heroRingColumn(section: .effort, domain: .effort,
                            detailRoute: .metric(HeroRingMetric.effort)) { effortRing(d: d, diameter: ring) }
+            // `provenanceKey` spells the same string the route does and stays a literal on purpose: it
+            // asks which SOURCE won this day, not which catalog entry to open. See `HeroRingMetric`.
             heroRingColumn(section: .rest, domain: .rest, provenanceKey: "sleep_performance",
                            detailRoute: .metric(HeroRingMetric.rest),
                            caption: restIsPendingSync ? "Pending sync" : nil,
@@ -3330,8 +3331,7 @@ struct TodayView: View {
     /// ring's edge. Mirrors Android's `HeroRingColumn(caption:)`.
     private func heroRingColumn<RingBody: View>(
         section: ScoreSection, domain: DomainTheme, provenanceKey: String? = nil,
-        onRingTap: (() -> Void)? = nil, onChevronTap: (() -> Void)? = nil,
-        detailRoute: TabRoute? = nil, caption: String? = nil,
+        onOpenBreakdown: (() -> Void)? = nil, detailRoute: TabRoute? = nil, caption: String? = nil,
         captionWidth: CGFloat = 98,
         @ViewBuilder ring: () -> RingBody
     ) -> some View {
@@ -3345,9 +3345,11 @@ struct TodayView: View {
             // A1: the body is the ring plus a contentShape so the whole disc is hittable, and the ring
             // carries NO in-ring cue. `.plain` is load-bearing: a bare NavigationLink applies the default
             // link chrome and would tint the ring, the same reason `metricRow` carries a button style.
-            // A column supplies EITHER a route (Effort, Rest) or an action (Charge, whose breakdown is a
-            // sheet rather than a destination), never both. A column with neither renders a plain ring,
-            // which is what a future domain with nothing richer to open should get.
+            // A column supplies EITHER a route (Effort, Rest) or a breakdown (Charge, whose richer
+            // explanation is a sheet rather than a destination), never both. `onOpenBreakdown` drives the
+            // ring AND the chevron, because for that score both lead to the same sheet and two arguments
+            // holding one closure would be two things to keep in step. A column with neither renders a
+            // plain ring, which is what a future domain with nothing richer to open should get.
             if let detailRoute {
                 NavigationLink(value: detailRoute) {
                     ring().contentShape(Rectangle())
@@ -3355,8 +3357,8 @@ struct TodayView: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel(Self.domainDetailAccessibilityLabel(domain))
                 .accessibilityAddTraits(.isButton)
-            } else if let onRingTap {
-                Button(action: onRingTap) {
+            } else if let onOpenBreakdown {
+                Button(action: onOpenBreakdown) {
                     ring().contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
@@ -3369,7 +3371,7 @@ struct TodayView: View {
             // ONE chevron affordance under every ring, so the row reads uniformly (no second cue on the
             // Charge ring). Charge's chevron opens the "what shaped it" breakdown (its richest explanation);
             // Effort / Rest open their scoring-guide section.
-            Button { if let onChevronTap { onChevronTap() } else { guideSection = section } } label: {
+            Button { if let onOpenBreakdown { onOpenBreakdown() } else { guideSection = section } } label: {
                 HStack(spacing: 3) {
                     // #937: an invisible LEADING twin of the trailing chevron. The word + chevron used to
                     // centre as ONE block, which pushed the word visibly off the ring's axis (worst on short
@@ -3397,8 +3399,8 @@ struct TodayView: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel(onChevronTap == nil ? Self.domainGuideAccessibilityLabel(domain)
-                                                     : "See what shaped your Charge")
+            .accessibilityLabel(onOpenBreakdown == nil ? Self.domainGuideAccessibilityLabel(domain)
+                                                        : "See what shaped your Charge")
             // Component 4, the real per-day source under the ring (only when this score has a value for
             // the day AND we resolved its winner; a calibrating / empty ring shows no provenance badge).
             // Apple Watch (M1): a watch-sourced score reads "Apple Watch" with its confidence bound to the

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -3247,12 +3247,19 @@ struct TodayView: View {
             // edge, INSIDE the ring frame so it adds no stacked height, keeping the #762 self-sizing row
             // untouched). It opens the Charge breakdown sheet (the existing ChargeBreakdownSection), built
             // lazily on tap. No new badge/dot/tier sits under the ring (that would re-load the #762 stack).
+            // The three keys are the ones `HeroRingDetailRouteTests` pins against `MetricCatalog`, and
+            // the same three the Liquid hero and the Key-Metrics tiles below already use. `TabRoute.metric`
+            // falls back to the Health screen on an unknown key rather than failing, which is exactly why
+            // they are pinned rather than trusted.
             heroRingColumn(section: .charge, domain: .charge, provenanceKey: "recovery",
-                           onRingTap: { showChargeBreakdown = true }) {
+                           onRingTap: { showChargeBreakdown = true },
+                           detailRoute: .metric(HeroRingMetric.charge)) {
                 chargeRing(score: score, d: d, diameter: ring)
             }
-            heroRingColumn(section: .effort, domain: .effort) { effortRing(d: d, diameter: ring) }
+            heroRingColumn(section: .effort, domain: .effort,
+                           detailRoute: .metric(HeroRingMetric.effort)) { effortRing(d: d, diameter: ring) }
             heroRingColumn(section: .rest, domain: .rest, provenanceKey: "sleep_performance",
+                           detailRoute: .metric(HeroRingMetric.rest),
                            caption: restIsPendingSync ? "Pending sync" : nil,
                            captionWidth: ring) { restRing(diameter: ring) }
         }
@@ -3284,6 +3291,16 @@ struct TodayView: View {
 
     /// The VoiceOver label for a hero ring's "how this score is calculated" button, with the domain word
     /// interpolated from a localized literal (so the spoken sentence is translated, not half-English).
+    private static func domainDetailAccessibilityLabel(_ domain: DomainTheme) -> LocalizedStringKey {
+        switch domain {
+        case .charge: return "Open your Charge detail"
+        case .effort: return "Open your Effort detail"
+        case .rest:   return "Open your Rest detail"
+        case .stress: return "Open your Stress detail"
+        }
+    }
+
+    /// The VoiceOver label for a hero ring's "how this score is calculated" chevron.
     private static func domainGuideAccessibilityLabel(_ domain: DomainTheme) -> LocalizedStringKey {
         switch domain {
         case .charge: return "How Charge is calculated"
@@ -3307,7 +3324,7 @@ struct TodayView: View {
     /// ring's edge. Mirrors Android's `HeroRingColumn(caption:)`.
     private func heroRingColumn<RingBody: View>(
         section: ScoreSection, domain: DomainTheme, provenanceKey: String? = nil,
-        onRingTap: (() -> Void)? = nil, caption: String? = nil,
+        onRingTap: (() -> Void)? = nil, detailRoute: TabRoute? = nil, caption: String? = nil,
         captionWidth: CGFloat = 98,
         @ViewBuilder ring: () -> RingBody
     ) -> some View {
@@ -3316,7 +3333,19 @@ struct TodayView: View {
             // with a contentShape so the whole disc is hittable). The tappable ring carries NO in-ring cue:
             // the single affordance is the label chevron below it (see the comment near the Button below).
             // The non-tappable rings render unchanged.
-            if let onRingTap {
+            if let detailRoute {
+                // The RING opens this score's own detail, which is what the Liquid Today has done since
+                // #1995 and what Android does. Here it was Charge only, wired to the breakdown sheet,
+                // while Effort and Rest were not tappable at all: two of the three rings did nothing, and
+                // the third went somewhere else. The chevron below keeps whatever it already opened, so
+                // this adds a destination rather than moving one.
+                NavigationLink(value: detailRoute) {
+                    ring().contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(Self.domainDetailAccessibilityLabel(domain))
+                .accessibilityAddTraits(.isButton)
+            } else if let onRingTap {
                 Button(action: onRingTap) {
                     ring().contentShape(Rectangle())
                 }

--- a/StrandTests/HeroRingDetailRouteTests.swift
+++ b/StrandTests/HeroRingDetailRouteTests.swift
@@ -14,7 +14,22 @@ import XCTest
 final class HeroRingDetailRouteTests: XCTestCase {
 
     /// Charge, Effort and Rest, in the order the hero row renders them.
-    private let heroKeys = ["recovery", "strain", "sleep_performance"]
+    ///
+    /// Read from the production constants rather than restated here. A private copy would have kept
+    /// passing while a shell was renamed out from under it, which is the one failure this file exists to
+    /// catch; the literals below pin that the constants themselves still say what the catalog expects.
+    private let heroKeys = HeroRingMetric.all
+
+    /// The constants' VALUES, pinned separately from their resolution. Reading the production list is
+    /// what ties the test to the shells; this is what stops the list itself drifting silently, and it is
+    /// where the Apple/Android divergence is recorded: Rest routes on `sleep_performance` here and on
+    /// `rest` there, because the two platforms' detail screens resolve different key spaces.
+    func testHeroRingKeysAreTheExpectedThree() {
+        XCTAssertEqual(HeroRingMetric.charge, "recovery")
+        XCTAssertEqual(HeroRingMetric.effort, "strain")
+        XCTAssertEqual(HeroRingMetric.rest, "sleep_performance")
+        XCTAssertEqual(HeroRingMetric.all, ["recovery", "strain", "sleep_performance"])
+    }
 
     func testEveryHeroRingKeyResolvesToACatalogMetric() {
         for key in heroKeys {

--- a/StrandTests/HeroRingDetailRouteTests.swift
+++ b/StrandTests/HeroRingDetailRouteTests.swift
@@ -9,8 +9,10 @@ import XCTest
 /// catalog key and the ring would keep working, keep animating, and quietly land on the wrong screen. No
 /// crash, no log, nothing to notice. Pinning the three keys here turns that into a build failure.
 ///
-/// The Key-Metrics tiles below the rings pass these same three keys, so this also guards the pair from
-/// drifting apart.
+/// The Liquid Key-Metrics tiles below the rings resolve their own destination through the same catalog
+/// on the same three keys, so this guards the pair from drifting apart. They read the constants rather
+/// than their own copies, which is what makes that true rather than merely intended: a private list here
+/// would have kept passing while either shell was renamed out from under it.
 final class HeroRingDetailRouteTests: XCTestCase {
 
     /// Charge, Effort and Rest, in the order the hero row renders them.

--- a/StrandTests/HeroRingDetailRouteTests.swift
+++ b/StrandTests/HeroRingDetailRouteTests.swift
@@ -1,8 +1,13 @@
 import XCTest
 @testable import Strand
 
-/// #1995: the three hero rings tap through to their metric dossier, so the ring and the Key-Metrics tile
-/// for the same score reach the identical screen.
+/// #1995: a hero ring taps through to its metric dossier, so the ring and the Key-Metrics tile for the
+/// same score reach the identical screen.
+///
+/// Charge is the exception and it is deliberate: a ring opens the richest explanation its shell has, so
+/// Charge keeps its breakdown sheet on the classic Today and on Android and only takes a route on the
+/// Liquid Today, which has no breakdown. Its key is still pinned here because the Liquid hero and both
+/// shells' tiles resolve it.
 ///
 /// `TabRoute.metric(key)` resolves through `MetricCatalog.all` and, when a key does not match, falls back
 /// to the Health screen rather than failing. That fallback is the reason these assertions exist: rename a


### PR DESCRIPTION
## What this PR does

Reported in #2035: tapping the rings at the top of Today should go straight into that score's insight
instead of taking more taps.

That is already true on the **Liquid Today**, which routes all three rings to their metric detail
(#1995), and on **Android**, which does the same through its own hero keys. It was never true on the
**classic Today**, and since Liquid is the default on both Apple platforms this only shows for someone
who has turned it off, which is why it went unnoticed.

What the classic shell actually did:

| Ring | Ring tap, before | Ring tap, after | Chevron, unchanged |
|---|---|---|---|
| Charge | breakdown sheet | breakdown sheet | breakdown sheet |
| Effort | **nothing** | Effort detail | scoring guide |
| Rest | **nothing** | Rest detail | scoring guide |

Two of the three rings were inert, and the only one-tap route for Effort and Rest went to the scoring
guide, which explains how the number is calculated rather than showing the number's own screen.

## What changes

The Effort and Rest rings open their own score's detail. Charge's ring keeps its breakdown sheet, and
every chevron keeps exactly what it opened before, so nothing is moved or removed and two destinations
are added.

Charge staying put is the parity answer, and I had it wrong in the first draft of this PR. Android does
NOT route all three rings; it routes Effort and Rest and keeps Charge on its breakdown, with the reason
at the call site: the breakdown "is richer than a trend and has no twin on the iOS liquid Today". That
clause is the rule. A ring opens the richest explanation its shell can offer. Liquid sends Charge to the
trend because it has no breakdown; the classic Today has one, which is the case that note describes, so
its Charge ring belongs on the breakdown. The classic Today now matches Android ring for ring.

VoiceOver announced "See what shaped your Charge" for whichever ring was tappable, which was true while
Charge was the only one. Each ring now announces opening its own detail, in all ten locales; the
chevron keeps its wording.

## The keys are now one set, not three copies

The three metric keys were literals in both Apple shells and restated a third time inside
`HeroRingDetailRouteTests`, so that test would have kept passing while a shell drifted out from under
it. They are one named set now, read by both shells and by the test, mirroring Android's existing
`HERO_*_METRIC_KEY` constants. This is the same tightening I suggested on #2056, applied here.

Rest deliberately stays `sleep_performance` on Apple against Android's `rest`: the two platforms'
detail screens resolve different key spaces, and making them agree would break the Android side rather
than fix anything. That divergence is now recorded in a test instead of in nobody's head.

`provenanceKey` keeps its own literals. It happens to use the same two strings but answers a different
question, and the Android note about `rest` against `sleep_performance` is the standing reminder that
two key spaces looking alike is not the same as being one.

## Android

No change needed, but not for the reason the first draft gave. Android has one Today shell, and it
already routes the two rings that were inert here while deliberately keeping Charge on its breakdown.
After this change the classic Today behaves the same way, so the two agree ring for ring. The Liquid
Today remains the odd one out on Charge, which is a pre-existing and documented consequence of its not
having a breakdown sheet.

## How it was tested

- `Tools/doc_comment_lint.py` and `Tools/i18n_audit.py --ci` clean; the catalogue parses with no
  duplicate keys and the four new accessibility strings carry all ten locales.
- `HeroRingDetailRouteTests` now reads the production constants, and gained a case pinning their values
  so the set itself cannot drift silently.
- App-target Swift has no local compiler available here, so this PR's own build is the gate. Worth a
  device check that the ring tap and the chevron are separately hittable with Liquid Today switched off.

## Checklist

- [x] Swift package tests pass for any package I touched, no packages changed
- [x] Full Android unit suite passes, no Android change
- [x] No new build warnings introduced by the changed code
- [x] UI changes use only design-system tokens
- [x] No hardcoded hex frame bytes; no protocol changes
- [x] Cross-platform considered: Android already has this
- [x] No generated Xcode project, credentials or private captures committed

