### PR TITLE
Read the Live Console out of the active device, not whichever field is populated

### DIFF
--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 import StrandAnalytics
 import WhoopProtocol
+import WhoopStore
 import OuraProtocol
 
 /// Observable snapshot of the live connection + biometric state, driven by FrameRouter
@@ -115,6 +116,13 @@ public final class LiveState: ObservableObject {
     /// beat only comes from a finger (`.worn`); "chg. detected"/"stopped" bracket `.charging`; a silent
     /// live-HR stream drops to `.off` (removed). Lets the Live view show On wrist / Off wrist.
     @Published public var ouraWearState: OuraWearState? = nil
+
+    /// The RING's own charge, when a ring is the live source. Separate from [batteryPct], which is the
+    /// WHOOP's, because `LiveState` is ONE object both sources write into: a bonded WHOOP beside a
+    /// streaming ring leaves the WHOOP's charge sitting in `batteryPct`, and a console that reads it
+    /// while a ring is the active device reports the wrong band's battery under the right band's name.
+    /// That is #2075, where a ring on 93% displayed the strap's 72%. Nil when no ring has reported.
+    @Published public var ouraBatteryPct: Int? = nil
 
     // MARK: - Battery runtime estimate (#713)
 
@@ -598,6 +606,7 @@ public final class LiveState: ObservableObject {
         clearStrapRange()                 // a stale clock-drift window must not outlive the link either
         lastFrameAtUnix = nil             // #987: a stale "last frame" freshness must not outlive it either
         ouraWearState = nil               // a stale worn/charging badge must not outlive the link either
+        ouraBatteryPct = nil              // nor a stale ring charge (#2075)
         // Perf: flush the durable log tail on disconnect (mirroring is batched in `append`), so a completed
         // session's tail is always persisted for a later scheduled export despite the per-line throttle.
         Self.persistTail(log)
@@ -1018,5 +1027,46 @@ public final class LiveState: ObservableObject {
         // Previous processes first, so the body stays in chronological order and the log-parsing tools read
         // it unchanged — they just get the night that a wake-time restart used to erase.
         return header + Self.previousSessionsText() + log.joined(separator: "\n")
+    }
+}
+
+/// What the Live Console should read out, given WHICH device is active.
+///
+/// `LiveState` is one object that every live source writes into, so "is this field populated" is not the
+/// same question as "does this field describe the device on screen". A bonded WHOOP sitting beside a
+/// streaming Oura ring leaves every WHOOP-only field truthful-looking while the console is naming the
+/// ring, which is #2075: the ring's own 93% was decoded and held, and the strap's stale 72% was what got
+/// drawn under "Oura Ring 5".
+///
+/// Pure and shared so the Apple and Android consoles cannot answer it differently.
+public enum LiveConsoleReadout {
+
+    /// Whether the ACTIVE registry device is a WHOOP.
+    ///
+    /// Defaults to true when the registry has not opened or the active row is not resolvable, which is
+    /// the WHOOP-first tone the console's device name already takes. Delegates to `SourceIdentity`, the
+    /// one place that answers this, rather than adding a second spelling of it.
+    ///
+    /// That default is load-bearing rather than cosmetic. A WHOOP adopting its serial identity re-keys
+    /// the active row mid-session (#1303), so the id being asked about can briefly name a row that no
+    /// longer exists; answering "WHOOP" there keeps a working strap's console intact, which is the right
+    /// call because the device that just re-keyed IS a WHOOP.
+    public static func activeIsWhoop(devices: [PairedDevice], activeId: String?) -> Bool {
+        guard let activeId, let active = devices.first(where: { $0.id == activeId }) else { return true }
+        return SourceIdentity.isWhoop(active)
+    }
+
+    /// The charge to show for the ACTIVE device, or nil to show nothing.
+    ///
+    /// A non-WHOOP active device never falls back to the WHOOP's charge. Showing nothing is the honest
+    /// answer when a ring has not reported yet; showing the strap's number would be a confident lie, and
+    /// it is the exact shape of the reported bug.
+    public static func batteryPercent(activeIsWhoop: Bool, whoopPct: Double?, ringPct: Int?) -> Int? {
+        // ROUNDS, and deliberately. The surfaces this replaced disagreed: Devices and the widget rounded,
+        // the Live Console truncated, so a strap on 72.6% read 73 on one screen and 72 on another. One
+        // seam has to pick, and for a percentage rounding is the accurate one. `.rounded()` is
+        // half-away-from-zero and Kotlin's Math.round is half-up, identical over the 0...100 this sees.
+        if activeIsWhoop { return whoopPct.map { Int($0.rounded()) } }
+        return ringPct
     }
 }

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -1727,6 +1727,10 @@ public final class OuraLiveSource: NSObject, ObservableObject {
 
             case .battery(let bat):
                 batteryPct = bat.percent
+                // #2075: publish the ring's charge into the shared LiveState too, beside `ouraWearState`.
+                // Holding it only here left the Live Console with nothing but the WHOOP's `batteryPct`,
+                // so it showed the strap's charge under the ring's name.
+                if feedsLive { live.ouraBatteryPct = bat.percent }
                 onBattery(bat.percent)
                 log("Oura: battery \(bat.percent)%")
                 enqueue([e], ts: now)

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -88740,6 +88740,64 @@
         }
       }
     },
