### PR TITLE
Show what SQLite actually complained about, in something that can hold it

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/DatabaseIntegrity.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/DatabaseIntegrity.swift
@@ -69,9 +69,9 @@ public enum DatabaseIntegrity {
 
     /// The part of a `verdict` worth showing a person, as one line.
     ///
-    /// `verdict` is kept VERBATIM on purpose: it is the forensic value, it goes in logs, and a reporter
-    /// pasting it into an issue should paste what SQLite actually said. But what SQLite actually says
-    /// begins with a banner and a newline:
+    /// `verdict` is kept VERBATIM on purpose: it is the forensic value, and a reporter pasting it into
+    /// an issue should paste what SQLite actually said rather than a summary of it. (It reaches no log
+    /// today: the only copy is the one shown.) What SQLite says begins with a banner and a newline:
     ///
     ///     *** in database main ***
     ///     Page 5 is never used
@@ -90,7 +90,8 @@ public enum DatabaseIntegrity {
         let joined = kept.isEmpty
             ? verdict.replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespaces)
             : kept.joined(separator: "; ")
-        guard joined.count > limit else { return joined }
-        return String(joined.prefix(limit - 1)).trimmingCharacters(in: .whitespaces) + "\u{2026}"
+        let cap = max(1, limit)
+        guard joined.count > cap else { return joined }
+        return String(joined.prefix(cap - 1)).trimmingCharacters(in: .whitespaces) + "\u{2026}"
     }
 }

--- a/Packages/WhoopStore/Sources/WhoopStore/DatabaseIntegrity.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/DatabaseIntegrity.swift
@@ -60,4 +60,37 @@ public enum DatabaseIntegrity {
         if rows.count == 1, rows[0].lowercased() == "ok" { return nil }
         return rows.first { $0.lowercased() != "ok" } ?? "quick_check returned no verdict"
     }
+
+    /// SQLite's banner line, which names the database being reported on and says nothing about what is
+    /// wrong with it. quick_check emits it ahead of the real diagnosis, joined into the SAME row.
+    private static func isBanner(_ line: String) -> Bool {
+        line.hasPrefix("*** in database") && line.hasSuffix("***")
+    }
+
+    /// The part of a `verdict` worth showing a person, as one line.
+    ///
+    /// `verdict` is kept VERBATIM on purpose: it is the forensic value, it goes in logs, and a reporter
+    /// pasting it into an issue should paste what SQLite actually said. But what SQLite actually says
+    /// begins with a banner and a newline:
+    ///
+    ///     *** in database main ***
+    ///     Page 5 is never used
+    ///
+    /// Rendered into a sentence, that spends the whole line on "*** in database main ***" and pushes the
+    /// only informative half ("Page 5 is never used") out of sight. This drops the banner, joins what is
+    /// left onto one line, and caps the length, so the detail a person sees is the diagnosis.
+    ///
+    /// Falls back to the raw verdict, newlines flattened, whenever stripping would leave nothing: a
+    /// verdict made ENTIRELY of banner is still better shown than shown as an empty parenthesis.
+    /// Mirrored by Android's `DataBackup.readableComplaint` on the same golden vectors.
+    public static func readableComplaint(_ verdict: String, limit: Int = 140) -> String {
+        let kept = verdict.split(separator: "\n", omittingEmptySubsequences: false)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty && !isBanner($0) }
+        let joined = kept.isEmpty
+            ? verdict.replacingOccurrences(of: "\n", with: " ").trimmingCharacters(in: .whitespaces)
+            : kept.joined(separator: "; ")
+        guard joined.count > limit else { return joined }
+        return String(joined.prefix(limit - 1)).trimmingCharacters(in: .whitespaces) + "\u{2026}"
+    }
 }

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/DatabaseIntegrityTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/DatabaseIntegrityTests.swift
@@ -141,6 +141,10 @@ final class DatabaseIntegrityTests: XCTestCase {
             DatabaseIntegrity.readableComplaint("*** in database main ***\nPage 5 is never used\nPage 9 is never used"),
             "Page 5 is never used; Page 9 is never used"
         )
+        // A nonsense limit must not trap: prefix(-1) is a precondition failure, and a display helper is
+        // the last place that should be able to crash a failure path.
+        XCTAssertEqual(DatabaseIntegrity.readableComplaint("*** in database main ***\nPage 5", limit: 0).count, 1)
+        XCTAssertEqual(DatabaseIntegrity.readableComplaint("*** in database main ***\nPage 5", limit: -5).count, 1)
         // Capped, because this rides inside a sentence that has to stay readable.
         let long = DatabaseIntegrity.readableComplaint("*** in database main ***\n" + String(repeating: "x", count: 500),
                                                       limit: 40)

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/DatabaseIntegrityTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/DatabaseIntegrityTests.swift
@@ -106,4 +106,45 @@ final class DatabaseIntegrityTests: XCTestCase {
         XCTAssertEqual(DatabaseIntegrity.verdict(fromRows: ["ok", "Page 9 is never used"]),
                        "Page 9 is never used")
     }
