### PR TITLE
Break the heart-rate line where the strap recorded nothing

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/TrendChart.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/TrendChart.swift
@@ -13,6 +13,26 @@ import Charts
 // ramp for sleep, the teal HRV scale for HRV, the amber strain ramp for strain.
 
 /// One point on a trend line.
+/// Segment ids for a bucketed time series, changing wherever the series SKIPS a bucket.
+///
+/// A bucket aggregate only emits rows for buckets that had samples, so an hour the strap was off simply
+/// is not in the list. Without this the line joins the two neighbours across that hour and draws a
+/// steady climb the wearer never had, which is a reading invented out of an absence. Handing these to
+/// `TrendPoint.segment` renders the two sides as separate lines, so a gap looks like a gap.
+///
+/// A step of exactly one bucket is contiguous. Anything longer means at least one bucket held nothing,
+/// and that is the break. No tolerance for "just one missing": a five-minute hole is still five minutes
+/// of invention, and the stress trace made the same call when it stopped drawing through unscored hours.
+///
+/// Byte-identical twin of the Kotlin `hrGapSegmentIds`.
+public func hrGapSegments(bucketTs: [Int], bucketSeconds: Int) -> [String] {
+    var segment = 0
+    return bucketTs.enumerated().map { i, ts in
+        if i > 0, ts - bucketTs[i - 1] > bucketSeconds { segment += 1 }
+        return String(segment)
+    }
+}
+
 public struct TrendPoint: Identifiable, Sendable {
     public var date: Date
     public var value: Double

--- a/Packages/StrandDesign/Tests/StrandDesignTests/HrGapSegmentsTests.swift
+++ b/Packages/StrandDesign/Tests/StrandDesignTests/HrGapSegmentsTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import StrandDesign
+
+/// A bucket aggregate omits buckets that had no samples, so without a break the line joins the two
+/// sides of an absence and draws a steady climb across hours the strap recorded nothing. These ids are
+/// what break it.
+///
+/// The same table is asserted in Kotlin `HrGapSegmentsTest`, so the two platforms cannot start
+/// disagreeing about what counts as a gap.
+final class HrGapSegmentsTests: XCTestCase {
+
+    private let b = 300
+
+    func testContiguousBucketsAreOneUnbrokenLine() {
+        XCTAssertEqual(hrGapSegments(bucketTs: [0, 300, 600, 900], bucketSeconds: b),
+                       ["0", "0", "0", "0"])
+    }
+
+    func testOneMissingBucketBreaksIt() {
+        XCTAssertEqual(hrGapSegments(bucketTs: [0, 300, 900, 1_200], bucketSeconds: b),
+                       ["0", "0", "1", "1"])
+    }
+
+    func testEveryGapAdvancesTheSegment() {
+        XCTAssertEqual(hrGapSegments(bucketTs: [0, 900, 1_200, 3_000], bucketSeconds: b),
+                       ["0", "1", "1", "2"])
+    }
+
+    func testALongAbsenceIsStillOneBreakNotMany() {
+        // The four and a half hour hole from the report: one break, not fifty-four.
+        XCTAssertEqual(hrGapSegments(bucketTs: [0, 300, 300 + 16_200], bucketSeconds: b),
+                       ["0", "0", "1"])
+    }
+
+    func testExactlyOneBucketApartIsNotAGap() {
+        XCTAssertEqual(hrGapSegments(bucketTs: [0, 300], bucketSeconds: b), ["0", "0"])
+    }
+
+    func testDegenerateInputsDoNotThrow() {
+        XCTAssertEqual(hrGapSegments(bucketTs: [], bucketSeconds: b), [])
+        XCTAssertEqual(hrGapSegments(bucketTs: [42], bucketSeconds: b), ["0"])
+    }
+
+    func testTheBucketWidthIsRespectedRatherThanAssumed() {
+        // A 15-second load (the narrow end of the dynamic sizing) must not read every step as a gap.
+        XCTAssertEqual(hrGapSegments(bucketTs: [0, 15, 30, 90], bucketSeconds: 15),
+                       ["0", "0", "0", "1"])
+    }
+}

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -5026,8 +5026,14 @@ struct TodayView: View {
             ?? calendarEnd
         let windowEndInclusive = max(windowStart, windowEndExclusive - 1)
         let hrBucketsLocal = await repo.hrBuckets(from: windowStart, to: windowEndInclusive, bucketSeconds: 300)
-        let hrPointsLocal = hrBucketsLocal
-            .map { TrendPoint(date: Date(timeIntervalSince1970: TimeInterval($0.ts)), value: $0.bpm) }
+        // A bucket with no samples is absent from the aggregate, so without a segment break the line
+        // joins its two neighbours and draws a steady climb across hours the strap recorded nothing.
+        let hrSegments = hrGapSegments(bucketTs: hrBucketsLocal.map(\.ts), bucketSeconds: 300)
+        let hrPointsLocal = hrBucketsLocal.enumerated()
+            .map { i, b in
+                TrendPoint(date: Date(timeIntervalSince1970: TimeInterval(b.ts)), value: b.bpm,
+                           segment: hrSegments[i])
+            }
         hrPoints = hrPointsLocal
         // The chart keeps plotting means; only the footer reads the samples behind them (#2032).
         hrDayMin = hrBucketsLocal.map(\.minBpm).min()

--- a/android/app/src/main/java/com/noop/ui/Charts.kt
+++ b/android/app/src/main/java/com/noop/ui/Charts.kt
@@ -273,6 +273,29 @@ fun Sparkline(
 
 // MARK: - LineChart
 
+/**
+ * Segment ids for a bucketed time series, changing wherever the series SKIPS a bucket.
+ *
+ * A bucket aggregate only emits rows for buckets that had samples, so an hour the strap was off simply
+ * is not in the list. The chart spaces points by index, so those two neighbours land side by side and
+ * the stroke joins them: a straight line drawn across time where nothing was measured, reading as a
+ * steady climb the wearer never had. Feeding these ids to [LineChart] breaks the stroke there instead,
+ * the same way an estimator change already breaks the VO2max line, so a gap looks like a gap.
+ *
+ * A step of exactly one bucket is contiguous. Anything longer means at least one bucket held nothing,
+ * and that is the break. No tolerance for "just one missing": a five-minute hole is still five minutes
+ * of invention, and the stress trace made the same call when it stopped drawing through unscored hours.
+ *
+ * Byte-identical twin of Swift `hrGapSegments`.
+ */
+internal fun hrGapSegmentIds(bucketTs: List<Long>, bucketSeconds: Long): List<String> {
+    var segment = 0
+    return bucketTs.mapIndexed { i, ts ->
+        if (i > 0 && ts - bucketTs[i - 1] > bucketSeconds) segment++
+        segment.toString()
+    }
+}
+
 /** Contiguous point-index ranges for a segmented line. A null/misaligned id list preserves the classic
  *  single-line behavior. Equal ids that reappear later become a new range because only adjacency connects. */
 internal fun lineChartSegmentRanges(count: Int, segmentIds: List<String>?): List<IntRange> {

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -5997,6 +5997,16 @@ private fun HrWindowPills(selection: HrWindow, onSelect: (HrWindow) -> Unit) {
     )
 }
 
+/** The width of the Today HR card's buckets.
+ *
+ *  ONE literal, read by the load below and by the gap test in [OverviewHRChart]. They have to agree:
+ *  [hrGapSegmentIds] calls any step wider than one bucket a gap, so a load widened to 600 against a
+ *  test still holding 300 would call EVERY step a gap and shatter the line into dots. The codebase
+ *  genuinely runs 60, 300, 3600 and a span-derived width for other charts, so the two drifting apart is
+ *  a live possibility rather than a theoretical one.
+ */
+internal const val HR_CARD_BUCKET_SECONDS = 300L
+
 @Composable
 private fun HeartRateTrendCard(
     viewModel: AppViewModel,
@@ -6063,7 +6073,9 @@ private fun HeartRateTrendCard(
         // #908: the Today HR curve reads the active strap ∪ canonical "my-whoop" union, NOT a hardcoded
         // "my-whoop". A strap re-added via the device manager banks live HR under its own fresh id, so a
         // pinned read showed the "no heart rate banked yet today" empty state. Single-WHOOP ⇒ one id ⇒ same.
-        buckets = viewModel.repo.hrBucketsUnion(viewModel.activeStrapId, start, end, 300L)
+        buckets = viewModel.repo.hrBucketsUnion(
+            viewModel.activeStrapId, start, end, HR_CARD_BUCKET_SECONDS,
+        )
         // The sleep that ended within the chart window (the night before / this morning), anchors
         // the band + the Charge-at-wake marker. A wide lower bound catches an onset before midnight.
         // Resolves the day's bridged MAIN-night span via `mainSleepSpan` (the SAME resolver the Sleep
@@ -6464,12 +6476,6 @@ private suspend fun PointerInputScope.hrChartTransformGestures(
 // time is mapped to a fractional list index by interpolating against the buckets' own timestamps, // markers then sit exactly on the rendered curve even when the strap history has gaps. Every layer
 // self-hides when its data is absent (no sleep, calibrating Charge, no workouts). Mirrors the macOS
 // OverviewHRChart (Packages/StrandDesign) in NOOP's own colour language. (PR #285)
-
-/** The width of the Today HR card's buckets, matching the 5-minute load its own comment describes.
- *  Named because [hrGapSegmentIds] compares steps against it: if the load ever changes width and this
- *  does not, every bucket reads as a gap and the line shatters, which is at least loud rather than
- *  silent. */
-internal const val HR_CARD_BUCKET_SECONDS = 300L
 
 @Composable
 private fun OverviewHRChart(

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -6465,6 +6465,12 @@ private suspend fun PointerInputScope.hrChartTransformGestures(
 // self-hides when its data is absent (no sleep, calibrating Charge, no workouts). Mirrors the macOS
 // OverviewHRChart (Packages/StrandDesign) in NOOP's own colour language. (PR #285)
 
+/** The width of the Today HR card's buckets, matching the 5-minute load its own comment describes.
+ *  Named because [hrGapSegmentIds] compares steps against it: if the load ever changes width and this
+ *  does not, every bucket reads as a gap and the line shatters, which is at least loud rather than
+ *  silent. */
+internal const val HR_CARD_BUCKET_SECONDS = 300L
+
 @Composable
 private fun OverviewHRChart(
     buckets: List<HrBucket>,
@@ -6482,6 +6488,9 @@ private fun OverviewHRChart(
 ) {
     // The line itself stays the existing shared component, unchanged, markers are a sibling overlay.
     val bucketTimestamps = remember(buckets) { buckets.map { it.bucket } }
+    val gapSegments = remember(bucketTimestamps) {
+        hrGapSegmentIds(bucketTimestamps, HR_CARD_BUCKET_SECONDS)
+    }
     val minV = bpm.min()
     val maxV = bpm.max()
     val span = (maxV - minV).takeIf { it > 0.0 } ?: 1.0
@@ -6609,6 +6618,9 @@ private fun OverviewHRChart(
             // formatter carries the unit — "14:32 · 87 bpm" instead of a bare "87".
             formatValue = { "${it.roundToInt()} bpm" },
             timestamps = bucketTimestamps,
+            // A bucket with no samples is absent from the aggregate, so without this the stroke joins
+            // the two neighbours and draws a steady climb across hours the strap recorded nothing.
+            segmentIds = gapSegments,
         )
 
         // 2) Wake divider + dashed rules + glow end-cap, drawn in one Canvas ON TOP of the line.

--- a/android/app/src/test/java/com/noop/ui/HrGapSegmentsTest.kt
+++ b/android/app/src/test/java/com/noop/ui/HrGapSegmentsTest.kt
@@ -1,0 +1,54 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * A bucket aggregate omits buckets that had no samples, and the chart spaces points by index, so
+ * without a break the stroke joins the two sides of an absence and draws a steady climb across hours
+ * the strap recorded nothing. These ids are what break it.
+ *
+ * The same table is asserted in Swift `HrGapSegmentsTests`, so the two platforms cannot start
+ * disagreeing about what counts as a gap.
+ */
+class HrGapSegmentsTest {
+
+    private val b = 300L
+
+    @Test fun contiguousBucketsAreOneUnbrokenLine() {
+        val ts = listOf(0L, 300L, 600L, 900L)
+        assertEquals(listOf("0", "0", "0", "0"), hrGapSegmentIds(ts, b))
+    }
+
+    @Test fun oneMissingBucketBreaksIt() {
+        // 0, 300, [900 missing 600], so the step from 300 to 900 spans two buckets.
+        val ts = listOf(0L, 300L, 900L, 1_200L)
+        assertEquals(listOf("0", "0", "1", "1"), hrGapSegmentIds(ts, b))
+    }
+
+    @Test fun everyGapAdvancesTheSegment() {
+        val ts = listOf(0L, 900L, 1_200L, 3_000L)
+        assertEquals(listOf("0", "1", "1", "2"), hrGapSegmentIds(ts, b))
+    }
+
+    @Test fun aLongAbsenceIsStillOneBreakNotMany() {
+        // The four and a half hour hole from the report: one break, not fifty-four.
+        val ts = listOf(0L, 300L, 300L + 16_200L)
+        assertEquals(listOf("0", "0", "1"), hrGapSegmentIds(ts, b))
+    }
+
+    @Test fun exactlyOneBucketApartIsNotAGap() {
+        assertEquals(listOf("0", "0"), hrGapSegmentIds(listOf(0L, 300L), b))
+    }
+
+    @Test fun degenerateInputsDoNotThrow() {
+        assertEquals(emptyList<String>(), hrGapSegmentIds(emptyList(), b))
+        assertEquals(listOf("0"), hrGapSegmentIds(listOf(42L), b))
+    }
+
+    @Test fun theBucketWidthIsRespectedRatherThanAssumed() {
+        // A 15-second load (the narrow end of the dynamic sizing) must not read every step as a gap.
+        val ts = listOf(0L, 15L, 30L, 90L)
+        assertEquals(listOf("0", "0", "0", "1"), hrGapSegmentIds(ts, 15L))
+    }
+}


### PR DESCRIPTION
## What this PR does

Reported from a testing build with a screenshot: a long straight diagonal across the middle of the
Today heart-rate chart, climbing steadily from 73 to 80 bpm through hours with no texture at all.

Nothing was wrong with the data. **The chart was drawing a reading that had never been taken.**

`hrBuckets` ends in `GROUP BY ts / :bucketSeconds`, and SQL only emits rows for buckets that had
samples, so a bucket the strap slept through is not in the list at all. The chart spaces points by
index, so the two buckets either side of an absence land next to each other and the stroke joins them.
Four and a half hours of nothing became a tidy ramp.

## The fix

**Both platforms already had the mechanism and neither was using it here.** Android's `LineChart` takes
`segmentIds` and breaks its stroke and fill where adjacent ids differ, which is how the VO2max line
already survives an estimator change. Apple's `TrendPoint` carries `segment` for the same purpose. The
heart-rate series now supplies them, so a gap renders as a gap.

Where the break falls is one pure helper per platform, pinned by **the same seven-case table on both**:
a step of exactly one bucket is contiguous, anything longer is a break. No tolerance for a single
missing bucket, because five minutes of invention is still invention, and the stress trace made the
same call when it stopped drawing through unscored hours.

## A second defect, deliberately left for its own change

Because points are spaced by **index rather than time**, an absence occupies no horizontal room, so the
axis compresses at every gap and the clock labels drift from the curve beneath them. Every point after
a gap sits at the wrong x.

That is not fixed here, and the reason is scope rather than reluctance:

- Teaching `LineChart` to keep placeholder slots touches its min/max, its selection hit-testing, and
  its timestamp and label alignment.
- Moving to a real time axis touches zoom, pan and the gridlines.
- **Densifying the series alone does not work**: `cleanValues = values.filter { it.isFinite() }` strips
  placeholders back out before drawing, which I checked before assuming it would.

Apple does not share this one: its chart already plots against real dates, so only the line-joining half
applied there.

I would rather that landed as its own reviewable change than appended to this one.

## How it was tested

- `compileFullDebugKotlin`, then the full suite on the pinned JDK 17: **5904 tests, 6 skipped, 0 failures**,
  including 7 new cases.
- Swift half covered by the StrandDesign suite in CI.
- `Tools/doc_comment_lint.py` clean. It caught a real defect during the work: the new helper had been
  inserted between `lineChartSegmentRanges`'s doc block and the function it documents.
- `Tools/i18n_audit.py --ci` clean; no user-facing copy changed.
- Worth a look on device that a genuinely contiguous day still draws as one unbroken line.

## Checklist

- [x] Swift package tests pass for any package I touched
- [x] Full Android unit suite passes
- [x] No new build warnings introduced by the changed code
- [x] UI changes use only design-system tokens; no new chrome, the existing segment mechanism
- [x] No hardcoded hex frame bytes; no protocol changes
- [x] Both platforms changed together, with the gap rule pinned identically
- [x] No generated Xcode project, credentials or private captures committed
