### PR TITLE
Enter a manual workout by its start and end, not only a duration

### DIFF
--- a/Strand/Data/WorkoutSource.swift
+++ b/Strand/Data/WorkoutSource.swift
@@ -336,33 +336,94 @@ enum WorkoutSource: Equatable {
                           zonesJSON: old.zonesJSON, notes: old.notes, steps: old.steps)
     }
 
+    /// The span cap a manual workout may cover, shared by both builders and the sheet's binding.
+    static let maxManualSpanSeconds = 24 * 60 * 60
+
+    /// The end a given duration implies. The sheet uses this when the user types a duration, so a typed
+    /// duration and a picked end produce identical rows.
+    static func endForDuration(start: Date, durationMin: Int) -> Date {
+        Date(timeIntervalSince1970: start.timeIntervalSince1970 + TimeInterval(durationMin * 60))
+    }
+
+    /// Whole minutes in a span, for the duration field's DISPLAY.
+    ///
+    /// Rounds, so a stored 45m17s bout reads as "45". That rounding is display-only now: the sheet keeps
+    /// the exact end as its state of record and saves that, where it previously round-tripped the span
+    /// through this number and wrote the rounded end back. Editing a detected workout's sport therefore
+    /// no longer shortens it by up to 30 seconds.
+    static func spanDurationMin(start: Date, end: Date) -> Int {
+        // .rounded() is half-away-from-zero, matching Kotlin's Math.round on the positive spans this
+        // sees, so the two platforms show the same minute for the same stored row.
+        Int(((end.timeIntervalSince1970 - start.timeIntervalSince1970) / 60).rounded())
+    }
+
+    /// Where the end lands when the START moves.
+    ///
+    /// Moving the start keeps the workout the same LENGTH rather than pinning the end, which is what a
+    /// user correcting "this began an hour earlier than I said" means. Pinning the end instead would
+    /// silently restretch the duration on every start correction.
+    static func endAfterStartMove(oldStart: Date, oldEnd: Date, newStart: Date) -> Date {
+        Date(timeIntervalSince1970: newStart.timeIntervalSince1970
+             + (oldEnd.timeIntervalSince1970 - oldStart.timeIntervalSince1970))
+    }
+
+    /// Build a retroactive manual workout from an explicit SPAN.
+    ///
+    /// The row has always been stored as `startTs`/`endTs`, so this is the shape the storage already
+    /// speaks; `buildManualRow` is the duration-shaped front door that delegates here (#2034). Split out
+    /// so the sheet can offer an end time without the value making a lossy round trip through whole
+    /// minutes.
+    ///
+    /// Validation is the duration form's, re-expressed: a span must be positive, at most
+    /// `maxManualSpanSeconds`, and must not end in the future. Twin of Android
+    /// `WorkoutEditing.buildManualRowFromSpan`.
+    static func buildManualRowFromSpan(start: Date, end: Date, sport: String,
+                                       avgHr: Int?, energyKcal: Double?, distanceM: Double? = nil,
+                                       now: Date = Date()) -> WorkoutRow? {
+        let trimmed = sport.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, start <= now else { return nil }
+        let s = Int(start.timeIntervalSince1970)
+        let e = Int(end.timeIntervalSince1970)
+        guard s > 0, e > s else { return nil }
+        let spanSeconds = e - s
+        guard spanSeconds <= maxManualSpanSeconds else { return nil }
+        guard e <= Int(now.timeIntervalSince1970) else { return nil }
+        if let hr = avgHr, !(25...250).contains(hr) { return nil }
+        if let k = energyKcal, k < 0 || k > 20_000 { return nil }
+        // Distance 0-1000 km (#1195): rejects a negative or absurd manual entry. 1000 km comfortably
+        // covers any single session (an Ironman bike is 180 km, an ultra 160 km).
+        if let d = distanceM, d < 0 || d > 1_000_000 { return nil }
+        return WorkoutRow(startTs: s, endTs: e, sport: trimmed, source: "manual",
+                          durationS: Double(spanSeconds), energyKcal: energyKcal,
+                          avgHr: avgHr, maxHr: nil, strain: nil, distanceM: distanceM,
+                          zonesJSON: nil, notes: nil, steps: nil)
+    }
+
     /// Build a retroactive manual workout (source "manual", persisted under the strap deviceId by the
     /// caller — where v1.67's live sessions live). Returns nil when the input can't make an honest row.
     /// strain/zones stay nil: with no captured HR window an APPROXIMATE strain is never fabricated.
+    ///
+    /// The duration-shaped front door. Delegates to `buildManualRowFromSpan` so the two entry points
+    /// cannot drift; it keeps the whole-minute bounds and the overflow guard, which only this shape needs.
     static func buildManualRow(start: Date, durationMin: Int, sport: String,
                                avgHr: Int?, energyKcal: Double?, distanceM: Double? = nil,
                                now: Date = Date()) -> WorkoutRow? {
         guard durationMin > 0, durationMin <= 24 * 60 else { return nil }
-        let trimmed = sport.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty, start <= now else { return nil }
-        if let hr = avgHr, !(25...250).contains(hr) { return nil }
-        if let k = energyKcal, k < 0 || k > 20_000 { return nil }
-        // Distance 0–1000 km (#1195): rejects a negative or absurd manual entry. 1000 km comfortably
-        // covers any single session (an Ironman bike is 180 km, an ultra 160 km).
-        if let d = distanceM, d < 0 || d > 1_000_000 { return nil }
         let s = Int(start.timeIntervalSince1970)
         guard s > 0 else { return nil }
         // Reject a row whose END lands in the future: `start <= now` alone still lets `start + duration`
-        // overshoot (a start 10 min ago + a 45 min duration ends 35 min ahead). Overflow-safe, and a row
-        // ending exactly at `now` stays valid. Twin of Android `WorkoutEditing` (#1067).
+        // overshoot (a start 10 min ago + a 45 min duration ends 35 min ahead). A row ending exactly at
+        // `now` stays valid. Twin of Android `WorkoutEditing` (#1067). The end check itself now lives in
+        // `buildManualRowFromSpan`; the overflow guard stays HERE, because only this shape does the
+        // addition that can overflow. It also runs BEFORE the Int -> TimeInterval -> Int round trip the
+        // delegation introduces. That round trip is exact for anything the guards admit: a real timestamp
+        // plus at most 24h is ~1.7e9, and Double represents integers exactly to 2^53.
         let durationSeconds = durationMin * 60
         guard durationSeconds <= Int.max - s else { return nil }
-        let end = s + durationSeconds
-        guard end <= Int(now.timeIntervalSince1970) else { return nil }
-        return WorkoutRow(startTs: s, endTs: end, sport: trimmed, source: "manual",
-                          durationS: Double(durationSeconds), energyKcal: energyKcal,
-                          avgHr: avgHr, maxHr: nil, strain: nil, distanceM: distanceM,
-                          zonesJSON: nil, notes: nil, steps: nil)
+        return buildManualRowFromSpan(
+            start: start,
+            end: Date(timeIntervalSince1970: TimeInterval(s + durationSeconds)),
+            sport: sport, avgHr: avgHr, energyKcal: energyKcal, distanceM: distanceM, now: now)
     }
 }
 

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -148871,6 +148871,180 @@
         }
       }
     },