+
+    /// Swift twin of the Kotlin `DataBackupIntegrityTest` readableComplaint cases: the verdict stays
+    /// forensic and verbatim, this is the half a person is shown.
+    func testReadableComplaintDropsTheBannerAndKeepsTheDiagnosis() {
+        // The reported shape: ONE row carrying the banner, a newline, then the only informative half.
+        XCTAssertEqual(
+            DatabaseIntegrity.readableComplaint("*** in database main ***\nPage 5 is never used"),
+            "Page 5 is never used"
+        )
+        // Captured from a REAL corrupted SQLite file (pages scribbled over, header left intact) rather
+        // than invented: quick_check(1) answers with ONE row holding the banner, a newline, and the
+        // diagnosis. The exact shape the reported Toast was truncating.
+        XCTAssertEqual(
+            DatabaseIntegrity.readableComplaint("*** in database main ***\nTree 2 page 7: btreeInitPage() returns error code 11"),
+            "Tree 2 page 7: btreeInitPage() returns error code 11"
+        )
+        // An attached database names itself, so the match cannot be on "main" alone.
+        XCTAssertEqual(
+            DatabaseIntegrity.readableComplaint("*** in database temp ***\nPage 9 is never used"),
+            "Page 9 is never used"
+        )
+        // Banner and nothing else: an empty parenthesis would be worse, so the raw verdict survives.
+        XCTAssertEqual(
+            DatabaseIntegrity.readableComplaint("*** in database main ***"),
+            "*** in database main ***"
+        )
+        // No banner at all: already the diagnosis, passes through untouched.
+        XCTAssertEqual(
+            DatabaseIntegrity.readableComplaint("row 12 missing from index sleepIdx"),
+            "row 12 missing from index sleepIdx"
+        )
+        XCTAssertEqual(
+            DatabaseIntegrity.readableComplaint("*** in database main ***\nPage 5 is never used\nPage 9 is never used"),
+            "Page 5 is never used; Page 9 is never used"
+        )
+        // Capped, because this rides inside a sentence that has to stay readable.
+        let long = DatabaseIntegrity.readableComplaint("*** in database main ***\n" + String(repeating: "x", count: 500),
+                                                      limit: 40)
+        XCTAssertEqual(long.count, 40)
+        XCTAssertTrue(long.hasSuffix("\u{2026}"))
+    }
 }

