### PR TITLE
Say what the coach consent actually sends

### DIFF
--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -210334,6 +210334,18 @@
         "ru": {"stringUnit": {"state": "translated", "value": "Открыть подробности стресса"}},
         "zh-Hans": {"stringUnit": {"state": "translated", "value": "打开压力详情"}},
         "zh-Hant": {"stringUnit": {"state": "translated", "value": "開啟壓力詳情"}}
+    } },
+    "On: your charge, rest, HRV and workouts are sent to the provider, each workout with its sport, duration, distance and heart rate." : { "localizations" : {
+        "de": {"stringUnit": {"state": "translated", "value": "An: Ladung, Erholung, HRV und Workouts gehen an den Anbieter, jedes Workout mit Sportart, Dauer, Distanz und Herzfrequenz."}},
+        "en": {"stringUnit": {"state": "translated", "value": "On: your charge, rest, HRV and workouts are sent to the provider, each workout with its sport, duration, distance and heart rate."}},
+        "es": {"stringUnit": {"state": "translated", "value": "Activado: tu carga, descanso, HRV y entrenamientos se envían al proveedor, cada entrenamiento con su deporte, duración, distancia y frecuencia cardíaca."}},
+        "fr": {"stringUnit": {"state": "translated", "value": "Activé : votre charge, repos, VFC et entraînements sont envoyés au fournisseur, chaque entraînement avec son sport, sa durée, sa distance et sa fréquence cardiaque."}},
+        "it": {"stringUnit": {"state": "translated", "value": "Attivo: carica, riposo, HRV e allenamenti vengono inviati al provider, ogni allenamento con sport, durata, distanza e frequenza cardiaca."}},
+        "pl": {"stringUnit": {"state": "translated", "value": "Włączone: Twój ładunek, odpoczynek, HRV i treningi trafiają do dostawcy, każdy trening ze sportem, czasem, dystansem i tętnem."}},
+        "pt-PT": {"stringUnit": {"state": "translated", "value": "Ligado: a tua carga, descanso, VFC e treinos são enviados ao fornecedor, cada treino com o desporto, duração, distância e frequência cardíaca."}},
+        "ru": {"stringUnit": {"state": "translated", "value": "Включено: заряд, отдых, ВСР и тренировки отправляются провайдеру, каждая тренировка с видом спорта, длительностью, дистанцией и пульсом."}},
+        "zh-Hans": {"stringUnit": {"state": "translated", "value": "开启：你的充能、休息、HRV 和训练会发送给服务商，每次训练包含运动类型、时长、距离和心率。"}},
+        "zh-Hant": {"stringUnit": {"state": "translated", "value": "開啟：你的充能、休息、HRV 和訓練會傳送給服務商，每次訓練包含運動類型、時長、距離和心率。"}}
     } }
   },
   "version": "1.0"