+    "End must be after the start.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Ende muss nach dem Beginn liegen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El fin debe ser posterior al inicio."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La fin doit être postérieure au début."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La fine deve essere successiva all'inizio."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O fim tem de ser posterior ao início."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершение должно быть позже начала."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "结束时间必须晚于开始时间。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "結束時間必須晚於開始時間。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koniec musi nastąpić po początku."
+          }
+        }
+      }
+    },
+    "End can't be in the future.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Ende kann nicht in der Zukunft liegen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "El fin no puede estar en el futuro."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La fin ne peut pas être dans le futur."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La fine non può essere nel futuro."
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O fim não pode ser no futuro."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завершение не может быть в будущем."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "结束时间不能在未来。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "結束時間不能在未來。"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koniec nie może przypadać w przyszłości."
+          }
+        }
+      }
+    },
+    "End date and time": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enddatum und -uhrzeit"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fecha y hora de fin"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date et heure de fin"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data e ora di fine"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data e hora de fim"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дата и время завершения"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "结束日期和时间"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "結束日期和時間"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Data i godzina zakończenia"
+          }
+        }
+      }
+    },
     "Start date and time": {
       "localizations": {
         "de": {

--- a/Strand/Screens/ManualWorkoutSheet.swift
+++ b/Strand/Screens/ManualWorkoutSheet.swift
@@ -31,7 +31,10 @@ struct ManualWorkoutSheet: View {
 
     @State private var sport: String
     @State private var start: Date
-    @State private var durationMin: Int
+    /// #2034: the span is `start` + `end`. Duration is DERIVED (`durationBinding`), never a second stored
+    /// copy, so the two cannot drift; the row has always been stored as `startTs`/`endTs` anyway, and
+    /// routing the save through whole minutes was what silently reshaped an edited session's end.
+    @State private var end: Date
     @State private var avgHrText: String
     @State private var kcalText: String
     /// Distance as ENTERED, in the user's unit (km or mi) — converted to stored metres on save (#1195).
@@ -70,8 +73,18 @@ struct ManualWorkoutSheet: View {
         // Seeds the LOCALE-STABLE editable form, not the localized display: the field's content is
         // persisted verbatim on save, and a translated word would split cross-source dedup per language.
         _sport = State(initialValue: e.map { WorkoutSource.editableSport($0.sport) } ?? "")
-        _start = State(initialValue: e.map { Date(timeIntervalSince1970: TimeInterval($0.startTs)) } ?? Date())
-        _durationMin = State(initialValue: e.map { max(1, Int((($0.durationS ?? Double($0.endTs - $0.startTs)) / 60).rounded())) } ?? 45)
+        // A fresh add opens on a VALID 45 minute session ending now, keeping the long-standing 45 minute
+        // default length. It used to start at `Date()` with a 45 minute duration, so the implied end was
+        // always 45 minutes in the future and `buildManualRow` rejected it: the sheet opened with Save
+        // already disabled. That was invisible while the only complaint was the catch-all "Check the
+        // values and try again."; now that an end in the future says so by name, it would greet every
+        // fresh add with a red line. Anchoring to the end is also the truer default for the retroactive
+        // entry this sheet is for.
+        let defaultEnd = Date()
+        _start = State(initialValue: e.map { Date(timeIntervalSince1970: TimeInterval($0.startTs)) }
+                       ?? defaultEnd.addingTimeInterval(-45 * 60))
+        _end = State(initialValue: e.map { Date(timeIntervalSince1970: TimeInterval($0.endTs)) }
+                     ?? defaultEnd)
         _avgHrText = State(initialValue: e?.avgHr.map(String.init) ?? "")
         _kcalText = State(initialValue: e?.energyKcal.map { String(Int($0.rounded())) } ?? "")
         // Pre-fill the distance in the user's unit so an untouched edit round-trips the stored metres
@@ -142,17 +155,23 @@ struct ManualWorkoutSheet: View {
                     sportPicker
                 }
                 // Raise the Sport field above the following rows so its floating suggestion dropdown
-                // (an overlay, see `sportPicker`) draws ON TOP of Start / Duration instead of behind them.
+                // (an overlay, see `sportPicker`) draws ON TOP of Start / End / Duration, not behind them.
                 .zIndex(1)
                 field(String(localized: "Start")) {
-                    DatePicker("", selection: $start, in: ...Date(),
+                    DatePicker("", selection: startBinding, in: ...Date(),
                                displayedComponents: [.date, .hourAndMinute])
                         .labelsHidden()
                         .accessibilityLabel("Start date and time")
                 }
+                field(String(localized: "End")) {
+                    DatePicker("", selection: $end, in: ...Date(),
+                               displayedComponents: [.date, .hourAndMinute])
+                        .labelsHidden()
+                        .accessibilityLabel("End date and time")
+                }
                 field(String(localized: "Duration")) {
                     HStack(spacing: 12) {
-                        Stepper(value: $durationMin, in: 1...(24 * 60), step: 5) {
+                        Stepper(value: durationBinding, in: 1...(24 * 60), step: 5) {
                             Text(durationLabel)
                                 .font(StrandFont.number(16))
                                 .foregroundStyle(StrandPalette.effortBright)
@@ -374,7 +393,32 @@ struct ManualWorkoutSheet: View {
 
     private var inputShape: RoundedRectangle { RoundedRectangle(cornerRadius: 10, style: .continuous) }
 
+    /// Moving the START keeps the workout's LENGTH and carries the end with it, which is what correcting
+    /// "this began an hour earlier" means. Computed from the old start before it is reassigned.
+    ///
+    /// Clamped so the carried end cannot land in the future: dragging the start forward would otherwise
+    /// push the end past now and invalidate the sheet on a move that looks entirely reasonable. Clamping
+    /// the START keeps the length the user set, where clamping the end would silently shorten the session.
+    private var startBinding: Binding<Date> {
+        Binding(get: { start },
+                set: { picked in
+                    let span = end.timeIntervalSince(start)
+                    let newStart = min(picked, Date().addingTimeInterval(-span))
+                    end = WorkoutSource.endAfterStartMove(oldStart: start, oldEnd: end, newStart: newStart)
+                    start = newStart
+                })
+    }
+
+    /// Duration is a VIEW of the span, not a stored copy. Reading clamps into the Stepper's own range so
+    /// an end that is currently before the start cannot hand it an out-of-range value; the honest verdict
+    /// on that state comes from `validationNote`, not from this label. Writing moves the end.
+    private var durationBinding: Binding<Int> {
+        Binding(get: { min(24 * 60, max(1, WorkoutSource.spanDurationMin(start: start, end: end))) },
+                set: { end = WorkoutSource.endForDuration(start: start, durationMin: $0) })
+    }
+
     private var durationLabel: String {
+        let durationMin = durationBinding.wrappedValue
         let h = durationMin / 60, m = durationMin % 60
         if h > 0 && m > 0 { return "\(h)h \(m)m" }
         if h > 0 { return "\(h)h" }
@@ -401,9 +445,9 @@ struct ManualWorkoutSheet: View {
         if !avgHrText.trimmingCharacters(in: .whitespaces).isEmpty && avgHr == nil { return nil }
         if !kcalText.trimmingCharacters(in: .whitespaces).isEmpty && kcal == nil { return nil }
         if !distanceText.trimmingCharacters(in: .whitespaces).isEmpty && distanceMeters == nil { return nil }
-        guard let base = WorkoutSource.buildManualRow(start: start, durationMin: durationMin,
-                                                      sport: sport, avgHr: avgHr, energyKcal: kcal,
-                                                      distanceM: distanceMeters)
+        guard let base = WorkoutSource.buildManualRowFromSpan(start: start, end: end,
+                                                              sport: sport, avgHr: avgHr, energyKcal: kcal,
+                                                              distanceM: distanceMeters)
         else { return nil }
         // Carry over captured-but-unexposed fields when editing an existing strap session.
         return WorkoutSource.preservingCaptured(base, from: editing)
@@ -424,6 +468,9 @@ struct ManualWorkoutSheet: View {
         guard builtRow == nil else { return nil }
         if sport.trimmingCharacters(in: .whitespaces).isEmpty { return String(localized: "Enter a sport.") }
         if start > Date() { return String(localized: "Start can't be in the future.") }
+        // The failure this feature introduces, so it gets its own line rather than the catch-all below.
+        if end <= start { return String(localized: "End must be after the start.") }
+        if end > Date() { return String(localized: "End can't be in the future.") }
         if !avgHrText.trimmingCharacters(in: .whitespaces).isEmpty, avgHr == nil || !(25...250).contains(avgHr ?? -1) {
             return String(localized: "Average HR must be 25-250 bpm.")
         }

--- a/StrandTests/WorkoutSourceTests.swift
+++ b/StrandTests/WorkoutSourceTests.swift
@@ -486,4 +486,106 @@ final class WorkoutSourceTests: XCTestCase {
         XCTAssertNil(m?.distanceM)
         XCTAssertNil(m?.avgHr)
     }
+    // MARK: - buildManualRowFromSpan (#2034)
+
+    /// #2034: entering a manual workout by its start and END, not only by a duration.
+    ///
+    /// The row has always been stored as `startTs`/`endTs`, so the span is the shape the storage already
+    /// speaks and the duration was the lossy intermediate. Mirrors Android `ManualWorkoutSpanTest` except
+    /// for its overflow case, which has no safe twin here: Kotlin guards a Long addition, while the
+    /// equivalent Swift input has to be built as a Date, and `Int(Double)` TRAPS on a value that large
+    /// rather than returning nil. The whole-minute bounds either side of it are already pinned by
+    /// `testBuildManualRowRejectsBadInput`.
+    func testSpanBuilderKeepsTheExactEndItIsGiven() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let start = now.addingTimeInterval(-7_200)
+        // 45m17s. The duration path cannot express this: it would store 45m00s and silently shorten the
+        // session by 17 seconds. This is the whole point of the span form.
+        let end = start.addingTimeInterval(45 * 60 + 17)
+        let r = WorkoutSource.buildManualRowFromSpan(start: start, end: end, sport: "Run",
+                                                     avgHr: nil, energyKcal: nil, now: now)
+        XCTAssertNotNil(r)
+        XCTAssertEqual(r?.startTs, Int(start.timeIntervalSince1970))
+        XCTAssertEqual(r?.endTs, Int(end.timeIntervalSince1970))
+        XCTAssertEqual(r?.durationS, Double(45 * 60 + 17))
+    }
+
+    func testDurationFrontDoorStillProducesTheIdenticalRow() {
+        // The delegation invariant. If these ever diverge, the auto-detected nudge and the sheet would
+        // write different rows for the same session.
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let start = now.addingTimeInterval(-7_200)
+        let viaDuration = WorkoutSource.buildManualRow(start: start, durationMin: 45, sport: "Run",
+                                                       avgHr: 140, energyKcal: 400, distanceM: 8_000,
+                                                       now: now)
+        let viaSpan = WorkoutSource.buildManualRowFromSpan(start: start,
+                                                           end: start.addingTimeInterval(45 * 60),
+                                                           sport: "Run", avgHr: 140, energyKcal: 400,
+                                                           distanceM: 8_000, now: now)
+        XCTAssertNotNil(viaDuration)
+        XCTAssertEqual(viaDuration, viaSpan)
+    }
+
+    func testSpanBuilderRejectsAnEndAtOrBeforeTheStart() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let start = now.addingTimeInterval(-7_200)
+        XCTAssertNil(WorkoutSource.buildManualRowFromSpan(start: start, end: start, sport: "Run",
+                                                          avgHr: nil, energyKcal: nil, now: now))
+        XCTAssertNil(WorkoutSource.buildManualRowFromSpan(start: start,
+                                                          end: start.addingTimeInterval(-1), sport: "Run",
+                                                          avgHr: nil, energyKcal: nil, now: now))
+    }
+
+    func testSpanBuilderRejectsASpanOverTwentyFourHours() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let cap = TimeInterval(WorkoutSource.maxManualSpanSeconds)
+        let start = now.addingTimeInterval(-cap - 60)
+        XCTAssertNotNil(WorkoutSource.buildManualRowFromSpan(start: start,
+                                                             end: start.addingTimeInterval(cap),
+                                                             sport: "Run", avgHr: nil, energyKcal: nil,
+                                                             now: now))
+        XCTAssertNil(WorkoutSource.buildManualRowFromSpan(start: start,
+                                                          end: start.addingTimeInterval(cap + 1),
+                                                          sport: "Run", avgHr: nil, energyKcal: nil,
+                                                          now: now))
+    }
+
+    func testSpanBuilderAllowsAnEndExactlyAtNowButNotOneSecondPast() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let start = now.addingTimeInterval(-7_200)
+        XCTAssertNotNil(WorkoutSource.buildManualRowFromSpan(start: start, end: now, sport: "Run",
+                                                             avgHr: nil, energyKcal: nil, now: now))
+        XCTAssertNil(WorkoutSource.buildManualRowFromSpan(start: start,
+                                                          end: now.addingTimeInterval(1), sport: "Run",
+                                                          avgHr: nil, energyKcal: nil, now: now))
+    }
+
+    func testSpanDurationMinRoundsForDisplayOnly() {
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        XCTAssertEqual(WorkoutSource.spanDurationMin(start: start,
+                                                     end: start.addingTimeInterval(45 * 60)), 45)
+        // 45m17s reads as 45, 45m45s reads as 46. The stored end is untouched either way.
+        XCTAssertEqual(WorkoutSource.spanDurationMin(start: start,
+                                                     end: start.addingTimeInterval(45 * 60 + 17)), 45)
+        XCTAssertEqual(WorkoutSource.spanDurationMin(start: start,
+                                                     end: start.addingTimeInterval(45 * 60 + 45)), 46)
+    }
+
+    func testEndForDurationIsTheInverseOfWholeMinutes() {
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        let end = WorkoutSource.endForDuration(start: start, durationMin: 45)
+        XCTAssertEqual(end, start.addingTimeInterval(45 * 60))
+        XCTAssertEqual(WorkoutSource.spanDurationMin(start: start, end: end), 45)
+    }
+
+    func testMovingTheStartCarriesTheEndAndKeepsTheLength() {
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        let end = start.addingTimeInterval(45 * 60 + 17)
+        let newStart = start.addingTimeInterval(-3_600)
+        let newEnd = WorkoutSource.endAfterStartMove(oldStart: start, oldEnd: end, newStart: newStart)
+        XCTAssertEqual(newEnd, newStart.addingTimeInterval(45 * 60 + 17))
+        // The length is what survives, including the seconds a duration field cannot show.
+        XCTAssertEqual(newEnd.timeIntervalSince(newStart), end.timeIntervalSince(start))
+    }
+
 }

--- a/android/app/src/main/java/com/noop/ui/WorkoutEditing.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutEditing.kt
@@ -376,11 +376,97 @@ object WorkoutEditing {
         return captured && built.avgHr != old.avgHr
     }
 
+    /** The span cap a manual workout may cover, shared by both builders and the sheet's binding. */
+    const val MAX_MANUAL_SPAN_SECONDS: Long = 24L * 60L * 60L
+
+    /**
+     * The end a given duration implies. The sheet uses this when the user types a duration, so a typed
+     * duration and a picked end produce byte-identical rows.
+     */
+    fun endForDuration(startSeconds: Long, durationMin: Int): Long =
+        startSeconds + durationMin.toLong() * 60L
+
+    /**
+     * Whole minutes in a span, for the duration field's DISPLAY.
+     *
+     * Rounds, so a stored 45m17s bout reads as "45". That rounding is display-only now: the sheet keeps
+     * the exact end as its state of record and saves that, where it previously round-tripped the span
+     * through this number and wrote the rounded end back. Editing a detected workout's sport therefore
+     * no longer shortens it by up to 30 seconds.
+     */
+    fun spanDurationMin(startSeconds: Long, endSeconds: Long): Int =
+        Math.round((endSeconds - startSeconds) / 60.0).toInt()
+
+    /**
+     * Where the end lands when the START moves.
+     *
+     * Moving the start keeps the workout the same LENGTH rather than pinning the end, which is what a
+     * user correcting "this began an hour earlier than I said" means. Pinning the end instead would
+     * silently restretch the duration on every start correction.
+     */
+    fun endAfterStartMove(oldStartSeconds: Long, oldEndSeconds: Long, newStartSeconds: Long): Long =
+        newStartSeconds + (oldEndSeconds - oldStartSeconds)
+
+    /**
+     * Build a retroactive manual workout from an explicit SPAN.
+     *
+     * The row has always been stored as `startTs`/`endTs`, so this is the shape the storage already
+     * speaks; [buildManualRow] is the duration-shaped front door that delegates here (#2034). Split out
+     * so the sheet can offer an end time without the value making a lossy round trip through whole
+     * minutes.
+     *
+     * Validation is the duration form's, re-expressed: a span must be positive, at most
+     * [MAX_MANUAL_SPAN_SECONDS], and must not end in the future.
+     *
+     * @param nowSeconds wall-clock now (unix seconds); injectable for tests.
+     */
+    fun buildManualRowFromSpan(
+        deviceId: String,
+        startSeconds: Long,
+        endSeconds: Long,
+        sport: String,
+        avgHr: Int?,
+        energyKcal: Double?,
+        nowSeconds: Long = System.currentTimeMillis() / 1000L,
+        distanceM: Double? = null,
+    ): WorkoutRow? {
+        val trimmed = sport.trim()
+        if (trimmed.isEmpty() || startSeconds <= 0 || startSeconds > nowSeconds) return null
+        if (endSeconds <= startSeconds) return null
+        val spanSeconds = endSeconds - startSeconds
+        if (spanSeconds > MAX_MANUAL_SPAN_SECONDS) return null
+        if (endSeconds > nowSeconds) return null
+        if (avgHr != null && avgHr !in 25..250) return null
+        if (energyKcal != null && (energyKcal < 0 || energyKcal > 20_000)) return null
+        // Distance 0-1000 km (#1195): rejects a negative or absurd manual entry. 1000 km comfortably
+        // covers any single session (an Ironman bike is 180 km, an ultra 160 km).
+        if (distanceM != null && (distanceM < 0 || distanceM > 1_000_000)) return null
+        return WorkoutRow(
+            deviceId = deviceId,
+            startTs = startSeconds,
+            endTs = endSeconds,
+            sport = trimmed,
+            source = "manual",
+            durationS = spanSeconds.toDouble(),
+            energyKcal = energyKcal,
+            avgHr = avgHr,
+            maxHr = null,
+            strain = null,
+            distanceM = distanceM,
+            zonesJSON = null,
+            notes = null,
+            routePolyline = null,
+        )
+    }
+
     /**
      * Build a retroactive manual workout (source "manual", written under the strap [deviceId] by the
      * caller — where live sessions land). Returns null when the input can't make an honest row.
      * strain/zones stay null: with no captured HR window an APPROXIMATE strain is never fabricated.
      * Mirrors macOS WorkoutSource.buildManualRow validation bound-for-bound.
+     *
+     * The duration-shaped front door. Delegates to [buildManualRowFromSpan] so the two entry points
+     * cannot drift; it keeps the whole-minute bounds and the overflow guard, which only this shape needs.
      *
      * @param startSeconds workout start, unix seconds.
      * @param nowSeconds wall-clock now (unix seconds); injectable for tests.
@@ -398,34 +484,20 @@ object WorkoutEditing {
         distanceM: Double? = null,
     ): WorkoutRow? {
         if (durationMin <= 0 || durationMin > 24 * 60) return null
-        val trimmed = sport.trim()
-        if (trimmed.isEmpty() || startSeconds > nowSeconds || startSeconds <= 0) return null
-        if (avgHr != null && avgHr !in 25..250) return null
-        if (energyKcal != null && (energyKcal < 0 || energyKcal > 20_000)) return null
-        // Distance 0–1000 km (#1195): rejects a negative or absurd manual entry. 1000 km comfortably
-        // covers any single session (an Ironman bike is 180 km, an ultra 160 km).
-        if (distanceM != null && (distanceM < 0 || distanceM > 1_000_000)) return null
         val durationSeconds = durationMin.toLong() * 60L
         // Keep both the addition and the future-end check overflow-safe. A valid start can be close to
-        // Long.MAX_VALUE in a boundary test even though production timestamps are much smaller.
+        // Long.MAX_VALUE in a boundary test even though production timestamps are much smaller. Checked
+        // HERE rather than in the span form, which takes an end that has already been computed.
         if (durationSeconds > Long.MAX_VALUE - startSeconds) return null
-        val endSeconds = startSeconds + durationSeconds
-        if (endSeconds > nowSeconds) return null
-        return WorkoutRow(
+        return buildManualRowFromSpan(
             deviceId = deviceId,
-            startTs = startSeconds,
-            endTs = endSeconds,
-            sport = trimmed,
-            source = "manual",
-            durationS = durationSeconds.toDouble(),
-            energyKcal = energyKcal,
+            startSeconds = startSeconds,
+            endSeconds = startSeconds + durationSeconds,
+            sport = sport,
             avgHr = avgHr,
-            maxHr = null,
-            strain = null,
+            energyKcal = energyKcal,
+            nowSeconds = nowSeconds,
             distanceM = distanceM,
-            zonesJSON = null,
-            notes = null,
-            routePolyline = null,
         )
     }
 

--- a/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt
@@ -2007,9 +2007,16 @@ private fun ManualWorkoutDialog(
     var startMillis by remember {
         mutableStateOf((editing?.startTs ?: (nowSec - 3_600)) * 1000L)
     }
+    // #2034: the END is state of record beside the start, not something re-derived from whole minutes on
+    // save. Duration stays as an input, two-way bound below, because "a 45 minute run" is how a session
+    // is often remembered; it is just no longer the thing that gets stored. A row opened only to fix its
+    // sport therefore keeps its exact span instead of snapping to the nearest minute.
+    var endMillis by remember {
+        mutableStateOf((editing?.endTs ?: (nowSec - 3_600 + 45 * 60)) * 1000L)
+    }
     var durationMin by remember {
         mutableStateOf(
-            editing?.let { (((it.durationS ?: (it.endTs - it.startTs).toDouble()) / 60).roundToInt()).coerceAtLeast(1).toString() }
+            editing?.let { WorkoutEditing.spanDurationMin(it.startTs, it.endTs).coerceAtLeast(1).toString() }
                 ?: "45",
         )
     }
@@ -2042,16 +2049,18 @@ private fun ManualWorkoutDialog(
         val distM: Double? = if (dText.isEmpty()) null else dText.toDoubleOrNull()?.let { v ->
             (if (unitSystem == UnitSystem.IMPERIAL) v / UnitFormatter.MILES_PER_KILOMETER else v) * 1000.0
         }
-        if (dur == null) return@run null
+        // A typed duration that is blank, unparseable or non-positive blocks Save. It also means the
+        // binding below did NOT move the end, so the span on screen would not be the span saved.
+        if (dur == null || dur <= 0) return@run null
         if (hrText.isNotEmpty() && hr == null) return@run null
         if (kText.isNotEmpty() && k == null) return@run null
         if (dText.isNotEmpty() && distM == null) return@run null
         // A manual workout ALWAYS lives under the strap source (where live-tracked sessions land), so
         // a "duplicate as manual" of an imported apple-health/whoop row never writes back to it.
-        val base = WorkoutEditing.buildManualRow(
+        val base = WorkoutEditing.buildManualRowFromSpan(
             deviceId = "my-whoop",
             startSeconds = (startMillis / 1000L).coerceAtMost(nowSec),
-            durationMin = dur,
+            endSeconds = endMillis / 1000L,
             sport = sport,
             avgHr = hr,
             energyKcal = k,
@@ -2089,8 +2098,43 @@ private fun ManualWorkoutDialog(
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 SportPickerField(sport, onChange = { sport = it })
-                StartTimeField(startMillis, onPick = { startMillis = it })
-                DialogField("Duration (minutes)", durationMin, onChange = { durationMin = it }, numeric = true)
+                SpanTimeField(
+                    uiString(R.string.l10n_workouts_screen_started_faa9e7e7),
+                    startMillis,
+                    // Moving the start keeps the LENGTH and carries the end with it. Computed from the
+                    // old start before it is reassigned, or the span would collapse.
+                    //
+                    // Clamped so the carried end cannot land in the future: dragging the start forward
+                    // would otherwise push the end past now and invalidate the sheet on a move that
+                    // looks entirely reasonable. Clamping the START keeps the length the user set,
+                    // where clamping the end would silently shorten the session instead.
+                    onPick = { picked ->
+                        val spanMillis = endMillis - startMillis
+                        val newStart = picked.coerceAtMost(System.currentTimeMillis() - spanMillis)
+                        endMillis = WorkoutEditing.endAfterStartMove(
+                            startMillis / 1000L, endMillis / 1000L, newStart / 1000L,
+                        ) * 1000L
+                        startMillis = newStart
+                    },
+                )
+                SpanTimeField(
+                    uiString(R.string.l10n_workouts_screen_ended_90303d8d),
+                    endMillis,
+                    onPick = { picked ->
+                        endMillis = picked
+                        durationMin = WorkoutEditing.spanDurationMin(startMillis / 1000L, picked / 1000L).toString()
+                    },
+                )
+                DialogField(
+                    "Duration (minutes)", durationMin,
+                    onChange = { typed ->
+                        durationMin = typed
+                        typed.trim().toIntOrNull()?.takeIf { it > 0 }?.let { m ->
+                            endMillis = WorkoutEditing.endForDuration(startMillis / 1000L, m) * 1000L
+                        }
+                    },
+                    numeric = true,
+                )
                 DialogField("Distance ($distUnit, optional)", distance, onChange = { distance = it }, numeric = true)
                 DialogField("Avg HR (bpm, optional)", avgHr, onChange = { avgHr = it }, numeric = true)
                 DialogField("Calories (kcal, optional)", kcal, onChange = { kcal = it }, numeric = true)
@@ -2154,16 +2198,20 @@ private fun ManualWorkoutDialog(
  * match (an exact catalogue hit, or a free-typed sport, collapses it).
  */
 /**
- * Absolute start date + time for the manual add/edit dialog — parity with the macOS/iOS sheet's
- * DatePicker (#598; the old Android sheet only took "minutes ago"). A tappable row that opens a date
- * picker, then chains to a time picker, both capped at now (you can't log a workout in the future).
+ * Absolute date + time for one end of the manual add/edit dialog's span — parity with the macOS/iOS
+ * sheet's DatePicker (#598; the old Android sheet only took "minutes ago"). A tappable row that opens a
+ * date picker, then chains to a time picker, both capped at now (you can't log a workout in the future).
+ *
+ * [caption] names which end it is, so the same picker serves Started and Ended (#2034). The cap is why
+ * the start's own handler clamps as well: this stops a FUTURE pick, not a pick that drags the carried
+ * end past now.
  */
 @Composable
-private fun StartTimeField(millis: Long, onPick: (Long) -> Unit) {
+private fun SpanTimeField(caption: String, millis: Long, onPick: (Long) -> Unit) {
     val context = LocalContext.current
     val label = remember(millis) { SimpleDateFormat("d MMM yyyy, h:mm a", Locale.US).format(java.util.Date(millis)) }
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(uiString(R.string.l10n_workouts_screen_started_faa9e7e7), style = NoopType.footnote, color = Palette.textSecondary)
+        Text(caption, style = NoopType.footnote, color = Palette.textSecondary)
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1084,6 +1084,7 @@
     <string name="l10n_workouts_screen_show_more_more_remaining_remaining_d1662e67">%1$s mehr anzeigen (%2$s bleibt übrig)</string>
     <string name="l10n_workouts_screen_show_more_more_sessions_25bce755">%1$s weitere Sessions anzeigen</string>
     <string name="l10n_workouts_screen_started_faa9e7e7">Beginn</string>
+    <string name="l10n_workouts_screen_ended_90303d8d">Ende</string>
     <string name="l10n_workouts_screen_the_average_above_was_edited_the_0a7881f0">Der Durchschnitt oben wurde bearbeitet. Graph, Zonen und Anstrengung bleiben aus der aufgezeichneten Sitzung.</string>
     <string name="l10n_workouts_screen_these_sessions_have_no_sport_label_53993414">Diese Sessions haben noch kein Sportlabel. Wähle eine für die fusionierte Sitzung.</string>
     <string name="l10n_workouts_screen_this_session_s_contribution_to_the_fe40ab3d">Der Beitrag dieser Sitzung zur Tages-Anstrengung, wie während des Workouts erfasst.</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -884,6 +884,7 @@
     <string name="l10n_workouts_screen_show_more_more_remaining_remaining_d1662e67">Mostrar %1$s más (%2$s restante)</string>
     <string name="l10n_workouts_screen_show_more_more_sessions_25bce755">Mostrar %1$s más sesiones</string>
     <string name="l10n_workouts_screen_started_faa9e7e7">Comienzo</string>
+    <string name="l10n_workouts_screen_ended_90303d8d">Fin</string>
     <string name="l10n_workouts_screen_the_average_above_was_edited_the_0a7881f0">El promedio de arriba fue editado. El gráfico, las zonas y el Esfuerzo se mantienen de la sesión registrada.</string>
     <string name="l10n_workouts_screen_these_sessions_have_no_sport_label_53993414">Estas sesiones aún no tienen etiqueta deportiva. Escoge uno para la sesión fusionada.</string>
     <string name="l10n_workouts_screen_this_session_s_contribution_to_the_fe40ab3d">La contribución de esta sesión al Esfuerzo del día, tal como se capturó durante el entrenamiento.</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -902,6 +902,7 @@
     <string name="l10n_workouts_screen_show_more_more_remaining_remaining_d1662e67">Afficher %1$s plus (%2$s restant)</string>
     <string name="l10n_workouts_screen_show_more_more_sessions_25bce755">Afficher plus de sessions %1$s</string>
     <string name="l10n_workouts_screen_started_faa9e7e7">Commencé</string>
+    <string name="l10n_workouts_screen_ended_90303d8d">Terminé</string>
     <string name="l10n_workouts_screen_the_average_above_was_edited_the_0a7881f0">La moyenne ci-dessus a été modifiée. Le graphique, les zones et l\'Effort restent ceux de la séance enregistrée.</string>
     <string name="l10n_workouts_screen_these_sessions_have_no_sport_label_53993414">Ces séances n\'ont pas encore de label sportif. Choisissez un pour la session fusionnée.</string>
     <string name="l10n_workouts_screen_this_session_s_contribution_to_the_fe40ab3d">La contribution de cette séance à l\'Effort du jour, telle que capturée pendant l\'entraînement.</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1035,6 +1035,7 @@
     <string name="l10n_workouts_screen_show_more_more_remaining_remaining_d1662e67">Pokaż więcej %1$s (pozostało %2$s)</string>
     <string name="l10n_workouts_screen_show_more_more_sessions_25bce755">Pokaż %1$s więcej sesji</string>
     <string name="l10n_workouts_screen_started_faa9e7e7">Rozpoczęło się</string>
+    <string name="l10n_workouts_screen_ended_90303d8d">Zakończyło się</string>
     <string name="l10n_workouts_screen_the_average_above_was_edited_the_0a7881f0">Powyższa średnia została edytowana. Wykres, strefy i Wysiłek pozostają z zarejestrowanej sesji.</string>
     <string name="l10n_workouts_screen_these_sessions_have_no_sport_label_53993414">Sesje te nie mają jeszcze etykiety sportowej. Wybierz jedną do połączonej sesji.</string>
     <string name="l10n_workouts_screen_this_session_s_contribution_to_the_fe40ab3d">Udział tej sesji w dziennym Wysiłek zarejestrowany podczas treningu.</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1049,6 +1049,7 @@
     <string name="l10n_workouts_screen_show_more_more_remaining_remaining_d1662e67">Mostrar %1$s mais (%2$s restantes)</string>
     <string name="l10n_workouts_screen_show_more_more_sessions_25bce755">Mostrar mais sessões %1$s</string>
     <string name="l10n_workouts_screen_started_faa9e7e7">Iniciado</string>
+    <string name="l10n_workouts_screen_ended_90303d8d">Terminado</string>
     <string name="l10n_workouts_screen_the_average_above_was_edited_the_0a7881f0">A média acima foi editada. O gráfico, as zonas e o esforço permanecem da sessão gravada.</string>
     <string name="l10n_workouts_screen_these_sessions_have_no_sport_label_53993414">Estas sessões ainda não têm rótulo desportivo. Escolha um para a sessão combinada.</string>
     <string name="l10n_workouts_screen_this_session_s_contribution_to_the_fe40ab3d">A contribuição desta sessão para o esforço do dia, tal como captado durante o treino.</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -1061,6 +1061,7 @@
     <string name="l10n_workouts_screen_show_more_more_remaining_remaining_d1662e67">Показать ещё %1$s (осталось %2$s)</string>
     <string name="l10n_workouts_screen_show_more_more_sessions_25bce755">Показать ещё %1$s сессий</string>
     <string name="l10n_workouts_screen_started_faa9e7e7">Начата</string>
+    <string name="l10n_workouts_screen_ended_90303d8d">Завершена</string>
     <string name="l10n_workouts_screen_the_average_above_was_edited_the_0a7881f0">Среднее значение выше было изменено вручную. График, зоны и Усилие остаются взятыми из записанной тренировки.</string>
     <string name="l10n_workouts_screen_these_sessions_have_no_sport_label_53993414">У этих сессий пока нет вида спорта. Выберите его для объединённой сессии.</string>
     <string name="l10n_workouts_screen_this_session_s_contribution_to_the_fe40ab3d">Вклад этой сессии в Усилие за день, зафиксированный во время тренировки.</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1026,6 +1026,7 @@
     <string name="l10n_workouts_screen_show_more_more_remaining_remaining_d1662e67">展开更多 %1$s 条记录 (还剩 %2$s 条)</string>
     <string name="l10n_workouts_screen_show_more_more_sessions_25bce755">展开更多 %1$s 次运动记录</string>
     <string name="l10n_workouts_screen_started_faa9e7e7">开始时间</string>
+    <string name="l10n_workouts_screen_ended_90303d8d">结束时间</string>
     <string name="l10n_workouts_screen_the_average_above_was_edited_the_0a7881f0">上方的平均值已被手动修改。不过图表、心率区间以及负荷分数仍将沿用实际记录的会话数据。</string>
     <string name="l10n_workouts_screen_these_sessions_have_no_sport_label_53993414">这些运动记录还没有打上项目标签。请为合并后的记录选一个标签吧。</string>
     <string name="l10n_workouts_screen_this_session_s_contribution_to_the_fe40ab3d">本次运动在发生期间积累的负荷，将直接计入您全天的总负荷(Effort)中。</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1178,6 +1178,7 @@
     <string name="l10n_workouts_screen_show_more_more_remaining_remaining_d1662e67">Show %1$s more (%2$s remaining)</string>
     <string name="l10n_workouts_screen_show_more_more_sessions_25bce755">Show %1$s more sessions</string>
     <string name="l10n_workouts_screen_started_faa9e7e7">Started</string>
+    <string name="l10n_workouts_screen_ended_90303d8d">Ended</string>
     <string name="l10n_workouts_screen_the_average_above_was_edited_the_0a7881f0">The average above was edited. The graph, zones and Effort stay from the recorded session.</string>
     <string name="l10n_workouts_screen_these_sessions_have_no_sport_label_53993414">These sessions have no sport label yet. Pick one for the merged session.</string>
     <string name="l10n_workouts_screen_this_session_s_contribution_to_the_fe40ab3d">This session\'s contribution to the day\'s Effort, as captured during the workout.</string>

--- a/android/app/src/test/java/com/noop/ui/ManualWorkoutSpanTest.kt
+++ b/android/app/src/test/java/com/noop/ui/ManualWorkoutSpanTest.kt
@@ -1,0 +1,110 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * #2034: entering a manual workout by its start and END, not only by a duration.
+ *
+ * The row has always been stored as `startTs`/`endTs`, so the span is the shape the storage already
+ * speaks and the duration was the lossy intermediate. These pin two things: that the span builder keeps
+ * the exact end it is given, and that the duration front door still produces byte-identical rows so the
+ * auto-workout nudge and every existing caller are unaffected.
+ *
+ * Twin of Swift `WorkoutSource.buildManualRowFromSpan`, same cases in the same order.
+ */
+class ManualWorkoutSpanTest {
+    private val now = 1_700_000_000L
+    private val start = now - 7_200L
+
+    @Test
+    fun spanBuilderKeepsTheExactEndItIsGiven() {
+        // 45m17s. The duration path cannot express this: it would store 45m00s and silently shorten the
+        // session by 17 seconds. This is the whole point of the span form.
+        val end = start + 45 * 60 + 17
+        val r = WorkoutEditing.buildManualRowFromSpan(
+            "my-whoop", start, end, "Run", null, null, now,
+        )
+        assertNotNull(r)
+        assertEquals(start, r!!.startTs)
+        assertEquals(end, r.endTs)
+        assertEquals((45 * 60 + 17).toDouble(), r.durationS!!, 0.0)
+    }
+
+    @Test
+    fun durationFrontDoorStillProducesTheIdenticalRow() {
+        // The delegation invariant. If these ever diverge, the nudge and the sheet would write different
+        // rows for the same session.
+        val viaDuration = WorkoutEditing.buildManualRow(
+            deviceId = "my-whoop", startSeconds = start, durationMin = 45,
+            sport = "Run", avgHr = 140, energyKcal = 400.0, nowSeconds = now, distanceM = 8_000.0,
+        )
+        val viaSpan = WorkoutEditing.buildManualRowFromSpan(
+            deviceId = "my-whoop", startSeconds = start, endSeconds = start + 45 * 60,
+            sport = "Run", avgHr = 140, energyKcal = 400.0, nowSeconds = now, distanceM = 8_000.0,
+        )
+        assertNotNull(viaDuration)
+        assertEquals(viaDuration, viaSpan)
+    }
+
+    @Test
+    fun rejectsAnEndAtOrBeforeTheStart() {
+        assertNull(WorkoutEditing.buildManualRowFromSpan("my-whoop", start, start, "Run", null, null, now))
+        assertNull(WorkoutEditing.buildManualRowFromSpan("my-whoop", start, start - 1, "Run", null, null, now))
+    }
+
+    @Test
+    fun rejectsASpanOverTwentyFourHours() {
+        val s = now - WorkoutEditing.MAX_MANUAL_SPAN_SECONDS - 60
+        assertNotNull(
+            WorkoutEditing.buildManualRowFromSpan(
+                "my-whoop", s, s + WorkoutEditing.MAX_MANUAL_SPAN_SECONDS, "Run", null, null, now,
+            ),
+        )
+        assertNull(
+            WorkoutEditing.buildManualRowFromSpan(
+                "my-whoop", s, s + WorkoutEditing.MAX_MANUAL_SPAN_SECONDS + 1, "Run", null, null, now,
+            ),
+        )
+    }
+
+    @Test
+    fun anEndExactlyAtNowIsValidButOneSecondPastIsNot() {
+        assertNotNull(WorkoutEditing.buildManualRowFromSpan("my-whoop", start, now, "Run", null, null, now))
+        assertNull(WorkoutEditing.buildManualRowFromSpan("my-whoop", start, now + 1, "Run", null, null, now))
+    }
+
+    @Test
+    fun spanDurationMinRoundsForDisplayOnly() {
+        assertEquals(45, WorkoutEditing.spanDurationMin(start, start + 45 * 60))
+        // 45m17s reads as 45, 45m45s reads as 46. The stored end is untouched either way.
+        assertEquals(45, WorkoutEditing.spanDurationMin(start, start + 45 * 60 + 17))
+        assertEquals(46, WorkoutEditing.spanDurationMin(start, start + 45 * 60 + 45))
+    }
+
+    @Test
+    fun endForDurationIsTheInverseOfWholeMinutes() {
+        assertEquals(start + 45 * 60, WorkoutEditing.endForDuration(start, 45))
+        assertEquals(45, WorkoutEditing.spanDurationMin(start, WorkoutEditing.endForDuration(start, 45)))
+    }
+
+    @Test
+    fun movingTheStartCarriesTheEndAndKeepsTheLength() {
+        val end = start + 45 * 60 + 17
+        val newStart = start - 3_600
+        val newEnd = WorkoutEditing.endAfterStartMove(start, end, newStart)
+        assertEquals(newStart + 45 * 60 + 17, newEnd)
+        // The length is what survives, including the seconds a duration field cannot show.
+        assertEquals(end - start, newEnd - newStart)
+    }
+
+    @Test
+    fun theDurationFormKeepsItsWholeMinuteBoundsAndOverflowGuard() {
+        assertNull(WorkoutEditing.buildManualRow("my-whoop", start, 0, "Run", null, null, now))
+        assertNull(WorkoutEditing.buildManualRow("my-whoop", start, 25 * 60, "Run", null, null, now))
+        // The overflow guard lives in the duration form because only it does the addition.
+        assertNull(WorkoutEditing.buildManualRow("my-whoop", Long.MAX_VALUE - 10, 45, "Run", null, null, now))
+    }
+}


### PR DESCRIPTION
Requested in #2034 by @riebschlaegerstar-sys: when adding or editing a workout, choosing when it ended is often easier than working out how long it ran.

## Why this is small

The row has always been stored as `startTs`/`endTs`. Duration was the lossy intermediate the sheet routed through:

```swift
let end = s + durationSeconds
return WorkoutRow(startTs: s, endTs: end, ...)
```

So the span is the shape the storage already speaks, and this is an input format change. No schema, no migration.

## Shape

`buildManualRowFromSpan` is the new primitive on both platforms. The duration-shaped `buildManualRow` keeps its whole-minute bounds and its overflow guard, which only that shape needs, and delegates to it. The auto-workout nudge and every other existing caller are untouched, and a test pins that both entry points produce identical rows so they cannot drift.

Validation is the old one re-expressed: a span must be positive, at most 24h, and must not end in the future.

## A fidelity bug it also removes

Neither `preservingCaptured` twin restores the span, so an edit re-derived the end from whole minutes:

```kotlin
(((it.durationS ?: (it.endTs - it.startTs)) / 60).roundToInt())
```

A detected 45m17s bout, opened only to correct its sport label, saved back as 45m00s. The sheet now keeps the exact end, on both platforms.

## Why the two platforms are structured differently

Apple keeps `start` and `end` as the only span state, with duration a derived `Binding`, so there is no second copy to drift. Android keeps a duration **text field**, which needs its own state to hold partial input while typing, two-way bound through the same pure helpers. The helpers and their tests are identical; only the input affordance differs.

Moving the start keeps the workout's LENGTH and carries the end with it, which is what correcting a start time means. Pinning the end instead would restretch the session on every start correction. The start is clamped so the carried end cannot land in the future, which preserves the length the user set rather than silently shortening the session.

## One deliberate behaviour change

Apple's fresh add now opens in a valid state. It previously seeded `start = Date()` with a 45 minute duration, so the implied end was always 45 minutes in the future and `buildManualRow` rejected it: the sheet opened with Save already disabled. That was invisible while the only complaint was the catch-all "Check the values and try again."; now that a future end says so by name, it would have greeted every fresh add with a red line. It now opens on a 45 minute session ending now, which is also the truer default for retroactive entry.

## Known, flagged rather than decided

A **merged** workout (#64) stores `durationS` as the SUM of its parts while `startTs`/`endTs` hold the honest outer span, and it classifies as MANUAL, so it is editable here. Saving one through this sheet now writes `durationS` equal to the span. The old path mangled it the other way, rewriting `endTs` to `start + sum` and collapsing the real span. Neither is obviously right and I did not want to pick silently: preserving a summed `durationS` through `preservingCaptured` is the plausible fix, and it wants its own change and its own tests.

Android's generic validation line still covers the "duration typed pushes the end past now" case without naming it. That hole is pre-existing and unchanged.

## Localization

Android: one new string, `Ended`, in all 8 locales. Apple: `End` already existed; `End must be after the start.`, `End can't be in the future.` and the `End date and time` accessibility label added across all 9, text-spliced and appended rather than sorted.

## Verification

Android, all with `--no-build-cache`: `compileFullDebugKotlin`, `syncRoomSchemaSnapshot` in its own invocation, the full `testFullDebugUnitTest`, and `lintVitalFullRelease -PstagingRelease` because this touches `strings.xml` and `ExtraTranslation` is fatal there and invisible to the other gates. `doc_comment_lint.py` and `i18n_audit.py --ci` clean.

New Android tests verified as actually executing, 9 of 9, and the 45 existing `WorkoutEditingTest` cases still pass against the delegating builder.

The Apple half is app-target, so it does not compile in this environment and CI is its first real check.
