### PR TITLE
Fill the stress widget without needing the app opened, and say why it is blank

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
+++ b/android/app/src/main/java/com/noop/analytics/DaytimeStress.kt
@@ -600,14 +600,24 @@ object DaytimeStress {
         floorDiv(localTs - phase, bucketSeconds) * bucketSeconds + phase
 
     /**
+     * Whether a LOCAL hour-of-day falls inside the waking window the timeline scores (06:00-22:00).
+     *
+     * Split out from [isWakingHour] so a caller holding a wall-clock hour rather than a bucket can ask
+     * the same question of the same constants. The stress widget needs exactly that: to say whether an
+     * empty curve means "nothing is coming until morning" or "today has not produced a scorable hour
+     * yet", it has to know the window, and reimplementing the comparison there would be a second copy
+     * of a rule whose whole point is having one.
+     */
+    internal fun isWakingHourOfDay(hourOfDay: Int): Boolean =
+        hourOfDay >= wakingStartHour && hourOfDay < wakingEndHour
+
+    /**
      * Whether a local hour-bucket start falls inside the waking window the timeline scores
      * (06:00–22:00). The single source of truth for "waking" — used both to build the calm
      * reference and to pick the hours to score, so the two can never drift apart.
      */
-    internal fun isWakingHour(bucket: Long): Boolean {
-        val hourOfDay = (floorDiv(bucket, bucketSeconds) % 24).toInt()
-        return hourOfDay >= wakingStartHour && hourOfDay < wakingEndHour
-    }
+    internal fun isWakingHour(bucket: Long): Boolean =
+        isWakingHourOfDay((floorDiv(bucket, bucketSeconds) % 24).toInt())
 
     /**
      * The day's "calm" reference for a signal: the quartile toward the calm end (lower

--- a/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
@@ -32,6 +32,7 @@ import com.noop.notif.BatteryAlertNotifier
 import com.noop.notif.IllnessAlertNotifier
 import com.noop.ui.NoopPrefs
 import com.noop.ui.appLaunchIntent
+import com.noop.widget.StressWidgetProducer
 import com.noop.widget.WidgetSnapshot
 import com.noop.widget.WidgetSnapshotStore
 import kotlinx.coroutines.CoroutineScope
@@ -198,6 +199,22 @@ class WhoopConnectionService : Service() {
 
     /** Wall-clock ms of the last [refreshHabitualMidsleep] attempt; 0 = never. */
     private var habitualMidsleepCachedAtMs: Long = 0L
+
+    /**
+     * Wall-clock ms of the last stress scoring done for the widget; 0 = never this process.
+     *
+     * The widget's stress curve used to be scored ONLY by `AppViewModel`, which runs while the app is
+     * open. `load` drops any curve that is not today's, so the widget reset to a bare dash every
+     * midnight and nothing refilled it until the app happened to be opened during waking hours. For
+     * anyone who uses the widget INSTEAD of opening the app, which is the point of a widget, it read as
+     * permanently broken.
+     *
+     * This service is the widget's heartbeat, so it scores here too. It cannot do so on every emission:
+     * this collector runs on `ble.state`, which moves at the live HR rate, while scoring reads a day of
+     * HR rows. [STRESS_RESCORE_INTERVAL_MS] is the gate, and it is matched to the data rather than to
+     * the stream, since the curve resolves to half-hours.
+     */
+    private var lastStressScoreAtMs: Long = 0L
 
     /** Smart-alarm light-sleep watcher (#207). Feeds the live HR while we're inside the wake window
      *  and, on a lighter-phase reading, advances the GUARANTEED alarm earlier. It can only ever move
@@ -448,6 +465,34 @@ class WhoopConnectionService : Service() {
                 // while the app UI is closed. Throttled + no-op without a placed widget (the store
                 // checks both); runCatching so a Glance hiccup never tears down the connection.
                 runCatching {
+                    // #2034 sibling: score today's stress HERE too, not only in the app. A null day is
+                    // the "this push says nothing about stress" signal `save` honours, so a throttled
+                    // tick leaves the stored curve alone instead of blanking it, and the widget keeps
+                    // whatever the last scoring pass produced.
+                    val nowMs = System.currentTimeMillis()
+                    val stressCurve = if (
+                        StressWidgetProducer.shouldRescore(
+                            nowMs, lastStressScoreAtMs, STRESS_RESCORE_INTERVAL_MS,
+                        )
+                    ) {
+                        // Stamped as soon as the interval elapses, BEFORE both the placement check and
+                        // the read. Two reasons, and the first is the one that bites: stamping inside
+                        // the placement branch would leave the gate permanently open for anyone WITHOUT
+                        // the widget, so `hasStressWidget` — which crosses into GlanceAppWidgetManager —
+                        // would run on every emission of a collector driven by live heart rate. The
+                        // second is that a slow or failing pass must not become a retry loop that reads
+                        // the day again on the very next sample.
+                        lastStressScoreAtMs = nowMs
+                        if (WidgetSnapshotStore.hasStressWidget(this@WhoopConnectionService)) {
+                            StressWidgetProducer.todayCurve(
+                                repo, (application as NoopApplication).activeDeviceId,
+                            )
+                        } else {
+                            null
+                        }
+                    } else {
+                        null
+                    }
                     WidgetSnapshotStore.push(
                         this@WhoopConnectionService,
                         WidgetSnapshot(
@@ -460,7 +505,9 @@ class WhoopConnectionService : Service() {
                             heartRate = state.heartRate,
                             batteryPct = state.batteryPct?.roundToInt(),
                             connected = state.connected,
-                            updatedAtMs = System.currentTimeMillis(),
+                            stressSeries = stressCurve?.points ?: emptyList(),
+                            stressDay = stressCurve?.epochDay,
+                            updatedAtMs = nowMs,
                         ),
                     )
                 }
@@ -757,6 +804,11 @@ class WhoopConnectionService : Service() {
     }
 
     companion object {
+        /** How often this service rescores the widget's stress curve. Matched to the curve's own
+         *  half-hour resolution and to the in-app analytics cadence, not to the live HR stream that
+         *  drives the collector it sits in. */
+        private const val STRESS_RESCORE_INTERVAL_MS = 15L * 60L * 1000L
+
         private const val CHANNEL_ID = "noop_strap_connection"
         private const val NOTIF_ID = 4201
         const val ACTION_STOP = "com.noop.ble.action.STOP_CONNECTION"

--- a/android/app/src/main/java/com/noop/widget/StressGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/StressGlanceWidget.kt
@@ -38,6 +38,7 @@ import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import com.noop.R
+import com.noop.analytics.DaytimeStress
 import com.noop.ui.MainActivity
 import com.noop.ui.uiString
 import java.text.DateFormat
@@ -146,9 +147,22 @@ private fun StressWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
         val stressLabel = uiString(R.string.l10n_stress_screen_stress_bad33342)
         val ofThree = uiString(R.string.l10n_stress_screen_of_3_46203495)
         val latest = snap.stressSeries.lastOrNull { it.level != null }?.level
+        // WHY there is no number, in words. A bare dash under a healthy-looking HR widget reads as a
+        // broken widget, and the two states behind it are different answers: outside the scored window
+        // nothing is coming until morning, whereas inside it the day simply has not produced a scorable
+        // hour yet. The Apple sheet already says "Calibrating" for the second; this says which is which.
+        // Built OUT here for the same reason `ofThree` is (#571).
+        val hourNow = java.time.LocalTime.now().hour
+        val outsideScoredWindow = !DaytimeStress.isWakingHourOfDay(hourNow)
+        val emptyReason = if (outsideScoredWindow) {
+            uiString(R.string.l10n_stress_glance_widget_resumes_in_the_morning_a640b49f)
+        } else {
+            uiString(R.string.score_state_title_calibrating)
+        }
         // Assembled by concatenation rather than as a template, so no English word is ever written
         // here: every part comes from a resource, and the separators carry no letters to translate.
-        val spoken = latest?.let { stressLabel + " " + formatLevel(it) + " " + ofThree } ?: stressLabel
+        val spoken = latest?.let { stressLabel + " " + formatLevel(it) + " " + ofThree }
+            ?: (stressLabel + " " + emptyReason)
 
         Row(verticalAlignment = Alignment.Vertical.Bottom) {
             Text(
@@ -162,6 +176,12 @@ private fun StressWidgetContent(snap: WidgetSnapshot, dark: Boolean) {
                 Spacer(GlanceModifier.width(4.dp))
                 Text(
                     text = ofThree,
+                    style = TextStyle(color = stressTextSecondary(dark), fontSize = 12.sp),
+                )
+            } else {
+                Spacer(GlanceModifier.width(6.dp))
+                Text(
+                    text = emptyReason,
                     style = TextStyle(color = stressTextSecondary(dark), fontSize = 12.sp),
                 )
             }

--- a/android/app/src/main/java/com/noop/widget/StressWidgetProducer.kt
+++ b/android/app/src/main/java/com/noop/widget/StressWidgetProducer.kt
@@ -48,6 +48,20 @@ internal object StressWidgetProducer {
     private var memo: Memo? = null
 
     /**
+     * Whether a background tick should rescore, given when it last did.
+     *
+     * The service's collector runs on `ble.state`, which moves at the live heart-rate rate, while
+     * scoring reads a day of heart-rate rows. The memo inside [todayCurve] cannot absorb that on its
+     * own: its fingerprint is the day's heart rate, which is exactly what changes on every one of
+     * those emissions, so a streaming strap misses the memo every time.
+     *
+     * [lastScoreAtMs] of 0 means "not yet this process", and any real wall clock is far past the
+     * interval, so the first tick after a launch always scores rather than waiting out a window.
+     */
+    fun shouldRescore(nowMs: Long, lastScoreAtMs: Long, intervalMs: Long): Boolean =
+        nowMs - lastScoreAtMs >= intervalMs
+
+    /**
      * Today's curve, recomputed only when today's heart rate has moved since the last call.
      *
      * Returns null when there is no device to read, which is the one case a caller must not treat as

--- a/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
@@ -140,6 +140,18 @@ object WidgetSnapshotStore {
         if (stressIds.isNotEmpty()) runCatching { StressGlanceWidget().updateAll(app) }
     }
 
+    /**
+     * Whether a stress widget is actually on a home screen.
+     *
+     * Exposed so a producer can skip SCORING for a widget nobody has placed. [push] already declines to
+     * send in that case, but by then the work is done, and stress is the one field whose production
+     * costs a day of heart-rate rows rather than a field read.
+     */
+    suspend fun hasStressWidget(context: Context): Boolean = runCatching {
+        GlanceAppWidgetManager(context.applicationContext)
+            .getGlanceIds(StressGlanceWidget::class.java).isNotEmpty()
+    }.getOrDefault(false)
+
     fun save(context: Context, snap: WidgetSnapshot) {
         val prefs = context.getSharedPreferences(FILE, Context.MODE_PRIVATE)
         val e = prefs.edit()

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1970,6 +1970,7 @@
     <string name="recording_chip_detail_history_experimental">Verlaufssynchronisierung ist auf 5.0 experimentell.</string>
     <string name="recording_chip_detail_connected_no_data">Noch keine Live-Herzfrequenz und kein synchronisierter Verlauf in dieser Sitzung.</string>
     <string name="score_state_title_calibrating">Kalibrierung</string>
+    <string name="l10n_stress_glance_widget_resumes_in_the_morning_a640b49f">Wird morgens fortgesetzt</string>
     <string name="score_state_title_needs_strap">Strap erforderlich</string>
     <string name="score_state_title_last_night">Letzte Nacht · %1$s</string>
     <string name="score_state_title_latest_sleep">Letzter Schlaf · %1$s</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1938,6 +1938,7 @@
     <string name="recording_chip_detail_history_experimental">La sincronización del historial es experimental en la 5.0.</string>
     <string name="recording_chip_detail_connected_no_data">Aún no hay frecuencia cardíaca en vivo ni historial sincronizado en esta sesión.</string>
     <string name="score_state_title_calibrating">Calibrando</string>
+    <string name="l10n_stress_glance_widget_resumes_in_the_morning_a640b49f">Se reanuda por la mañana</string>
     <string name="score_state_title_needs_strap">Necesita la banda</string>
     <string name="score_state_title_last_night">Anoche · %1$s</string>
     <string name="score_state_title_latest_sleep">Último sueño · %1$s</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1956,6 +1956,7 @@
     <string name="recording_chip_detail_history_experimental">La synchronisation de l\'historique est expérimentale sur 5.0.</string>
     <string name="recording_chip_detail_connected_no_data">Aucune fréquence cardiaque en direct ni historique synchronisé durant cette session.</string>
     <string name="score_state_title_calibrating">Calibration en cours</string>
+    <string name="l10n_stress_glance_widget_resumes_in_the_morning_a640b49f">Reprend le matin</string>
     <string name="score_state_title_needs_strap">Nécessite le bracelet</string>
     <string name="score_state_title_last_night">La nuit dernière · %1$s</string>
     <string name="score_state_title_latest_sleep">Dernier sommeil · %1$s</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1923,6 +1923,7 @@
     <string name="recording_chip_detail_history_experimental">Synchronizacja historii jest eksperymentalna w wersji 5.0.</string>
     <string name="recording_chip_detail_connected_no_data">W tej sesji nie ma jeszcze tętna na żywo ani zsynchronizowanej historii.</string>
     <string name="score_state_title_calibrating">Kalibracja</string>
+    <string name="l10n_stress_glance_widget_resumes_in_the_morning_a640b49f">Wznowi się rano</string>
     <string name="score_state_title_needs_strap">Potrzebuje paska</string>
     <string name="score_state_title_last_night">Ostatnia noc · %1$s</string>
     <string name="score_state_title_latest_sleep">Ostatni sen · %1$s</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1931,6 +1931,7 @@
     <string name="recording_chip_detail_history_experimental">A sincronização do histórico é experimental na versão 5.0.</string>
     <string name="recording_chip_detail_connected_no_data">Ainda não há frequência cardíaca em direto nem histórico sincronizado nesta sessão.</string>
     <string name="score_state_title_calibrating">A calibrar</string>
+    <string name="l10n_stress_glance_widget_resumes_in_the_morning_a640b49f">Retoma de manhã</string>
     <string name="score_state_title_needs_strap">Precisa da pega</string>
     <string name="score_state_title_last_night">Ontem à noite · %1$s</string>
     <string name="score_state_title_latest_sleep">Último sono · %1$s</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -1920,6 +1920,7 @@
     <string name="recording_chip_detail_history_experimental">Синхронизация истории экспериментальна на 5.0.</string>
     <string name="recording_chip_detail_connected_no_data">Пока нет ни пульса в реальном времени, ни синхронизированной истории в этой сессии.</string>
     <string name="score_state_title_calibrating">Калибровка</string>
+    <string name="l10n_stress_glance_widget_resumes_in_the_morning_a640b49f">Возобновится утром</string>
     <string name="score_state_title_needs_strap">Нужен ремешок</string>
     <string name="score_state_title_last_night">Прошлая ночь · %1$s</string>
     <string name="score_state_title_latest_sleep">Последний сон · %1$s</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1862,6 +1862,7 @@
     <string name="recording_chip_detail_history_experimental">历史同步在 5.0 上属实验性。</string>
     <string name="recording_chip_detail_connected_no_data">本次连接尚无实时心率或已同步的历史记录。</string>
     <string name="score_state_title_calibrating">校准中</string>
+    <string name="l10n_stress_glance_widget_resumes_in_the_morning_a640b49f">早晨恢复</string>
     <string name="score_state_title_needs_strap">需要手环</string>
     <string name="score_state_title_last_night">昨晚 · %1$s</string>
     <string name="score_state_title_latest_sleep">最近睡眠 · %1$s</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2077,6 +2077,7 @@
     <string name="recording_chip_detail_history_experimental">History sync is experimental on 5.0.</string>
     <string name="recording_chip_detail_connected_no_data">No live heart rate or synced history yet this session.</string>
     <string name="score_state_title_calibrating">Calibrating</string>
+    <string name="l10n_stress_glance_widget_resumes_in_the_morning_a640b49f">Resumes in the morning</string>
     <string name="score_state_title_needs_strap">Needs the strap</string>
     <string name="score_state_title_last_night">Last night · %1$s</string>
     <string name="score_state_title_latest_sleep">Latest sleep · %1$s</string>

--- a/android/app/src/test/java/com/noop/widget/StressWidgetBackgroundScoringTest.kt
+++ b/android/app/src/test/java/com/noop/widget/StressWidgetBackgroundScoringTest.kt
@@ -1,0 +1,80 @@
+package com.noop.widget
+
+import com.noop.analytics.DaytimeStress
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The stress widget's two blank states, and the gate that stops it staying blank.
+ *
+ * The curve used to be scored ONLY by `AppViewModel`, which runs while the app is open, while the BLE
+ * service, the widget's actual heartbeat, pushed heart rate without ever scoring stress. `load` drops
+ * any curve that is not today's, so the widget reset to a bare dash every midnight and nothing refilled
+ * it until the app happened to be opened during waking hours. For anyone who uses the widget INSTEAD of
+ * opening the app it read as permanently broken.
+ *
+ * The service now scores too, throttled, because its collector runs at the live heart-rate rate.
+ */
+class StressWidgetBackgroundScoringTest {
+    private val interval = 15L * 60L * 1000L
+
+    @Test
+    fun theFirstTickAfterLaunchScores() {
+        // 0 means "not yet this process". If this were treated as a recent score the widget would stay
+        // blank for a whole interval after every launch, which is the state being fixed.
+        assertTrue(StressWidgetProducer.shouldRescore(nowMs = 1_700_000_000_000, lastScoreAtMs = 0L, intervalMs = interval))
+    }
+
+    @Test
+    fun aTickInsideTheIntervalDoesNotRescore() {
+        val now = 1_700_000_000_000
+        assertFalse(StressWidgetProducer.shouldRescore(now, now - (interval - 1), interval))
+        // The collector runs on live heart rate, so this is the common case by a wide margin.
+        assertFalse(StressWidgetProducer.shouldRescore(now, now - 1_000, interval))
+    }
+
+    @Test
+    fun theIntervalBoundaryItselfRescores() {
+        val now = 1_700_000_000_000
+        assertTrue(StressWidgetProducer.shouldRescore(now, now - interval, interval))
+        assertTrue(StressWidgetProducer.shouldRescore(now, now - (interval + 1), interval))
+    }
+
+    @Test
+    fun theScoredWindowIsSixAmToTenPm() {
+        // The window the timeline actually scores. A blank OUTSIDE it is "nothing until morning"; a
+        // blank inside it is "no scorable hour yet", and the widget says which.
+        assertEquals(6, DaytimeStress.wakingStartHour)
+        assertEquals(22, DaytimeStress.wakingEndHour)
+        assertTrue(DaytimeStress.isWakingHourOfDay(6))
+        assertTrue(DaytimeStress.isWakingHourOfDay(11))
+        assertTrue(DaytimeStress.isWakingHourOfDay(21))
+        // Both ends are exclusive-at-the-top: 22:00 is already outside.
+        assertFalse(DaytimeStress.isWakingHourOfDay(22))
+        assertFalse(DaytimeStress.isWakingHourOfDay(5))
+    }
+
+    @Test
+    fun theHoursBehindTheReportedBlankAreOutsideTheWindow() {
+        // The screenshot that prompted this was taken at 01:02, and the log at 11:20 was inside the
+        // window. Pinning both keeps the two states distinguishable rather than collapsing into one.
+        assertFalse(DaytimeStress.isWakingHourOfDay(1))
+        assertFalse(DaytimeStress.isWakingHourOfDay(0))
+        assertTrue(DaytimeStress.isWakingHourOfDay(11))
+    }
+
+    @Test
+    fun theBucketFormAndTheHourFormAgree() {
+        // The two must not drift: the widget asks by hour, the scorer asks by bucket, one rule.
+        for (h in 0..23) {
+            val bucketAtHour = h.toLong() * 3600L
+            assertEquals(
+                "hour $h",
+                DaytimeStress.isWakingHourOfDay(h),
+                DaytimeStress.isWakingHour(bucketAtHour),
+            )
+        }
+    }
+}


### PR DESCRIPTION
Reported with a screenshot of a full heart-rate widget beside an empty stress one, both stamped with the same update time, and then again as "doesn't work for me at all". Those are two different problems and both are real.

## 1. The widget could only ever be filled by opening the app

`StressWidgetProducer.todayCurve` had exactly two callers: the Stress screen, and `AppViewModel` inside the block that keeps the widget fresh **while the app is open**. The BLE service is the widget's actual heartbeat, and it pushed heart rate without ever scoring stress.

Combined with `load`, which drops any curve that is not today's:

```kotlin
stressSeries = p.getLong(KEY_STRESS_DAY, MIN).takeIf { it == today }?.let { decode(...) } ?: emptyList(),
```

the widget reset to a bare dash every midnight and nothing refilled it until the app happened to be opened during waking hours. For anyone who uses the widget INSTEAD of opening the app, which is the point of a widget, it was permanently blank.

The service now scores too. It cannot do so per emission: that collector runs on `ble.state`, which moves at the live heart-rate rate, while scoring reads a day of heart-rate rows. A 15 minute gate handles it, matched to the curve's own half-hour resolution rather than to the stream.

Two details that matter more than the gate itself:

- A throttled tick passes a **null** `stressDay`, which is the existing "this push says nothing about stress" signal `save` already honours, so it leaves the stored curve alone rather than blanking it. The contract was already there and documented; nothing new was invented for it.
- The gate is stamped **before** the placement check. Stamping inside it would leave the gate permanently open for every user WITHOUT the widget, so `hasStressWidget` would cross into `GlanceAppWidgetManager` on every heart beat. I wrote it the wrong way round first and caught it on re-review.

`hasStressWidget` is new, so a producer can skip the one field whose production costs a day of rows rather than a field read. `push` already declines to send with no widget placed, but by then the work is done.

That does trade away a sliver of a stated principle. `push` deliberately saves even with no widget placed, "so a widget added later renders fresh data instantly". A newly-placed stress widget now fills on the next scoring pass rather than the next push, so within 15 minutes or immediately on the next app open. Worth it, I think, for the one field that reads a day of rows, but it is a real trade rather than a free win.

## 2. The blank said nothing

Stress scores 06:00 to 22:00 (`wakingStartHour` / `wakingEndHour`). So an empty curve at 01:00 is correct and nothing is coming until morning, while an empty one at 11:00 means the day has not produced a scorable hour yet. Both rendered as the same bare em dash under a healthy-looking neighbour, which reads as a broken widget.

The Apple sheet already says "Calibrating" for the second case, with the comment *"the honest blank ... empty by construction rather than by failure."* Android now says which of the two it is, in the accessibility description as well as on screen.

`isWakingHourOfDay` is split out of `isWakingHour` so the widget asks the scorer's own constants instead of keeping a second copy of the rule. A test walks all 24 hours asserting the bucket form and the hour form agree, which also pins that splitting it changed nothing.

## Ruled out while tracing this

From the reporter's log, so this does not get refiled as a data problem:

- **Not the device id**: the day carried 134,806 heart-rate rows under exactly the id the producer reads
- **Not the minimum-sample gate**, at that volume
- **Not the motion mask**: `activityMaskFraction` is 0.30 and empty gravity yields an empty map, so `0.0 >= 0.30` is false and nothing is masked, exactly as its comment claims
- **Not the service overwriting the curve**: `save` correctly guards on `if (snap.stressDay != null)`
- **Not #1635**, which is independent of the bonding failure

## Not addressed here

The strap log has no stress diagnostics at all, so none of the above was visible in it; all of it came from reading source against the reporter's row counts. A log line naming the day, scored hours, sample count and reference would make the next report answerable, and wants its own change.

Apple's widget timeline is a different mechanism and is not touched.

**Scope.** This covers users whose background connection is ON, which is what runs the service. With it off nothing runs in the background at all, so the curve still only fills while the app is open. That is inherent rather than a gap here: the only other periodic pusher, `CoachBriefScheduler`, is a once-a-day user-armed WorkManager job, not a heartbeat.

The reason text reads the clock at composition, so across the 06:00 boundary it can briefly lag until the next push. Self-correcting, and live heart rate makes pushes frequent.

## Verification

Android, all with `--no-build-cache`: `compileFullDebugKotlin`, `syncRoomSchemaSnapshot` in its own invocation, the full `testFullDebugUnitTest`, and `lintVitalFullRelease -PstagingRelease` because this touches `strings.xml`. `doc_comment_lint.py` and `i18n_audit.py --ci` clean. New tests verified as actually executing, 6 of 6.

One new string across all 8 Android locales; the "Calibrating" case reuses the existing translated `score_state_title_calibrating` rather than adding a second copy of the same word.

Not exercised on a strap: the background path needs a placed widget and a day of live heart rate, so it wants on-device confirmation that the curve appears without opening the app.