--- a/Strand/Data/DataBackup.swift
+++ b/Strand/Data/DataBackup.swift
@@ -138,7 +138,7 @@ enum DataBackup {
     private struct ExportIntegrityFailure: LocalizedError {
         let complaint: String
         var errorDescription: String? {
-            String(localized: "the NOOP database failed its integrity check (SQLite reports: \(complaint)). A backup of it would not restore. Export the WHOOP-format CSV (Settings → Export data) to save what's still readable.")
+            String(localized: "the NOOP database failed its integrity check (SQLite reports: \(DatabaseIntegrity.readableComplaint(complaint))). A backup of it would not restore. Export the WHOOP-format CSV (Settings → Export data) to save what's still readable.")
         }
     }
 
@@ -429,7 +429,7 @@ enum DataBackup {
             && (fm.fileExists(atPath: source.path + "-wal") || fm.fileExists(atPath: source.path + "-shm"))
         if !legacySidecarsPresent,
            let complaint = DatabaseIntegrity.quickCheckFailure(atPath: source.path) {
-            return .failure(String(localized: "This backup file is damaged and can't be restored (SQLite reports: \(complaint)). Your current data was left untouched. Try an earlier backup file."))
+            return .failure(String(localized: "This backup file is damaged and can't be restored (SQLite reports: \(DatabaseIntegrity.readableComplaint(complaint))). Your current data was left untouched. Try an earlier backup file."))
         }
 
         let dbURL = URL(fileURLWithPath: dbPath)
@@ -479,11 +479,11 @@ enum DataBackup {
                 removeIfPresent(dbURL)
                 if sidecar != dbURL, fm.fileExists(atPath: sidecar.path) {
                     try? fm.copyItem(at: sidecar, to: dbURL)
-                    return .failure(String(localized: "Import failed its post-restore integrity check (SQLite reports: \(complaint)). Your previous data was rolled back automatically and is unchanged."))
+                    return .failure(String(localized: "Import failed its post-restore integrity check (SQLite reports: \(DatabaseIntegrity.readableComplaint(complaint))). Your previous data was rolled back automatically and is unchanged."))
                 }
                 // Fresh install: there was no previous store to preserve, so removing the damaged
                 // file (done above) restores the exact pre-import state — an empty slate.
-                return .failure(String(localized: "Import failed its post-restore integrity check (SQLite reports: \(complaint)). The damaged file was removed; there was no previous data to roll back."))
+                return .failure(String(localized: "Import failed its post-restore integrity check (SQLite reports: \(DatabaseIntegrity.readableComplaint(complaint))). The damaged file was removed; there was no previous data to roll back."))
             }
 
             // Restore sidecars only for legacy plain-SQLite backups whose WAL wasn't

--- a/android/app/src/main/java/com/noop/data/DataBackup.kt
+++ b/android/app/src/main/java/com/noop/data/DataBackup.kt
@@ -151,9 +151,9 @@ object DataBackup {
         // connection (WAL allows concurrent readers). Twin of the Apple writeVerifiedBackupZip.
         sqliteQuickCheckFailure(dbFile)?.let { complaint ->
             throw IOException(
-                "Couldn't export: the NOOP database failed its integrity check (SQLite reports: " +
-                    "$complaint). A backup of it would not restore. Export the WHOOP-format CSV " +
-                    "instead to save what's still readable."
+                "Couldn't export: the NOOP database failed its integrity check, so a backup of it " +
+                    "would not restore. Export the WHOOP-format CSV instead to save what's still " +
+                    "readable. (SQLite: ${readableComplaint(complaint)})"
             )
         }
 
@@ -327,8 +327,8 @@ object DataBackup {
             tempSqlite.delete()
             tempSettings.delete()
             return ImportResult.Failed(
-                "This backup file is damaged and can't be restored (SQLite reports: $complaint). " +
-                    "Your current data is untouched. Try an earlier backup file."
+                "This backup file is damaged, so nothing was restored. Your current data is " +
+                    "untouched. Try an earlier backup file. (SQLite: ${readableComplaint(complaint)})"
             )
         }
 
@@ -379,21 +379,22 @@ object DataBackup {
             if (rollbackFile.exists()) {
                 if (runCatching { rollbackFile.copyTo(dbFile, overwrite = true) }.isSuccess) {
                     rollbackFile.delete()
-                    message = "The backup failed its integrity check after the copy (SQLite reports: " +
-                        "$complaint). Your previous data was rolled back automatically and is unchanged."
+                    message = "The backup failed its integrity check after the copy. Your previous " +
+                        "data was rolled back automatically and is unchanged. " +
+                        "(SQLite: ${readableComplaint(complaint)})"
                 } else {
                     // The roll-back copy itself failed: KEEP the snapshot on disk — it is now the
                     // only good copy of the user's data — and tell the user exactly where it is.
-                    message = "The backup failed its integrity check after the copy (SQLite reports: " +
-                        "$complaint), and rolling back also failed. Your previous data is preserved at " +
-                        "${rollbackFile.name} next to the app's database."
+                    message = "The backup failed its integrity check after the copy, and rolling " +
+                        "back also failed. Your previous data is preserved at ${rollbackFile.name} " +
+                        "next to the app's database. (SQLite: ${readableComplaint(complaint)})"
                 }
             } else {
                 // Fresh install: nothing existed before the import, so removing the damaged file
                 // returns to the exact pre-import (empty) state.
                 dbFile.delete()
-                message = "The backup failed its integrity check after the copy (SQLite reports: " +
-                    "$complaint). There was no previous data to roll back."
+                message = "The backup failed its integrity check after the copy. There was no " +
+                    "previous data to roll back. (SQLite: ${readableComplaint(complaint)})"
             }
             return ImportResult.Failed(message)
         }
@@ -660,6 +661,44 @@ object DataBackup {
         if (rows.size == 1 && rows[0].equals("ok", ignoreCase = true)) return null
         return rows.firstOrNull { !it.equals("ok", ignoreCase = true) }
             ?: "quick_check returned no verdict"
+    }
+
+    /**
+     * SQLite's banner line, which names the database being reported on and says nothing about what is
+     * wrong with it. quick_check emits it ahead of the real diagnosis, joined into the SAME row.
+     */
+    private fun isBanner(line: String): Boolean =
+        line.startsWith("*** in database") && line.endsWith("***")
+
+    /**
+     * The part of a [quickCheckVerdict] worth showing a person, as one line.
+     *
+     * The verdict is kept VERBATIM on purpose: it is the forensic value, it goes in logs, and a reporter
+     * pasting it into an issue should paste what SQLite actually said. But what SQLite actually says
+     * begins with a banner and a newline:
+     *
+     *     *** in database main ***
+     *     Page 5 is never used
+     *
+     * Rendered into a sentence, that spends the whole line on "*** in database main ***" and pushes the
+     * only informative half ("Page 5 is never used") out of sight, which is exactly what a truncating
+     * Toast showed. This drops the banner, joins what is left onto one line, and caps the length, so the
+     * detail a person sees is the diagnosis.
+     *
+     * Falls back to the raw verdict, newlines flattened, whenever stripping would leave nothing: a
+     * verdict made ENTIRELY of banner is still better shown than shown as an empty parenthesis.
+     * Mirrors the Apple `DatabaseIntegrity.readableComplaint` on the same golden vectors.
+     */
+    fun readableComplaint(verdict: String, limit: Int = 140): String {
+        val kept = verdict.split('\n')
+            .map { it.trim() }
+            .filter { it.isNotEmpty() && !isBanner(it) }
+        val joined = if (kept.isEmpty()) {
+            verdict.replace('\n', ' ').trim()
+        } else {
+            kept.joinToString("; ")
+        }
+        return if (joined.length <= limit) joined else joined.take(limit - 1).trimEnd() + "\u2026"
     }
 
     /**

--- a/android/app/src/main/java/com/noop/data/DataBackup.kt
+++ b/android/app/src/main/java/com/noop/data/DataBackup.kt
@@ -673,8 +673,9 @@ object DataBackup {
     /**
      * The part of a [quickCheckVerdict] worth showing a person, as one line.
      *
-     * The verdict is kept VERBATIM on purpose: it is the forensic value, it goes in logs, and a reporter
-     * pasting it into an issue should paste what SQLite actually said. But what SQLite actually says
+     * The verdict is kept VERBATIM on purpose: it is the forensic value, and a reporter pasting it into
+     * an issue should paste what SQLite actually said rather than a summary of it. (It reaches no log
+     * today: the only copy is the one shown, which is why the dialog can copy it.) What SQLite says
      * begins with a banner and a newline:
      *
      *     *** in database main ***
@@ -698,7 +699,8 @@ object DataBackup {
         } else {
             kept.joinToString("; ")
         }
-        return if (joined.length <= limit) joined else joined.take(limit - 1).trimEnd() + "\u2026"
+        val cap = limit.coerceAtLeast(1)
+        return if (joined.length <= cap) joined else joined.take(cap - 1).trimEnd() + "\u2026"
     }
 
     /**

--- a/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/BackupSyncScreen.kt
@@ -71,6 +71,9 @@ fun BackupSyncScreen() {
     var auto by remember { mutableStateOf(BackupSyncPrefs.autoEnabled(context)) }
     var lastMs by remember { mutableStateOf(BackupSyncPrefs.lastBackupMs(context)) }
     var busy by remember { mutableStateOf(false) }
+    // #1014 family: these failures carry a next step in their LAST clause, which is exactly what a
+    // Toast drops. Held here and shown in a dialog, the same way Settings does.
+    var backupFailure by remember { mutableStateOf<String?>(null) }
     // How many dated snapshots to keep; pruning deletes the oldest beyond this (BackupSync.snapshotsToPrune).
     var keep by remember { mutableStateOf(BackupSyncPrefs.keepCount(context)) }
     var keepMenu by remember { mutableStateOf(false) }
@@ -119,13 +122,12 @@ fun BackupSyncScreen() {
                             Runtime.getRuntime().exit(0)
                         }
                     }
-                    is DataBackup.ImportResult.Failed ->
-                        Toast.makeText(context, r.message, Toast.LENGTH_LONG).show()
+                    is DataBackup.ImportResult.Failed -> backupFailure = r.message
                     // #1807: recoverable, but not from here — this screen restores a folder snapshot
                     // directly and has no confirm step to hang the override on. Settings → Backup & restore
-                    // → Import does, and shows the same sentence with a way through.
-                    is DataBackup.ImportResult.TooLarge ->
-                        Toast.makeText(context, r.message, Toast.LENGTH_LONG).show()
+                    // → Import does, and shows the same sentence with a way through. Which is the reason
+                    // it has to be READABLE here: the dialog is where the reader learns where to go.
+                    is DataBackup.ImportResult.TooLarge -> backupFailure = r.message
                 }
             } finally {
                 busy = false
@@ -492,6 +494,10 @@ fun BackupSyncScreen() {
                 }
             },
         )
+    }
+
+    backupFailure?.let { failure ->
+        BackupFailureDialog(message = failure, onDismiss = { backupFailure = null })
     }
 }
 

--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -49,6 +49,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AutoGraph
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.TextButton
+import androidx.compose.ui.platform.LocalContext
+import android.content.ClipData
+import android.content.ClipboardManager
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -1481,3 +1486,40 @@ private fun Modifier.clickableNoRipple(onClick: () -> Unit): Modifier =
         interactionSource = remember { MutableInteractionSource() },
         onClick = onClick,
     )
+
+// MARK: - Backup / restore failure
+
+/**
+ * The dialog a failed backup, restore or export ends on.
+ *
+ * These messages run to several sentences and each one finishes with the part the reader can act on,
+ * so a Toast was the wrong container: the reported case clipped at "SQLite reports: *** in d..." and
+ * threw away BOTH the diagnosis and the "your current data is untouched" that followed it. What
+ * survived was the one fragment that helps nobody. A dialog shows the sentence whole.
+ *
+ * [Copy] puts it on the clipboard, so a corruption report carries SQLite's own words rather than a
+ * fragment retyped off a screenshot. Apple has shown these in an alert all along; this is Android
+ * catching up to it.
+ */
+@Composable
+fun BackupFailureDialog(message: String, onDismiss: () -> Unit) {
+    val context = LocalContext.current
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = Palette.surfaceOverlay,
+        text = { Text(message, style = NoopType.subhead, color = Palette.textSecondary) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(uiString(R.string.l10n_components_close_bbfa773e), color = Palette.accent)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = {
+                val clip = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+                clip?.setPrimaryClip(ClipData.newPlainText("NOOP backup error", message))
+            }) {
+                Text(uiString(R.string.l10n_components_copy_af74f7c5), color = Palette.textSecondary)
+            }
+        },
+    )
+}

--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -1517,6 +1517,10 @@ fun BackupFailureDialog(message: String, onDismiss: () -> Unit) {
             TextButton(onClick = {
                 val clip = context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
                 clip?.setPrimaryClip(ClipData.newPlainText("NOOP backup error", message))
+                // Dismiss on copy. Android 13+ shows its own clipboard confirmation, but minSdk here is
+                // 26, and on everything below that a Copy that left the dialog sitting there gave no
+                // sign it had done anything. Dialog buttons conventionally dismiss anyway.
+                onDismiss()
             }) {
                 Text(uiString(R.string.l10n_components_copy_af74f7c5), color = Palette.textSecondary)
             }

--- a/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SettingsScreen.kt
@@ -544,6 +544,10 @@ fun SettingsScreen(
      * need to send the user back through the picker.
      */
     var oversizeRestore by remember { mutableStateOf<Pair<android.net.Uri, String>?>(null) }
+    // #1014 family: a failed import/export ends on a multi-sentence message whose LAST clause is the
+    // part the reader can act on. A Toast truncated it, so what survived was the SQLite banner and
+    // nothing else. Held here and shown in a dialog instead.
+    var backupFailure by remember { mutableStateOf<String?>(null) }
 
     // #646/#651: LogExport's zip build + file read now run on Dispatchers.IO instead of blocking the
     // caller, so these buttons no longer freeze the UI — but nothing else stopped a second tap mid-export
@@ -764,7 +768,10 @@ fun SettingsScreen(
                     Toast.makeText(context, note, Toast.LENGTH_LONG).show()
                 },
                 onFailure = { e ->
-                    Toast.makeText(context, "Backup problem: ${e.message}", Toast.LENGTH_LONG).show()
+                    // The EXPORT-side integrity refusal lands here (#1014): a corrupt store is caught
+                    // before it is archived, and the message names the CSV route that still works. That
+                    // is a next step, so it needs the dialog for the same reason the import failures do.
+                    backupFailure = "Backup problem: ${e.message}"
                 },
             )
         }
@@ -812,9 +819,7 @@ fun SettingsScreen(
                     "Backup imported. Fully close and reopen NOOP for it to take effect.",
                     Toast.LENGTH_LONG,
                 ).show()
-                is DataBackup.ImportResult.Failed -> Toast.makeText(
-                    context, result.message, Toast.LENGTH_LONG,
-                ).show()
+                is DataBackup.ImportResult.Failed -> backupFailure = result.message
                 // #1807: refused ONLY for size, which is recoverable — offer to go ahead rather than
                 // ending on a Toast the user can do nothing about. The cap is a decompression guard
                 // against a hostile archive; a backup they just picked out of their own files is not
@@ -3322,6 +3327,10 @@ fun SettingsScreen(
             }
         }
 
