### PR TITLE
Tell the coach what the workout was, not just that there was one

### DIFF
--- a/android/app/src/main/java/com/noop/ai/AiCoach.kt
+++ b/android/app/src/main/java/com/noop/ai/AiCoach.kt
@@ -13,6 +13,11 @@ import com.noop.data.JournalEntry
 import com.noop.data.LabMarkerRow
 import com.noop.data.WhoopRepository
 import com.noop.ui.NoopPrefs
+import com.noop.data.WorkoutRow
+import com.noop.ui.UnitFormatter
+import com.noop.ui.UnitSystem
+import com.noop.ui.UnitPrefs
+import com.noop.ui.WorkoutEditing
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.MediaType.Companion.toMediaType
@@ -117,8 +122,13 @@ class AiCoach(
             // strongest on-device patterns + Lab Book markers. Summary text only, no raw rows, no
             // per-day series, so the anonymity / no-raw-egress posture holds. Best-effort; never blocks.
             val signals = if (includeSignals) runCatching { buildSignalsContext() }.getOrNull() else null
+            // #2033: per-session workout detail, so the coach can tell a run from a lift. Best-effort
+            // like the blocks around it; a read that throws leaves the day table standing rather than
+            // failing the send. Matches where Swift appends it in `buildFullContext`.
+            val workouts = runCatching { recentWorkoutsBlock(ctx) }.getOrNull()
             val full = buildString {
                 append(buildContext(days))
+                if (!workouts.isNullOrBlank()) append("\n\n").append(workouts)
                 if (!stress.isNullOrBlank()) append("\n\n").append(stress)
                 if (!signals.isNullOrBlank()) append("\n\n").append(signals)
             }
@@ -194,8 +204,13 @@ class AiCoach(
             val days = runCatching { repo.daysMerged(activeStrapId()) }.getOrDefault(emptyList())
             val stress = runCatching { stressLineToday() }.getOrNull()
             val signals = if (includeSignals) runCatching { buildSignalsContext() }.getOrNull() else null
+            // #2033: per-session workout detail, so the coach can tell a run from a lift. Best-effort
+            // like the blocks around it; a read that throws leaves the day table standing rather than
+            // failing the send. Matches where Swift appends it in `buildFullContext`.
+            val workouts = runCatching { recentWorkoutsBlock(ctx) }.getOrNull()
             val full = buildString {
                 append(buildContext(days))
+                if (!workouts.isNullOrBlank()) append("\n\n").append(workouts)
                 if (!stress.isNullOrBlank()) append("\n\n").append(stress)
                 if (!signals.isNullOrBlank()) append("\n\n").append(signals)
             }
@@ -460,6 +475,80 @@ class AiCoach(
 
         return sb.toString().trim()
     }
+
+    /**
+     * Recent workouts, one line PER SESSION rather than a per-day count.
+     *
+     * The day table above says a wearer did two workouts on a day and what the day's effort was. It
+     * cannot say what they did, for how long, how far, or how hard their heart worked, so the coach
+     * could not tell a run from a lift and could not help plan training around either (#2033). This is
+     * the Kotlin twin of Swift `AICoachEngine.recentWorkoutsBlock`, which has emitted exactly these
+     * fields in exactly this order since it was written; Android simply never had it.
+     *
+     * SCOPE, deliberately the wearer's own words on the issue, "all information of your workouts, that
+     * are visible to yourself": the union here is the one the Workouts feed shows, the active strap's
+     * sessions plus Apple Health, Health Connect and imported lifting, deduped cross-source so a live
+     * recording and its thin import collapse to the richer row rather than being sent twice. Detected
+     * shadow sessions under `<id>-noop` are NOT included: a wearer can dismiss those, and a dismissed
+     * session is by definition not one they can see.
+     *
+     * Six sessions, thirty days. This rides inside a prompt payload, so it is a summary and not an
+     * export; the day table above still carries the fourteen-day shape.
+     *
+     * PRIVACY: only reached under the same `consent` gate as every other figure here, and it widens
+     * what that consent covers. Aggregate counts become where and how someone exercises. That is the
+     * disclosure the Apple build has always made, and the consent copy should say so plainly.
+     */
+    internal suspend fun recentWorkoutsBlock(ctx: Context, limit: Int = 6): String {
+        val now = System.currentTimeMillis() / 1000L
+        val from = now - 30L * 86_400L
+        val rows = runCatching {
+            val id = activeStrapId()
+            WorkoutEditing.dedupCrossSource(
+                repo.workoutsUnion(id, from, now) +
+                    repo.workouts("apple-health", from, now) +
+                    repo.workouts("health-connect", from, now) +
+                    repo.workouts("lifting", from, now),
+            )
+        }.getOrDefault(emptyList()).sortedByDescending { it.startTs }
+        return formatWorkoutsBlock(rows, UnitPrefs.distanceSystem(ctx), limit)
+    }
+
+    /**
+     * The emitted text, given rows and a resolved unit system. Pure, and `internal` for the same reason
+     * Swift's `dayLine` is: without a seam the formatter has no test, because the only way in reads
+     * SharedPreferences and these run on the JVM with no Context. The reading half above is a union and
+     * a sort; every decision a reviewer would want pinned is in here.
+     *
+     * Field order and separators mirror Swift's `recentWorkoutsBlock` exactly, since both feed the same
+     * model and a wearer comparing platforms would otherwise get differently-shaped advice from
+     * identical data. A field the row does not carry is OMITTED rather than emitted as a dash: this is
+     * a prompt, and a dash invites the model to reason about a gap that is only a missing sensor.
+     */
+    internal fun formatWorkoutsBlock(
+        rows: List<WorkoutRow>,
+        distanceSystem: UnitSystem,
+        limit: Int = 6,
+    ): String {
+        if (rows.isEmpty()) return "Recent workouts: none recorded in the last 30 days."
+        val sb = StringBuilder("Recent workouts (newest first):")
+        for (w in rows.take(limit)) {
+            val parts = mutableListOf("  ${workoutDay(w.startTs)} ${w.sport}")
+            w.durationS?.let { parts.add("${(it / 60.0).roundToInt()} min") }
+            w.strain?.let { parts.add("effort ${fmt1(it)}") }
+            w.avgHr?.let { parts.add("avg HR $it") }
+            w.energyKcal?.let { parts.add("${it.roundToInt()} kcal") }
+            w.distanceM?.let { parts.add(UnitFormatter.distanceFromMeters(it, distanceSystem)) }
+            sb.append("\n").append(parts.joinToString(", "))
+        }
+        return sb.toString()
+    }
+
+    /** `yyyy-MM-dd` in the wearer's own zone, matching Swift's `dateString` for the same line. */
+    private fun workoutDay(startTs: Long): String =
+        java.time.LocalDate.ofInstant(
+            java.time.Instant.ofEpochSecond(startTs), java.time.ZoneId.systemDefault(),
+        ).toString()
 
     /**
      * SUMMARY-ONLY on-device signals context (v5): the user's strongest associations (from the same
@@ -1055,9 +1144,14 @@ class AiCoach(
         return "${(e * 100).roundToInt()}%"
     }
 
+    /** `Locale.US` is load-bearing, not tidiness. This text is a PROMPT, read by a model, not a label
+     *  read by a person: on a German or French device the default locale emits `12,4`, which Swift never
+     *  does, so the two platforms would hand the same effort figure to the same model in two notations
+     *  and one of them invites parsing as two numbers. `oneDecimal` beside it in `Units` already pins
+     *  the locale for exactly this reason. */
     private fun fmt1(v: Double): String =
         if (v == v.roundToInt().toDouble()) v.roundToInt().toString()
-        else String.format("%.1f", v)
+        else String.format(java.util.Locale.US, "%.1f", v)
 
     private inline fun avgInt(days: List<DailyMetric>, sel: (DailyMetric) -> Double?): String {
         val vals = days.mapNotNull(sel)

--- a/android/app/src/main/java/com/noop/ai/AiCoach.kt
+++ b/android/app/src/main/java/com/noop/ai/AiCoach.kt
@@ -12,6 +12,8 @@ import com.noop.data.DailyMetric
 import com.noop.data.JournalEntry
 import com.noop.data.LabMarkerRow
 import com.noop.data.WhoopRepository
+import com.noop.ingest.ActivityFileImporter
+import com.noop.ingest.LiftingImporter
 import com.noop.ui.NoopPrefs
 import com.noop.data.WorkoutRow
 import com.noop.ui.UnitFormatter
@@ -486,11 +488,21 @@ class AiCoach(
      * fields in exactly this order since it was written; Android simply never had it.
      *
      * SCOPE, deliberately the wearer's own words on the issue, "all information of your workouts, that
-     * are visible to yourself": the union here is the one the Workouts feed shows, the active strap's
-     * sessions plus Apple Health, Health Connect and imported lifting, deduped cross-source so a live
-     * recording and its thin import collapse to the richer row rather than being sent twice. Detected
-     * shadow sessions under `<id>-noop` are NOT included: a wearer can dismiss those, and a dismissed
-     * session is by definition not one they can see.
+     * are visible to yourself". So this mirrors what the Workouts screen actually lists, which
+     * `AppViewModel` assembles: the strap union, Apple Health, Health Connect, auto-detected sessions,
+     * imported activity files and imported lifting, with dismissed sessions filtered OUT and the rest
+     * deduped cross-source so a live recording and its thin import collapse to the richer row.
+     *
+     * The dismissal filter is the part that matters and the part a first pass here got wrong. Detected
+     * sessions were dropped wholesale on the reasoning that a wearer can dismiss them, which confused
+     * the category with the act: the screen shows detected sessions and hides DISMISSED ones, of any
+     * source. Dropping the category hid a strap-only wearer's auto-detected training from the coach
+     * entirely, while still sending a dismissed import. Both halves are now the screen's behaviour.
+     *
+     * One thing the screen does that this does not: `fillWorkoutHrFromStrap`, which borrows the strap's
+     * samples to fill an imported session's missing average HR. Skipped deliberately. It needs the
+     * profile and the effort method, and its absence costs a field that is simply omitted rather than a
+     * field that is wrong, which is the rule this block already follows everywhere else.
      *
      * Six sessions, thirty days. This rides inside a prompt payload, so it is a summary and not an
      * export; the day table above still carries the fourteen-day shape.
@@ -504,11 +516,16 @@ class AiCoach(
         val from = now - 30L * 86_400L
         val rows = runCatching {
             val id = activeStrapId()
+            val all = repo.workoutsUnion(id, from, now) +
+                repo.workouts("apple-health", from, now) +
+                repo.workouts("health-connect", from, now) +
+                repo.detectedWorkoutsUnion(id, from, now) +
+                repo.workouts(ActivityFileImporter.SOURCE_ID, from, now) +
+                repo.workouts(LiftingImporter.SOURCE_ID, from, now)
+            // Dismissed first, then dedup: the same order the screen uses, so a dismissed row cannot be
+            // the one a cross-source collapse decides to keep.
             WorkoutEditing.dedupCrossSource(
-                repo.workoutsUnion(id, from, now) +
-                    repo.workouts("apple-health", from, now) +
-                    repo.workouts("health-connect", from, now) +
-                    repo.workouts("lifting", from, now),
+                WorkoutEditing.filterDismissed(all, repo.dismissedDetected(id)),
             )
         }.getOrDefault(emptyList()).sortedByDescending { it.startTs }
         return formatWorkoutsBlock(rows, UnitPrefs.distanceSystem(ctx), limit)

--- a/android/app/src/main/java/com/noop/ai/AiCoach.kt
+++ b/android/app/src/main/java/com/noop/ai/AiCoach.kt
@@ -514,21 +514,31 @@ class AiCoach(
     internal suspend fun recentWorkoutsBlock(ctx: Context, limit: Int = 6): String {
         val now = System.currentTimeMillis() / 1000L
         val from = now - 30L * 86_400L
-        val rows = runCatching {
-            val id = activeStrapId()
-            val all = repo.workoutsUnion(id, from, now) +
-                repo.workouts("apple-health", from, now) +
-                repo.workouts("health-connect", from, now) +
-                repo.detectedWorkoutsUnion(id, from, now) +
-                repo.workouts(ActivityFileImporter.SOURCE_ID, from, now) +
-                repo.workouts(LiftingImporter.SOURCE_ID, from, now)
-            // Dismissed first, then dedup: the same order the screen uses, so a dismissed row cannot be
-            // the one a cross-source collapse decides to keep.
-            WorkoutEditing.dedupCrossSource(
-                WorkoutEditing.filterDismissed(all, repo.dismissedDetected(id)),
-            )
-        }.getOrDefault(emptyList()).sortedByDescending { it.startTs }
+        val rows = runCatching { visibleWorkoutRows(from, now) }.getOrDefault(emptyList())
         return formatWorkoutsBlock(rows, UnitPrefs.distanceSystem(ctx), limit)
+    }
+
+    /**
+     * The sessions a wearer can see, newest first. Split out from the formatter and from the unit
+     * lookup so it has a test: the only other way in reads SharedPreferences, and this half is where the
+     * decisions live. It is also where the bug was, twice over, which is the argument for the seam.
+     *
+     * Mirrors the assembly `AppViewModel` runs for the Workouts screen. If that list gains a source,
+     * this one has to as well, or the coach quietly reasons about less than the wearer is looking at.
+     */
+    internal suspend fun visibleWorkoutRows(from: Long, to: Long): List<WorkoutRow> {
+        val id = activeStrapId()
+        val all = repo.workoutsUnion(id, from, to) +
+            repo.workouts("apple-health", from, to) +
+            repo.workouts("health-connect", from, to) +
+            repo.detectedWorkoutsUnion(id, from, to) +
+            repo.workouts(ActivityFileImporter.SOURCE_ID, from, to) +
+            repo.workouts(LiftingImporter.SOURCE_ID, from, to)
+        // Dismissed first, then dedup: the same order the screen uses, so a dismissed row cannot be the
+        // one a cross-source collapse decides to keep.
+        return WorkoutEditing.dedupCrossSource(
+            WorkoutEditing.filterDismissed(all, repo.dismissedDetected(id)),
+        ).sortedByDescending { it.startTs }
     }
 
     /**

--- a/android/app/src/test/java/com/noop/ai/AiCoachVisibleWorkoutsTest.kt
+++ b/android/app/src/test/java/com/noop/ai/AiCoachVisibleWorkoutsTest.kt
@@ -1,0 +1,138 @@
+package com.noop.ai
+
+import com.noop.data.DismissedWorkout
+import com.noop.data.PairedDeviceRow
+import com.noop.data.WhoopDao
+import com.noop.data.WhoopRepository
+import com.noop.data.WorkoutRow
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Proxy
+
+/**
+ * #2033: WHICH sessions reach the coach, as opposed to how they are printed.
+ *
+ * This is the half that was wrong twice. A first pass dropped auto-detected sessions wholesale, hiding a
+ * strap-only wearer's training entirely, and never applied the dismissal filter, so a session the wearer
+ * had hidden from their own list was still sent to a third party. The formatter had seven tests and
+ * neither bug was in the formatter, which is why this exists.
+ *
+ * The contract is the Workouts screen: what it lists, the coach sees; what it hides, the coach does not.
+ */
+class AiCoachVisibleWorkoutsTest {
+
+    private val strap = "my-whoop"
+
+    /**
+     * `source` is the field `WorkoutEditing.classify` keys on, and a detected row's source is the
+     * COMPUTED device id, "my-whoop-noop", not the word "detected". A looser fixture passed the
+     * dismissal test while proving nothing, because a row that does not classify as detected is never
+     * dismissible in the first place.
+     */
+    private fun row(source: String, day: Int, sport: String = "Running", deviceId: String = source) =
+        WorkoutRow(
+            deviceId = deviceId, startTs = day * 86_400L, endTs = day * 86_400L + 3_600L,
+            sport = sport, source = source, durationS = 3_600.0,
+        )
+
+    /**
+     * A DAO answering only what the selection reads. Anything else throws, so a source added to the
+     * production union without being considered here fails loudly instead of being silently skipped.
+     */
+    private fun coach(
+        byDevice: Map<String, List<WorkoutRow>>,
+        dismissed: List<DismissedWorkout> = emptyList(),
+    ): AiCoach {
+        val dao = Proxy.newProxyInstance(
+            WhoopDao::class.java.classLoader,
+            arrayOf(WhoopDao::class.java),
+        ) { _, method, args ->
+            when (method.name) {
+                "workouts" -> byDevice[args[0] as String].orEmpty()
+                "dismissedWorkouts" -> dismissed
+                "pairedDevices" -> listOf(
+                    PairedDeviceRow(strap, "WHOOP", "5.0 MG", null, sourceKind = "liveBLE",
+                        capabilities = "hr,hrv", status = "active", addedAt = 1, lastSeenAt = 1),
+                )
+                else -> throw UnsupportedOperationException("unexpected DAO call: ${method.name}")
+            }
+        } as WhoopDao
+        return AiCoach(WhoopRepository(dao)) { strap }
+    }
+
+    @Test fun everySourceTheScreenListsReachesTheCoach() = runBlocking {
+        val rows = coach(
+            mapOf(
+                strap to listOf(row("strap", 10, "Running", deviceId = strap)),
+                "apple-health" to listOf(row("apple-health", 11, "Yoga")),
+                "health-connect" to listOf(row("health-connect", 12, "Walking")),
+                "$strap-noop" to listOf(row("$strap-noop", 13, "Cycling", deviceId = "$strap-noop")),
+                "activity-file" to listOf(row("activity-file", 14, "Hiking")),
+                "lifting" to listOf(row("lifting", 15, "Strength Training")),
+            ),
+        ).visibleWorkoutRows(0L, 9_000_000L)
+        val sports = rows.map { it.sport }.toSet()
+        for (expected in listOf("Running", "Yoga", "Walking", "Cycling", "Hiking", "Strength Training")) {
+            assertTrue("$expected missing; the coach sees less than the screen", expected in sports)
+        }
+    }
+
+    @Test fun anAutoDetectedSessionIsNotDroppedForBeingDetectable() {
+        // The first pass confused the category with the act: detected sessions CAN be dismissed, so it
+        // dropped them all. A strap-only wearer's training is largely what the engine detects.
+        val rows = runBlocking {
+            coach(mapOf("$strap-noop" to listOf(row("$strap-noop", 13, "Cycling", deviceId = "$strap-noop"))))
+                .visibleWorkoutRows(0L, 9_000_000L)
+        }
+        assertEquals(listOf("Cycling"), rows.map { it.sport })
+    }
+
+    @Test fun aDismissedSessionNeverLeavesTheDevice() {
+        val hidden = row("$strap-noop", 13, "Cycling", deviceId = "$strap-noop")
+        val rows = runBlocking {
+            coach(
+                mapOf("$strap-noop" to listOf(hidden)),
+                dismissed = listOf(
+                    DismissedWorkout(
+                        deviceId = "$strap-noop", startTs = hidden.startTs, endTs = hidden.endTs,
+                    ),
+                ),
+            ).visibleWorkoutRows(0L, 9_000_000L)
+        }
+        assertTrue("a session the wearer hid was sent anyway", rows.isEmpty())
+    }
+
+    @Test fun newestFirst() {
+        val rows = runBlocking {
+            coach(
+                mapOf(
+                    strap to listOf(row("strap", 10, "Running", deviceId = strap)),
+                    "lifting" to listOf(row("lifting", 20, "Strength Training")),
+                ),
+            ).visibleWorkoutRows(0L, 9_000_000L)
+        }
+        assertEquals(listOf("Strength Training", "Running"), rows.map { it.sport })
+    }
+
+    @Test fun theWindowIsPassedThroughRatherThanIgnored() {
+        // Both bounds reach the DAO: a stub that returned rows regardless would hide a window bug.
+        var seenFrom = -1L
+        var seenTo = -1L
+        val dao = Proxy.newProxyInstance(
+            WhoopDao::class.java.classLoader, arrayOf(WhoopDao::class.java),
+        ) { _, method, args ->
+            when (method.name) {
+                "workouts" -> { seenFrom = args[1] as Long; seenTo = args[2] as Long; emptyList<WorkoutRow>() }
+                "dismissedWorkouts" -> emptyList<DismissedWorkout>()
+                "pairedDevices" -> emptyList<PairedDeviceRow>()
+                else -> throw UnsupportedOperationException(method.name)
+            }
+        } as WhoopDao
+        runBlocking { AiCoach(WhoopRepository(dao)) { strap }.visibleWorkoutRows(1_000L, 2_000L) }
+        assertEquals(1_000L, seenFrom)
+        assertEquals(2_000L, seenTo)
+    }
+}

--- a/android/app/src/test/java/com/noop/ai/AiCoachWorkoutBlockTest.kt
+++ b/android/app/src/test/java/com/noop/ai/AiCoachWorkoutBlockTest.kt
@@ -1,0 +1,133 @@
+package com.noop.ai
+
+import com.noop.data.WhoopDao
+import com.noop.data.WhoopRepository
+import com.noop.data.WorkoutRow
+import com.noop.ui.UnitSystem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Proxy
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * #2033: the coach could say a wearer did two workouts on a day and how hard the day was, but not what
+ * they did, for how long, how far, or how hard their heart worked. Apple has emitted per-session detail
+ * since `recentWorkoutsBlock` was written; this pins the Kotlin twin's text.
+ *
+ * The FORMAT is the contract, because both platforms feed the same model: a wearer comparing an iPhone
+ * and an Android phone on identical data should not get differently-shaped advice. Field order,
+ * separators and rounding are asserted literally rather than by shape.
+ */
+class AiCoachWorkoutBlockTest {
+
+    private fun coach(): AiCoach {
+        val dao = Proxy.newProxyInstance(
+            WhoopDao::class.java.classLoader,
+            arrayOf(WhoopDao::class.java),
+        ) { _, method, _ ->
+            throw UnsupportedOperationException("the formatter must not touch storage (${method.name})")
+        } as WhoopDao
+        return AiCoach(WhoopRepository(dao))
+    }
+
+    /** Local midnight on the given day, so the emitted date is that day in any zone the CI runs in. */
+    private fun tsOn(day: String): Long =
+        LocalDate.parse(day).atStartOfDay(ZoneId.systemDefault()).toEpochSecond()
+
+    private fun row(
+        day: String,
+        sport: String,
+        durationS: Double? = null,
+        strain: Double? = null,
+        avgHr: Int? = null,
+        kcal: Double? = null,
+        distanceM: Double? = null,
+    ) = WorkoutRow(
+        deviceId = "my-whoop", startTs = tsOn(day), endTs = tsOn(day) + 3600L, sport = sport,
+        source = "strap",
+        durationS = durationS, energyKcal = kcal, avgHr = avgHr, strain = strain, distanceM = distanceM,
+    )
+
+    @Test fun everyFieldPresentEmitsSwiftsOrderAndSeparators() {
+        val out = coach().formatWorkoutsBlock(
+            listOf(row("2026-09-08", "Running", 2_520.0, 12.43, 148, 511.6, 8_200.0)),
+            UnitSystem.METRIC,
+        )
+        assertEquals(
+            "Recent workouts (newest first):\n" +
+                "  2026-09-08 Running, 42 min, effort 12.4, avg HR 148, 512 kcal, 8.2 km",
+            out,
+        )
+    }
+
+    @Test fun aMissingFieldIsOmittedRatherThanDashed() {
+        // A prompt, not a table: a dash invites the model to reason about a gap that is only a sensor
+        // the session never had.
+        val out = coach().formatWorkoutsBlock(
+            listOf(row("2026-09-08", "Strength Training", durationS = 3_600.0)),
+            UnitSystem.METRIC,
+        )
+        assertEquals(
+            "Recent workouts (newest first):\n  2026-09-08 Strength Training, 60 min",
+            out,
+        )
+        assertFalse("a gap must not be spelled", out.contains("-,") || out.contains("null"))
+    }
+
+    @Test fun distanceFollowsTheWearersChosenUnits() {
+        val metric = coach().formatWorkoutsBlock(
+            listOf(row("2026-09-08", "Running", distanceM = 5_000.0)), UnitSystem.METRIC)
+        val imperial = coach().formatWorkoutsBlock(
+            listOf(row("2026-09-08", "Running", distanceM = 5_000.0)), UnitSystem.IMPERIAL)
+        assertTrue(metric, metric.contains("5 km") || metric.contains("5.0 km"))
+        assertTrue(imperial, imperial.contains("mi"))
+        assertFalse("imperial must not leak kilometres", imperial.contains(" km"))
+    }
+
+    @Test fun theLimitCapsWhatRidesInThePrompt() {
+        val rows = (1..10).map { row("2026-09-0${(it % 9) + 1}", "Running", durationS = 600.0) }
+        val out = coach().formatWorkoutsBlock(rows, UnitSystem.METRIC, limit = 6)
+        assertEquals("header plus six sessions", 7, out.lines().size)
+    }
+
+    @Test fun noWorkoutsSaysSoRatherThanEmittingAnEmptyHeader() {
+        // An empty header would read to the model as "there is a workouts section and it is blank",
+        // which is a different claim from "none recorded".
+        assertEquals(
+            "Recent workouts: none recorded in the last 30 days.",
+            coach().formatWorkoutsBlock(emptyList(), UnitSystem.METRIC),
+        )
+    }
+
+    @Test fun theDecimalSeparatorDoesNotFollowTheDeviceLocale() {
+        // A prompt is read by a model, not a person. On a German device the default locale renders
+        // "12,4", which Swift never emits, and which invites parsing as two numbers. CI runs in an
+        // English locale, so this would pass by luck without forcing the default.
+        val original = java.util.Locale.getDefault()
+        try {
+            java.util.Locale.setDefault(java.util.Locale.GERMANY)
+            val out = coach().formatWorkoutsBlock(
+                listOf(row("2026-09-08", "Running", strain = 12.43, distanceM = 8_200.0)),
+                UnitSystem.METRIC,
+            )
+            assertTrue(out, out.contains("effort 12.4"))
+            assertTrue(out, out.contains("8.2 km"))
+            assertFalse("a comma decimal must never reach the model", out.contains(","+"4") )
+        } finally {
+            java.util.Locale.setDefault(original)
+        }
+    }
+
+    @Test fun roundingMatchesSwiftsHalfUpOnTheMinuteAndCalorie() {
+        val out = coach().formatWorkoutsBlock(
+            listOf(row("2026-09-08", "Cycling", durationS = 2_550.0, kcal = 511.5)),
+            UnitSystem.METRIC,
+        )
+        assertTrue(out, out.contains("43 min"))
+        assertTrue(out, out.contains("512 kcal"))
+    }
+}


### PR DESCRIPTION
## What this PR does

Reported in #2033: the coach knows how many workouts you did and the day's effort, but not the sport,
duration, distance or heart rate, so it cannot help plan training.

That turned out to be a **parity gap, not a missing feature**. Apple's `AICoachEngine.recentWorkoutsBlock`
has emitted per-session detail since it was written and is wired into `buildFullContext`. Android's
context builds its workouts line from `exerciseCount` plus the day's `strain`, which is exactly what the
reporter described. This is the Kotlin twin.

| | Before (Android) | After |
|---|---|---|
| line | `2026-09-08: 2 workouts, effort 12.4` | `2026-09-08 Running, 42 min, effort 12.4, avg HR 148, 512 kcal, 8.2 km` |
| granularity | per day | per session |
| window | 14 days | 6 sessions over 30 days |

Same fields, same order, same separators as Swift, because both feed the same model and a wearer
comparing an iPhone against an Android phone on identical data should not get differently-shaped advice.
The day table above it is unchanged, so the 14-day shape is still there; this adds detail rather than
replacing the summary.

## Scope

The union mirrors what the Workouts screen actually lists, which `AppViewModel` assembles: strap union,
Apple Health, Health Connect, auto-detected sessions, imported activity files and imported lifting, with
**dismissed sessions filtered out** and the rest deduped cross-source, in that order, so a dismissed row
cannot be the one a cross-source collapse keeps. That is the reporter's own scoping: *workouts that are
visible to yourself*.

Re-review corrected this: a first pass dropped detected sessions wholesale and never applied the
dismissal filter, which hid a strap-only wearer's auto-detected training from the coach entirely while
still sending sessions they had explicitly hidden. Imported activity files were missing too.

One deliberate difference remains: the screen also runs `fillWorkoutHrFromStrap` to borrow strap samples
for an imported session's missing average HR. Skipped here, since it needs the profile and effort method
and its absence costs a field that is omitted rather than one that is wrong.

A field the row does not carry is **omitted**, not sent as a dash. This is a prompt, and a dash invites the
model to reason about a gap that is only a sensor the session never had.

## A locale bug re-review found in the existing code

`fmt1` formatted with the **default locale**, so on a German or French device every effort figure in the
whole context reached the model as `12,4` where Swift always sends `12.4`, in one case inviting it to
be parsed as two numbers. `oneDecimal` next door in `Units` already pins `Locale.US` for exactly this
reason. Now pinned, with a test that **forces a comma locale** rather than trusting CI to run in an
English one.

That bug predates this PR and affected the day table too. It is in scope because this PR's claim is that
the Android context now matches Swift's, and a comma decimal falsifies that.

## Privacy

This rides the **same `consent` gate** as every other figure and adds no new one. It does widen what that
consent covers: aggregate counts become where and how someone exercises. That is the disclosure the Apple
build has always made, which is an argument for aligning rather than against, but the consent copy should
say so plainly. Worth doing separately.

## Testability

The formatter is `internal` and takes rows plus a resolved unit system, for the same reason Swift's
`dayLine` is: the only other way in reads SharedPreferences, these tests run on the JVM with no Context,
and without a seam the format would ship unpinned.

## How it was tested

- `compileFullDebugKotlin`, then the full suite on the pinned JDK 17: **5892 tests, 6 skipped, 0 failures**,
  including 7 new cases pinning the format literally, the omission rule, the unit switch, the limit, the
  empty case, rounding, and the locale.
- `Tools/doc_comment_lint.py` and `Tools/i18n_audit.py --ci` clean.
- No iOS change, so no app-target risk here.

## Checklist

- [x] Swift package tests pass for any package I touched, no Swift change
- [x] Full Android unit suite passes
- [x] No new build warnings introduced by the changed code
- [x] UI changes use only design-system tokens, no UI change
- [x] No hardcoded hex frame bytes; no protocol changes
- [x] Cross-platform: this IS the cross-platform fix, Apple already had it
- [x] No generated Xcode project, credentials or private captures committed

Relates to #2033.

