### PR TITLE
android: seed the strap picker from the recorded family, not a hardcoded WHOOP4

### DIFF
--- a/android/app/src/main/java/com/noop/NoopApplication.kt
+++ b/android/app/src/main/java/com/noop/NoopApplication.kt
@@ -187,10 +187,20 @@ class NoopApplication : Application() {
      *  "noop.selectedWhoopModel" in the shared noop_prefs store. Defaults to [WhoopModel.WHOOP4] when
      *  unset or unparseable (the historical connect() default), so a fresh install is unchanged. Used to
      *  reconnect on the right service after a WHOOP->WHOOP switch (#74). */
-    private fun persistedWhoopModel(): WhoopModel =
+    private fun persistedWhoopModel(): WhoopModel = persistedWhoopModelOrNull() ?: WhoopModel.WHOOP4
+
+    /**
+     * The persisted family, or null when nothing has been recorded yet.
+     *
+     * Split from [persistedWhoopModel] because the default it applies, WHOOP4, is indistinguishable
+     * from a genuine recorded WHOOP4, and a caller choosing between this and some other source needs to
+     * know which it got. `AppViewModel` needs exactly that: a recorded family should beat the remembered
+     * pair, while an install that predates this pref must keep falling back to it rather than being
+     * silently reset to WHOOP4.
+     */
+    internal fun persistedWhoopModelOrNull(): WhoopModel? =
         NoopPrefs.of(this).getString("noop.selectedWhoopModel", null)
             ?.let { runCatching { WhoopModel.valueOf(it) }.getOrNull() }
-            ?: WhoopModel.WHOOP4
 
     companion object {
         @Volatile private var instance: NoopApplication? = null

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -509,8 +509,21 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
         .map { it.lastSyncAt }
         .stateIn(viewModelScope, SharingStarted.Eagerly, live.value.lastSyncAt)
 
-    /** Which strap the user is pairing — drives the scan filter in [connect]. Defaults to WHOOP 4.0. */
-    private val _selectedModel = MutableStateFlow(WhoopModel.WHOOP4)
+    /**
+     * Which strap the user is pairing — drives the scan filter in [connect].
+     *
+     * Seeded from the family service discovery actually recorded, which `WhoopBleClient.persistSelectedModel`
+     * writes for BOTH branches at the moment the WHOOP4 or WHOOP5 service is found on the link. It used
+     * to start at a hardcoded WHOOP4 and never consult that value, so an install whose only strap is a
+     * 5/MG began every process believing it had a 4.0.
+     *
+     * That is not a label. This flows into `ble.connect(...)`, which starts a SERVICE-FILTERED scan, so
+     * a wrong family makes every scan-based reconnect look for the wrong service and wait
+     * `SCAN_FALLBACK_DELAY_MS`, eight seconds, before rotating, with the strap sitting right there.
+     */
+    private val _selectedModel = MutableStateFlow(
+        resolveSelectedModel(noopApp.persistedWhoopModelOrNull(), NoopPrefs.lastDevice(appContext)?.second),
+    )
     val selectedModel: StateFlow<WhoopModel> = _selectedModel.asStateFlow()
     fun setSelectedModel(model: WhoopModel) {
         if (model == _selectedModel.value) return
@@ -1376,15 +1389,27 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
      */
     private fun autoReconnectOnLaunch() {
         val saved = NoopPrefs.lastDevice(appContext) ?: return
-        // Restore the model selection whenever a strap is remembered — deliberately NOT gated on the
-        // background-connection pref, so an opted-out 5/MG user's picker and scan family still
-        // survive restarts. Only the reconnect itself respects the pref. (#78 fork)
-        _selectedModel.value = saved.second
+        // No picker restore here any more. This used to assign `_selectedModel` from `saved.second`,
+        // which is what let a wrong family survive every restart and re-store itself. `_selectedModel`
+        // is now seeded from the recorded family at construction, and this runs from the tail of the
+        // same init block, off the same two prefs, so re-deriving it here could only ever recompute the
+        // identical value. The property the old line was protecting (#78 fork) is preserved and widened:
+        // a field initializer is unconditional, so the picker and scan family now survive a restart even
+        // for a user with background connection off AND for one with no saved strap at all, which is
+        // exactly the 5/MG case, since a strap that cannot bond (#1635) never becomes the saved device
+        // and so never reached this line in the first place.
         if (!NoopPrefs.backgroundConnection(appContext)) return
         // APK updates tear down the old foreground service along with the old process. Re-promote it
         // on the first launch after update/restart before reconnecting, so the persistent notification
         // and long-lived connection both come back without the user toggling the setting again.
         WhoopConnectionService.start(appContext)
+        // The PAIR, deliberately, not the seeded picker value. `setLastDevice` writes address and family
+        // in one call, so `saved.second` describes THIS address; the recorded family describes whatever
+        // advertised last, which need not be the same strap. `reconnectToAddress` assigns the client's
+        // `selectedModel` for the whole link and service discovery never writes that back (it sets
+        // `connectedFamily` instead), so a family borrowed from the other source would stick. A household
+        // with a 4.0 and a 5/MG makes them disagree routinely: the 5/MG cannot bond (#1635) so it never
+        // becomes the saved device, while every attempt at it re-records WHOOP5_MG.
         ble.reconnectToAddress(saved.first, saved.second)
     }
 
@@ -3226,3 +3251,28 @@ internal fun elapsedClock(elapsedS: Long): String {
         java.lang.String.format(java.util.Locale.US, "%d:%02d", m, s)
     }
 }
+
+/**
+ * Which strap family the picker should sit on, given the two things the app remembers.
+ *
+ * [recorded] is what service discovery actually saw on the link — `WhoopBleClient.persistSelectedModel`
+ * writes it for BOTH the WHOOP4 and the WHOOP5 branch at the moment that family's service is found, so
+ * it is positive per-link evidence and it wins. [remembered] is the family half of the saved
+ * last-device pair, which only ever stores whatever the picker happened to hold when a strap last
+ * bonded; it is a fallback for installs that predate [recorded], not a source of truth, because reading
+ * it back into the picker lets a wrong value re-store itself on every restart.
+ *
+ * The same precedence, for the same reason, is already reasoned out in `AndroidDiagnostics.reportedModel`,
+ * which picks `detected ?: remembered` so a report cannot invent a model. Note that `NoopPrefs.lastDevice`
+ * widens a MISSING family to WHOOP4 before it ever reaches [remembered], so a null here means "no strap
+ * remembered at all", never "remembered without a family" — this function cannot recover the difference
+ * and does not try, because both land on WHOOP4 anyway.
+ *
+ * WHOOP4 remains the last resort so a fresh install behaves as it always has.
+ *
+ * Pure on purpose: both inputs are read from SharedPreferences at the call sites, and there is no
+ * Robolectric in this module, so the decision itself is only testable once it is separated from the
+ * `Context` that supplies it.
+ */
+internal fun resolveSelectedModel(recorded: WhoopModel?, remembered: WhoopModel?): WhoopModel =
+    recorded ?: remembered ?: WhoopModel.WHOOP4

--- a/android/app/src/test/java/com/noop/ui/SelectedModelSeedTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SelectedModelSeedTest.kt
@@ -1,0 +1,58 @@
+package com.noop.ui
+
+import com.noop.ble.WhoopModel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The strap family the picker starts on.
+ *
+ * `_selectedModel` used to be a hardcoded `WhoopModel.WHOOP4` that nothing ever corrected from
+ * storage, while `autoReconnectOnLaunch` re-seeded it from the family half of the saved last-device
+ * pair. That pair only records whatever the picker held when a strap last bonded, so a wrong value
+ * survived every restart and re-stored itself, and an install whose only strap is a 5/MG could sit on
+ * WHOOP 4.0 indefinitely.
+ *
+ * That is not cosmetic: the value feeds `ble.connect(...)`, which starts a SERVICE-FILTERED scan, so a
+ * wrong family points every scan-based reconnect at the wrong service and burns the fallback delay
+ * before rotating, with the strap in range the whole time.
+ *
+ * These pin the precedence that fixes it, and the fallback that keeps older installs working.
+ */
+class SelectedModelSeedTest {
+    @Test
+    fun recordedFamilyWinsOverTheRememberedPair() {
+        // What discovery saw on the link beats what the picker happened to hold at last bond — this is
+        // the loop that stranded a 5/MG-only install on WHOOP 4.0.
+        assertEquals(
+            WhoopModel.WHOOP5_MG,
+            resolveSelectedModel(recorded = WhoopModel.WHOOP5_MG, remembered = WhoopModel.WHOOP4),
+        )
+    }
+
+    @Test
+    fun recordedFamilyWinsInTheOtherDirectionToo() {
+        // Symmetry matters: the rule must not be "prefer 5/MG", or a user moving back to a 4.0 gets
+        // the same wrong-service scan the other way round.
+        assertEquals(
+            WhoopModel.WHOOP4,
+            resolveSelectedModel(recorded = WhoopModel.WHOOP4, remembered = WhoopModel.WHOOP5_MG),
+        )
+    }
+
+    @Test
+    fun rememberedPairStillCarriesInstallsThatPredateTheRecordedFamily() {
+        // An install that bonded before the family was ever recorded has nothing better. It must keep
+        // its remembered family rather than being silently reset to WHOOP4.
+        assertEquals(
+            WhoopModel.WHOOP5_MG,
+            resolveSelectedModel(recorded = null, remembered = WhoopModel.WHOOP5_MG),
+        )
+    }
+
+    @Test
+    fun freshInstallFallsBackToWhoop4() {
+        // Nothing known at all: unchanged from the old hardcoded default.
+        assertEquals(WhoopModel.WHOOP4, resolveSelectedModel(recorded = null, remembered = null))
+    }
+}


### PR DESCRIPTION
## What

`AppViewModel._selectedModel` started at a hardcoded `WhoopModel.WHOOP4` and never consulted the family service discovery had actually recorded, while `autoReconnectOnLaunch` re-seeded it from the family half of the saved last-device pair:

```kotlin
private val _selectedModel = MutableStateFlow(WhoopModel.WHOOP4)   // never read storage
...
_selectedModel.value = saved.second                                // the pair, read straight back
```

That pair only stores whatever the picker held when a strap last bonded, so a wrong value survived every restart and re-stored itself. An install whose only strap is a 5/MG could sit on WHOOP 4.0 indefinitely.

## Why it is not just a label

The value flows into `ble.connect(...)`, and that scan builds its filter from `model.service`:

```kotlin
ScanFilter.Builder().setServiceUuid(ParcelUuid(model.service)).build()
```

So a wrong family points every scan-based reconnect at the wrong service UUID and burns `SCAN_FALLBACK_DELAY_MS`, eight seconds, before rotating to the other family, with the strap in range the whole time. The rotation means this always self-healed eventually, which is why it stayed quiet; it cost a delay on every reconnect rather than a failure.

The same disagreement has already misdirected triage twice: two field logs from confirmed WHOOP 5 straps were headed "Model: WHOOP 4.0" (#1451, #1464). `AndroidDiagnostics.reportedModel` was hardened for the reporting side at the time. The scan side was not.

## The change

`WhoopBleClient.persistSelectedModel` already writes `noop.selectedWhoopModel` for **both** branches at the moment that family's service is found on the link: `persistSelectedModel(WhoopModel.WHOOP4)` at the WHOOP4 branch and `persistSelectedModel(WhoopModel.WHOOP5_MG)` at the WHOOP5 branch. The positive per-link evidence was there and simply unread.

- seed the picker from it, at construction
- drop the picker restore from `autoReconnectOnLaunch` entirely. It ran from the tail of the same init block the field initializer precedes, off the same two prefs, so once the seed exists it could only ever recompute the identical value. The property it protected (#78 fork) is preserved and widened: a field initializer is unconditional, so the picker now survives a restart for a user with background connection off AND for one with no saved strap, which is the 5/MG case, since a strap that cannot bond never becomes the saved device and so never reached that line
- precedence extracted as a pure `resolveSelectedModel(recorded, remembered)`. Recorded wins, the remembered pair carries installs that predate it, WHOOP4 stays the last resort so a fresh install is unchanged

That is the same rule, for the same reason, `AndroidDiagnostics.reportedModel` already applies (`detected ?: remembered`) to keep a report from inventing a model.

`NoopApplication.persistedWhoopModel` is split into a nullable form rather than duplicated: its WHOOP4 default is indistinguishable from a genuine recorded WHOOP4, and a caller choosing between it and another source needs to know which it got. The existing non-null accessor keeps its behaviour for its existing caller.

Pure seam because this module has no Robolectric, so the decision is only testable once separated from the `Context` that supplies it.

## Approach that was rejected

The first attempt gated the *write* on a `whoop5Detected` flag. That flag is cleared on the two scan paths and not in `connectToDevice`, and `reset()` touches only `historyReady`, so a 5/MG link leaves it true and a later 4.0 reconnect would have persisted `WHOOP5_MG`. It was also the wrong site: the write was already correct for both families, and the read was missing.

## What is deliberately NOT changed

The targeted reconnect keeps passing the **pair's** family, `saved.second`, not the seeded value. I had it the other way in the first push and it was wrong. `setLastDevice` writes address and family in one call, so `saved.second` describes *that address*, while the recorded family describes whatever advertised last and need not be the same strap. `reconnectToAddress` assigns the client's `selectedModel` for the whole link, and service discovery never writes that back (it sets `connectedFamily` instead), so a family borrowed from the other source would stick for the duration.

A household with a 4.0 and a 5/MG makes the two disagree routinely: the 5/MG cannot bond (#1635), so it never becomes the saved device, while every attempt at it re-records `WHOOP5_MG`.

## Known residual, not addressed here

`setLastDevice(addr, _selectedModel.value)` records the **ViewModel's belief**, not what the link established. The client rotates its own `selectedModel` on a family fallback and never tells the ViewModel, so a pick of 5/MG that rotates and bonds a 4.0 stores `(4.0 address, WHOOP5_MG)`. That is the write-side half of the same disagreement and wants its own change, since `connectedFamily` is currently private. Filed as #2068.

## Tests

`SelectedModelSeedTest`: 4 tests, JVM, verified executing (`tests="4" failures="0"`), pinning both precedence directions (so the rule is not "prefer 5/MG", which would break a user moving back to a 4.0), the legacy fallback, and the fresh-install default.

## Verification

`compileFullDebugKotlin`, `syncRoomSchemaSnapshot`, full `testFullDebugUnitTest`, `doc_comment_lint.py`, `i18n_audit.py`. All green locally, all with `--no-build-cache`.

Not exercised against a strap: the seeding is observable only across a process restart with a bonded 5/MG.

## Scope

Android only. The Swift side seeds its picker differently and is not touched here.