+        backupFailure?.let { failure ->
+            BackupFailureDialog(message = failure, onDismiss = { backupFailure = null })
+        }
+
         oversizeRestore?.let { (pendingUri, pendingMessage) ->
             AlertDialog(
                 onDismissRequest = { oversizeRestore = null },
@@ -3340,13 +3349,17 @@ fun SettingsScreen(
                                 DataBackup.importFrom(context, pendingUri, allowOversize = true)
                             }
                             backupBusy = false
-                            val note = when (again) {
-                                is DataBackup.ImportResult.NeedsRestart ->
-                                    "Backup imported. Fully close and reopen NOOP for it to take effect."
-                                is DataBackup.ImportResult.Failed -> again.message
-                                is DataBackup.ImportResult.TooLarge -> again.message
+                            when (again) {
+                                is DataBackup.ImportResult.NeedsRestart -> Toast.makeText(
+                                    context,
+                                    "Backup imported. Fully close and reopen NOOP for it to take effect.",
+                                    Toast.LENGTH_LONG,
+                                ).show()
+                                // Same reason as the first attempt: these carry a next step, and a Toast
+                                // is where a next step goes to be truncated.
+                                is DataBackup.ImportResult.Failed -> backupFailure = again.message
+                                is DataBackup.ImportResult.TooLarge -> backupFailure = again.message
                             }
-                            Toast.makeText(context, note, Toast.LENGTH_LONG).show()
                         }
                     }) {
                         Text(

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1385,6 +1385,8 @@
     <string name="l10n_components_glowring_value_ac0e87de">Glühwert</string>
     <string name="l10n_components_increase_accessibility_0949c0e9">%1$s erhöhen</string>
     <string name="l10n_components_ringfill_59cd4fb9">ringFill</string>
+    <string name="l10n_components_close_bbfa773e">Schließen</string>
+    <string name="l10n_components_copy_af74f7c5">Kopieren</string>
     <string name="l10n_connection_help_allow_nearby_devices_f7c74880">Geräte in der Nähe zulassen</string>
     <string name="l10n_connection_help_charge_it_and_put_it_on_31b04814">Lade es und lege es auf</string>
     <string name="l10n_connection_help_close_the_official_whoop_app_768d7d17">Schließe die offizielle WHOOP App</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -1185,6 +1185,8 @@
     <string name="l10n_components_glowring_value_ac0e87de">valor brillante</string>
     <string name="l10n_components_increase_accessibility_0949c0e9">Aumento de %1$s</string>
     <string name="l10n_components_ringfill_59cd4fb9">Anillo</string>
+    <string name="l10n_components_close_bbfa773e">Cerrar</string>
+    <string name="l10n_components_copy_af74f7c5">Copiar</string>
     <string name="l10n_connection_help_allow_nearby_devices_f7c74880">Permitir dispositivos cercanos</string>
     <string name="l10n_connection_help_charge_it_and_put_it_on_31b04814">Cargarlo y ponerlo en</string>
     <string name="l10n_connection_help_close_the_official_whoop_app_768d7d17">Cerrar la aplicación oficial WHOOP</string>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -1203,6 +1203,8 @@
     <string name="l10n_components_glowring_value_ac0e87de">Valeur d\'éclat</string>
     <string name="l10n_components_increase_accessibility_0949c0e9">Augmenter %1$s</string>
     <string name="l10n_components_ringfill_59cd4fb9">bagueRemplir</string>
+    <string name="l10n_components_close_bbfa773e">Fermer</string>
+    <string name="l10n_components_copy_af74f7c5">Copier</string>
     <string name="l10n_connection_help_allow_nearby_devices_f7c74880">Permettre aux périphériques à proximité</string>
     <string name="l10n_connection_help_charge_it_and_put_it_on_31b04814">Chargez-le et mettez-le</string>
     <string name="l10n_connection_help_close_the_official_whoop_app_768d7d17">Fermez l\'application officielle WHOOP</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -1334,6 +1334,8 @@
     <string name="l10n_components_glowring_value_ac0e87de">wartość świecąca</string>
     <string name="l10n_components_increase_accessibility_0949c0e9">Zwiększ %1$s</string>
     <string name="l10n_components_ringfill_59cd4fb9">Wypełnienie pierścienia</string>
+    <string name="l10n_components_close_bbfa773e">Zamknij</string>
+    <string name="l10n_components_copy_af74f7c5">Kopia</string>
     <string name="l10n_connection_help_allow_nearby_devices_f7c74880">Zezwalaj na urządzenia w pobliżu</string>
     <string name="l10n_connection_help_charge_it_and_put_it_on_31b04814">Energia i załóż</string>
     <string name="l10n_connection_help_close_the_official_whoop_app_768d7d17">Zamknij oficjalną aplikację WHOOP</string>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -1348,6 +1348,8 @@
     <string name="l10n_components_glowring_value_ac0e87de">valor do anel luminoso</string>
     <string name="l10n_components_increase_accessibility_0949c0e9">Aumentar %1$s</string>
     <string name="l10n_components_ringfill_59cd4fb9">ringFill</string>
+    <string name="l10n_components_close_bbfa773e">Fechar</string>
+    <string name="l10n_components_copy_af74f7c5">Cópia</string>
     <string name="l10n_connection_help_allow_nearby_devices_f7c74880">Permitir dispositivos próximos</string>
     <string name="l10n_connection_help_charge_it_and_put_it_on_31b04814">Carregue e coloque-o</string>
     <string name="l10n_connection_help_close_the_official_whoop_app_768d7d17">Feche a aplicação oficial do WHOOP</string>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -1396,6 +1396,8 @@
     <string name="l10n_components_chunks_chunks_pulled_cec186cf">Получено фрагментов: %1$s</string>
     <string name="l10n_components_decrease_accessibility_df5f1511">Уменьшить %1$s</string>
     <string name="l10n_components_increase_accessibility_0949c0e9">Увеличить %1$s</string>
+    <string name="l10n_components_close_bbfa773e">Закрыть</string>
+    <string name="l10n_components_copy_af74f7c5">Копировать</string>
     <string name="l10n_connection_help_allow_nearby_devices_f7c74880">Разрешить «Устройства поблизости»</string>
     <string name="l10n_connection_help_charge_it_and_put_it_on_31b04814">Зарядите его и наденьте</string>
     <string name="l10n_connection_help_close_the_official_whoop_app_768d7d17">Закройте официальное приложение WHOOP</string>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -1324,6 +1324,8 @@
     <string name="l10n_components_glowring_value_ac0e87de">glowring-value</string>
     <string name="l10n_components_increase_accessibility_0949c0e9">增加 %1$s</string>
     <string name="l10n_components_ringfill_59cd4fb9">ringFill</string>
+    <string name="l10n_components_close_bbfa773e">关闭</string>
+    <string name="l10n_components_copy_af74f7c5">复制</string>
     <string name="l10n_connection_help_allow_nearby_devices_f7c74880">允许“附近设备”权限</string>
     <string name="l10n_connection_help_charge_it_and_put_it_on_31b04814">给它充电并佩戴在手腕上</string>
     <string name="l10n_connection_help_close_the_official_whoop_app_768d7d17">从后台彻底关闭 WHOOP 官方 App</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1479,6 +1479,8 @@
     <string name="l10n_components_glowring_value_ac0e87de">glowring-value</string>
     <string name="l10n_components_increase_accessibility_0949c0e9">Increase %1$s</string>
     <string name="l10n_components_ringfill_59cd4fb9">ringFill</string>
+    <string name="l10n_components_close_bbfa773e">Close</string>
+    <string name="l10n_components_copy_af74f7c5">Copy</string>
     <string name="l10n_connection_help_allow_nearby_devices_f7c74880">Allow Nearby devices</string>
     <string name="l10n_connection_help_charge_it_and_put_it_on_31b04814">Charge it and put it on</string>
     <string name="l10n_connection_help_close_the_official_whoop_app_768d7d17">Close the official WHOOP app</string>

--- a/android/app/src/test/java/com/noop/data/DataBackupIntegrityTest.kt
+++ b/android/app/src/test/java/com/noop/data/DataBackupIntegrityTest.kt
@@ -1,6 +1,7 @@
 package com.noop.data
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -43,5 +44,63 @@ class DataBackupIntegrityTest {
             "Page 9 is never used",
             DataBackup.quickCheckVerdict(listOf("ok", "Page 9 is never used")),
         )
+    }
+
+    // ── readableComplaint: the verdict is forensic, this is what a person is shown ──
+
+    /** The reported shape. The verdict is ONE row carrying SQLite's banner, a newline, and then the
+     *  only half that says anything. Shown whole it spends the line on the banner, which is what a
+     *  truncating Toast displayed. */
+    @Test fun theBannerIsDroppedAndTheDiagnosisKept() {
+        assertEquals(
+            "Page 5 is never used",
+            DataBackup.readableComplaint("*** in database main ***\nPage 5 is never used"),
+        )
+    }
+
+    /** Captured from a REAL corrupted SQLite file (pages scribbled over, header left intact) rather
+     *  than invented: quick_check(1) answers with ONE row holding the banner, a newline, and the
+     *  diagnosis. This is the exact shape the reported Toast was truncating. */
+    @Test fun theRealQuickCheckShapeYieldsItsDiagnosis() {
+        assertEquals(
+            "Tree 2 page 7: btreeInitPage() returns error code 11",
+            DataBackup.readableComplaint("*** in database main ***\nTree 2 page 7: btreeInitPage() returns error code 11"),
+        )
+    }
+
+    /** An attached database names itself in the banner, so the match cannot be on "main" alone. */
+    @Test fun anyDatabaseNameInTheBannerIsDropped() {
+        assertEquals(
+            "Page 9 is never used",
+            DataBackup.readableComplaint("*** in database temp ***\nPage 9 is never used"),
+        )
+    }
+
+    /** Banner and nothing else: showing an empty parenthesis would be worse than showing the banner,
+     *  so the raw verdict survives as the fallback. */
+    @Test fun aVerdictOfNothingButBannerIsStillShown() {
+        assertEquals("*** in database main ***", DataBackup.readableComplaint("*** in database main ***"))
+    }
+
+    /** A verdict with no banner at all is already the diagnosis and passes through untouched. */
+    @Test fun aPlainVerdictIsUnchanged() {
+        assertEquals(
+            "row 12 missing from index sleepIdx",
+            DataBackup.readableComplaint("row 12 missing from index sleepIdx"),
+        )
+    }
+
+    @Test fun severalComplaintsAreJoinedOntoOneLine() {
+        assertEquals(
+            "Page 5 is never used; Page 9 is never used",
+            DataBackup.readableComplaint("*** in database main ***\nPage 5 is never used\nPage 9 is never used"),
+        )
+    }
+
+    /** Capped, because this rides inside a sentence that has to stay readable. */
+    @Test fun anOverlongComplaintIsCappedWithAnEllipsis() {
+        val out = DataBackup.readableComplaint("*** in database main ***\n" + "x".repeat(500), limit = 40)
+        assertEquals(40, out.length)
+        assertTrue(out.endsWith("\u2026"))
     }
 }

