### PR TITLE
Make two export headers say what they actually mean

### DIFF
--- a/Strand/System/DebugDataDiagnostics.swift
+++ b/Strand/System/DebugDataDiagnostics.swift
@@ -40,10 +40,29 @@ enum DebugDataDiagnostics {
     /// rides the VALUE. "Provides(48h):" is 15 and overhung the column in a report that is aligned by hand
     /// and read by eye.
     /// Byte-identical to the Kotlin `AndroidDiagnostics.strapProvidesLine`.
-    static func strapProvidesLine(hr: Bool, rr: Bool, motion: Bool, steps: Bool) -> String {
+    static func strapProvidesLine(hr: Bool, rr: Bool, motion: Bool, steps: Bool,
+                                  deviceId: String) -> String {
         func mark(_ b: Bool) -> String { b ? "yes" : "NO" }
+        // The DEVICE rides the value beside the window, for the same reason the window does. This asks
+        // ONE id, the active one, while every scorer reads the union of the active, canonical and
+        // computed ids. Those disagree on a re-added strap, an archived spine, or a Health Connect
+        // import, and the line then reads as "this install has no heart rate" when it means "the active
+        // strap id delivered none". That misreading cost real triage time on #2012.
         return "Provides:    HR \(mark(hr)) · R-R \(mark(rr)) · motion \(mark(motion)) · steps \(mark(steps))"
-            + " (last 48h)"
+            + " (\(deviceId), last 48h)"
+    }
+
+    /// The note that says the funnel did NOT analyse the latest night, and which one it skipped.
+    ///
+    /// The funnel deliberately walks back to the most recent night carrying skin temperature, because a
+    /// night without it reports "skin=0" and teaches nothing. That fallback is right; printing its result
+    /// under a heading that says "latest night" is not. On #2012 it reported a night four days older than
+    /// the export with no indication, and reading it as the latest night is what a careful reader does.
+    ///
+    /// Empty when the funnel really did take the newest session, so the common case stays unchanged.
+    /// Byte-identical to the Kotlin `AndroidDiagnostics.funnelFallbackNote`.
+    static func funnelFallbackNote(chosenDay: String, newestDay: String) -> String {
+        chosenDay == newestDay ? "" : " (NOT the latest night: \(newestDay) carried no skin temperature)"
     }
 
     static func strapStateLines() -> [String] {
@@ -157,7 +176,8 @@ enum DebugDataDiagnostics {
                from: Int(Date().timeIntervalSince1970) - 48 * 3600,
                to: Int(Date().timeIntervalSince1970)) {
             lines.append(strapProvidesLine(hr: present.hr, rr: present.rr,
-                                           motion: present.gravity, steps: present.steps))
+                                           motion: present.gravity, steps: present.steps,
+                                           deviceId: repo.deviceId))
         }
 
         // Data state from the preloaded day spine.
@@ -251,7 +271,10 @@ enum DebugDataDiagnostics {
         let hr = await repo.hrSamples(from: cs.startTs, to: cs.endTs, limit: 200_000)
         let rr = (try? await store.rrIntervals(deviceId: did, from: cs.startTs, to: cs.endTs, limit: 200_000)) ?? []
         let resp = (try? await store.respSamples(deviceId: did, from: cs.startTs, to: cs.endTs, limit: 200_000)) ?? []
-        lines.append("Night \(dayStamp(cs.startTs)): grav=\(grav.count) hr=\(hr.count) rr=\(rr.count) resp=\(resp.count) skin=\(skin.count)")
+        lines.append("Night \(dayStamp(cs.startTs))"
+                     + funnelFallbackNote(chosenDay: dayStamp(cs.startTs),
+                                          newestDay: dayStamp(newest.startTs))
+                     + ": grav=\(grav.count) hr=\(hr.count) rr=\(rr.count) resp=\(resp.count) skin=\(skin.count)")
         if grav.isEmpty && hr.isEmpty {
             // #1617 follow-up: do NOT assert "freshly re-added" without testing the other explanation.
             // Several ids can hold one physical strap's data (#1193/#740), and when the history spine and

--- a/StrandTests/StrapProvidesLineTests.swift
+++ b/StrandTests/StrapProvidesLineTests.swift
@@ -10,23 +10,46 @@ final class StrapProvidesLineTests: XCTestCase {
 
     func testAnUnbondedMGStreamsHeartDataAndNothingElse() {
         XCTAssertEqual(
-            DebugDataDiagnostics.strapProvidesLine(hr: true, rr: true, motion: false, steps: false),
-            "Provides:    HR yes · R-R yes · motion NO · steps NO (last 48h)"
+            DebugDataDiagnostics.strapProvidesLine(hr: true, rr: true, motion: false, steps: false,
+                                                   deviceId: "my-whoop"),
+            "Provides:    HR yes · R-R yes · motion NO · steps NO (my-whoop, last 48h)"
         )
     }
 
     func testAFullySyncedStrapProvidesAllFour() {
         XCTAssertEqual(
-            DebugDataDiagnostics.strapProvidesLine(hr: true, rr: true, motion: true, steps: true),
-            "Provides:    HR yes · R-R yes · motion yes · steps yes (last 48h)"
+            DebugDataDiagnostics.strapProvidesLine(hr: true, rr: true, motion: true, steps: true,
+                                                   deviceId: "my-whoop"),
+            "Provides:    HR yes · R-R yes · motion yes · steps yes (my-whoop, last 48h)"
         )
     }
 
     /// NO is capitalised and yes is not, deliberately: the absences are what the line exists to surface,
     /// and a reader scanning a report should catch them without reading the labels.
     func testAbsenceIsTheHalfThatStandsOut() {
-        let line = DebugDataDiagnostics.strapProvidesLine(hr: true, rr: false, motion: false, steps: true)
+        let line = DebugDataDiagnostics.strapProvidesLine(hr: true, rr: false, motion: false, steps: true,
+                                                       deviceId: "my-whoop")
         XCTAssertEqual(line.components(separatedBy: "NO").count - 1, 2, line)
-        XCTAssertEqual(line, "Provides:    HR yes · R-R NO · motion NO · steps yes (last 48h)")
+        XCTAssertEqual(line, "Provides:    HR yes · R-R NO · motion NO · steps yes (my-whoop, last 48h)")
+    }
+
+    /// #2012: the line asks ONE id, the active one, while every scorer reads the union of the active,
+    /// canonical and computed ids. On a re-added strap or an archived spine those disagree, and the line
+    /// then reads as "this install has no heart rate" when it means "the active strap id delivered none".
+    /// Naming the id is what stops a reader drawing the first conclusion, which cost real triage time.
+    func testTheLineNamesWhoseDataItIsDescribing() {
+        XCTAssertEqual(
+            "Provides:    HR NO · R-R NO · motion NO · steps NO (whoop-5A0FAKE, last 48h)",
+            DebugDataDiagnostics.strapProvidesLine(hr: false, rr: false, motion: false, steps: false,
+                                                   deviceId: "whoop-5A0FAKE"))
+    }
+
+    /// The funnel's heading says "latest night"; when it falls back it has to say so.
+    func testTheFunnelNoteFiresOnlyWhenAnOlderNightWasAnalysed() {
+        XCTAssertEqual("", DebugDataDiagnostics.funnelFallbackNote(chosenDay: "2026-09-09",
+                                                                   newestDay: "2026-09-09"))
+        XCTAssertEqual(
+            " (NOT the latest night: 2026-09-09 carried no skin temperature)",
+            DebugDataDiagnostics.funnelFallbackNote(chosenDay: "2026-09-05", newestDay: "2026-09-09"))
     }
 }

--- a/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/testcentre/AndroidDiagnostics.kt
@@ -74,6 +74,19 @@ object AndroidDiagnostics {
         }
 
     /**
+     * The note that says the funnel did NOT analyse the latest night, and which one it skipped.
+     *
+     * The funnel deliberately walks back to the most recent night carrying skin temperature, because a
+     * night without it reports "skin=0" and teaches nothing. That fallback is right; printing its result
+     * under a heading that says "latest night" is not. On #2012 it reported a night four days older than
+     * the export with no indication, and reading it as the latest night is what a careful reader does.
+     *
+     * Empty when the funnel really did take the newest session, so the common case stays unchanged.
+     */
+    internal fun funnelFallbackNote(chosenDay: String, newestDay: String): String =
+        if (chosenDay == newestDay) "" else " (NOT the latest night: $newestDay carried no skin temperature)"
+
+    /**
      * What the active strap actually delivered over the window — the line that says which scores can
      * exist at all.
      *
@@ -92,10 +105,22 @@ object AndroidDiagnostics {
      * and read by eye.
      * Pure so it is unit-tested directly; byte-identical to the Swift twin.
      */
-    internal fun strapProvidesLine(hr: Boolean, rr: Boolean, motion: Boolean, steps: Boolean): String {
+    internal fun strapProvidesLine(
+        hr: Boolean,
+        rr: Boolean,
+        motion: Boolean,
+        steps: Boolean,
+        deviceId: String,
+    ): String {
         fun mark(b: Boolean) = if (b) "yes" else "NO"
+        // The DEVICE rides the value beside the window, for the same reason the window does. This asks
+        // ONE id, the active one, while every scorer reads the union of the active, canonical and
+        // computed ids. Those disagree on a re-added strap, an archived spine, or a Health Connect
+        // import, and the line then reads as "this install has no heart rate" when it means "the active
+        // strap id delivered none". That misreading cost real triage time on #2012, where the header
+        // said HR NO while the same export scored a day off 28,141 samples read through the union.
         return "Provides:    HR ${mark(hr)} · R-R ${mark(rr)} · motion ${mark(motion)} · steps ${mark(steps)}" +
-            " (last 48h)"
+            " ($deviceId, last 48h)"
     }
 
     /**
@@ -196,7 +221,7 @@ object AndroidDiagnostics {
                 val nowSec = now / 1000L
                 val present = com.noop.data.WhoopRepository.from(context)
                     .streamPresence(activeId, nowSec - 48L * 3600L, nowSec)
-                add(strapProvidesLine(present.hr, present.rr, present.gravity, present.steps))
+                add(strapProvidesLine(present.hr, present.rr, present.gravity, present.steps, activeId))
             }
             // #1735: row COUNTS alone cannot separate "Health Connect never brought the ride in" from
             // "it did, but nothing has re-scored since". Both halves of that need a WHEN, and neither had
@@ -278,7 +303,8 @@ object AndroidDiagnostics {
                 add("(no sleep session in the last 14 days to analyze)")
                 return@runCatching
             }
-            var session = recent.last()   // non-null (list checked non-empty), newest by ASC start order
+            val newestSession = recent.last()   // non-null (list checked non-empty), newest by ASC start
+            var session = newestSession
             var skin = repo.skinTempSamples(id, session.startTs, session.endTs, Int.MAX_VALUE)
             if (skin.isEmpty()) {
                 for (s in recent.asReversed()) {
@@ -290,7 +316,11 @@ object AndroidDiagnostics {
             val hr = repo.hrSamplesForDevice(id, session.startTs, session.endTs, Int.MAX_VALUE)
             val rr = repo.rrIntervalsForDevice(id, session.startTs, session.endTs, Int.MAX_VALUE)
             val resp = repo.respSamples(id, session.startTs, session.endTs, Int.MAX_VALUE)
-            add("Night ${dayStamp(session.startTs)}: grav=${grav.size} hr=${hr.size} rr=${rr.size} resp=${resp.size} skin=${skin.size}")
+            add(
+                "Night ${dayStamp(session.startTs)}" +
+                    funnelFallbackNote(dayStamp(session.startTs), dayStamp(newestSession.startTs)) +
+                    ": grav=${grav.size} hr=${hr.size} rr=${rr.size} resp=${resp.size} skin=${skin.size}",
+            )
             if (grav.isEmpty() && hr.isEmpty()) {
                 // #1617 follow-up: do NOT assert "freshly re-added" without testing the other explanation.
                 // Several ids can hold one physical strap's data (#1193/#740), and when the history spine

--- a/android/app/src/test/java/com/noop/testcentre/StrapProvidesLineTest.kt
+++ b/android/app/src/test/java/com/noop/testcentre/StrapProvidesLineTest.kt
@@ -17,16 +17,20 @@ class StrapProvidesLineTest {
     @Test
     fun `an unbonded 5MG streams heart data and nothing else`() {
         assertEquals(
-            "Provides:    HR yes · R-R yes · motion NO · steps NO (last 48h)",
-            AndroidDiagnostics.strapProvidesLine(hr = true, rr = true, motion = false, steps = false),
+            "Provides:    HR yes · R-R yes · motion NO · steps NO (my-whoop, last 48h)",
+            AndroidDiagnostics.strapProvidesLine(
+                hr = true, rr = true, motion = false, steps = false, deviceId = "my-whoop",
+            ),
         )
     }
 
     @Test
     fun `a fully synced strap provides all four`() {
         assertEquals(
-            "Provides:    HR yes · R-R yes · motion yes · steps yes (last 48h)",
-            AndroidDiagnostics.strapProvidesLine(hr = true, rr = true, motion = true, steps = true),
+            "Provides:    HR yes · R-R yes · motion yes · steps yes (my-whoop, last 48h)",
+            AndroidDiagnostics.strapProvidesLine(
+                hr = true, rr = true, motion = true, steps = true, deviceId = "my-whoop",
+            ),
         )
     }
 
@@ -36,8 +40,34 @@ class StrapProvidesLineTest {
      */
     @Test
     fun `absence is the half that stands out`() {
-        val line = AndroidDiagnostics.strapProvidesLine(hr = true, rr = false, motion = false, steps = true)
+        val line = AndroidDiagnostics.strapProvidesLine(
+            hr = true, rr = false, motion = false, steps = true, deviceId = "my-whoop",
+        )
         assertEquals(2, Regex("NO").findAll(line).count())
-        assertEquals("Provides:    HR yes · R-R NO · motion NO · steps yes (last 48h)", line)
+        assertEquals("Provides:    HR yes · R-R NO · motion NO · steps yes (my-whoop, last 48h)", line)
+    }
+
+    /**
+     * #2012: the line asks ONE id, the active one, while every scorer reads the union of the active,
+     * canonical and computed ids. On a re-added strap or an archived spine those disagree, and the line
+     * then reads as "this install has no heart rate" when it means "the active strap id delivered none".
+     * Naming the id is what stops a reader drawing the first conclusion, which cost real triage time.
+     */
+    @Test
+    fun `the line names whose data it is describing`() {
+        val line = AndroidDiagnostics.strapProvidesLine(
+            hr = false, rr = false, motion = false, steps = false, deviceId = "whoop-5A0FAKE",
+        )
+        assertEquals("Provides:    HR NO · R-R NO · motion NO · steps NO (whoop-5A0FAKE, last 48h)", line)
+    }
+
+    /** The funnel's heading says "latest night"; when it falls back it has to say so. */
+    @Test
+    fun `the funnel note fires only when an older night was analysed`() {
+        assertEquals("", AndroidDiagnostics.funnelFallbackNote("2026-09-09", "2026-09-09"))
+        assertEquals(
+            " (NOT the latest night: 2026-09-09 carried no skin temperature)",
+            AndroidDiagnostics.funnelFallbackNote("2026-09-05", "2026-09-09"),
+        )
     }
 }


### PR DESCRIPTION
Both of these cost real triage time on #2012, and they are the same fault: a header that states less than it means, in a report read by eye.

## 1. `Provides:` did not say whose data it was describing

It asks **one** id, the active one:

```sql
EXISTS(SELECT 1 FROM hrSample WHERE deviceId = :deviceId AND ts >= :from AND ts <= :to) AS hr
```

while every scorer reads `hrSamplesUnion` (active + canonical + computed). Those disagree on a re-added strap, an archived spine, or a Health Connect import.

In the #2012 export the line said `HR NO · R-R NO (last 48h)` while the same file scored a day off **28,141** HR samples read through the union. Both statements were correct; the header just invited the wrong conclusion, and I drew it myself before checking the query. It now names the id it asked.

## 2. "Analytics funnels (latest night)" could silently report an older night

The funnel deliberately walks back to the most recent night carrying skin temperature:

```kotlin
if (skin.isEmpty()) { for (s in recent.asReversed()) { … session = s; skin = sk; break } }
```

That fallback is right: a night without skin temp reports `skin=0` and teaches nothing. Printing its result under a heading that says "latest night" is not. The #2012 export analysed `Night 2026-09-05` in a log taken on **09-09** with no indication, so a reader reasonably concludes the latest night is four days stale.

It now says which night it actually took and which it skipped.

## Scope

Neither changes what is measured, only what the reader is told. Both notes are empty or unchanged in the common case, so a healthy export reads exactly as before.

This does **not** address the open half of #2012 (the pending-sync trigger not being scoped to the night being scored) or the diagnostic for it, which is #2077.

## Also found, filed separately

The same export shows `sleep-detect day=2026-09-06 NO-NIGHT hr=88654 rr=61667 grav=88582 skin=88582 reason=staged-none` which is a fully-worn night that staged nothing, while the nights either side staged fine. That is a candidate scoring bug rather than a diagnostics one, and change 2 above is part of what would make it visible in a future export.

## Verification

Pure helpers, twinned, byte-identical strings pinned on both sides. The three existing `strapProvidesLine` pins were **repinned to the same shape** rather than deleted, since they were guarding the old format on purpose.

Android with `--no-build-cache`: `compileFullDebugKotlin`, `syncRoomSchemaSnapshot` in its own invocation, the full `testFullDebugUnitTest`, `doc_comment_lint.py`, `i18n_audit.py --ci`. Tests verified as actually executing, 5 of 5 in the changed class.

The Apple half is app-target, so CI is its first compile.