+    "Last reported by the ring": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zuletzt vom Ring gemeldet"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Último valor informado por el anillo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dernière valeur transmise par la bague"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ultimo dato riportato dall'anello"
+          }
+        },
+        "pt-PT": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Último valor comunicado pelo anel"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Последние данные от кольца"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由指环最后上报"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "由指環最後回報"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ostatnio zgłoszone przez pierścień"
+          }
+        }
+      }
+    },
     "Last seen %@": {
       "localizations": {
         "de": {

--- a/Strand/Screens/DevicesView.swift
+++ b/Strand/Screens/DevicesView.swift
@@ -188,9 +188,16 @@ private struct DevicesContent: View {
                     pairingHint: device.status == .active ? live.pairingHint : nil,
                     // Reboot in flight + link currently down → "Reconnecting…" (#166).
                     isReconnecting: device.status == .active && live.rebootInProgress && !live.connected,
-                    // The live battery belongs to whichever device is ACTIVE + connected (the WHOOP, a
-                    // generic strap, or an FTMS machine all funnel into live.batteryPct). nil otherwise.
-                    liveBatteryPct: (device.status == .active && live.connected) ? live.batteryPct.map { Int($0.rounded()) } : nil,
+                    // The live battery belongs to whichever device is ACTIVE + connected. A WHOOP, a
+                    // generic strap and an FTMS machine all funnel into live.batteryPct, but an Oura ring
+                    // does NOT: it reports its own charge, so an active ring row used to draw the strap's
+                    // stale number under the ring's name (#2075). Asked PER ROW rather than of the active
+                    // device, which is the stronger question and the one this loop can actually answer.
+                    liveBatteryPct: (device.status == .active && live.connected)
+                        ? LiveConsoleReadout.batteryPercent(
+                            activeIsWhoop: SourceCoordinator.isWhoop(device),
+                            whoopPct: live.batteryPct, ringPct: live.ouraBatteryPct)
+                        : nil,
                     liveBatteryMv: (device.status == .active && live.connected) ? live.batteryMv : nil,
                     // Firmware version for the ACTIVE strap. It's a STABLE property (NOOP can't change a
                     // strap's firmware), so prefer the live handshake value but fall back to the last-known

--- a/Strand/Screens/LiveView.swift
+++ b/Strand/Screens/LiveView.swift
@@ -51,7 +51,22 @@ struct LiveView: View {
     @AppStorage(UnitPrefs.effortScaleKey) private var effortScaleRaw = EffortScale.hundred.rawValue
     private var effortScale: EffortScale { UnitPrefs.resolveEffortScale(effortScaleRaw) }
 
-    private var activeConnection: Bool { live.connected && live.bonded }
+    /// Whether the ACTIVE registry device is a WHOOP, resolved once and handed to the leaves.
+    private var activeIsWhoop: Bool {
+        LiveConsoleReadout.activeIsWhoop(
+            devices: model.deviceRegistry?.devices ?? [],
+            activeId: model.deviceRegistry?.activeDeviceId,
+        )
+    }
+
+    /// A trusted WHOOP link, for the console readouts and the bond-only controls.
+    ///
+    /// Gated on the active device actually BEING a WHOOP (#2075). `LiveState` is one object that every
+    /// live source writes into, so `connected && bonded` stays true for a bonded strap while an Oura
+    /// ring is the device on screen. That showed the WHOOP pill, the WHOOP charge and live WHOOP-only
+    /// controls under the ring's name, and made the pill's own ring branch unreachable, because this one
+    /// is tested first.
+    private var activeConnection: Bool { activeIsWhoop && live.connected && live.bonded }
 
     /// A non-WHOOP live source (the Oura ring) that is connected and actively streaming live HR. It
     /// authenticates and streams but never reaches a WHOOP encrypted bond, so `bonded` stays false and
@@ -186,7 +201,8 @@ struct LiveView: View {
                         SourceBadge("SYNCING \(live.syncChunksThisSession)", tint: StrandPalette.metricCyan)
                     }
                     Spacer(minLength: 8)
-                    LiveHeaderStats(activeConnection: activeConnection, deviceName: activeDeviceName)
+                    LiveHeaderStats(activeConnection: activeConnection, activeIsWhoop: activeIsWhoop,
+                                    deviceName: activeDeviceName)
                 }
                 VStack(alignment: .leading, spacing: 12) {
                     HStack(spacing: 12) {
@@ -199,7 +215,8 @@ struct LiveView: View {
                         }
                         Spacer(minLength: 0)
                     }
-                    LiveHeaderStats(activeConnection: activeConnection, deviceName: activeDeviceName)
+                    LiveHeaderStats(activeConnection: activeConnection, activeIsWhoop: activeIsWhoop,
+                                    deviceName: activeDeviceName)
                 }
             }
         }
@@ -259,16 +276,16 @@ struct LiveView: View {
         card {
             ViewThatFits(in: .horizontal) {
                 HStack(alignment: .center, spacing: NoopMetrics.space6) {
-                    LiveHeartReadout(hrMax: model.profile.hrMax)
+                    LiveHeartReadout(activeIsWhoop: activeIsWhoop, hrMax: model.profile.hrMax)
                         .frame(minWidth: 260, maxWidth: 340)
                     Divider().overlay(StrandPalette.hairline)
-                    LivePhysiology()
+                    LivePhysiology(activeIsWhoop: activeIsWhoop)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 VStack(alignment: .leading, spacing: 18) {
-                    LiveHeartReadout(hrMax: model.profile.hrMax)
+                    LiveHeartReadout(activeIsWhoop: activeIsWhoop, hrMax: model.profile.hrMax)
                     Divider().overlay(StrandPalette.hairline)
-                    LivePhysiology()
+                    LivePhysiology(activeIsWhoop: activeIsWhoop)
                 }
             }
         }
@@ -282,7 +299,7 @@ struct LiveView: View {
     private var signalTrustRail: some View {
         VStack(alignment: .leading, spacing: NoopMetrics.gap) {
             SectionHeader("Signal Trust", overline: "Proof that the console is current")
-            LiveSignalTrustRail(activeConnection: activeConnection)
+            LiveSignalTrustRail(activeConnection: activeConnection, activeIsWhoop: activeIsWhoop)
         }
     }
 
@@ -709,12 +726,24 @@ struct LiveView: View {
 private struct LiveHeaderStats: View {
     @EnvironmentObject private var live: LiveState
     let activeConnection: Bool
+    /// Resolved by the parent (#2075), so the charge below can belong to the device being named.
+    let activeIsWhoop: Bool
     let deviceName: String
     /// #218: an Oura ring streams live HR WITHOUT a WHOOP bond, so `activeConnection` (which needs the bond)
     /// is false for it and the wear stat read "—" mid-stream. A live HR stream is itself the wear signal
     /// (Oura only emits PPG HR while worn). `streamingLiveHR` is Oura-only, so this never widens WHOOP.
     private var ringStreaming: Bool { live.connected && live.streamingLiveHR }
     private var liveLink: Bool { activeConnection || ringStreaming }
+
+    /// The ACTIVE device's charge (#2075). A non-WHOOP active device never falls back to the strap's
+    /// number: an em dash says "not reported", where the strap's charge under the ring's name is a
+    /// confident lie, and was exactly what the report saw.
+    private var batteryLabel: String {
+        LiveConsoleReadout.batteryPercent(
+            activeIsWhoop: activeIsWhoop, whoopPct: live.batteryPct, ringPct: live.ouraBatteryPct,
+        ).map { "\($0)%" } ?? "—"
+    }
+
     /// A streaming Oura ring is definitionally worn (PPG needs skin contact), and `worn` isn't reset on a
     /// source switch — so a stale `worn=false` from a prior WHOOP WRIST_OFF must not read "Off wrist"
     /// mid-stream. For WHOOP `ringStreaming` is always false, so this is just `live.worn`. #218.
@@ -730,7 +759,7 @@ private struct LiveHeaderStats: View {
     var body: some View {
         HStack(spacing: 16) {
             stat(String(localized: "Device"), deviceName)
-            stat(String(localized: "Battery"), live.batteryPct.map { "\(Int($0))%" } ?? "—")
+            stat(String(localized: "Battery"), batteryLabel)
             stat(String(localized: "Worn"), liveLink ? (wornNow ? String(localized: "Yes") : String(localized: "No")) : "—")
             stat(String(localized: "Last sync"), lastSyncLabel)
         }
@@ -757,13 +786,15 @@ private struct LiveHeaderStats: View {
 /// re-renders only this leaf. The vessel replaces the old flat pulse-ring, the count-up number replaces
 /// the CountUpText numeral.
 private struct LiveHeartReadout: View {
+    /// Resolved by the parent (#2075); this leaf does not re-derive it.
+    let activeIsWhoop: Bool
     @EnvironmentObject private var model: AppModel
     @EnvironmentObject private var live: LiveState
     let hrMax: Int
 
     /// Smoothed, spike-filtered live HR from AppModel (median over a short window).
     private var displayHR: Int? { model.bpm }
-    private var activeConnection: Bool { live.connected && live.bonded }
+    private var activeConnection: Bool { activeIsWhoop && live.connected && live.bonded }
 
     /// The live HR zone for the focal readout's colour world (presentation only). 0 = below Zone 1.
     private var liveZone: Int {
@@ -856,8 +887,11 @@ private struct LiveHeartReadout: View {
 /// this leaf, never the whole console.
 private struct LivePhysiology: View {
     @EnvironmentObject private var live: LiveState
+    /// Resolved by the parent (#2075). Passed rather than observed so this leaf keeps owning only
+    /// LiveState, which is what makes the ~1 Hz R-R / frame notifies re-render it alone.
+    let activeIsWhoop: Bool
 
-    private var activeConnection: Bool { live.connected && live.bonded }
+    private var activeConnection: Bool { activeIsWhoop && live.connected && live.bonded }
     /// Oura ring actively streaming live HR — trusted stream without a WHOOP bond (see LiveView.ringStreaming).
     private var ringStreaming: Bool { live.connected && live.streamingLiveHR }
 
@@ -978,6 +1012,15 @@ private struct LiveSignalTrustRail: View {
     @EnvironmentObject private var model: AppModel
     @EnvironmentObject private var live: LiveState
     let activeConnection: Bool
+    /// Resolved by the parent (#2075): the battery tile below must describe the ACTIVE device.
+    let activeIsWhoop: Bool
+
+    /// The ACTIVE device's charge, or nil when it has not reported one.
+    private var activeBatteryPct: Int? {
+        LiveConsoleReadout.batteryPercent(
+            activeIsWhoop: activeIsWhoop, whoopPct: live.batteryPct, ringPct: live.ouraBatteryPct,
+        )
+    }
 
     private var displayHR: Int? { model.bpm }
     /// Oura ring actively streaming live HR — trusted stream without a WHOOP bond (see LiveView.ringStreaming).
@@ -1014,7 +1057,7 @@ private struct LiveSignalTrustRail: View {
     }
 
     private var batteryTint: Color {
-        guard let pct = live.batteryPct else { return StrandPalette.textTertiary }
+        guard let pct = activeBatteryPct.map({ Double($0) }) else { return StrandPalette.textTertiary }
         if pct <= 15 { return StrandPalette.metricRose }
         if pct <= 30 { return StrandPalette.statusWarning }
         return StrandPalette.accent
@@ -1061,11 +1104,14 @@ private struct LiveSignalTrustRail: View {
                   tint: live.backfilling ? StrandPalette.metricCyan : StrandPalette.textSecondary,
                   frac: live.backfilling ? 0.6 : (live.lastSyncedAt == nil ? nil : 1)),
             .init(title: String(localized: "Battery"),
-                  value: live.batteryPct.map { "\(Int($0))%" } ?? String(localized: "Unknown"),
-                  detail: live.charging == true ? String(localized: "Charging") : String(localized: "Last reported by strap"),
+                  value: activeBatteryPct.map { "\($0)%" } ?? String(localized: "Unknown"),
+                  // "by strap" only when a strap is what reported it (#2075).
+                  detail: live.charging == true ? String(localized: "Charging")
+                          : activeIsWhoop ? String(localized: "Last reported by strap")
+                          : String(localized: "Last reported by the ring"),
                   icon: "battery.75percent",
                   tint: batteryTint,
-                  frac: live.batteryPct.map { max(0.02, min(1, $0 / 100)) }),
+                  frac: activeBatteryPct.map { max(0.02, min(1, Double($0) / 100)) }),
             // Wear is only trustworthy on a live link: `worn` defaults true (LiveState) and is only
             // updated by WRIST_ON/OFF events, so while OFFLINE it would otherwise read a false-green
             // "On wrist". Gate the value AND tint on a live link (triage fix for PR#191).

--- a/StrandTests/LiveConsoleReadoutTests.swift
+++ b/StrandTests/LiveConsoleReadoutTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+import WhoopStore
+@testable import Strand
+
+/// #2075: the Live Console must read out the ACTIVE device, not whichever field happens to be populated.
+///
+/// `LiveState` is one object every live source writes into, so a bonded WHOOP sitting beside a streaming
+/// Oura ring leaves every WHOOP-only field truthful-looking while the console is naming the ring. The
+/// report was a ring on 93% displaying the strap's 72% under "Oura Ring 5", with a WHOOP pairing pill.
+///
+/// Mirrors Android `LiveConsoleReadoutTest` case-for-case.
+final class LiveConsoleReadoutTests: XCTestCase {
+
+    private func device(_ id: String, _ brand: String) -> PairedDevice {
+        PairedDevice(id: id, brand: brand, model: "m", nickname: nil, peripheralId: nil,
+                     sourceKind: .liveBLE, capabilities: [.hr],
+                     status: .active, addedAt: 1000, lastSeenAt: 1000)
+    }
+
+    // MARK: - activeIsWhoop
+
+    func testAnOuraActiveDeviceIsNotAWhoop() {
+        let rows = [device("my-whoop", "WHOOP"), device("oura-123", "Oura")]
+        XCTAssertFalse(LiveConsoleReadout.activeIsWhoop(devices: rows, activeId: "oura-123"))
+        XCTAssertTrue(LiveConsoleReadout.activeIsWhoop(devices: rows, activeId: "my-whoop"))
+    }
+
+    func testTheLegacySeededRowIsAWhoopWhateverItsBrandSays() {
+        // SourceIdentity's rule: the seeded id counts even if the brand column is blank.
+        XCTAssertTrue(LiveConsoleReadout.activeIsWhoop(devices: [device("my-whoop", "")], activeId: "my-whoop"))
+    }
+
+    func testAnUnresolvableActiveDeviceStaysWhoopFirst() {
+        // Before the registry opens, the console already names "WHOOP"; the gate must agree rather than
+        // blanking a working strap's readouts on a cold start.
+        XCTAssertTrue(LiveConsoleReadout.activeIsWhoop(devices: [], activeId: nil))
+        XCTAssertTrue(LiveConsoleReadout.activeIsWhoop(devices: [], activeId: "oura-123"))
+    }
+
+    func testBrandMatchingIsCaseInsensitive() {
+        XCTAssertTrue(LiveConsoleReadout.activeIsWhoop(devices: [device("w1", "whoop")], activeId: "w1"))
+        XCTAssertFalse(LiveConsoleReadout.activeIsWhoop(devices: [device("o1", "OURA")], activeId: "o1"))
+    }
+
+    // MARK: - batteryPercent
+
+    func testAWhoopActiveDeviceShowsTheStrapCharge() {
+        XCTAssertEqual(
+            LiveConsoleReadout.batteryPercent(activeIsWhoop: true, whoopPct: 72.4, ringPct: 93), 72)
+    }
+
+    /// ROUNDS, it does not truncate. The surfaces this seam replaced disagreed: Devices and the widget
+    /// rounded, the Live Console truncated. Folding them onto a truncating seam would have quietly moved
+    /// five readouts down by a point, which is the kind of change nobody reports and everyone notices.
+    func testTheChargeIsRoundedNotTruncated() {
+        XCTAssertEqual(LiveConsoleReadout.batteryPercent(activeIsWhoop: true, whoopPct: 72.6, ringPct: nil), 73)
+        XCTAssertEqual(LiveConsoleReadout.batteryPercent(activeIsWhoop: true, whoopPct: 72.4, ringPct: nil), 72)
+        // The exact half goes up, matching Kotlin's Math.round over a positive percentage.
+        XCTAssertEqual(LiveConsoleReadout.batteryPercent(activeIsWhoop: true, whoopPct: 72.5, ringPct: nil), 73)
+        XCTAssertEqual(LiveConsoleReadout.batteryPercent(activeIsWhoop: true, whoopPct: 99.7, ringPct: nil), 100)
+    }
+
+    func testARingActiveDeviceShowsTheRingCharge() {
+        // The reported numbers exactly: ring 93, strap 72.40, console showed 72.
+        XCTAssertEqual(
+            LiveConsoleReadout.batteryPercent(activeIsWhoop: false, whoopPct: 72.4, ringPct: 93), 93)
+    }
+
+    func testARingActiveDeviceNeverFallsBackToTheStrapCharge() {
+        // The heart of it. Nothing is the honest answer; the strap's number under the ring's name is a
+        // confident lie, and is the bug.
+        XCTAssertNil(
+            LiveConsoleReadout.batteryPercent(activeIsWhoop: false, whoopPct: 72.4, ringPct: nil))
+    }
+
+    /// The Devices list asks this PER ROW rather than of the active
+    /// device, which is the stronger question there because the row itself is in hand. Composed here so
+    /// the two halves are pinned together the way the screen actually uses them.
+    /// Calls `SourceIdentity.isWhoop` directly, where the screens call `SourceCoordinator.isWhoop`.
+    /// That wrapper is main-actor isolated, so a synchronous test cannot reach it, and it delegates to
+    /// this verbatim with no logic of its own — so the behaviour under test is the same one.
+    func testARingRowShowsTheRingChargeEvenWhenTheStrapReportedOne() {
+        let ring = device("oura-123", "Oura")
+        let strap = device("my-whoop", "WHOOP")
+        XCTAssertEqual(
+            LiveConsoleReadout.batteryPercent(activeIsWhoop: SourceIdentity.isWhoop(ring),
+                                              whoopPct: 72.4, ringPct: 93), 93)
+        XCTAssertEqual(
+            LiveConsoleReadout.batteryPercent(activeIsWhoop: SourceIdentity.isWhoop(strap),
+                                              whoopPct: 72.4, ringPct: 93), 72)
+    }
+
+    func testAWhoopActiveDeviceIgnoresAnyRingCharge() {
+        // Symmetry: a ring that reported earlier must not leak into a strap's readout either.
+        XCTAssertNil(
+            LiveConsoleReadout.batteryPercent(activeIsWhoop: true, whoopPct: nil, ringPct: 93))
+    }
+}

--- a/StrandiOS/Widgets/WidgetPublish.swift
+++ b/StrandiOS/Widgets/WidgetPublish.swift
@@ -3,6 +3,26 @@ import Foundation
 import WidgetKit
 
 extension WidgetSnapshot {
+    /// The ACTIVE device's charge for the widget (#2075).
+    ///
+    /// `LiveState.batteryPct` is the WHOOP's, and `LiveState` is one object every live source writes
+    /// into, so publishing it unconditionally put the strap's charge on the widget while a ring was the
+    /// active device. Same rule as the Live Console, through the same seam.
+    ///
+    /// `@MainActor` like both publishers that call it: `AppModel.deviceRegistry` and `LiveState` are
+    /// main-actor isolated, so a nonisolated helper cannot read them.
+    @MainActor
+    static func activeBatteryPct(from model: AppModel) -> Int? {
+        LiveConsoleReadout.batteryPercent(
+            activeIsWhoop: LiveConsoleReadout.activeIsWhoop(
+                devices: model.deviceRegistry?.devices ?? [],
+                activeId: model.deviceRegistry?.activeDeviceId,
+            ),
+            whoopPct: model.live.batteryPct,
+            ringPct: model.live.ouraBatteryPct,
+        )
+    }
+
     /// Build a glance snapshot from the live app state and publish it to the shared App Group, then
     /// ask WidgetKit to refresh. Called when the app becomes active and after a Health sync.
     ///
@@ -81,7 +101,7 @@ extension WidgetSnapshot {
         let snap = WidgetSnapshot(
             recovery: day?.recovery.map { Int($0.rounded()) },
             bpm: model.bpm ?? model.live.heartRate,
-            batteryPct: model.live.batteryPct.map { Int($0.rounded()) },
+            batteryPct: activeBatteryPct(from: model),
             bonded: model.live.bonded,
             updated: Date(),
             // Stored 0–100 axis for ring fill; display string carries the #313 scale.
@@ -118,7 +138,7 @@ extension WidgetSnapshot {
         // ONCE per tick instead of loading it again inside saveAndReloadIfChanged.
         let previous = snap
         snap.bpm = model.bpm ?? model.live.heartRate
-        snap.batteryPct = model.live.batteryPct.map { Int($0.rounded()) }
+        snap.batteryPct = Self.activeBatteryPct(from: model)
         snap.bonded = model.live.bonded
         snap.updated = now
         saveAndReloadIfChanged(snap, previous: previous)

--- a/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
+++ b/android/app/src/main/java/com/noop/ble/SourceCoordinator.kt
@@ -146,6 +146,13 @@ class SourceCoordinator(
     private val _ouraWearState = MutableStateFlow<OuraWearState?>(null)
     val ouraWearState: StateFlow<OuraWearState?> = _ouraWearState.asStateFlow()
 
+    /** The RING's own charge while a live Oura source is up, for the Live Console's battery read (#2075).
+     *  Separate from `LiveState.batteryPct`, which is the WHOOP's: one shared LiveState means a bonded
+     *  strap leaves its charge sitting there, and a console that read it while a ring was active
+     *  reported the wrong band's battery under the right band's name. Mirrors [ouraWearState]. */
+    private val _ouraBatteryPct = MutableStateFlow<Int?>(null)
+    val ouraBatteryPct: StateFlow<Int?> = _ouraBatteryPct.asStateFlow()
+
     /** Collects the active Oura source's adoptPhase / needsPairing into the mirrors above; cancelled and
      *  nulled on teardown so a forgotten ring never leaks a stale outcome. */
     private var ouraStateJob: kotlinx.coroutines.Job? = null
@@ -590,6 +597,7 @@ class SourceCoordinator(
             launch { source.adoptPhase.collect { _ouraAdoptPhase.value = it } }
             launch { source.needsPairing.collect { _ouraNeedsPairing.value = it } }
             launch { source.ouraWearState.collect { _ouraWearState.value = it } }
+            launch { source.batteryPct.collect { _ouraBatteryPct.value = it } }   // #2075
         }
         return source
     }
@@ -628,6 +636,7 @@ class SourceCoordinator(
         _ouraAdoptPhase.value = OuraLiveSource.AdoptPhase.Idle
         _ouraNeedsPairing.value = null
         _ouraWearState.value = null   // #628: no live Oura source -> no wear badge
+        _ouraBatteryPct.value = null  // #2075: nor a stale ring charge
         // A stale speed/cadence/power readout must not outlive the strap session (the source's own stop()
         // already pushes an empty SensorMetrics, but reset here too so leaving for WHOOP / FTMS / Huami —
         // none of which feed this flow — is clean and immediate).

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -4154,6 +4154,16 @@ class WhoopBleClient(
     @Volatile
     private var whoopIsActiveDevice = true
 
+    /**
+     * Whether a WHOOP is the ACTIVE device, for readouts that must describe the right band (#2075).
+     *
+     * Read-only view of the flag [setWhoopIsActiveDevice] maintains from the coordinator's own start/stop
+     * closures, which derive it from `SourceIdentity.isWhoop` on the active row. Exposed so a producer on
+     * a hot path can ask without a registry read: the widget push rides a collector driven by live heart
+     * rate, and reading the DB there to answer a battery label would be absurd.
+     */
+    val activeDeviceIsWhoop: Boolean get() = whoopIsActiveDevice
+
     /** The last entry point [whoopConnectAllowed] turned away, so a rotation timer cannot flood the log. */
     private var lastBlockedConnectReason: String? = null
 

--- a/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
@@ -30,6 +30,7 @@ import com.noop.location.GpsSession
 import com.noop.location.LocationTracker
 import com.noop.notif.BatteryAlertNotifier
 import com.noop.notif.IllnessAlertNotifier
+import com.noop.ui.LiveConsoleReadout
 import com.noop.ui.NoopPrefs
 import com.noop.ui.appLaunchIntent
 import com.noop.widget.StressWidgetProducer
@@ -503,7 +504,17 @@ class WhoopConnectionService : Service() {
                             restPct = dayState.widgetRest,
                             effortPct = dayState.widgetEffort,
                             heartRate = state.heartRate,
-                            batteryPct = state.batteryPct?.roundToInt(),
+                            // The ACTIVE device's charge (#2075). This service is the widget's
+                            // HEARTBEAT, so publishing the WHOOP's field here would have overwritten the
+                            // app-side fix within a minute and left the ring showing the strap's charge.
+                            // `activeDeviceIsWhoop` is the coordinator's own flag, so no registry read
+                            // lands on a collector driven by live heart rate.
+                            batteryPct = LiveConsoleReadout.batteryPercent(
+                                activeIsWhoop = ble.activeDeviceIsWhoop,
+                                whoopPct = state.batteryPct,
+                                ringPct = (application as NoopApplication)
+                                    .sourceCoordinator.ouraBatteryPct.value,
+                            ),
                             connected = state.connected,
                             stressSeries = stressCurve?.points ?: emptyList(),
                             stressDay = stressCurve?.epochDay,

--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -186,6 +186,19 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
     private val _activeDeviceName = MutableStateFlow<String?>(null)
     val activeDeviceName: StateFlow<String?> = _activeDeviceName.asStateFlow()
 
+    /** Whether the ACTIVE registry device is a WHOOP (#2075). Published beside the name and refreshed in
+     *  the SAME registry read, so the console can never name one device while reading another's state.
+     *
+     *  For the SCREENS, which need something to recompose on. The widget producers deliberately read
+     *  `WhoopBleClient.activeDeviceIsWhoop` instead: two of them write that one snapshot field, and a
+     *  flow that lags the coordinator's flag would make the widget flicker between the two devices'
+     *  charges. Both derive from `SourceIdentity.isWhoop` on the active row. */
+    private val _activeIsWhoop = MutableStateFlow(true)
+    val activeIsWhoop: StateFlow<Boolean> = _activeIsWhoop.asStateFlow()
+
+    /** The active Oura ring's own charge, for the Live Console (#2075). Mirrors [ouraWearState]. */
+    val ouraBatteryPct: StateFlow<Int?> get() = noopApp.sourceCoordinator.ouraBatteryPct
+
     /** WHOOP-style day streak (#569): consecutive local days that carry a Charge score, computed on
      *  device from the merged daily metrics. A day "qualifies" when its [com.noop.data.DailyMetric] has a
      *  non-null `recovery`. Pure math lives in [com.noop.analytics.StreakCalculator] (Swift/Kotlin twin). */
@@ -239,6 +252,8 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
             val all = runCatching { noopApp.deviceRegistry.all() }.getOrDefault(emptyList())
             val active = all.firstOrNull { it.status == com.noop.data.DeviceStatus.active.name }
             _activeDeviceName.value = active?.let { displayName(it) }
+            // Same read, same row: the name and the "is it a WHOOP" verdict cannot disagree (#2075).
+            _activeIsWhoop.value = LiveConsoleReadout.activeIsWhoop(all, active?.id)
         }
     }
 
@@ -1049,7 +1064,20 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                             restPct = anchorRow?.let { RestScorer.restFromDaily(it)?.roundToInt() },
                             effortPct = anchorRow?.strain?.roundToInt(),
                             heartRate = live.heartRate,
-                            batteryPct = live.batteryPct?.roundToInt(),
+                            // The ACTIVE device's charge (#2075): a ring reports its own and does not
+                            // funnel into live.batteryPct, so publishing that put the strap's number on
+                            // the widget while a ring was active.
+                            //
+                            // Deliberately `ble.activeDeviceIsWhoop` rather than the [activeIsWhoop] flow
+                            // beside it. TWO producers write this one field, this and the BLE service,
+                            // and they must not disagree or the widget would flicker between a strap's
+                            // charge and a ring's. The flow exists for Compose, which needs something to
+                            // recompose on; the producers share the coordinator's flag.
+                            batteryPct = LiveConsoleReadout.batteryPercent(
+                                activeIsWhoop = ble.activeDeviceIsWhoop,
+                                whoopPct = live.batteryPct,
+                                ringPct = noopApp.sourceCoordinator.ouraBatteryPct.value,
+                            ),
                             connected = live.connected,
                             stressSeries = stressCurve?.points ?: emptyList(),
                             stressDay = stressCurve?.epochDay,

--- a/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/DevicesScreen.kt
@@ -121,6 +121,8 @@ fun DevicesScreen(
 ) {
     val scope = rememberCoroutineScope()
     val live by viewModel.live.collectAsStateWithLifecycle()
+    // #2075: a ring reports its OWN charge and does not funnel into live.batteryPct.
+    val ouraBatteryPct by viewModel.ouraBatteryPct.collectAsStateWithLifecycle()
     // #592 extended-battery probe result — non-null (incl. the " waiting" sentinel) shows the result dialog.
     val batteryProbeResult by viewModel.extendedBatteryProbe.collectAsStateWithLifecycle()
     // #690 body-location probe result — same non-null-shows-the-dialog contract.
@@ -249,10 +251,17 @@ fun DevicesScreen(
                 pairingHint = if (device.status == DeviceStatus.active.name) live.pairingHint else null,
                 // Reboot in flight + link currently down → "Reconnecting…" (#166).
                 isReconnecting = device.status == DeviceStatus.active.name && live.rebootInProgress && !live.connected,
-                // The live battery belongs to whichever device is ACTIVE + connected (WHOOP, a generic
-                // strap, or an FTMS machine all funnel into live.batteryPct). null otherwise.
+                // The live battery belongs to whichever device is ACTIVE + connected. A WHOOP, a generic
+                // strap and an FTMS machine all funnel into live.batteryPct, but an Oura ring does NOT: it
+                // reports its own charge, so an active ring row used to draw the strap's stale number under
+                // the ring's name (#2075). Asked PER ROW rather than of the active device, which is the
+                // stronger question and the one this loop can actually answer. null otherwise.
                 liveBatteryPct = if (device.status == DeviceStatus.active.name && live.connected)
-                    live.batteryPct?.let { Math.round(it).toInt() } else null,
+                    LiveConsoleReadout.batteryPercent(
+                        activeIsWhoop = SourceCoordinator.isWhoop(device),
+                        whoopPct = live.batteryPct,
+                        ringPct = ouraBatteryPct,
+                    ) else null,
                 liveBatteryMv = if (device.status == DeviceStatus.active.name && live.connected)
                     live.batteryMv else null,
                 livePackSocPct = if (device.status == DeviceStatus.active.name && live.connected)

--- a/android/app/src/main/java/com/noop/ui/LiveConsoleReadout.kt
+++ b/android/app/src/main/java/com/noop/ui/LiveConsoleReadout.kt
@@ -1,0 +1,53 @@
+package com.noop.ui
+
+import com.noop.ble.SourceIdentity
+import com.noop.data.PairedDeviceRow
+
+/**
+ * What the Live Console should read out, given WHICH device is active.
+ *
+ * [com.noop.ble.LiveState] is one object that every live source writes into, so "is this field
+ * populated" is not the same question as "does this field describe the device on screen". A bonded
+ * WHOOP sitting beside a streaming Oura ring leaves every WHOOP-only field truthful-looking while the
+ * console is naming the ring, which is #2075: the ring's own charge was decoded and held, and the
+ * strap's stale one was what got drawn under the ring's name.
+ *
+ * Pure twin of Swift `LiveConsoleReadout`, so the two consoles cannot answer it differently.
+ */
+object LiveConsoleReadout {
+
+    /**
+     * Whether the ACTIVE registry device is a WHOOP.
+     *
+     * Defaults to true when the registry has not opened or the active row is not resolvable, which is
+     * the WHOOP-first tone the console's device name already takes. Delegates to [SourceIdentity], the
+     * one place that answers this, rather than adding a second spelling of it: that file's own note is
+     * that two spellings which could disagree is how a strap's samples end up filed under a ring.
+     *
+     * That default is load-bearing rather than cosmetic. A WHOOP adopting its serial identity re-keys the
+     * active row mid-session (#1303) without going through the ViewModel's setActive, so the id being
+     * asked about can briefly name a row that no longer exists; answering "WHOOP" there keeps a working
+     * strap's console intact, which is right because the device that just re-keyed IS a WHOOP. It also
+     * means the verdict is exactly as fresh as the device NAME beside it, since both come from the same
+     * registry read: they can go stale together, but they can never disagree, and disagreeing is the bug.
+     */
+    fun activeIsWhoop(devices: List<PairedDeviceRow>, activeId: String?): Boolean {
+        if (activeId == null) return true
+        val active = devices.firstOrNull { it.id == activeId } ?: return true
+        return SourceIdentity.isWhoop(active)
+    }
+
+    /**
+     * The charge to show for the ACTIVE device, or null to show nothing.
+     *
+     * A non-WHOOP active device never falls back to the WHOOP's charge. Showing nothing is the honest
+     * answer when a ring has not reported yet; showing the strap's number would be a confident lie, and
+     * it is the exact shape of the reported bug.
+     */
+    fun batteryPercent(activeIsWhoop: Boolean, whoopPct: Double?, ringPct: Int?): Int? =
+        // ROUNDS, and deliberately. The surfaces this replaced disagreed: Devices and the widget rounded,
+        // the Live Console truncated, so a strap on 72.6% read 73 on one screen and 72 on another. One
+        // seam has to pick, and for a percentage rounding is the accurate one. Math.round is half-up and
+        // Swift's .rounded() is half-away-from-zero, identical over the 0..100 this sees.
+        if (activeIsWhoop) whoopPct?.let { Math.round(it).toInt() } else ringPct
+}

--- a/android/app/src/main/java/com/noop/ui/LiveScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/LiveScreen.kt
@@ -99,6 +99,9 @@ fun LiveScreen(viewModel: AppViewModel, onManageDevices: () -> Unit = {}) {
     // #628: the Oura ring's live wear/charge state (null for WHOOP / before evidence). Preferred by the
     // "Worn" stat below, so removing the ring or putting it on the charger flips it instead of lingering.
     val ouraWear by viewModel.ouraWearState.collectAsStateWithLifecycle()
+    // #2075: the console must read out the ACTIVE device, not whichever LiveState field is populated.
+    val activeIsWhoop by viewModel.activeIsWhoop.collectAsStateWithLifecycle()
+    val ouraBatteryPct by viewModel.ouraBatteryPct.collectAsStateWithLifecycle()
     val bpm by viewModel.bpm.collectAsStateWithLifecycle()
     val selectedModel by viewModel.selectedModel.collectAsStateWithLifecycle()
     // Active band name (MW-6) — names the band whose live data the console shows; falls back to "WHOOP".
@@ -131,7 +134,11 @@ fun LiveScreen(viewModel: AppViewModel, onManageDevices: () -> Unit = {}) {
         if (live.bonded) viewModel.getBattery()
     }
 
-    val activeConnection = live.connected && live.bonded
+    // Gated on the active device actually BEING a WHOOP (#2075). LiveState is one object every live
+    // source writes into, so `connected && bonded` stays true for a bonded strap while an Oura ring is
+    // the device on screen. That showed the WHOOP pill, the WHOOP charge and WHOOP-only controls under
+    // the ring's name, and made the pill's own ring branch unreachable, because this one is tested first.
+    val activeConnection = activeIsWhoop && live.connected && live.bonded
 
     // Live HR zone for the focal readout's colour world (presentation only — same shared HrZones model
     // the live-workout screen uses). 0 = below Zone 1 / no HR yet.
@@ -228,7 +235,8 @@ fun LiveScreen(viewModel: AppViewModel, onManageDevices: () -> Unit = {}) {
         // Console header — the pill + a connection-mode badge (+ a live SYNCING badge during a history
         // offload), with battery / worn / last-sync stats. Mirrors the macOS consoleHeader.
         item {
-        ConsoleHeader(live = live, activeConnection = activeConnection, ouraWear = ouraWear)
+        ConsoleHeader(live = live, activeConnection = activeConnection, ouraWear = ouraWear,
+            activeIsWhoop = activeIsWhoop, ouraBatteryPct = ouraBatteryPct)
         }
 
         // Primary Connect affordance, surfaced ABOVE the fold whenever there's no link — the real
@@ -338,7 +346,8 @@ fun LiveScreen(viewModel: AppViewModel, onManageDevices: () -> Unit = {}) {
 
         // Signal Trust rail — one tile per signal that has to be current for the console to be trusted.
         item {
-        SignalTrustRail(live = live, bpm = bpm, activeConnection = activeConnection)
+        SignalTrustRail(live = live, bpm = bpm, activeConnection = activeConnection,
+            activeIsWhoop = activeIsWhoop, ouraBatteryPct = ouraBatteryPct)
         }
 
         // Max HR + the top-zone entry threshold (read-only; manage coaching in Automations).
@@ -783,7 +792,16 @@ private fun ActiveBandRow(name: String, onManageDevices: () -> Unit) {
 }
 
 @Composable
-private fun ConsoleHeader(live: LiveState, activeConnection: Boolean, ouraWear: OuraWearState? = null) {
+private fun ConsoleHeader(
+    live: LiveState,
+    activeConnection: Boolean,
+    ouraWear: OuraWearState? = null,
+    /** Resolved by the caller (#2075), so the charge below belongs to the device being named.
+     *  NOT defaulted: a default would let a new call site silently fall back to WHOOP state, which is
+     *  precisely the bug this fixes. */
+    activeIsWhoop: Boolean,
+    ouraBatteryPct: Int?,
+) {
     NoopCard(padding = 14.dp) {
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             // Badges row — pill + connection-mode badge + a live SYNCING badge during an offload.
@@ -817,7 +835,11 @@ private fun ConsoleHeader(live: LiveState, activeConnection: Boolean, ouraWear: 
                 // Charging bolt next to the battery % when the strap reports it's charging (PR #568 reimpl).
                 HeaderStat(
                     "Battery",
-                    live.batteryPct?.let { "${it.toInt()}%" } ?: "—",
+                    // The ACTIVE device's charge. A non-WHOOP active device never falls back to the
+                    // strap's number: an em dash says "not reported", where the strap's charge under
+                    // the ring's name is a confident lie, and was the reported bug (#2075).
+                    LiveConsoleReadout.batteryPercent(activeIsWhoop, live.batteryPct, ouraBatteryPct)
+                        ?.let { "$it%" } ?: "—",
                     charging = live.charging == true,
                 )
                 HeaderStat("Worn", wornLabel(live, activeConnection, ouraWear))
@@ -1160,8 +1182,14 @@ private fun LiveProofMetric(modifier: Modifier, label: String, value: String, ti
 // MARK: - Signal Trust rail
 
 @Composable
-private fun SignalTrustRail(live: LiveState, bpm: Int?, activeConnection: Boolean) {
-    val tiles = signalTiles(live, bpm, activeConnection)
+private fun SignalTrustRail(
+    live: LiveState,
+    bpm: Int?,
+    activeConnection: Boolean,
+    activeIsWhoop: Boolean,
+    ouraBatteryPct: Int?,
+) {
+    val tiles = signalTiles(live, bpm, activeConnection, activeIsWhoop, ouraBatteryPct)
     Column(verticalArrangement = Arrangement.spacedBy(Metrics.gap)) {
         SectionHeader(title = uiString(R.string.l10n_live_screen_signal_trust_4a91fe00), overline = "Proof that the console is current")
         // Two tiles per row (a LazyVerticalGrid can't live inside the scrolling ScreenScaffold —
@@ -1185,7 +1213,13 @@ private data class SignalTile(
     val tint: Color,
 )
 
-private fun signalTiles(live: LiveState, bpm: Int?, activeConnection: Boolean): List<SignalTile> = listOf(
+private fun signalTiles(
+    live: LiveState,
+    bpm: Int?,
+    activeConnection: Boolean,
+    activeIsWhoop: Boolean,
+    ouraBatteryPct: Int?,
+): List<SignalTile> = listOf(
     SignalTile(
         "Heart rate",
         bpm?.let { "$it bpm" } ?: "Missing",
@@ -1227,9 +1261,14 @@ private fun signalTiles(live: LiveState, bpm: Int?, activeConnection: Boolean): 
     ),
     SignalTile(
         "Battery",
-        live.batteryPct?.let { "${it.toInt()}%" } ?: "Unknown",
-        if (live.charging == true) "Charging" else "Last reported by strap",
-        batteryTint(live.batteryPct),
+        LiveConsoleReadout.batteryPercent(activeIsWhoop, live.batteryPct, ouraBatteryPct)
+            ?.let { "$it%" } ?: "Unknown",
+        // "by strap" only when a strap is what reported it (#2075).
+        if (live.charging == true) "Charging"
+        else if (activeIsWhoop) "Last reported by strap" else "Last reported by the ring",
+        batteryTint(
+            LiveConsoleReadout.batteryPercent(activeIsWhoop, live.batteryPct, ouraBatteryPct)?.toDouble(),
+        ),
     ),
     // Wear is only trustworthy on a live link: `worn` defaults true and is only updated by
     // WRIST_ON/OFF events, so while OFFLINE it would read a false-green "On wrist". Gate value + tint

--- a/android/app/src/test/java/com/noop/ui/LiveConsoleReadoutTest.kt
+++ b/android/app/src/test/java/com/noop/ui/LiveConsoleReadoutTest.kt
@@ -1,0 +1,112 @@
+package com.noop.ui
+
+import com.noop.ble.SourceIdentity
+import com.noop.data.PairedDeviceRow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #2075: the Live Console must read out the ACTIVE device, not whichever field happens to be populated.
+ *
+ * `LiveState` is one object every live source writes into, so a bonded WHOOP sitting beside a streaming
+ * Oura ring leaves every WHOOP-only field truthful-looking while the console is naming the ring. The
+ * report was a ring on 93% displaying the strap's 72% under "Oura Ring 5", with a WHOOP pairing pill.
+ *
+ * Mirrors Swift `LiveConsoleReadoutTests` case-for-case.
+ */
+class LiveConsoleReadoutTest {
+
+    private fun row(id: String, brand: String) = PairedDeviceRow(
+        id = id, brand = brand, model = "m", nickname = null, peripheralId = null,
+        sourceKind = "liveBLE", capabilities = "hr", status = "active", addedAt = 0L, lastSeenAt = 0L,
+    )
+
+    // MARK: - activeIsWhoop
+
+    @Test
+    fun `an oura active device is not a whoop`() {
+        val rows = listOf(row("my-whoop", "WHOOP"), row("oura-123", "Oura"))
+        assertFalse(LiveConsoleReadout.activeIsWhoop(rows, "oura-123"))
+        assertTrue(LiveConsoleReadout.activeIsWhoop(rows, "my-whoop"))
+    }
+
+    @Test
+    fun `the legacy seeded row is a whoop whatever its brand says`() {
+        // SourceIdentity's rule: the seeded id counts even if the brand column is blank.
+        assertTrue(LiveConsoleReadout.activeIsWhoop(listOf(row("my-whoop", "")), "my-whoop"))
+    }
+
+    @Test
+    fun `an unresolvable active device stays whoop-first`() {
+        // Before the registry opens the console already names WHOOP; the gate must agree rather than
+        // blanking a working strap's readouts on a cold start.
+        assertTrue(LiveConsoleReadout.activeIsWhoop(emptyList(), null))
+        assertTrue(LiveConsoleReadout.activeIsWhoop(emptyList(), "oura-123"))
+    }
+
+    @Test
+    fun `brand matching is case insensitive`() {
+        assertTrue(LiveConsoleReadout.activeIsWhoop(listOf(row("w1", "whoop")), "w1"))
+        assertFalse(LiveConsoleReadout.activeIsWhoop(listOf(row("o1", "OURA")), "o1"))
+    }
+
+    // MARK: - batteryPercent
+
+    @Test
+    fun `a whoop active device shows the strap charge`() {
+        assertEquals(72, LiveConsoleReadout.batteryPercent(true, 72.4, 93))
+    }
+
+    /**
+     * ROUNDS, it does not truncate. The surfaces this seam replaced disagreed: Devices and the widget
+     * rounded, the Live Console truncated. Folding them onto a truncating seam would have quietly moved
+     * five readouts down by a point, which is the kind of change nobody reports and everyone notices.
+     */
+    @Test
+    fun `the charge is rounded, not truncated`() {
+        assertEquals(73, LiveConsoleReadout.batteryPercent(true, 72.6, null))
+        assertEquals(72, LiveConsoleReadout.batteryPercent(true, 72.4, null))
+        // The exact half goes up, matching Swift's half-away-from-zero over a positive percentage.
+        assertEquals(73, LiveConsoleReadout.batteryPercent(true, 72.5, null))
+        assertEquals(100, LiveConsoleReadout.batteryPercent(true, 99.7, null))
+    }
+
+    @Test
+    fun `a ring active device shows the ring charge`() {
+        // The reported numbers exactly: ring 93, strap 72.40, console showed 72.
+        assertEquals(93, LiveConsoleReadout.batteryPercent(false, 72.4, 93))
+    }
+
+    @Test
+    fun `a ring active device never falls back to the strap charge`() {
+        // The heart of it. Nothing is the honest answer; the strap's number under the ring's name is a
+        // confident lie, and is the bug.
+        assertNull(LiveConsoleReadout.batteryPercent(false, 72.4, null))
+    }
+
+    /**
+     * The Devices list asks this PER ROW rather than of the active device, which is the stronger question
+     * there because the row itself is in hand. Composed here so the two halves are pinned together the
+     * way the screen uses them.
+     *
+     * Calls [SourceIdentity.isWhoop] directly, where the screens call `SourceCoordinator.isWhoop`, which
+     * delegates to it verbatim. Kept the same either side so the Swift twin can do likewise: there that
+     * wrapper is main-actor isolated and a synchronous test cannot reach it.
+     */
+    @Test
+    fun `a ring row shows the ring charge even when the strap reported one`() {
+        val ring = row("oura-123", "Oura")
+        val strap = row("my-whoop", "WHOOP")
+        assertEquals(93, LiveConsoleReadout.batteryPercent(SourceIdentity.isWhoop(ring), 72.4, 93))
+        assertEquals(72, LiveConsoleReadout.batteryPercent(SourceIdentity.isWhoop(strap), 72.4, 93))
+    }
+
+    @Test
+    fun `a whoop active device ignores any ring charge`() {
+        // Symmetry: a ring that reported earlier must not leak into a strap's readout either.
+        assertNull(LiveConsoleReadout.batteryPercent(true, null, 93))
+    }
+}


### PR DESCRIPTION
Reported by @rafaelphh with an Oura Ring 5 active beside a WHOOP 5.0. The console named the ring, then showed a WHOOP pairing pill and the strap's battery underneath it. The report is accurate on both counts and the battery comparison localises it exactly: ring 93%, strap 72.40%, console drew 72%.

## One root cause behind both symptoms

`LiveState` is a single object that every live source writes into, so "is this field populated" is not the same question as "does this field describe the device on screen". Nothing in the console asked the second question.

## The pill was a precedence bug, not a missing case

The Oura branch already existed. It was unreachable:

```swift
private var activeConnection: Bool { live.connected && live.bonded }   // pure WHOOP state
...
  (activeConnection && live.encryptedBond) ? "Bonded · streaming"
: activeConnection                         ? "Live HR (not fully paired)"
: ringStreaming                            ? "Streaming"
```

A bonded strap keeps `activeConnection` true, and it is tested first, so an authenticated streaming ring could never reach its own branch. `activeConnection` is now gated on the active device actually being a WHOOP. That also settles the reporter's last point: the bond-only controls (buzz, alarm, HRV snapshot) all key off the same flag, so they stop being live while a ring is active.

Android had the identical ordering in `LiveScreen.kt`, so this was never Apple-only.

## The battery was missing plumbing

The ring's charge was decoded and held in the Oura source but never published, so the console had nothing but the WHOOP field to draw. It now publishes beside `ouraWearState`, which already had exactly this shape.

A non-WHOOP active device **never** falls back to the strap's number. An em dash says "not reported"; the strap's charge under the ring's name is a confident lie, and was the bug. Both battery surfaces are covered on each platform: the header stat and the signal-trust tile, the second of which also stopped claiming "Last reported by strap" regardless of what reported it.

## Shape

The active-device test delegates to `SourceIdentity.isWhoop` rather than adding a second spelling. That file's own note is that two spellings which could disagree is how a strap's samples end up filed under a ring, which is the same class of bug one layer down.

Apple writes ring state straight into `LiveState`; Android routes it through `SourceCoordinator` flows. Each follows the plumbing it already has rather than being forced into one shape. The decision itself is a single pure twin, `LiveConsoleReadout`, with 8 mirrored tests a side covering both halves, including the reported numbers as a literal case.

Apple's console carries **three** copies of the `activeConnection` rule across its leaves, which is part of how this drifted. All three are gated, with the flag resolved once by the parent and passed down, so the 1 Hz R-R leaf keeps observing only `LiveState` and does not start re-rendering on `AppModel`.

## Also cleaned up in passing

The two new Compose parameters are deliberately **not** defaulted. A default would let a future call site silently fall back to WHOOP state, which is the exact bug being fixed; with one call site each, requiring them makes that a compile error instead.

## The same leak reached two more surfaces, now fixed here

Found by auditing the two halves against each other, and both are on **both** platforms.

**The Devices list** attributed `live.batteryPct` to whichever row was ACTIVE, over a comment stating the assumption that broke: *"the WHOOP, a generic strap, or an FTMS machine all funnel into live.batteryPct"*. An Oura ring does not, so an active ring row drew the strap's stale charge under the ring's name. It is asked **per row** there (`SourceIdentity.isWhoop(device)`) rather than of the active device, because the row itself is in hand, which is the stronger question.

**The home-screen widget** published the same field on both platforms, so it showed the strap's charge while a ring was active.

Both matter beyond tidiness. A battery readout exists so someone knows when to charge; the strap's number standing in for a ring is a flat night when the ring is low, on the very screen you would check.

**Checked and deliberately left alone:** the Data Sources pill and Android's onboarding battery. Both sit inside explicitly WHOOP-labelled rows, where WHOOP state is correct.

## The seam rounds, deliberately

The surfaces it replaced disagreed: Devices and the widget **rounded**, the Live Console **truncated**. So a strap on 72.6% read 73 on one screen and 72 on another, and folding them onto a truncating seam would have quietly moved five readouts down by a point. Rounding is the accurate choice for a percentage, and `Math.round` (half-up) and `.rounded()` (half-away-from-zero) agree over the 0 to 100 this sees. All eight surfaces now match.

A test pins it either side with values that can actually distinguish the two: 72.6, 72.4, 72.5 and 99.7. The original cases used 72.4, which rounds and truncates alike, so they would have passed either way.

## Known, flagged rather than fixed

The tile strings in Android's `signalTiles` are bare literals, this change included, because it is not `@Composable` and the i18n audit cannot see inside it. That is pre-existing for the whole tile list ("Missing", "Encrypted", "Partial", and the rest) and is its own piece of work, not something to half-do here.

## Verification

Android, all with `--no-build-cache`: `compileFullDebugKotlin`, `syncRoomSchemaSnapshot` in its own invocation, the full `testFullDebugUnitTest`, `doc_comment_lint.py`, `i18n_audit.py --ci`. New Android tests verified as actually executing, 9 of 9 (the ninth composes the per-row question the Devices list asks).

One new Apple string across all 9 locales, appended rather than sorted. The Apple half is app-target, so it does not compile in this environment and CI is its first real check; `project.yml` globs the `StrandTests` directory, so the new test file is picked up without a project change.

Not exercised on hardware: reproducing it needs both a WHOOP and an Oura ring registered, with the ring active.