--- a/android/app/src/test/java/com/noop/data/DataBackupIntegrityTest.kt
+++ b/android/app/src/test/java/com/noop/data/DataBackupIntegrityTest.kt
@@ -97,6 +97,13 @@ class DataBackupIntegrityTest {
         )
     }
 
+    /** A nonsense limit must not throw: take(-1) is an exception in Kotlin and prefix(-1) traps in
+     *  Swift, and a display helper is the last place that should be able to crash a failure path. */
+    @Test fun adegenerateLimitStillReturnsSomething() {
+        assertEquals(1, DataBackup.readableComplaint("*** in database main ***\nPage 5", limit = 0).length)
+        assertEquals(1, DataBackup.readableComplaint("*** in database main ***\nPage 5", limit = -5).length)
+    }
+
     /** Capped, because this rides inside a sentence that has to stay readable. */
     @Test fun anOverlongComplaintIsCappedWithAnEllipsis() {
         val out = DataBackup.readableComplaint("*** in database main ***\n" + "x".repeat(500), limit = 40)


### PR DESCRIPTION
A corrupt-backup toast, reported from a staging build:

> This backup file is damaged and can't be restored (SQLite reports: *** in d…

Everything the reader needed was past the cut. Two independent faults got it there.

## 1. The detail shown was the wrong half

`quick_check(1)` answers with **one row** holding its banner, a newline, and then the diagnosis. Captured from a genuinely corrupted file rather than assumed:

```
'*** in database main ***\nTree 2 page 7: btreeInitPage() returns error code 11'
```

So the sentence spent its whole line naming the database and pushed the only informative part out of sight. That matches the pinned golden vectors from #1014, which say the same thing.

`readableComplaint` drops the banner, joins what remains onto one line, and caps the length.

The verdict itself stays **verbatim**, so this is a presentation step beside `quickCheckVerdict` rather than a change to it: a reporter pasting it into an issue should paste what SQLite actually said rather than a summary of it. Mirrored on both platforms against the same golden vectors, including the captured one, so the shape being handled is the shape SQLite emits rather than the shape I imagined.

A verdict made entirely of banner falls back to showing the banner: an empty parenthesis would be worse.

## 2. The container was the wrong size

Every one of these messages ends on the part the reader can act on:

- "Your current data is untouched. Try an earlier backup file."
- "Your previous data was rolled back automatically and is unchanged."
- "Your previous data is preserved at `<file>` next to the app's database."
- "Export the WHOOP-format CSV instead to save what's still readable."

A Toast truncates from the right, so those are exactly what got dropped. Android now shows them in a dialog with **Copy**, so a corruption report carries SQLite's own words instead of a fragment retyped off a screenshot.

Re-review caught a fourth path: the **export-side** refusal, which lands in a different launcher's `onFailure` and had the same problem. It goes to the same dialog now.

Android also reorders its sentences so the next step precedes the diagnostic, which is what should survive if anything ever truncates again.

## Why Apple's copy is untouched

Apple shows these in `.alert(title, message)` and truncates nothing, so the ordering fault is Android's alone. Apple gets the banner strip (an interpolated expression, so the localization keys are unchanged) and nothing else. Rewording those four strings would have invalidated **nine** translations each to fix a problem that platform does not have.

## Strings

Two new keys, `Close` and `Copy`, both reusing the English text and the existing translations already in the tree for the same words rather than inventing any. `values-zh` had no `Copy` string at all, and the audit's non-focus ratchet caught the gap I would otherwise have left (49 → 50); it is 复制, matching the 关闭 already beside it.

## Verification

- `WhoopStoreTests.DatabaseIntegrityTests` 6 green locally (snapshot-SQLite harness)
- `DataBackupIntegrityTest` 12 green, forced full rerun after a `syncRoomSchemaSnapshot` in its own invocation
- `i18n_audit.py --ci` green, `doc_comment_lint.py` green
- `lintVitalFullRelease -PstagingRelease` green, which is the gate for `ExtraTranslation` after a `strings.xml` change

Not verified on a device: the dialog's appearance, and Copy landing on the clipboard. Both are ordinary Compose, but neither was run on hardware here.

## Found by re-review

- **The verdict reaches no log.** An earlier draft of this comment claimed it "goes in logs". It does not: these gates write nowhere, so the only copy of SQLite's own words is the one on screen, which is exactly why the dialog can copy it. Putting it in the shareable strap log is worth doing, but that log lives in `WhoopBleClient`'s prefs ring and reaching into it from `DataBackup` is a coupling that wants its own change. The claim is corrected here rather than the code, and the comment now says where the only copy actually is.
- **Copy dismisses the dialog.** Android 13+ shows a system clipboard confirmation, but minSdk is 26, and below that a Copy that left the dialog open gave no sign anything had happened.
- **A limit of zero or less would have thrown**: Kotlin's `take(-1)` is an exception, Swift's `prefix(-1)` a precondition failure. A display helper on a failure path is the last place that should be able to crash. Both clamp, both pin it.