### PR TITLE
Remember the strap the link proved, not the one the picker was showing

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -86,6 +86,26 @@ import kotlin.math.roundToInt
 data class HcWritebackStatus(val code: String, val atMs: Long, val written: Int)
 
 /**
+ * Which model to remember for a strap we are connected to.
+ *
+ * POSITIVE EVIDENCE ONLY. `whoop5Detected` is set when service discovery finds the WHOOP 5 service ON
+ * THIS LINK, so a hit proves what answered. Its absence proves nothing, because a 5 whose service was
+ * not found looks identical from here to a 4.0, so a miss leaves today's behaviour exactly as it was
+ * rather than relabelling a genuine 4.0 in the other direction.
+ *
+ * It matters because `autoReconnectOnLaunch` reads the stored pair straight back into the picker, so
+ * persisting the picker's own value makes a wrong model self-perpetuating: restore stale, connect,
+ * store stale again. A field log showed the result, "Auto-reconnecting to your saved WHOOP 4.0" on an
+ * install whose active device is a 5.0 MG. The pair also feeds family selection, so a link running as
+ * WHOOP4 while talking to an MG is not merely a wrong label.
+ *
+ * The BLE client already pins its own `selectedModel` to 5/MG on this same detection. The persisted
+ * half never learned; this is that half.
+ */
+internal fun lastDeviceModelFor(detectedWhoop5: Boolean, selected: WhoopModel): WhoopModel =
+    if (detectedWhoop5) WhoopModel.WHOOP5_MG else selected
+
+/**
  * The pure half of the body-clock binning (#852): hourly HR buckets + a timezone offset -> a per-hour
  * activity profile and the number of distinct local days it spans.
  *
@@ -862,7 +882,19 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                     reconcileStrapAlarm()
                     // Remember this strap so we can reconnect to it directly on the next launch (#67),
                     // e.g. after an APK update restarts the process.
-                    ble.lastDeviceAddress?.let { NoopPrefs.setLastDevice(appContext, it, _selectedModel.value) }
+                    //
+                    // The model stored is the one the LINK proved, not the one the picker happens to hold.
+                    // `_selectedModel` is the picker's value, and `autoReconnectOnLaunch` reads this pair
+                    // straight back into it, so a wrong model here is self-perpetuating: restore stale,
+                    // connect, store stale again. A field log showed the consequence, "Auto-reconnecting
+                    // to your saved WHOOP 4.0" on an install whose active device is a 5.0 MG with a 4.0
+                    // registered from days earlier. That pair also feeds the family selection, and a link
+                    // running as WHOOP4 while talking to an MG makes every later diagnosis nonsense.
+                    ble.lastDeviceAddress?.let {
+                        NoopPrefs.setLastDevice(
+                            appContext, it, lastDeviceModelFor(state.whoop5Detected, _selectedModel.value),
+                        )
+                    }
                 }
                 lastBonded = state.bonded
             }

--- a/android/app/src/test/java/com/noop/ui/LastDeviceModelTest.kt
+++ b/android/app/src/test/java/com/noop/ui/LastDeviceModelTest.kt
@@ -1,0 +1,42 @@
+package com.noop.ui
+
+import com.noop.ble.WhoopModel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Which model gets remembered for a strap, and why it cannot be the picker's value.
+ *
+ * `autoReconnectOnLaunch` reads the stored pair straight back into the picker, so persisting the
+ * picker makes a wrong model self-perpetuating: restore stale, connect, store stale again. A field log
+ * showed it, "Auto-reconnecting to your saved WHOOP 4.0" on an install whose active device is a 5.0 MG.
+ * The pair also feeds family selection, so this is not only a label.
+ */
+class LastDeviceModelTest {
+
+    @Test fun detectionOverridesAStalePicker() {
+        // The reported shape: the picker still says 4.0 from an older strap, the link is a 5/MG.
+        assertEquals(
+            WhoopModel.WHOOP5_MG,
+            lastDeviceModelFor(detectedWhoop5 = true, selected = WhoopModel.WHOOP4),
+        )
+    }
+
+    @Test fun detectionAgreeingWithThePickerChangesNothing() {
+        assertEquals(
+            WhoopModel.WHOOP5_MG,
+            lastDeviceModelFor(detectedWhoop5 = true, selected = WhoopModel.WHOOP5_MG),
+        )
+    }
+
+    @Test fun noDetectionKeepsTodaysBehaviourExactly() {
+        // Absence is not evidence: a 5 whose service was not found looks like a 4.0 from here, so a
+        // miss must not relabel a genuine 4.0 in the other direction.
+        for (picked in WhoopModel.entries) {
+            assertEquals(
+                picked,
+                lastDeviceModelFor(detectedWhoop5 = false, selected = picked),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## What this PR does

A field log read **"Auto-reconnecting to your saved WHOOP 4.0…"** on an install whose active device is
a **5.0 MG** on firmware 50.41.1.0, with a 4.0 registered from three days earlier. The app was naming
the wrong strap while talking to the right one.

The remembered pair is written on a bond transition as `(address, _selectedModel.value)`, and
`_selectedModel` is the **picker's** value, not anything the link established. `autoReconnectOnLaunch`
then reads that pair straight back into the picker. So a wrong model is **self-perpetuating**: restore
stale, connect, store stale again, with nothing in the loop able to correct it.

**It is not only a label.** The same pair feeds family selection, and a link running as WHOOP4 while
talking to an MG makes every diagnosis downstream of it nonsense, on a strap family that is already
hard to diagnose.

## The fix

Store the model **service discovery proved**. `whoop5Detected` is set when the WHOOP 5 service is found
*on that link*, so a hit corrects the picker.

**A miss changes nothing, deliberately.** A 5 whose service was not found looks identical from here to
a 4.0, so treating absence as evidence would mislabel a genuine 4.0 in the other direction. Both
easy-connect and scan clear the flag when an attempt begins, so that fallthrough is today's behaviour
exactly, byte for byte.

## The codebase already agreed with this, one path over

`WhoopModel.fallbackScanModel` exists because, in its own words, *"a stale/missing persisted preference
can point the scan at the wrong service so it runs forever with the strap right there"*, and its
remedy is rotating families **"and persisting whichever one actually advertises"**.

That is precisely this rule, applied to the scan (PR#195). The bonded-transition write never got it.
The BLE client also pins its **own** `selectedModel` to 5/MG on this same detection; the persisted half
is the one that never learned.

## Checked while building, so it is not guesswork

- `WhoopModel` has exactly two entries, `WHOOP4` and `WHOOP5_MG` ("WHOOP 5.0 / MG"), so there is no
  plain-5 to over-specify. Mapping a detection to `WHOOP5_MG` is the only option, and it is what the
  client already does.
- `setLastDevice` has exactly one caller, so there is no second writer to race.
- `whoop5Detected` is cleared only at the *start* of a connect attempt and set at service discovery, so
  it is live at the bonded edge where the write happens.

## Known residual: this corrects in one direction only

`whoop5Detected` can prove a 5/MG and cannot prove a 4.0, so a stale **5/MG** picker connected to a
genuine **4.0** still persists the wrong model. That inverse case is live for anyone with both straps
registered, which includes the reporter.

The symmetric signal exists, `connectedFamily`, set at discovery from whichever service was actually
found. I deliberately did not use it here. It is guarded by a separate `familyEstablished` flag, and
its own documentation explains why in unusually blunt terms: `connectedFamily` defaults to WHOOP4, is
NOT cleared between connections, and so before discovery holds either that default or the PREVIOUS
link's family. "Both are guesses, and the source must not come from a guess." A 4.0 reached while it
still said WHOOP5 read the standard battery stub and BANKED it, reading 81% against a true 39.2%.

Reading it correctly also carries an ordering contract, `familyEstablished` before `connectedFamily`,
which that documentation says is silently lost if the two are swapped. Adding a second reader of that
pair is worth doing deliberately, with hardware to check it against, rather than folded into a change
about a label. Whoever picks it up should start from that comment.

## What this does NOT address

The reporter's underlying problem is the one tracked in 1635: the strap cannot bond, so history never
offloads. This changes what gets remembered and displayed, not that.

## How it was tested

- `compileFullDebugKotlin`, then the full suite on the pinned JDK 17: **5900 tests, 0 failures**,
  including 3 new cases covering the reported shape, agreement, and the deliberate no-op.
- `Tools/doc_comment_lint.py` and `Tools/i18n_audit.py --ci` clean.
- BLE behaviour is not testable off a strap. The helper is pure and pinned; the wiring reads one
  existing flag at one existing call site.

## Checklist

- [x] Swift package tests pass for any package I touched, no Swift change
- [x] Full Android unit suite passes
- [x] No new build warnings introduced by the changed code
- [x] No hardcoded hex frame bytes; no protocol changes; no destructive commands
- [x] No generated Xcode project, credentials or private captures committed