--- a/Strand/Screens/CoachView.swift
+++ b/Strand/Screens/CoachView.swift
@@ -281,8 +281,12 @@ struct CoachView: View {
                 VStack(alignment: .leading, spacing: 1) {
                     Text("Let the coach use my data")
                         .font(StrandFont.subhead).foregroundStyle(StrandPalette.textPrimary)
+                    // The ON line NAMES what a session carries rather than saying "workouts" and
+                    // leaving the reader to guess how much that is: the sport, how long, how far and how
+                    // hard, per session. This toggle is the only place someone is asked to agree to it.
+                    // Android says the same sentence (#2033).
                     Text(coach.dataConsent
-                         ? "On: your charge, rest, HRV and workouts are shared with the provider for tailored coaching."
+                         ? "On: your charge, rest, HRV and workouts are sent to the provider, each workout with its sport, duration, distance and heart rate."
                          : "Off: the coach answers generally and sends none of your metrics.")
                         .font(StrandFont.footnote).foregroundStyle(StrandPalette.textTertiary)
                         .fixedSize(horizontal: false, vertical: true)

--- a/android/app/src/main/java/com/noop/ui/CoachScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachScreen.kt
@@ -366,14 +366,21 @@ private fun CoachChat(vm: CoachViewModel) {
         }
 
         // Data-access consent, off by default; no metrics are sent until this is on.
+        //
+        // The ON line NAMES what a session carries, rather than saying "workouts" and leaving the
+        // reader to guess how much that is. It used to mean a count and an effort figure; since #2033
+        // it means the sport, how long, how far and how hard, per session. That is a materially
+        // different disclosure and the toggle is the only place someone is asked to agree to it, so it
+        // says so instead of making them read a PR to find out. Localised rather than inline, which the
+        // i18n baseline also wanted: an English literal here reached every locale untranslated.
         val consent by vm.consent.collectAsStateWithLifecycle()
         NoopCard(padding = 14.dp, tint = Palette.chargeColor) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text(uiString(R.string.l10n_coach_screen_let_the_coach_use_my_data_405d1188), style = NoopType.subhead, color = Palette.textPrimary)
                     Text(
-                        if (consent) "On: your recovery, sleep, HRV and workouts are shared with the provider for tailored coaching."
-                        else "Off: the coach answers generally and sends none of your metrics.",
+                        if (consent) uiString(R.string.coach_consent_on)
+                        else uiString(R.string.coach_consent_off),
                         style = NoopType.footnote, color = Palette.textTertiary,
                     )
                 }

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2767,4 +2767,6 @@
     <string name="coach_key_rejected_hint">Füge den korrigierten Schlüssel ein. Deine Unterhaltung bleibt erhalten.</string>
     <string name="coach_key_rejected_placeholder">%1$s-Schlüssel einfügen</string>
     <string name="coach_key_rejected_action">Schlüssel aktualisieren</string>
+    <string name="coach_consent_on">An: Ladung, Erholung, HRV und Workouts gehen an den Anbieter, jedes Workout mit Sportart, Dauer, Distanz und Herzfrequenz.</string>
+    <string name="coach_consent_off">Aus: Der Coach antwortet allgemein und sendet keine deiner Werte.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2754,4 +2754,6 @@
     <string name="coach_key_rejected_hint">Pega la clave corregida. Tu conversación se conserva.</string>
     <string name="coach_key_rejected_placeholder">Pega tu clave de %1$s</string>
     <string name="coach_key_rejected_action">Actualizar clave</string>
+    <string name="coach_consent_on">Activado: tu carga, descanso, HRV y entrenamientos se envían al proveedor, cada entrenamiento con su deporte, duración, distancia y frecuencia cardíaca.</string>
+    <string name="coach_consent_off">Desactivado: el coach responde en general y no envía ninguna de tus métricas.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2753,4 +2753,6 @@
     <string name="coach_key_rejected_hint">Collez la clé corrigée. Votre conversation est conservée.</string>
     <string name="coach_key_rejected_placeholder">Collez votre clé %1$s</string>
     <string name="coach_key_rejected_action">Mettre à jour la clé</string>
+    <string name="coach_consent_on">Activé : votre charge, repos, VFC et entraînements sont envoyés au fournisseur, chaque entraînement avec son sport, sa durée, sa distance et sa fréquence cardiaque.</string>
+    <string name="coach_consent_off">Désactivé : le coach répond de façon générale et n\'envoie aucune de vos données.</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2758,4 +2758,6 @@
     <string name="coach_key_rejected_hint">Wklej poprawiony klucz. Twoja rozmowa zostanie zachowana.</string>
     <string name="coach_key_rejected_placeholder">Wklej swój klucz %1$s</string>
     <string name="coach_key_rejected_action">Zaktualizuj klucz</string>
+    <string name="coach_consent_on">Włączone: Twój ładunek, odpoczynek, HRV i treningi trafiają do dostawcy, każdy trening ze sportem, czasem, dystansem i tętnem.</string>
+    <string name="coach_consent_off">Wyłączone: coach odpowiada ogólnie i nie wysyła żadnych Twoich danych.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2746,4 +2746,6 @@
     <string name="coach_key_rejected_hint">Cola a chave corrigida. A tua conversa é mantida.</string>
     <string name="coach_key_rejected_placeholder">Cola a tua chave %1$s</string>
     <string name="coach_key_rejected_action">Atualizar chave</string>
+    <string name="coach_consent_on">Ligado: a tua carga, descanso, VFC e treinos são enviados ao fornecedor, cada treino com o desporto, duração, distância e frequência cardíaca.</string>
+    <string name="coach_consent_off">Desligado: o coach responde de forma geral e não envia nenhuma das tuas métricas.</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -2637,4 +2637,6 @@
     <string name="coach_key_rejected_hint">Вставьте исправленный ключ. Ваш разговор сохранится.</string>
     <string name="coach_key_rejected_placeholder">Вставьте ключ %1$s</string>
     <string name="coach_key_rejected_action">Обновить ключ</string>
+    <string name="coach_consent_on">Включено: заряд, отдых, ВСР и тренировки отправляются провайдеру, каждая тренировка с видом спорта, длительностью, дистанцией и пульсом.</string>
+    <string name="coach_consent_off">Выключено: коуч отвечает в общем виде и не отправляет ваши показатели.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2667,4 +2667,6 @@
     <string name="coach_key_rejected_hint">粘贴更正后的密钥。你的对话会保留。</string>
     <string name="coach_key_rejected_placeholder">粘贴你的 %1$s 密钥</string>
     <string name="coach_key_rejected_action">更新密钥</string>
+    <string name="coach_consent_on">开启：你的充能、休息、HRV 和训练会发送给服务商，每次训练包含运动类型、时长、距离和心率。</string>
+    <string name="coach_consent_off">关闭：教练只作一般性回答，不发送你的任何数据。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2783,4 +2783,6 @@
     <string name="coach_key_rejected_hint">Paste the corrected key. Your conversation is kept.</string>
     <string name="coach_key_rejected_placeholder">Paste your %1$s key</string>
     <string name="coach_key_rejected_action">Update key</string>
+    <string name="coach_consent_on">On: your charge, rest, HRV and workouts are sent to the provider, each workout with its sport, duration, distance and heart rate.</string>
+    <string name="coach_consent_off">Off: the coach answers generally and sends none of your metrics.</string>
 </resources>


### PR DESCRIPTION
## What this PR does

The coach's data-access toggle read *"your charge, rest, HRV and workouts are shared with the
provider"*. That sentence was written when a workout meant **a count and the day's effort**. Since the
per-session detail landed in #2061 it means the **sport, how long, how far and how hard**, for each of
the last six sessions. On Apple it has meant that all along.

"Workouts" was carrying all of that, and invites the reading *"that I worked out"*.

| | |
|---|---|
| before | On: your charge, rest, HRV and workouts are shared with the provider for tailored coaching. |
| after | On: your charge, rest, HRV and workouts are sent to the provider, each workout with its sport, duration, distance and heart rate. |

This toggle is the only place anyone is asked to agree to it. Finding out by reading a merge message is
not consent.

The OFF line is unchanged in meaning.

## Two things fixed alongside, because the sentence was being rewritten anyway

**The Android line was an inline English literal**, so every locale read it in English no matter what
the device was set to. It is a string resource now, present in all eight, which the i18n baseline
already wanted and which takes one entry off that backlog. The Apple twin is in the catalogue in ten
locales.

**Android said "recovery, sleep" where the app's own UI, and the Apple twin, say charge and rest.**
Aligned. Using words the interface does not use is a small confusion of its own.

## Scope

Copy and localisation only. No behaviour change: nothing new is sent, the gate is the same gate, and
turning the toggle off still sends nothing. This makes the existing disclosure accurate rather than
widening it.

## How it was tested

- `compileFullDebugKotlin`, then the full suite on the pinned JDK 17: **5897 tests, 6 skipped, 0 failures**.
- `Tools/i18n_audit.py --ci` clean, including the new-literal gate that this PR had to satisfy properly
  rather than by baselining.
- `Tools/doc_comment_lint.py` clean, and `lintVitalFullRelease -PstagingRelease` passes, so no
  ExtraTranslation from the eight new locale entries.
- Apple side is a copy change in a view; the app build on this PR is its gate.

## Checklist

- [x] Swift package tests pass for any package I touched, no packages changed
- [x] Full Android unit suite passes
- [x] No new build warnings introduced by the changed code
- [x] UI changes use only design-system tokens, no layout change
- [x] No hardcoded hex frame bytes; no protocol changes
- [x] Both platforms changed together, and now say the same sentence
- [x] No generated Xcode project, credentials or private captures committed

Relates to #2033.
