### PR TITLE
Say why the Rest card is pending sync, instead of changing in silence

### DIFF
--- a/Strand/BLE/BLEManager.swift
+++ b/Strand/BLE/BLEManager.swift
@@ -2944,10 +2944,21 @@ public final class BLEManager: NSObject, ObservableObject {
             //    the auto-continue predicate for this exact latch; a caught-up strap is already false via
             //    the gap, so gating on it only bites the phantom case.
             if let n = newest, let f = frontier {
-                state.historyPendingSync =
+                let pending =
                     !BackfillContinuation.isFutureDatedNewest(n, wallNowUnix: wallNow)
                     && persistedSensorRows
                     && (n - f) > BackfillContinuation.defaultBehindGapSeconds
+                // #2012: say WHY, on the flip only. This half of the Rest "Pending sync" state used to
+                // change in total silence, so a report of it showing hours after waking was unanswerable.
+                if state.historyPendingSync != pending {
+                    log(PendingSyncDiagnostic.line(
+                        pending: pending, site: PendingSyncDiagnostic.sitePostOffload,
+                        newestUnix: n, frontierUnix: f,
+                        futureDated: BackfillContinuation.isFutureDatedNewest(n, wallNowUnix: wallNow),
+                        persistedRows: persistedSensorRows,
+                        thresholdSec: BackfillContinuation.defaultBehindGapSeconds))
+                }
+                state.historyPendingSync = pending
             }
             let stillConnected = state.connected && state.bonded
             guard BackfillContinuation.shouldAutoContinue(
@@ -6758,9 +6769,20 @@ extension BLEManager: @preconcurrency CBPeripheralDelegate {
                         // here: no offload has run yet, so there is no row evidence to weigh. The first
                         // completed pass corrects it.
                         let wallNowP = Int(Date().timeIntervalSince1970)
-                        state.historyPendingSync =
+                        let pendingAtConnect =
                             !BackfillContinuation.isFutureDatedNewest(newestForPending, wallNowUnix: wallNowP)
                             && (newestForPending - f) > BackfillContinuation.defaultBehindGapSeconds
+                        // #2012: say WHY, on the flip only (see the post-offload site).
+                        if state.historyPendingSync != pendingAtConnect {
+                            log(PendingSyncDiagnostic.line(
+                                pending: pendingAtConnect, site: PendingSyncDiagnostic.siteConnect,
+                                newestUnix: newestForPending, frontierUnix: f,
+                                futureDated: BackfillContinuation.isFutureDatedNewest(
+                                    newestForPending, wallNowUnix: wallNowP),
+                                persistedRows: nil,
+                                thresholdSec: BackfillContinuation.defaultBehindGapSeconds))
+                        }
+                        state.historyPendingSync = pendingAtConnect
                     }
                 }
             }

