### PR TITLE
Break the heart rate line where the strap recorded nothing, on every surface that draws one

### DIFF
--- a/Packages/StrandDesign/Sources/StrandDesign/TrendChart.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/TrendChart.swift
@@ -12,19 +12,6 @@ import Charts
 // score), but any gradient + value-range can be supplied — pass the blue sleep
 // ramp for sleep, the teal HRV scale for HRV, the amber strain ramp for strain.
 
-/// One point on a trend line.
-/// Segment ids for a bucketed time series, changing wherever the series SKIPS a bucket.
-///
-/// A bucket aggregate only emits rows for buckets that had samples, so an hour the strap was off simply
-/// is not in the list. Without this the line joins the two neighbours across that hour and draws a
-/// steady climb the wearer never had, which is a reading invented out of an absence. Handing these to
-/// `TrendPoint.segment` renders the two sides as separate lines, so a gap looks like a gap.
-///
-/// A step of exactly one bucket is contiguous. Anything longer means at least one bucket held nothing,
-/// and that is the break. No tolerance for "just one missing": a five-minute hole is still five minutes
-/// of invention, and the stress trace made the same call when it stopped drawing through unscored hours.
-///
-/// Byte-identical twin of the Kotlin `hrGapSegmentIds`.
 /// The index runs that `hrGapSegments` implies: one range per unbroken stretch, in order.
 ///
 /// Charts can hand a segment id to the plotting library and let it split the line. A hand-drawn sparkline
@@ -45,6 +32,18 @@ public func hrGapRuns(segments: [String]) -> [ClosedRange<Int>] {
     return runs
 }
 