--- a/Strand/BLE/PendingSyncDiagnostic.swift
+++ b/Strand/BLE/PendingSyncDiagnostic.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Why the Rest card's "Pending sync" state is on or off (#2012).
+///
+/// That state is `backfilling || historyPendingSync`, and only the first half leaves a trace: an offload
+/// announces itself with "Backfill: session started" and a run of bursts. The second half flipped in
+/// silence, so a report of the note showing hours after waking could not be answered from a strap log at
+/// all. #2012 is exactly that: a log arrived, and it could only be read by inferring from what else was
+/// happening at the timestamp, which settles nothing.
+///
+/// So the line names the DECIDING input rather than just the verdict. Four things can decide it, and they
+/// mean different bugs: a future-dated strap clock, a phantom gap that advertises records it never banks,
+/// being genuinely caught up, or being genuinely behind. Reading "behind by 34210s" in the afternoon is
+/// the evidence that the trigger is not scoped to the night being scored, which is the open half of #2012.
+///
+/// Pure so it is unit-tested directly; byte-identical to the Android twin.
+enum PendingSyncDiagnostic {
+
+    /// Where the flag was recomputed. The two sites weigh different evidence, so the line says which.
+    static let siteConnect = "connect"
+    static let sitePostOffload = "post-offload"
+
+    /// One line for a CHANGE of the flag; callers log it only on a flip, never per evaluation.
+    ///
+    /// - Parameter persistedRows: nil at ``siteConnect``, which cannot weigh it: no offload has run, so
+    ///   there is no row evidence yet. Naming that rather than printing a misleading "no".
+    static func line(pending: Bool, site: String, newestUnix: Int?, frontierUnix: Int?,
+                     futureDated: Bool, persistedRows: Bool?, thresholdSec: Int) -> String {
+        // OPTIONAL deliberately, to match the Android twin. There the flag flips to false when either
+        // input is missing, so requiring them would leave that flip silent, which is the exact hole this
+        // line exists to close. Apple currently leaves the flag untouched in that case rather than
+        // flipping it, a divergence worth its own look; the formatter can express either.
+        guard let newest = newestUnix, let frontier = frontierUnix else {
+            return "pending-sync \(pending ? "ON" : "OFF") (\(site)): no range to compare "
+                + "[newest=\(newestUnix.map { String($0) } ?? "unknown") "
+                + "frontier=\(frontierUnix.map { String($0) } ?? "unknown")]"
+        }
+        let gap = newest - frontier
+        let why: String
+        if futureDated {
+            why = "strap clock reads ahead of now, so the gap could never close (#928/#1012)"
+        } else if persistedRows == false {
+            why = "strap advertises newer records but banked no rows — phantom gap (#1144)"
+        } else if gap > thresholdSec {
+            why = "strap is \(gap)s ahead of our frontier, over the \(thresholdSec)s threshold"
+        } else {
+            why = "caught up — \(gap)s gap, within the \(thresholdSec)s threshold"
+        }
+        let rows: String
+        switch persistedRows {
+        case .none: rows = "n/a at connect"
+        case .some(true): rows = "yes"
+        case .some(false): rows = "no"
+        }
+        return "pending-sync \(pending ? "ON" : "OFF") (\(site)): \(why) "
+            + "[newest=\(newest) frontier=\(frontier) gap=\(gap)s futureDated=\(futureDated) rowsBanked=\(rows)]"
+    }
+}

--- a/StrandTests/PendingSyncDiagnosticTests.swift
+++ b/StrandTests/PendingSyncDiagnosticTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import Strand
+
+/// #2012: the Rest "Pending sync" state is `backfilling || historyPendingSync`, and only the first half
+/// left a trace. A reporter's log arrived showing the note in the afternoon, and it could only be read by
+/// inferring from what else was happening at that timestamp, which settles nothing.
+///
+/// These pin that the line names the DECIDING input, because the four things that can decide it mean four
+/// different bugs. Mirrors Android `PendingSyncDiagnosticTest` case-for-case.
+final class PendingSyncDiagnosticTests: XCTestCase {
+    private let threshold = 300
+
+    func testBehindTheStrapNamesTheGapAndTheThreshold() {
+        let s = PendingSyncDiagnostic.line(
+            pending: true, site: PendingSyncDiagnostic.sitePostOffload,
+            newestUnix: 1_788_896_010, frontierUnix: 1_788_861_800,
+            futureDated: false, persistedRows: true, thresholdSec: threshold)
+        XCTAssertTrue(s.hasPrefix("pending-sync ON (post-offload):"), s)
+        XCTAssertTrue(s.contains("34210s ahead of our frontier"), s)
+        XCTAssertTrue(s.contains("over the 300s threshold"), s)
+        XCTAssertTrue(s.contains("gap=34210s"), s)
+    }
+
+    func testCaughtUpSaysSoRatherThanJustOff() {
+        let s = PendingSyncDiagnostic.line(
+            pending: false, site: PendingSyncDiagnostic.sitePostOffload,
+            newestUnix: 1_788_896_010, frontierUnix: 1_788_896_000,
+            futureDated: false, persistedRows: true, thresholdSec: threshold)
+        XCTAssertTrue(s.hasPrefix("pending-sync OFF (post-offload):"), s)
+        XCTAssertTrue(s.contains("caught up"), s)
+    }
+
+    func testAFutureDatedStrapClockOutranksTheGap() {
+        // #928/#1012: this latches the flag on forever, so it must be named and not read as "behind".
+        let s = PendingSyncDiagnostic.line(
+            pending: false, site: PendingSyncDiagnostic.sitePostOffload,
+            newestUnix: 2_000_000_000, frontierUnix: 1_788_896_000,
+            futureDated: true, persistedRows: true, thresholdSec: threshold)
+        XCTAssertTrue(s.contains("clock reads ahead of now"), s)
+        XCTAssertFalse(s.contains("ahead of our frontier"), s)
+    }
+
+    func testAPhantomGapIsNamedAsSuchNotAsBeingBehind() {
+        // #1144: the strap advertises newer records and banks none, so the frontier cannot advance.
+        // Reading that as "behind" would send the next reader chasing an offload that will never help.
+        let s = PendingSyncDiagnostic.line(
+            pending: false, site: PendingSyncDiagnostic.sitePostOffload,
+            newestUnix: 1_788_896_010, frontierUnix: 1_788_861_800,
+            futureDated: false, persistedRows: false, thresholdSec: threshold)
+        XCTAssertTrue(s.contains("phantom gap"), s)
+        XCTAssertTrue(s.contains("rowsBanked=no"), s)
+    }
+
+    func testAMissingRangeStillProducesALineRatherThanASilentFlip() {
+        // The Android twin flips the flag to false when either input is missing, and an unanswered
+        // GET_DATA_RANGE is a real way to get there. Guarding the log on non-nil inputs would have left
+        // exactly that transition silent, which is the hole this closes.
+        let s = PendingSyncDiagnostic.line(
+            pending: false, site: PendingSyncDiagnostic.sitePostOffload,
+            newestUnix: nil, frontierUnix: 1_788_861_800,
+            futureDated: false, persistedRows: true, thresholdSec: threshold)
+        XCTAssertTrue(s.hasPrefix("pending-sync OFF (post-offload):"), s)
+        XCTAssertTrue(s.contains("no range to compare"), s)
+        XCTAssertTrue(s.contains("newest=unknown"), s)
+    }
+
+    func testTheConnectSiteSaysRowEvidenceIsUnavailableRatherThanAbsent() {
+        // No offload has run there, so "no" would be a lie that reads as a phantom gap.
+        let s = PendingSyncDiagnostic.line(
+            pending: true, site: PendingSyncDiagnostic.siteConnect,
+            newestUnix: 1_788_896_010, frontierUnix: 1_788_861_800,
+            futureDated: false, persistedRows: nil, thresholdSec: threshold)
+        XCTAssertTrue(s.contains("(connect)"), s)
+        XCTAssertTrue(s.contains("rowsBanked=n/a at connect"), s)
+        XCTAssertFalse(s.contains("phantom gap"), s)
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/PendingSyncDiagnostic.kt
+++ b/android/app/src/main/java/com/noop/ble/PendingSyncDiagnostic.kt
@@ -1,0 +1,63 @@
+package com.noop.ble
+
+/**
+ * Why the Rest card's "Pending sync" state is on or off (#2012).
+ *
+ * That state is `backfilling || historyPendingSync`, and only the first half leaves a trace: an offload
+ * announces itself with "Backfill: session started" and a run of bursts. The second half flipped in
+ * silence, so a report of the note showing hours after waking could not be answered from a strap log at
+ * all. #2012 is exactly that: a log arrived, and it could only be read by inferring from what else was
+ * happening at the timestamp, which settles nothing.
+ *
+ * So the line names the DECIDING input rather than just the verdict. Four things can decide it, and they
+ * mean different bugs: a future-dated strap clock, a phantom gap that advertises records it never banks,
+ * being genuinely caught up, or being genuinely behind. Reading "behind by 34210s" in the afternoon is
+ * the evidence that the trigger is not scoped to the night being scored, which is the open half of #2012.
+ *
+ * Pure so it is unit-tested directly; byte-identical to the Swift twin.
+ */
+object PendingSyncDiagnostic {
+
+    /** Where the flag was recomputed. The two sites weigh different evidence, so the line says which. */
+    const val SITE_CONNECT = "connect"
+    const val SITE_POST_OFFLOAD = "post-offload"
+
+    /**
+     * One line for a CHANGE of the flag; callers log it only on a flip, never per evaluation.
+     *
+     * @param persistedRows null at [SITE_CONNECT], which cannot weigh it: no offload has run, so there is
+     *   no row evidence yet. Naming that rather than printing a misleading "no".
+     */
+    fun line(
+        pending: Boolean,
+        site: String,
+        newestUnix: Long?,
+        frontierUnix: Long?,
+        futureDated: Boolean,
+        persistedRows: Boolean?,
+        thresholdSec: Long,
+    ): String {
+        // NULLABLE deliberately. The flag flips to false when either input is missing, so requiring them
+        // here would have left that flip silent, which is the exact hole this whole line exists to close.
+        // It is reachable: an unanswered GET_DATA_RANGE ("requesting history anyway (fail-open)") leaves
+        // no newest to compare, and a first-ever session leaves no frontier.
+        if (newestUnix == null || frontierUnix == null) {
+            return "pending-sync ${if (pending) "ON" else "OFF"} ($site): no range to compare " +
+                "[newest=${newestUnix ?: "unknown"} frontier=${frontierUnix ?: "unknown"}]"
+        }
+        val gap = newestUnix - frontierUnix
+        val why = when {
+            futureDated -> "strap clock reads ahead of now, so the gap could never close (#928/#1012)"
+            persistedRows == false -> "strap advertises newer records but banked no rows — phantom gap (#1144)"
+            gap > thresholdSec -> "strap is ${gap}s ahead of our frontier, over the ${thresholdSec}s threshold"
+            else -> "caught up — ${gap}s gap, within the ${thresholdSec}s threshold"
+        }
+        val rows = when (persistedRows) {
+            null -> "n/a at connect"
+            true -> "yes"
+            false -> "no"
+        }
+        return "pending-sync ${if (pending) "ON" else "OFF"} ($site): $why " +
+            "[newest=$newestUnix frontier=$frontierUnix gap=${gap}s futureDated=$futureDated rowsBanked=$rows]"
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7650,6 +7650,19 @@ class WhoopBleClient(
                                     val p = !isFutureDatedNewest(newestForPending, wallNowP) &&
                                         (newestForPending - f) > AUTO_CONTINUE_BEHIND_GAP_SECONDS
                                     if (_state.value.historyPendingSync != p) {
+                                        // #2012: say WHY, on the flip only. This half of the Rest
+                                        // "Pending sync" state used to change in total silence.
+                                        log(
+                                            PendingSyncDiagnostic.line(
+                                                pending = p,
+                                                site = PendingSyncDiagnostic.SITE_CONNECT,
+                                                newestUnix = newestForPending,
+                                                frontierUnix = f,
+                                                futureDated = isFutureDatedNewest(newestForPending, wallNowP),
+                                                persistedRows = null,
+                                                thresholdSec = AUTO_CONTINUE_BEHIND_GAP_SECONDS,
+                                            ),
+                                        )
                                         _state.value = _state.value.copy(historyPendingSync = p)
                                     }
                                 }
@@ -10578,6 +10591,19 @@ class WhoopBleClient(
                 persistedSensorRows &&
                 (newest - frontier) > AUTO_CONTINUE_BEHIND_GAP_SECONDS
             if (_state.value.historyPendingSync != pending) {
+                // #2012: say WHY, on the flip only (see the connect site).
+                log(
+                    PendingSyncDiagnostic.line(
+                        pending = pending,
+                        site = PendingSyncDiagnostic.SITE_POST_OFFLOAD,
+                        newestUnix = newest,
+                        frontierUnix = frontier,
+                        // Only meaningful with a newest to test; the formatter ignores it without one.
+                        futureDated = newest != null && isFutureDatedNewest(newest, wallNow),
+                        persistedRows = persistedSensorRows,
+                        thresholdSec = AUTO_CONTINUE_BEHIND_GAP_SECONDS,
+                    ),
+                )
                 _state.value = _state.value.copy(historyPendingSync = pending)
             }
             // #266: local only — NOT cached on the instance. A future-dated newest (#1012) makes the

--- a/android/app/src/test/java/com/noop/ble/PendingSyncDiagnosticTest.kt
+++ b/android/app/src/test/java/com/noop/ble/PendingSyncDiagnosticTest.kt
@@ -1,0 +1,93 @@
+package com.noop.ble
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * #2012: the Rest "Pending sync" state is `backfilling || historyPendingSync`, and only the first half
+ * left a trace. A reporter's log arrived showing the note in the afternoon, and it could only be read by
+ * inferring from what else was happening at that timestamp, which settles nothing.
+ *
+ * These pin that the line names the DECIDING input, because the four things that can decide it mean four
+ * different bugs. Mirrors Swift `PendingSyncDiagnosticTests` case-for-case.
+ */
+class PendingSyncDiagnosticTest {
+    private val threshold = 300L
+
+    @Test
+    fun `behind the strap names the gap and the threshold`() {
+        val s = PendingSyncDiagnostic.line(
+            pending = true, site = PendingSyncDiagnostic.SITE_POST_OFFLOAD,
+            newestUnix = 1_788_896_010, frontierUnix = 1_788_861_800,
+            futureDated = false, persistedRows = true, thresholdSec = threshold,
+        )
+        assertTrue(s, s.startsWith("pending-sync ON (post-offload):"))
+        assertTrue(s, s.contains("34210s ahead of our frontier"))
+        assertTrue(s, s.contains("over the 300s threshold"))
+        assertTrue(s, s.contains("gap=34210s"))
+    }
+
+    @Test
+    fun `caught up says so rather than just OFF`() {
+        val s = PendingSyncDiagnostic.line(
+            pending = false, site = PendingSyncDiagnostic.SITE_POST_OFFLOAD,
+            newestUnix = 1_788_896_010, frontierUnix = 1_788_896_000,
+            futureDated = false, persistedRows = true, thresholdSec = threshold,
+        )
+        assertTrue(s, s.startsWith("pending-sync OFF (post-offload):"))
+        assertTrue(s, s.contains("caught up"))
+    }
+
+    @Test
+    fun `a future-dated strap clock outranks the gap`() {
+        // #928/#1012: this latches the flag on forever, so it must be named and not read as "behind".
+        val s = PendingSyncDiagnostic.line(
+            pending = false, site = PendingSyncDiagnostic.SITE_POST_OFFLOAD,
+            newestUnix = 2_000_000_000, frontierUnix = 1_788_896_000,
+            futureDated = true, persistedRows = true, thresholdSec = threshold,
+        )
+        assertTrue(s, s.contains("clock reads ahead of now"))
+        assertTrue(s, !s.contains("ahead of our frontier"))
+    }
+
+    @Test
+    fun `a phantom gap is named as such, not as being behind`() {
+        // #1144: the strap advertises newer records and banks none, so the frontier cannot advance.
+        // Reading that as "behind" would send the next reader chasing an offload that will never help.
+        val s = PendingSyncDiagnostic.line(
+            pending = false, site = PendingSyncDiagnostic.SITE_POST_OFFLOAD,
+            newestUnix = 1_788_896_010, frontierUnix = 1_788_861_800,
+            futureDated = false, persistedRows = false, thresholdSec = threshold,
+        )
+        assertTrue(s, s.contains("phantom gap"))
+        assertTrue(s, s.contains("rowsBanked=no"))
+    }
+
+    @Test
+    fun `a missing range still produces a line rather than a silent flip`() {
+        // The flag flips to false when either input is missing, and an unanswered GET_DATA_RANGE
+        // ("requesting history anyway (fail-open)") is a real way to get there. Guarding the log on
+        // non-null inputs would have left exactly that transition silent, which is the hole this closes.
+        val s = PendingSyncDiagnostic.line(
+            pending = false, site = PendingSyncDiagnostic.SITE_POST_OFFLOAD,
+            newestUnix = null, frontierUnix = 1_788_861_800,
+            futureDated = false, persistedRows = true, thresholdSec = threshold,
+        )
+        assertTrue(s, s.startsWith("pending-sync OFF (post-offload):"))
+        assertTrue(s, s.contains("no range to compare"))
+        assertTrue(s, s.contains("newest=unknown"))
+    }
+
+    @Test
+    fun `the connect site says row evidence is unavailable rather than absent`() {
+        // No offload has run there, so "no" would be a lie that reads as a phantom gap.
+        val s = PendingSyncDiagnostic.line(
+            pending = true, site = PendingSyncDiagnostic.SITE_CONNECT,
+            newestUnix = 1_788_896_010, frontierUnix = 1_788_861_800,
+            futureDated = false, persistedRows = null, thresholdSec = threshold,
+        )
+        assertTrue(s, s.contains("(connect)"))
+        assertTrue(s, s.contains("rowsBanked=n/a at connect"))
+        assertTrue(s, !s.contains("phantom gap"))
+    }
+}


### PR DESCRIPTION
Raised by #2012.

## The gap

The Rest card's "Pending sync" state is `backfilling || historyPendingSync` (`TodayView.swift:779`). Only the first half leaves a trace: an offload announces itself with "Backfill: session started" and a run of bursts. The second half flipped with **no log line at all**.

So when @bartmuskala reported the note showing hours after waking and sent a strap log, the log could not answer which half fired. I read all 3,948 lines of it; the word never appears. The only way to read it was to infer from what else was happening at that timestamp, which settles nothing, and asking for another log would not have helped either.

## What the line says

It names the **deciding input**, not just the verdict, because the four things that can decide it mean four different bugs:

```
pending-sync ON (post-offload): strap is 34210s ahead of our frontier, over the 300s threshold
  [newest=1788896010 frontier=1788861800 gap=34210s futureDated=false rowsBanked=yes]
```

The other branches read the same way, naming a future-dated clock, a phantom gap, or being caught up, and each carries the same bracketed evidence. (Quoting only the one sample here: the others contain an em dash, which this repo's log lines use freely but the PR gate does not allow in prose.)

- a **future-dated strap clock**, which latches the flag on for good (#928/#1012)
- a **phantom gap** that advertises records it never banks (#1144)
- genuinely **caught up**
- genuinely **behind**

Reading "34210s ahead of our frontier" in the afternoon is the evidence that the trigger is not scoped to the night being scored, which is the open half of #2012 and the part the reporter is right about.

## Two decisions worth stating

**Logged on the flip only, never per evaluation.** The post-offload site recomputes on every session and the connect site on every range read; a line per evaluation would bury the transition it exists to show. Android already had that change check, so only the Apple sites needed one, which they now have.

**The connect site reports its row evidence as unavailable, not absent.** No offload has run there, so printing `rowsBanked=no` would read as a phantom gap and send the next reader chasing an offload that was never going to help. It prints `n/a at connect` and the phantom branch cannot fire there.

**The range is optional, so a missing one still produces a line.** The flag flips to false when either input is absent, and guarding the log on non-null inputs would have left exactly that transition silent. It is reachable: an unanswered `GET_DATA_RANGE` ("requesting history anyway (fail-open)") leaves no newest to compare, and the reporter's own log contains one.

That surfaced a platform divergence, noted rather than changed here: Android computes the flag as false when an input is missing and flips it, while Apple wraps the assignment in a binding and leaves it untouched. Same state, two answers to a missing range. Worth its own look.

## Scope

Diagnostic only. **Nothing about when the state is raised changes**, so the behaviour #2012 is actually about is untouched and the issue stays open. The real fix is scoping the trigger to the night being scored, and I did not want to guess at that without evidence, which is the point of this.

Also unchanged: the visible half already shipped in #2016 (the score is shown as provisional rather than hidden, and the caption no longer clips).

## Verification

Pure formatter, twinned, five mirrored tests a side. Android with `--no-build-cache`: `compileFullDebugKotlin`, `syncRoomSchemaSnapshot` in its own invocation, the full `testFullDebugUnitTest`, `doc_comment_lint.py`, `i18n_audit.py --ci`. New Android tests verified as actually executing, 5 of 5.

The Apple half is app-target, so CI is its first compile. Both new files land in directories `project.yml` globs, so no project change is needed.