+/// Segment ids for a bucketed time series, changing wherever the series SKIPS a bucket.
+///
+/// A bucket aggregate only emits rows for buckets that had samples, so an hour the strap was off simply
+/// is not in the list. Without this the line joins the two neighbours across that hour and draws a
+/// steady climb the wearer never had, which is a reading invented out of an absence. Handing these to
+/// `TrendPoint.segment` renders the two sides as separate lines, so a gap looks like a gap.
+///
+/// A step of exactly one bucket is contiguous. Anything longer means at least one bucket held nothing,
+/// and that is the break. No tolerance for "just one missing": a five-minute hole is still five minutes
+/// of invention, and the stress trace made the same call when it stopped drawing through unscored hours.
+///
+/// Byte-identical twin of the Kotlin `hrGapSegmentIds`.
 public func hrGapSegments(bucketTs: [Int], bucketSeconds: Int) -> [String] {
     var segment = 0
     return bucketTs.enumerated().map { i, ts in
@@ -53,6 +52,7 @@ public func hrGapSegments(bucketTs: [Int], bucketSeconds: Int) -> [String] {
     }
 }
 
+/// One point on a trend line.
 public struct TrendPoint: Identifiable, Sendable {
     public var date: Date
     public var value: Double

--- a/Packages/StrandDesign/Sources/StrandDesign/TrendChart.swift
+++ b/Packages/StrandDesign/Sources/StrandDesign/TrendChart.swift
@@ -25,6 +25,26 @@ import Charts
 /// of invention, and the stress trace made the same call when it stopped drawing through unscored hours.
 ///
 /// Byte-identical twin of the Kotlin `hrGapSegmentIds`.
+/// The index runs that `hrGapSegments` implies: one range per unbroken stretch, in order.
+///
+/// Charts can hand a segment id to the plotting library and let it split the line. A hand-drawn sparkline
+/// cannot, so it needs the runs themselves to know where to lift the pen. Same rule, same source of truth,
+/// rather than a second walk that could disagree with the first (#2082).
+///
+/// An empty input yields no runs. A run of one is still a run: a lone bucket between two gaps is real data
+/// and a caller that drops it would be hiding a reading rather than a gap.
+public func hrGapRuns(segments: [String]) -> [ClosedRange<Int>] {
+    guard !segments.isEmpty else { return [] }
+    var runs: [ClosedRange<Int>] = []
+    var start = 0
+    for i in 1..<segments.count where segments[i] != segments[i - 1] {
+        runs.append(start...(i - 1))
+        start = i
+    }
+    runs.append(start...(segments.count - 1))
+    return runs
+}
+
 public func hrGapSegments(bucketTs: [Int], bucketSeconds: Int) -> [String] {
     var segment = 0
     return bucketTs.enumerated().map { i, ts in

--- a/Packages/StrandDesign/Tests/StrandDesignTests/HrGapRunsTests.swift
+++ b/Packages/StrandDesign/Tests/StrandDesignTests/HrGapRunsTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import StrandDesign
+
+/// #2082: the default Liquid Today sparkline draws its points evenly by index and strokes one continuous
+/// path, so hours the strap recorded nothing close up silently and sparse readings look continuous.
+///
+/// A chart can hand a segment id to the plotting library; a hand-drawn sparkline has to know where to lift
+/// the pen. These pin that the runs follow the SAME rule `hrGapSegments` already applies, rather than a
+/// second walk that could disagree with it.
+final class HrGapRunsTests: XCTestCase {
+
+    func testAContiguousSeriesIsOneRun() {
+        let segs = hrGapSegments(bucketTs: [0, 300, 600, 900], bucketSeconds: 300)
+        XCTAssertEqual(hrGapRuns(segments: segs), [0...3])
+    }
+
+    func testAGapSplitsTheRunWhereTheDataStops() {
+        // 0,300 then a three-hour hole, then two more buckets.
+        let segs = hrGapSegments(bucketTs: [0, 300, 11_100, 11_400], bucketSeconds: 300)
+        XCTAssertEqual(hrGapRuns(segments: segs), [0...1, 2...3])
+    }
+
+    func testALoneBucketBetweenTwoGapsIsStillARun() {
+        // Dropping it would hide a real reading rather than a gap, which is the opposite of the point.
+        let segs = hrGapSegments(bucketTs: [0, 7_200, 14_400], bucketSeconds: 300)
+        XCTAssertEqual(hrGapRuns(segments: segs), [0...0, 1...1, 2...2])
+    }
+
+    func testEmptyInputYieldsNoRuns() {
+        XCTAssertEqual(hrGapRuns(segments: []), [])
+    }
+
+    func testASingleBucketIsOneRunOfOne() {
+        XCTAssertEqual(hrGapRuns(segments: hrGapSegments(bucketTs: [0], bucketSeconds: 300)), [0...0])
+    }
+
+    /// The runs must tile the input exactly: every index in exactly one run, in order. A sparkline that
+    /// silently dropped or repeated a bucket would be a worse lie than the one this removes.
+    func testTheRunsTileTheSeriesExactly() {
+        let segs = hrGapSegments(bucketTs: [0, 300, 5_000, 5_300, 5_600, 90_000], bucketSeconds: 300)
+        let runs = hrGapRuns(segments: segs)
+        XCTAssertEqual(runs.flatMap { Array($0) }, Array(0..<segs.count))
+    }
+}

--- a/Strand/Liquid/LiquidPrimitives.swift
+++ b/Strand/Liquid/LiquidPrimitives.swift
@@ -221,10 +221,16 @@ enum LiquidRender {
             return p
         }
         var ctx = base
-        ctx.stroke(curve(), with: .color(tint.opacity(0.9)), style: StrokeStyle(lineWidth: 2.4, lineCap: .round, lineJoin: .round))
-        // travelling glint
+        // Built ONCE. The glint strokes the same geometry as the line under it, and this runs inside a
+        // 60fps TimelineView, so building it per stroke walked the whole series twice a frame for two
+        // identical paths.
+        let line = curve()
+        ctx.stroke(line, with: .color(tint.opacity(0.9)), style: StrokeStyle(lineWidth: 2.4, lineCap: .round, lineJoin: .round))
+        // Travelling glint. The dash pattern restarts at each subpath, so a day broken into several runs
+        // shows a tick per run rather than one glint travelling the whole line. Cosmetic, and the honest
+        // alternative (one glint walking across gaps) would re-assert the continuity this change removes.
         let phase = -(now * 55).truncatingRemainder(dividingBy: 414)
-        ctx.stroke(curve(), with: .color(.white.opacity(0.55)),
+        ctx.stroke(line, with: .color(.white.opacity(0.55)),
                    style: StrokeStyle(lineWidth: 1.1, lineCap: .round, dash: [14, 400], dashPhase: phase))
         // endpoint pulse
         let ex = px(n - 1), ey = py(values[n - 1])

--- a/Strand/Liquid/LiquidPrimitives.swift
+++ b/Strand/Liquid/LiquidPrimitives.swift
@@ -176,7 +176,12 @@ enum LiquidRender {
     }
 
     /// The live heart-rate curve as a glowing liquid thread with a travelling glint.
-    static func thread(_ base: GraphicsContext, _ size: CGSize, values: [Double], now: Double, tint: Color) {
+    /// - Parameter segments: per-value line identity from `hrGapSegments`, or nil for a series known to be
+    ///   contiguous. Values whose ids differ are stroked as SEPARATE subpaths, so a stretch the strap never
+    ///   recorded reads as a break instead of a straight climb across it (#2082). Nil produces byte-for-byte
+    ///   the path this drew before, which is what keeps the live 1 Hz stream untouched.
+    static func thread(_ base: GraphicsContext, _ size: CGSize, values: [Double], now: Double, tint: Color,
+                       segments: [String]? = nil) {
         guard values.count >= 2 else { return }
         let w = size.width, h = size.height, pad: Double = 10
         var mn = Double.greatestFiniteMagnitude, mx = -Double.greatestFiniteMagnitude
@@ -185,14 +190,28 @@ enum LiquidRender {
         let n = values.count
         func px(_ i: Int) -> Double { pad + Double(i) * (w - 2 * pad) / Double(n - 1) }
         func py(_ v: Double) -> Double { h - pad - (v - mn) / span * (h - 2 * pad) }
-        func curve() -> Path {
-            var p = Path()
-            p.move(to: CGPoint(x: px(0), y: py(values[0])))
-            for i in 1..<(n - 1) {
+        func appendRun(_ p: inout Path, _ lo: Int, _ hi: Int) {
+            // A lone bucket between two gaps is real data. A bare `move` strokes nothing, so give the round
+            // cap a zero-length line to draw: without it an isolated reading would silently vanish, which
+            // is the same class of lie as the joined line this change removes.
+            guard hi > lo else {
+                p.move(to: CGPoint(x: px(lo), y: py(values[lo])))
+                p.addLine(to: CGPoint(x: px(lo), y: py(values[lo])))
+                return
+            }
+            p.move(to: CGPoint(x: px(lo), y: py(values[lo])))
+            for i in (lo + 1)..<hi {
                 let xc = (px(i) + px(i + 1)) / 2, yc = (py(values[i]) + py(values[i + 1])) / 2
                 p.addQuadCurve(to: CGPoint(x: xc, y: yc), control: CGPoint(x: px(i), y: py(values[i])))
             }
-            p.addLine(to: CGPoint(x: px(n - 1), y: py(values[n - 1])))
+            p.addLine(to: CGPoint(x: px(hi), y: py(values[hi])))
+        }
+        func curve() -> Path {
+            var p = Path()
+            // One run when nothing says otherwise, and that run is the exact path this drew before.
+            var runs: [ClosedRange<Int>] = [0...(n - 1)]
+            if let segs = segments, segs.count == n { runs = hrGapRuns(segments: segs) }
+            for r in runs { appendRun(&p, r.lowerBound, r.upperBound) }
             return p
         }
         var ctx = base
@@ -341,6 +360,10 @@ struct LiquidTube: View {
 /// The live heart-rate thread. `bpm` is the recent series (any length ≥ 2).
 struct LiquidThread: View {
     let bpm: [Double]
+    /// Per-value line identity from `hrGapSegments`, or nil for a series known to be contiguous (#2082).
+    /// The live 1 Hz stream passes nil and is drawn exactly as before; the banked 5-minute fallback passes
+    /// ids so the hours a strap recorded nothing read as breaks rather than a climb across them.
+    var segments: [String]? = nil
     var tint: Color = Color(.sRGB, red: 1, green: 107/255, blue: 129/255, opacity: 1)
     var height: CGFloat = 96
     var animated: Bool = true
@@ -356,7 +379,7 @@ struct LiquidThread: View {
         TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { tl in   // 60fps to flow smoothly on ProMotion
             let now = liquidSeconds(tl.date)
             Canvas { context, size in
-                LiquidRender.thread(context, size, values: bpm, now: now, tint: tint)
+                LiquidRender.thread(context, size, values: bpm, now: now, tint: tint, segments: segments)
             }
         }
         .frame(height: height)
@@ -365,7 +388,7 @@ struct LiquidThread: View {
     /// One-shot render (no travelling glint / pulse) — used until first data load settles.
     private var staticThread: some View {
         Canvas { context, size in
-            LiquidRender.thread(context, size, values: bpm, now: 0, tint: tint)
+            LiquidRender.thread(context, size, values: bpm, now: 0, tint: tint, segments: segments)
         }
         .frame(height: height)
     }

--- a/Strand/Liquid/LiquidPrimitives.swift
+++ b/Strand/Liquid/LiquidPrimitives.swift
@@ -191,12 +191,15 @@ enum LiquidRender {
         func px(_ i: Int) -> Double { pad + Double(i) * (w - 2 * pad) / Double(n - 1) }
         func py(_ v: Double) -> Double { h - pad - (v - mn) / span * (h - 2 * pad) }
         func appendRun(_ p: inout Path, _ lo: Int, _ hi: Int) {
-            // A lone bucket between two gaps is real data. A bare `move` strokes nothing, so give the round
-            // cap a zero-length line to draw: without it an isolated reading would silently vanish, which
-            // is the same class of lie as the joined line this change removes.
+            // A lone bucket between two gaps is real data, and it has to draw as something. A bare `move`
+            // strokes nothing at all, and a ZERO-length line is at the mercy of whether the renderer keeps
+            // a degenerate subpath alive for its round cap. Give it a hair of width instead, so the cap has
+            // something to round and the reading is a dot rather than a coin flip. Losing it would be the
+            // same class of lie as the joined line this change removes: data on screen that is not there.
             guard hi > lo else {
-                p.move(to: CGPoint(x: px(lo), y: py(values[lo])))
-                p.addLine(to: CGPoint(x: px(lo), y: py(values[lo])))
+                let x = px(lo), y = py(values[lo])
+                p.move(to: CGPoint(x: x - 0.6, y: y))
+                p.addLine(to: CGPoint(x: x + 0.6, y: y))
                 return
             }
             p.move(to: CGPoint(x: px(lo), y: py(values[lo])))
@@ -206,11 +209,14 @@ enum LiquidRender {
             }
             p.addLine(to: CGPoint(x: px(hi), y: py(values[hi])))
         }
+        // Resolved ONCE, outside `curve()`. That closure is called twice per frame and this runs inside a
+        // 60fps TimelineView, so leaving the walk in there re-split the whole series 120 times a second for
+        // an answer that cannot change between strokes.
+        // One run when nothing says otherwise, and that run is the exact path this drew before.
+        var runs: [ClosedRange<Int>] = [0...(n - 1)]
+        if let segs = segments, segs.count == n { runs = hrGapRuns(segments: segs) }
         func curve() -> Path {
             var p = Path()
-            // One run when nothing says otherwise, and that run is the exact path this drew before.
-            var runs: [ClosedRange<Int>] = [0...(n - 1)]
-            if let segs = segments, segs.count == n { runs = hrGapRuns(segments: segs) }
             for r in runs { appendRun(&p, r.lowerBound, r.upperBound) }
             return p
         }

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -65,6 +65,12 @@ struct LiquidTodayView: View {
     @State private var importedStepsDay: Int?      // Apple Health steps for the selected day (middle tier)
     @State private var importedActiveKcalDay: Double?  // #616: Apple Health active energy for the day (calorie fallback)
     @State private var hrValues: [Double] = []     // hrBuckets since midnight → 5-min means
+    /// Line identity for [hrValues], from the bucket timestamps this used to discard (#2082).
+    ///
+    /// A bucket with no samples is simply absent from the aggregate, so mapping straight to `bpm` closed
+    /// every hole up and drew a day of sparse live windows as one continuous line. That bites hardest on a
+    /// strap whose history never offloads, where heart rate exists ONLY for the windows it was connected.
+    @State private var hrSegments: [String] = []
     @State private var workouts: [WorkoutRow] = [] // newest-first
     /// #today-hosted-cards: the shared SleepModel that backs every SleepModel-derived hosted sleep card
     /// (Stages vs typical today; more to follow). Built ONCE in `load()` from the SAME inputs the Sleep tab
@@ -710,7 +716,8 @@ struct LiquidTodayView: View {
                     // Isolated leaf: it observes LiveState so the ~1 Hz HR notifies re-render ONLY
                     // this card, never the whole Today. Shows the current bpm live with a rolling
                     // beat-by-beat trace; falls back to today's banked 5-minute trace when idle.
-                    LiquidLiveHR(tint: liquidHeart, fallback: hrValues, animated: dataLoaded)
+                    LiquidLiveHR(tint: liquidHeart, fallback: hrValues, fallbackSegments: hrSegments,
+                                 animated: dataLoaded)
                 }
             }
             .buttonStyle(LiquidPressStyle())
@@ -1740,7 +1747,11 @@ struct LiquidTodayView: View {
         // #616: same-day imported active energy — the calorie fallback when the strap banked no on-device
         // HR estimate for the day, so the tile/card/detail agree (imported-first, mirrors steps).
         importedActiveKcalDay = (await appleA).filter { $0.day == selectedDayKey }.compactMap { $0.activeKcal }.max()
-        hrValues = (await hrA).map { $0.bpm }
+        // Awaited ONCE: the timestamps and the means have to come from the same read, or the segments
+        // would describe a different series than the one drawn.
+        let hrBuckets = await hrA
+        hrValues = hrBuckets.map { $0.bpm }
+        hrSegments = hrGapSegments(bucketTs: hrBuckets.map { $0.ts }, bucketSeconds: 300)
         workouts = (await wkA).filter { $0.startTs >= from && $0.startTs < to }
 
         let (chargeSource, effortSource, restSource) = await (chargeSourceA, effortSourceA, restSourceA)
@@ -2336,6 +2347,10 @@ private struct LiquidFullWidthNavigationAction: View {
 private struct LiquidLiveHR: View {
     var tint: Color
     var fallback: [Double]        // today's banked 5-minute buckets — shown when there's no live stream
+    /// Line identity for [fallback] only (#2082). The live series is 1 Hz and contiguous by construction,
+    /// so it passes nil and draws exactly as before; the banked buckets skip the hours nothing was
+    /// recorded, and without this the sparkline joined across them as though the day were continuous.
+    var fallbackSegments: [String] = []
     var animated: Bool
 
     @EnvironmentObject private var live: LiveState
@@ -2397,7 +2412,10 @@ private struct LiquidLiveHR: View {
             if series.count >= 2 {
                 ZStack {
                     LiquidHeartRateGrid()
-                    LiquidThread(bpm: series, tint: tint, height: 92, animated: animated)
+                    LiquidThread(bpm: series,
+                                 segments: isLive ? nil : (fallbackSegments.count == series.count
+                                                           ? fallbackSegments : nil),
+                                 tint: tint, height: 92, animated: animated)
                 }
                 .frame(height: 92)
                 .clipShape(RoundedRectangle(cornerRadius: NoopMetrics.space2, style: .continuous))

--- a/StrandTests/HrTraceTests.swift
+++ b/StrandTests/HrTraceTests.swift
@@ -185,7 +185,8 @@ final class HrTraceTests: XCTestCase {
     /// recorded nothing in between, so the pen lifts. x is mapped by time, so the gap already occupied
     /// its true width on screen; the line drawn across it was the invented part.
     func testAGapSplitsTheTraceIntoRuns() {
-        let pts = HrTrace.points(series([(0, 60), (60, 61), (600, 62), (660, 63)]), width: 100, height: 50)
+        // A 90-minute disconnect, which is the shape actually reported.
+        let pts = HrTrace.points(series([(0, 60), (60, 61), (5_460, 62), (5_520, 63)]), width: 100, height: 50)
         XCTAssertEqual(pts.map { $0.startsRun }, [false, false, true, false])
         XCTAssertEqual(HrTrace.runs(pts), [0...1, 2...3])
     }
@@ -206,8 +207,15 @@ final class HrTraceTests: XCTestCase {
     /// A reading marooned between two gaps is a run of one. It gets a dot rather than being dropped,
     /// which is the same call the single-point series already makes.
     func testAMaroonedReadingIsItsOwnRun() {
-        let pts = HrTrace.points(series([(0, 60), (600, 61), (1_200, 62)]), width: 100, height: 50)
+        let pts = HrTrace.points(series([(0, 60), (5_400, 61), (10_800, 62)]), width: 100, height: 50)
         XCTAssertEqual(HrTrace.runs(pts), [0...0, 1...1, 2...2])
+    }
+
+    /// The threshold is the widget's OWN definition of too-old rather than a number picked in the
+    /// renderer, so the line breaks exactly where the headline reading would already have been dropped.
+    /// Pinned, because the two drifting apart would be silent.
+    func testTheGapThresholdMatchesTheStaleCap() {
+        XCTAssertEqual(Int64(HrDisplay.staleCap), HrTrace.gapSec)
     }
 
     /// The common case is unchanged: a trace with no gaps is one run, and draws exactly as before.

--- a/StrandTests/HrTraceTests.swift
+++ b/StrandTests/HrTraceTests.swift
@@ -178,4 +178,42 @@ final class HrTraceTests: XCTestCase {
         XCTAssertNil(HrDisplay.resolve(bpm: nil, newestPointTs: nil, now: now).bpm)
         XCTAssertNil(HrDisplay.resolve(bpm: 0, newestPointTs: nil, now: now).bpm)
     }
+
+    // MARK: gaps
+
+    /// The gap rule, at the trace's own bucket width: a step of MORE than one bucket means the strap
+    /// recorded nothing in between, so the pen lifts. x is mapped by time, so the gap already occupied
+    /// its true width on screen; the line drawn across it was the invented part.
+    func testAGapSplitsTheTraceIntoRuns() {
+        let pts = HrTrace.points(series([(0, 60), (60, 61), (600, 62), (660, 63)]), width: 100, height: 50)
+        XCTAssertEqual(pts.map { $0.startsRun }, [false, false, true, false])
+        XCTAssertEqual(HrTrace.runs(pts), [0...1, 2...3])
+    }
+
+    /// The threshold from both sides. A minute is the normal cadence, and a few skipped minutes are
+    /// ordinary background jitter rather than a disconnect, so neither breaks the line. Getting this
+    /// wrong the other way would shatter every trace into dots.
+    func testJitterIsNotAGapButSilencePastTheThresholdIs() {
+        func startsRun(_ stepSec: Int64) -> Bool {
+            HrTrace.points(series([(0, 60), (stepSec, 61)]), width: 100, height: 50)[1].startsRun
+        }
+        XCTAssertFalse(startsRun(HrTrace.bucketSec))
+        XCTAssertFalse(startsRun(3 * HrTrace.bucketSec))
+        XCTAssertFalse(startsRun(HrTrace.gapSec))
+        XCTAssertTrue(startsRun(HrTrace.gapSec + 1))
+    }
+
+    /// A reading marooned between two gaps is a run of one. It gets a dot rather than being dropped,
+    /// which is the same call the single-point series already makes.
+    func testAMaroonedReadingIsItsOwnRun() {
+        let pts = HrTrace.points(series([(0, 60), (600, 61), (1_200, 62)]), width: 100, height: 50)
+        XCTAssertEqual(HrTrace.runs(pts), [0...0, 1...1, 2...2])
+    }
+
+    /// The common case is unchanged: a trace with no gaps is one run, and draws exactly as before.
+    func testAContiguousTraceIsOneRunAndAnEmptyOneHasNone() {
+        let pts = HrTrace.points(series([(0, 60), (60, 61), (120, 62)]), width: 100, height: 50)
+        XCTAssertEqual(HrTrace.runs(pts), [0...2])
+        XCTAssertEqual(HrTrace.runs([]), [])
+    }
 }

--- a/StrandiOSShared/HrTrace.swift
+++ b/StrandiOSShared/HrTrace.swift
@@ -37,6 +37,13 @@ public enum HrTrace {
     /// behind a trace a few hundred points wide, which costs space and buys nothing the eye resolves.
     public static let bucketSec: Int64 = 60
 
+    /// What counts as a GAP: nothing recorded for five minutes. Deliberately more forgiving than the
+    /// Today chart's "more than one bucket", because that chart reads a fixed DB grid where a missing
+    /// bucket really is missing data, while this series only gains a point when the app publishes one.
+    /// Background scheduling routinely skips a minute, and at a one-bucket threshold that jitter would
+    /// shatter an ordinary trace into dots — far worse than the joined-across-a-gap line being fixed.
+    public static let gapSec: Int64 = 5 * bucketSec
+
     /// Hard cap, so a clock jump backwards cannot grow the series without bound.
     public static let maxPoints = 200
 
@@ -83,9 +90,37 @@ public enum HrTrace {
     }
 
     /// A point in the trace's drawing box, origin top-left.
+    ///
+    /// `startsRun` means LIFT THE PEN before this point: nothing was recorded for `gapSec` before it.
+    /// The trace joined every point unconditionally, and because x is mapped by TIME rather than by
+    /// index, a 90-minute disconnect inside the 3-hour window drew as one confident diagonal across
+    /// half the widget. The gap was already the right width; it was the line across it that was never
+    /// measured: the same defect #2082 describes on the Today sparkline, on a second surface.
     public struct Pt: Equatable {
         public let x: CGFloat
         public let y: CGFloat
+        public let startsRun: Bool
+
+        public init(x: CGFloat, y: CGFloat, startsRun: Bool = false) {
+            self.x = x
+            self.y = y
+            self.startsRun = startsRun
+        }
+    }
+
+    /// The trace split into runs of consecutive readings: each range is a stretch the strap recorded
+    /// without a break, and the pen lifts between one run and the next. A series with no gaps is one
+    /// run, which is the common case and draws exactly as it always did.
+    public static func runs(_ points: [Pt]) -> [ClosedRange<Int>] {
+        guard !points.isEmpty else { return [] }
+        var out: [ClosedRange<Int>] = []
+        var start = 0
+        for i in 1..<points.count where points[i].startsRun {
+            out.append(start...(i - 1))
+            start = i
+        }
+        out.append(start...(points.count - 1))
+        return out
     }
 
     /// The trace as coordinates inside a `width` x `height` box.
@@ -110,10 +145,10 @@ public enum HrTrace {
             if p.bpm > hi { hi = p.bpm }
         }
         let range = CGFloat(hi - lo)
-        return series.map { p in
+        return series.enumerated().map { i, p in
             let x = span <= 0 ? 0 : CGFloat(p.ts - t0) / span * width
             let y = range <= 0 ? height / 2 : height - CGFloat(p.bpm - lo) / range * height
-            return Pt(x: x, y: y)
+            return Pt(x: x, y: y, startsRun: i > 0 && p.ts - series[i - 1].ts > gapSec)
         }
     }
 

--- a/StrandiOSShared/HrTrace.swift
+++ b/StrandiOSShared/HrTrace.swift
@@ -37,12 +37,16 @@ public enum HrTrace {
     /// behind a trace a few hundred points wide, which costs space and buys nothing the eye resolves.
     public static let bucketSec: Int64 = 60
 
-    /// What counts as a GAP: nothing recorded for five minutes. Deliberately more forgiving than the
-    /// Today chart's "more than one bucket", because that chart reads a fixed DB grid where a missing
-    /// bucket really is missing data, while this series only gains a point when the app publishes one.
-    /// Background scheduling routinely skips a minute, and at a one-bucket threshold that jitter would
-    /// shatter an ordinary trace into dots — far worse than the joined-across-a-gap line being fixed.
-    public static let gapSec: Int64 = 5 * bucketSec
+    /// What counts as a GAP. Deliberately NOT the Today chart's "more than one bucket": that chart reads
+    /// a fixed DB grid, where a missing bucket really is missing data, while this series only gains a
+    /// point when the app PUBLISHES one, and background scheduling routinely skips a minute. At a
+    /// one-bucket threshold that ordinary jitter would shatter a healthy trace into dots, which is a
+    /// worse lie than the joined line being fixed.
+    ///
+    /// Set to `HrDisplay.staleCap` rather than to a number picked here, so the line breaks exactly where
+    /// the widget would already have dropped the headline reading for being too old to represent HR at
+    /// all. `testTheGapThresholdMatchesTheStaleCap` pins the two together.
+    public static let gapSec: Int64 = 15 * bucketSec
 
     /// Hard cap, so a clock jump backwards cannot grow the series without bound.
     public static let maxPoints = 200

--- a/StrandiOSWidgets/HeartRateWidget.swift
+++ b/StrandiOSWidgets/HeartRateWidget.swift
@@ -58,12 +58,37 @@ private struct HrTraceShape: Shape {
             path.addEllipse(in: CGRect(x: max(first.x, r) - r, y: first.y - r, width: r * 2, height: r * 2))
             return path
         }
-        path.move(to: CGPoint(x: first.x, y: first.y))
-        for p in pts.dropFirst() { path.addLine(to: CGPoint(x: p.x, y: p.y)) }
-        if filled {
-            path.addLine(to: CGPoint(x: pts[pts.count - 1].x, y: rect.maxY))
-            path.addLine(to: CGPoint(x: first.x, y: rect.maxY))
-            path.closeSubpath()
+        // Draw a run at a time, lifting the pen across the gaps. x is mapped by TIME, so a gap already
+        // occupies its true width; it was only the line drawn across it that was never measured.
+        for run in HrTrace.runs(pts) {
+            let head = pts[run.lowerBound]
+            guard run.lowerBound != run.upperBound else {
+                // A lone reading between two gaps is not a line either, and gets the same dot the
+                // single-point series above does.
+                if !filled {
+                    // Held a full dot inside the box: the likeliest lone run of all is the NEWEST
+                    // reading after a long disconnect, which sits exactly on the right edge.
+                    let dot: CGFloat = 2.5
+                    let cx = min(max(head.x, dot), max(rect.maxX - dot, dot))
+                    path.addEllipse(in: CGRect(x: cx - dot, y: head.y - dot,
+                                               width: dot * 2, height: dot * 2))
+                }
+                continue
+            }
+            // Each run closes its own area, so the gradient stops at the gap along with the line.
+            if filled {
+                path.move(to: CGPoint(x: head.x, y: rect.maxY))
+                path.addLine(to: CGPoint(x: head.x, y: head.y))
+            } else {
+                path.move(to: CGPoint(x: head.x, y: head.y))
+            }
+            for i in (run.lowerBound + 1)...run.upperBound {
+                path.addLine(to: CGPoint(x: pts[i].x, y: pts[i].y))
+            }
+            if filled {
+                path.addLine(to: CGPoint(x: pts[run.upperBound].x, y: rect.maxY))
+                path.closeSubpath()
+            }
         }
         return path
     }

--- a/android/app/src/main/java/com/noop/widget/HrTrace.kt
+++ b/android/app/src/main/java/com/noop/widget/HrTrace.kt
@@ -24,6 +24,13 @@ object HrTrace {
      *  a trace 300 pixels wide, which costs prefs space and buys nothing the eye can resolve. */
     const val BUCKET_SEC: Long = 60
 
+    /** What counts as a GAP: nothing recorded for five minutes. Deliberately more forgiving than the
+     *  Today chart's "more than one bucket", because that chart reads a fixed DB grid where a missing
+     *  bucket really is missing data, while this series only gains a point when the app publishes one.
+     *  Background scheduling routinely skips a minute, and at a one-bucket threshold that jitter would
+     *  shatter an ordinary trace into dots — far worse than the joined-across-a-gap line being fixed. */
+    const val GAP_SEC: Long = 5 * BUCKET_SEC
+
     /** Hard cap, so a clock jump backwards cannot grow the series without bound. WINDOW_SEC/BUCKET_SEC
      *  is 180; the slack absorbs a boundary point without letting the list run away. */
     const val MAX_POINTS: Int = 200
@@ -161,8 +168,31 @@ object HrTrace {
      */
     const val WIDTH_HEADROOM: Float = 2f
 
-    /** A point in the trace's pixel box, origin top-left, as the renderer wants it. */
-    data class Pt(val x: Float, val y: Float)
+    /** A point in the trace's pixel box, origin top-left, as the renderer wants it.
+     *
+     *  [startsRun] means LIFT THE PEN before this point: nothing was recorded for [GAP_SEC] before it.
+     *  The renderer joined every point unconditionally, and because x is mapped by TIME rather than by
+     *  index, a 90-minute disconnect inside the 3-hour window drew as one confident diagonal across
+     *  half the widget. The gap was already the right width; it was the line across it that was never
+     *  measured: the same defect #2082 describes on the Today sparkline, on a second surface. */
+    data class Pt(val x: Float, val y: Float, val startsRun: Boolean = false)
+
+    /** The trace split into runs of consecutive readings: each range is a stretch the strap recorded
+     *  without a break, and the pen lifts between one run and the next. A series with no gaps is one
+     *  run, which is the common case and draws exactly as it always did. */
+    fun runs(points: List<Pt>): List<IntRange> {
+        if (points.isEmpty()) return emptyList()
+        val out = mutableListOf<IntRange>()
+        var start = 0
+        for (i in 1 until points.size) {
+            if (points[i].startsRun) {
+                out.add(start..(i - 1))
+                start = i
+            }
+        }
+        out.add(start..(points.size - 1))
+        return out
+    }
 
     /**
      * The trace as pixels inside a `width` x `height` box.
@@ -189,10 +219,10 @@ object HrTrace {
             if (p.bpm > hi) hi = p.bpm
         }
         val range = (hi - lo).toFloat()
-        return series.map { p ->
+        return series.mapIndexed { i, p ->
             val x = if (span <= 0f) 0f else (p.ts - t0) / span * width
             val y = if (range <= 0f) height / 2f else height - (p.bpm - lo) / range * height
-            Pt(x, y)
+            Pt(x, y, startsRun = i > 0 && p.ts - series[i - 1].ts > GAP_SEC)
         }
     }
 

--- a/android/app/src/main/java/com/noop/widget/HrTrace.kt
+++ b/android/app/src/main/java/com/noop/widget/HrTrace.kt
@@ -24,12 +24,16 @@ object HrTrace {
      *  a trace 300 pixels wide, which costs prefs space and buys nothing the eye can resolve. */
     const val BUCKET_SEC: Long = 60
 
-    /** What counts as a GAP: nothing recorded for five minutes. Deliberately more forgiving than the
-     *  Today chart's "more than one bucket", because that chart reads a fixed DB grid where a missing
-     *  bucket really is missing data, while this series only gains a point when the app publishes one.
-     *  Background scheduling routinely skips a minute, and at a one-bucket threshold that jitter would
-     *  shatter an ordinary trace into dots — far worse than the joined-across-a-gap line being fixed. */
-    const val GAP_SEC: Long = 5 * BUCKET_SEC
+    /** What counts as a GAP. Deliberately NOT the Today chart's "more than one bucket": that chart reads
+     *  a fixed DB grid, where a missing bucket really is missing data, while this series only gains a
+     *  point when the app PUBLISHES one, and background scheduling routinely skips a minute. At a
+     *  one-bucket threshold that ordinary jitter would shatter a healthy trace into dots, which is a
+     *  worse lie than the joined line being fixed.
+     *
+     *  Set to [HrDisplay.STALE_CAP_MS] rather than to a number picked here, so the line breaks exactly
+     *  where the widget would already have dropped the headline reading for being too old to represent
+     *  HR at all. `theGapThresholdMatchesTheStaleCap` pins the two together. */
+    const val GAP_SEC: Long = 15 * BUCKET_SEC
 
     /** Hard cap, so a clock jump backwards cannot grow the series without bound. WINDOW_SEC/BUCKET_SEC
      *  is 180; the slack absorbs a boundary point without letting the list run away. */

--- a/android/app/src/main/java/com/noop/widget/HrTraceRenderer.kt
+++ b/android/app/src/main/java/com/noop/widget/HrTraceRenderer.kt
@@ -62,12 +62,6 @@ internal object HrTraceRenderer {
         val usableH = (h - strokePx).coerceAtLeast(1f)
         fun px(p: HrTrace.Pt) = p.x to (inset + p.y / h * usableH)
 
-        val line = Path()
-        points.forEachIndexed { i, p ->
-            val (x, y) = px(p)
-            if (i == 0) line.moveTo(x, y) else line.lineTo(x, y)
-        }
-
         // A single point has no line to stroke, so give it a dot — otherwise a widget placed this
         // minute renders as an empty chart, which reads as "no data" rather than "one reading".
         if (points.size == 1) {
@@ -79,11 +73,38 @@ internal object HrTraceRenderer {
             return bmp
         }
 
+        // Draw a run at a time, lifting the pen across the gaps. x is mapped by TIME, so a gap already
+        // occupies its true width; it was only the line drawn across it that was never measured.
+        val line = Path()
+        val fill = Path()
+        for (r in HrTrace.runs(points)) {
+            val (x0, y0) = px(points[r.first])
+            if (r.first == r.last) {
+                // A lone reading between two gaps has no segment to stroke, so give it a hair of width
+                // and let the round cap render it as the dot it is rather than dropping it silently.
+                // Held a full dot inside the bitmap: the likeliest lone run of all is the NEWEST reading
+                // after a long disconnect, which sits exactly on the right edge.
+                val dx = x0.coerceIn(strokePx, (w.toFloat() - strokePx).coerceAtLeast(strokePx))
+                line.moveTo(dx - inset, y0)
+                line.lineTo(dx + inset, y0)
+            } else {
+                line.moveTo(x0, y0)
+                for (i in (r.first + 1)..r.last) {
+                    val (x, y) = px(points[i])
+                    line.lineTo(x, y)
+                }
+            }
+            // Each run closes its own area, so the gradient stops at the gap along with the line.
+            fill.moveTo(x0, h.toFloat())
+            for (i in r) {
+                val (x, y) = px(points[i])
+                fill.lineTo(x, y)
+            }
+            fill.lineTo(px(points[r.last]).first, h.toFloat())
+            fill.close()
+        }
+
         // Fill first, so the stroke sits on top of its own gradient rather than under it.
-        val fill = Path(line)
-        fill.lineTo(points.last().x, h.toFloat())
-        fill.lineTo(points.first().x, h.toFloat())
-        fill.close()
         canvas.drawPath(fill, Paint().apply {
             isAntiAlias = true
             isDither = true   // 565 bands a smooth ramp without it

--- a/android/app/src/main/java/com/noop/widget/HrTraceRenderer.kt
+++ b/android/app/src/main/java/com/noop/widget/HrTraceRenderer.kt
@@ -77,22 +77,22 @@ internal object HrTraceRenderer {
         // occupies its true width; it was only the line drawn across it that was never measured.
         val line = Path()
         val fill = Path()
+        val dots = ArrayList<Pair<Float, Float>>()
         for (r in HrTrace.runs(points)) {
             val (x0, y0) = px(points[r.first])
             if (r.first == r.last) {
-                // A lone reading between two gaps has no segment to stroke, so give it a hair of width
-                // and let the round cap render it as the dot it is rather than dropping it silently.
-                // Held a full dot inside the bitmap: the likeliest lone run of all is the NEWEST reading
-                // after a long disconnect, which sits exactly on the right edge.
-                val dx = x0.coerceIn(strokePx, (w.toFloat() - strokePx).coerceAtLeast(strokePx))
-                line.moveTo(dx - inset, y0)
-                line.lineTo(dx + inset, y0)
-            } else {
-                line.moveTo(x0, y0)
-                for (i in (r.first + 1)..r.last) {
-                    val (x, y) = px(points[i])
-                    line.lineTo(x, y)
-                }
+                // A lone reading between two gaps has no segment to stroke, so it gets the SAME dot the
+                // single-point series above gets, rather than being dropped silently. Held a full dot
+                // inside the bitmap: the likeliest lone run of all is the NEWEST reading after a long
+                // disconnect, which sits exactly on the right edge. Its fill would be zero-width, so it
+                // contributes no area either.
+                dots.add(x0.coerceIn(strokePx, (w.toFloat() - strokePx).coerceAtLeast(strokePx)) to y0)
+                continue
+            }
+            line.moveTo(x0, y0)
+            for (i in (r.first + 1)..r.last) {
+                val (x, y) = px(points[i])
+                line.lineTo(x, y)
             }
             // Each run closes its own area, so the gradient stops at the gap along with the line.
             fill.moveTo(x0, h.toFloat())
@@ -121,6 +121,14 @@ internal object HrTraceRenderer {
             strokeJoin = Paint.Join.ROUND
             color = lineColor
         })
+
+        if (dots.isNotEmpty()) {
+            val dotPaint = Paint().apply {
+                isAntiAlias = true
+                color = lineColor
+            }
+            for ((dx, dy) in dots) canvas.drawCircle(dx, dy, strokePx, dotPaint)
+        }
         return bmp
     }
 }

--- a/android/app/src/test/java/com/noop/widget/HrTraceTest.kt
+++ b/android/app/src/test/java/com/noop/widget/HrTraceTest.kt
@@ -225,7 +225,8 @@ class HrTraceTest {
      *  its true width on screen; the line drawn across it was the invented part. */
     @Test
     fun `a gap splits the trace into runs`() {
-        val pts = HrTrace.points(series(0L to 60, 60L to 61, 600L to 62, 660L to 63), 100f, 50f)
+        // A 90-minute disconnect, which is the shape actually reported.
+        val pts = HrTrace.points(series(0L to 60, 60L to 61, 5_460L to 62, 5_520L to 63), 100f, 50f)
         assertEquals(listOf(false, false, true, false), pts.map { it.startsRun })
         assertEquals(listOf(0..1, 2..3), HrTrace.runs(pts))
     }
@@ -247,8 +248,16 @@ class HrTraceTest {
      *  which is the same call the single-point series already makes. */
     @Test
     fun `a marooned reading is its own run`() {
-        val pts = HrTrace.points(series(0L to 60, 600L to 61, 1_200L to 62), 100f, 50f)
+        val pts = HrTrace.points(series(0L to 60, 5_400L to 61, 10_800L to 62), 100f, 50f)
         assertEquals(listOf(0..0, 1..1, 2..2), HrTrace.runs(pts))
+    }
+
+    /** The threshold is the widget's OWN definition of too-old rather than a number picked in the
+     *  renderer, so the line breaks exactly where the headline reading would already have been dropped.
+     *  Pinned, because the two drifting apart would be silent. */
+    @Test
+    fun `the gap threshold matches the stale cap`() {
+        assertEquals(HrDisplay.STALE_CAP_MS / 1_000L, HrTrace.GAP_SEC)
     }
 
     /** The common case is unchanged: a trace with no gaps is one run, and draws exactly as before. */

--- a/android/app/src/test/java/com/noop/widget/HrTraceTest.kt
+++ b/android/app/src/test/java/com/noop/widget/HrTraceTest.kt
@@ -1,6 +1,7 @@
 package com.noop.widget
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -217,5 +218,44 @@ class HrTraceTest {
     fun `a degenerate request still yields a drawable width`() {
         assertTrue(HrTrace.widestAtHeight(0, 0) >= 1)
         assertTrue(HrTrace.widestAtHeight(-10, -10) >= 1)
+    }
+
+    /** The gap rule, at the trace's own bucket width: a step of MORE than one bucket means the strap
+     *  recorded nothing in between, so the pen lifts. x is mapped by time, so the gap already occupied
+     *  its true width on screen; the line drawn across it was the invented part. */
+    @Test
+    fun `a gap splits the trace into runs`() {
+        val pts = HrTrace.points(series(0L to 60, 60L to 61, 600L to 62, 660L to 63), 100f, 50f)
+        assertEquals(listOf(false, false, true, false), pts.map { it.startsRun })
+        assertEquals(listOf(0..1, 2..3), HrTrace.runs(pts))
+    }
+
+    /** The threshold from both sides. A minute is the normal cadence, and a few skipped minutes are
+     *  ordinary background jitter rather than a disconnect, so neither breaks the line. Getting this
+     *  wrong the other way would shatter every trace into dots. */
+    @Test
+    fun `jitter is not a gap but silence past the threshold is`() {
+        fun startsRun(stepSec: Long) =
+            HrTrace.points(series(0L to 60, stepSec to 61), 100f, 50f)[1].startsRun
+        assertFalse(startsRun(HrTrace.BUCKET_SEC))
+        assertFalse(startsRun(3 * HrTrace.BUCKET_SEC))
+        assertFalse(startsRun(HrTrace.GAP_SEC))
+        assertTrue(startsRun(HrTrace.GAP_SEC + 1))
+    }
+
+    /** A reading marooned between two gaps is a run of one. It gets a dot rather than being dropped,
+     *  which is the same call the single-point series already makes. */
+    @Test
+    fun `a marooned reading is its own run`() {
+        val pts = HrTrace.points(series(0L to 60, 600L to 61, 1_200L to 62), 100f, 50f)
+        assertEquals(listOf(0..0, 1..1, 2..2), HrTrace.runs(pts))
+    }
+
+    /** The common case is unchanged: a trace with no gaps is one run, and draws exactly as before. */
+    @Test
+    fun `a contiguous trace is one run and an empty one has none`() {
+        val pts = HrTrace.points(series(0L to 60, 60L to 61, 120L to 62), 100f, 50f)
+        assertEquals(listOf(0..2), HrTrace.runs(pts))
+        assertEquals(emptyList<IntRange>(), HrTrace.runs(emptyList()))
     }
 }


### PR DESCRIPTION
Addresses #2082.

## The defect

The default Apple Today shell threw its bucket timestamps away one line before they could be used:

```swift
hrValues = (await hrA).map { $0.bpm }
```

A bucket with no samples is simply absent from the aggregate, so discarding `ts` closed every hole up and drew a day of sparse live windows as one continuous line. It bites hardest on a strap whose history never offloads, where heart rate exists ONLY for the windows it was connected, which is exactly the install with the biggest holes.

## Reusing the rule rather than rewriting it

PR #2064 made the neighbouring Today chart break at gaps and left the pure helper behind. A chart can hand a segment id to the plotting library and let it split the line; a hand-drawn sparkline has to know where to lift the pen. So this adds `hrGapRuns`, a sibling of `hrGapSegments` that turns the same ids into index ranges, rather than a second walk that could disagree with the first.

`LiquidThread` takes those runs and strokes one subpath each.

## Why the live stream is untouched

Passing `nil` produces **byte-for-byte the path this drew before**: with one run covering the whole series, `appendRun(0, n-1)` is the original `move` / quad-loop / `addLine` sequence exactly. The live 1 Hz series is contiguous by construction and passes nil, so nothing about it changes.

## A run of one still draws

A bare `move` strokes nothing, so a lone bucket between two gaps needs something to stroke. It gets a hair of width (±0.6pt) rather than a zero-length line: a degenerate subpath is at the mercy of whether the renderer keeps it alive for its round cap, and an isolated reading silently vanishing is the same class of lie as the joined line this removes.

The run split is also resolved **once**, outside `curve()`. That closure is called twice per frame inside a 60fps `TimelineView`, so leaving the walk inside it re-split the whole series 120 times a second for an answer that cannot change between strokes.

## What it deliberately does not do

Gap **width** is still not proportional: points are spaced by index, so a three-hour hole and a five-minute one read the same. A break already stops the line asserting data that was never recorded, which is the defect in #2082. Time-based spacing would mean reworking a primitive the live stream shares, and that wants its own decision rather than riding along here.

Not a regression from #2064 either: the sparkline always discarded its timestamps, and that change only made the contrast visible by correcting the surface beside it.

## The other callers, checked rather than assumed

`LiquidThread` has two more callers and both are correctly unaffected, each drawing a rolling live buffer that is contiguous by construction:

- `LiveView.swift` R-R trace: `live.rrRecent.suffix(18)`
- Android `RRStrip`: `rrRecent.takeLast(18)`

Android does have the `LiquidThread` primitive, so "Apple only" needed checking rather than asserting. It holds: Android has no Liquid Today shell, so no banked-heart-rate sparkline, and its Today card already breaks its line from the Android half of #2064.

## Verification

`doc_comment_lint.py` and `i18n_audit.py --ci` clean. Six tests on the new helper, including one asserting the runs **tile the series exactly**, since a sparkline that silently dropped or repeated a bucket would be a worse lie than the one being removed.

Honest limit: unlike the analytics package, `StrandDesign` imports SwiftUI and cannot build on Linux, so those tests run in CI rather than locally, and the Apple app target never compiles in this environment. I kept `hrGapRuns` beside `hrGapSegments` anyway rather than moving it somewhere testable, because splitting one rule across two modules is how the two spellings drift apart.

The glint and endpoint pulse now stroke across multiple subpaths. That reads fine by construction (the dash phase runs the total length, the pulse sits on the newest point) but it is a visual judgement, so it is worth a look on a device with a gappy day.


---

## The same defect on a second surface: the heart rate widget

Asked for a parity check, and the honest answer was not "Apple only". Both **widget** traces had the same defect, and in a worse form.

`HrTraceRenderer` (Android) and `HrTraceShape` (Apple) each built one continuous path over every point:

```swift
path.move(to: CGPoint(x: first.x, y: first.y))
for p in pts.dropFirst() { path.addLine(to: CGPoint(x: p.x, y: p.y)) }
```

The aggravating factor is that `HrTrace.points` maps x by **TIME**, not by index:

```kotlin
val x = if (span <= 0f) 0f else (p.ts - t0) / span * width
```

So unlike the sparkline, the gap already occupies its true width, and the line is then drawn straight across it. A 90-minute disconnect inside the 3-hour window renders as one confident diagonal spanning half the widget, under a time axis implying it was measured. On the home screen, read without opening anything.

`HrTrace.Pt` now carries whether the pen lifts before it, `HrTrace.runs` splits on that, and both renderers draw a run at a time. Each run closes its own fill, so the gradient stops at the gap along with the line. A reading marooned between two gaps gets the same dot a single-point series already got, clamped inside the box, since the likeliest lone run of all is the newest reading after a long disconnect, sitting exactly on the right edge.

### The threshold is deliberately NOT the Today chart's

This was the one real risk in the change, and it pushed back on the first version I wrote. The Today chart breaks on "more than one bucket" because it reads a fixed DB grid, where a missing bucket really is missing data. The widget series is different: it only gains a point when the app **publishes** one, and background scheduling routinely skips a minute. At a one-bucket threshold that ordinary jitter would have shattered a perfectly healthy trace into dots, which is a worse lie than the one being fixed.

The two ways of being wrong are not symmetric. Too small hits every user every day; too large just leaves the milder version of the bug. So this wants the conservative end, and a value the app already reasons about rather than one invented in the renderer.

`GAP_SEC` / `gapSec` is therefore **`HrDisplay.STALE_CAP_MS`, 15 minutes**: past that the widget already drops the headline reading as too old to represent heart rate at all. The line now breaks exactly where the number above it would have been withdrawn, which is one rule rather than two. A test pins the two together on each platform, since drifting apart would otherwise be silent.

It is pinned from both sides as well: one bucket, three buckets and exactly `GAP_SEC` are all contiguous; `GAP_SEC + 1` is a gap. The gap fixtures are a 90-minute disconnect, the shape actually reported.

### A naming divergence worth recording

The audit also turned up that Swift's `hrGapSegments` is spelled `hrGapSegmentIds` on Android (`Charts.kt:291`). Same rule, different name, so a parity grep on either name misses its twin. Not changed here, since renaming is unrelated churn on a branch that already spans two platforms, but it is the exact hazard that makes these surfaces drift.

### Verification

Every consumer of `HrTrace.points` was enumerated rather than assumed: exactly one per platform, both fixed. 28 Kotlin tests in `HrTraceTest` green (95 across the widget package), including the five new gap cases. The Swift twins mirror them one for one and run in CI, as `StrandiOSShared` never compiles on Linux.

`doc_comment_lint.py` and `i18n_audit.py --ci` both clean.

### One divergence found and deliberately left alone

A lone reading draws as a **solid dot** on Android (`drawCircle`, FILL) and as a **ring** on Apple, because `HrTraceShape` is stroked and a stroked ellipse is an outline. That is pre-existing, being how each platform already drew a single-point series, and this change only makes it visible more often. Each platform is now at least self-consistent: Android's lone run gets the identical dot its single-point case gets, rather than the 4x2dp pill an earlier pass here left it with. Unifying the two is a visual call on a surface I cannot render locally, so it is better made deliberately than smuggled in on this branch.