### PR TITLE
Let the daily brief reach the screen it was generated for

### DIFF
--- a/Strand/AI/AICoach.swift
+++ b/Strand/AI/AICoach.swift
@@ -616,11 +616,23 @@ final class AICoachEngine: ObservableObject {
         didLoadPersistedMessages = true
         guard messages.isEmpty, let store = await repo.storeHandle() else { return }
         guard let rows = try? await store.coachMessages(), !rows.isEmpty else { return }
+        // Recover the day this transcript was last written on FROM THE ROWS. `conversationDay` lives in
+        // memory, so a process restart brought it back nil, and `isStaleConversation(nil, ...)` is false
+        // by design (nothing sent yet is never stale), which meant a restored conversation from any
+        // previous day was never retired, by `send` or by anything else (#2087).
+        let newest = rows.map(\.createdAt).max() ?? 0
+        let lastDay = Self.localEpochDay(Date(timeIntervalSince1970: TimeInterval(newest)))
+        // Retire by NOT restoring. The next append replaces the stored rows wholesale, so nothing is
+        // deleted here and a transcript is never destroyed by merely opening the screen.
+        guard !Self.isStaleConversation(lastEpochDay: lastDay, todayEpochDay: Self.localEpochDay()) else {
+            return
+        }
         messages = rows
             .sorted { $0.orderIndex < $1.orderIndex }
             .map { ChatMessage(id: UUID(uuidString: $0.id) ?? UUID(),
                                 role: ChatMessage.Role(rawValue: $0.role) ?? .user,
                                 text: $0.text) }
+        conversationDay = lastDay
     }
 
     /// Replace the ENTIRE persisted conversation with the current in-memory `messages`. Called once

--- a/Strand/Screens/CoachView.swift
+++ b/Strand/Screens/CoachView.swift
@@ -150,7 +150,11 @@ struct CoachView: View {
         // transcript genuinely empty.
         .task {
             await coach.loadPersistedMessagesIfNeeded()
-            if let stored = CoachBriefScheduler.consumeStoredBrief() {
+            // Gated on the transcript BEFORE consuming. `consumeStoredBrief()` clears the unconsumed
+            // flag, and `surfaceScheduledBrief` then drops the text if a transcript exists, so a brief
+            // that arrived on a day with a conversation already open was consumed and thrown away, gone
+            // for good. Android checked first and so only ever failed to SHOW it (#2087).
+            if coach.messages.isEmpty, let stored = CoachBriefScheduler.consumeStoredBrief() {
                 coach.surfaceScheduledBrief(stored)
             }
             CoachBriefScheduler.activateIfEnabled { await coach.generateBrief() }

--- a/StrandTests/CoachConversationDayTests.swift
+++ b/StrandTests/CoachConversationDayTests.swift
@@ -117,4 +117,44 @@ final class CoachConversationDayTests: XCTestCase {
         let earlier = lateEvening.addingTimeInterval(-3_600)
         XCTAssertEqual(AICoachEngine.localEpochDay(earlier, calendar: la), d0)
     }
+
+    // MARK: - #2087: recovering a RESTORED transcript's day from its rows
+
+    /// `conversationDay` lives in memory, so a process restart brought it back nil, and
+    /// `isStaleConversation` treats nil as "never stale" BY DESIGN (nothing sent yet cannot be). So a
+    /// conversation restored from any previous day was never retired, by `send` or by anything else,
+    /// and the scheduled brief, which only surfaces onto an EMPTY transcript, could never appear again
+    /// after the first day. The day has to come back from the stored rows' `createdAt`.
+    ///
+    /// Twin of the Kotlin `a transcript written last night is stale after local midnight`.
+    func testATranscriptWrittenLastNightIsStaleAfterLocalMidnight() {
+        // A row written at 23:00 UTC on the 10th, the way a late-evening turn is stored.
+        var comps = DateComponents()
+        comps.year = 2026; comps.month = 9; comps.day = 10; comps.hour = 23
+        let createdAt = Int(utc.date(from: comps)!.timeIntervalSince1970)
+
+        let lastDay = AICoachEngine.localEpochDay(Date(timeIntervalSince1970: TimeInterval(createdAt)),
+                                                  calendar: utc)
+        XCTAssertEqual(lastDay, day(2026, 9, 10))
+        XCTAssertTrue(AICoachEngine.isStaleConversation(lastEpochDay: lastDay,
+                                                        todayEpochDay: day(2026, 9, 11)))
+        XCTAssertFalse(AICoachEngine.isStaleConversation(lastEpochDay: lastDay,
+                                                         todayEpochDay: day(2026, 9, 10)))
+    }
+
+    /// The newest row decides the day, not the oldest: a conversation started yesterday and continued
+    /// past midnight belongs to today, and must NOT be retired out from under the user.
+    func testTheNewestRowDecidesTheTranscriptDay() {
+        func at(_ y: Int, _ m: Int, _ d: Int, _ h: Int) -> Int {
+            var c = DateComponents(); c.year = y; c.month = m; c.day = d; c.hour = h
+            return Int(utc.date(from: c)!.timeIntervalSince1970)
+        }
+        let rows = [at(2026, 9, 10, 23), at(2026, 9, 11, 0)]
+        let newest = rows.max()!
+        let lastDay = AICoachEngine.localEpochDay(Date(timeIntervalSince1970: TimeInterval(newest)),
+                                                  calendar: utc)
+        XCTAssertEqual(lastDay, day(2026, 9, 11))
+        XCTAssertFalse(AICoachEngine.isStaleConversation(lastEpochDay: lastDay,
+                                                         todayEpochDay: day(2026, 9, 11)))
+    }
 }

--- a/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/CoachViewModel.kt
@@ -20,7 +20,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.time.Instant
 import java.time.LocalDate
+import java.time.ZoneId
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -482,8 +484,17 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
         if (_messages.value.isNotEmpty()) return
         val rows = runCatching { coachDao.coachMessages() }.getOrDefault(emptyList())
         if (rows.isEmpty()) return
+        // Recover the day this transcript was last written on FROM THE ROWS. [conversationDay] lives in
+        // memory, so a process restart brought it back null, and `isStaleConversation(null, ...)` is
+        // false by design (nothing sent yet is never stale) — which meant a restored conversation from
+        // any previous day was never retired, by [send] or by anything else (#2087).
+        val lastDay = localEpochDay(rows.maxOf { it.createdAt })
+        // Retire by NOT restoring. The next append replaces the stored rows wholesale, so nothing is
+        // deleted here and a transcript is never destroyed by merely opening the screen.
+        if (isStaleConversation(lastDay, LocalDate.now().toEpochDay())) return
         _messages.value = rows.sortedBy { it.orderIndex }
             .map { ChatMsg(id = it.id, role = it.role, text = it.text) }
+        conversationDay = lastDay
     }
 
     /** Replace the ENTIRE persisted conversation with the current in-memory [_messages]. Called once
@@ -623,6 +634,17 @@ class CoachViewModel(app: Application) : AndroidViewModel(app) {
          * what's sent. (parity with Swift `maxStoredMessages`)
          */
         private const val MAX_STORED_MESSAGES = 40
+
+        /**
+         * The LOCAL epoch day an epoch-SECONDS instant falls on: the same value
+         * `LocalDate.now().toEpochDay()` yields for "now", for a stored row's `createdAt`.
+         *
+         * Zone is injectable so the rule is pinned without depending on the machine's, and the
+         * conversion goes through the calendar rather than dividing by 86 400, because a local day is
+         * not always 86 400 seconds. Twin of Swift `AICoachEngine.localEpochDay(_:calendar:)`.
+         */
+        internal fun localEpochDay(epochSeconds: Long, zone: ZoneId = ZoneId.systemDefault()): Long =
+            Instant.ofEpochSecond(epochSeconds).atZone(zone).toLocalDate().toEpochDay()
 
         /**
          * True when a transcript last written on [lastEpochDay] should be retired before a question

--- a/android/app/src/test/java/com/noop/ui/CoachConversationDayTest.kt
+++ b/android/app/src/test/java/com/noop/ui/CoachConversationDayTest.kt
@@ -100,6 +100,19 @@ class CoachConversationDayTest {
         assertEquals(day(2026, 3, 9), CoachViewModel.localEpochDay(localMidnight + 23 * 3_600, ny))
     }
 
+    /** The NEWEST row dates the transcript, not the oldest: a conversation started last night and
+     *  carried past midnight belongs to today, and must not be retired out from under the user.
+     *  Twin of the Swift `testTheNewestRowDecidesTheTranscriptDay`. */
+    @Test
+    fun `the newest row decides the transcript day`() {
+        fun at(y: Int, m: Int, d: Int, h: Int) =
+            LocalDate.of(y, m, d).atStartOfDay(utc).toEpochSecond() + h * 3_600L
+        val rows = listOf(at(2026, 9, 10, 23), at(2026, 9, 11, 0))
+        val lastDay = CoachViewModel.localEpochDay(rows.max(), utc)
+        assertEquals(day(2026, 9, 11), lastDay)
+        assertFalse(CoachViewModel.isStaleConversation(lastDay, day(2026, 9, 11)))
+    }
+
     /** The two rules together, which is how the restore path uses them: a transcript last written late
      *  last night is stale the moment the local date rolls over, even minutes later. */
     @Test

--- a/android/app/src/test/java/com/noop/ui/CoachConversationDayTest.kt
+++ b/android/app/src/test/java/com/noop/ui/CoachConversationDayTest.kt
@@ -1,9 +1,11 @@
 package com.noop.ui
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.LocalDate
+import java.time.ZoneId
 
 /**
  * Pins [CoachViewModel.isStaleConversation] — the day boundary that retires the coach transcript.
@@ -54,5 +56,58 @@ class CoachConversationDayTest {
     fun yearBoundaryIsJustAnotherDay() {
         assertTrue(CoachViewModel.isStaleConversation(day(2025, 12, 31), day(2026, 1, 1)))
         assertFalse(CoachViewModel.isStaleConversation(day(2026, 1, 1), day(2025, 12, 31)))
+    }
+
+    // ── localEpochDay: recovering a RESTORED transcript's day from its rows (#2087) ──────────────
+    //
+    // conversationDay lives in memory, so a process restart brought it back null. isStaleConversation
+    // treats null as "never stale" by design, so a conversation restored from any previous day was
+    // never retired, and the scheduled brief, which only surfaces onto an EMPTY transcript, could
+    // never appear again after the first day. The day has to come back from the rows themselves.
+
+    private val utc: ZoneId = ZoneId.of("UTC")
+
+    @Test
+    fun `an instant maps to its local day`() {
+        // 2026-09-11T00:00:00Z
+        val midnightUtc = LocalDate.of(2026, 9, 11).atStartOfDay(utc).toEpochSecond()
+        assertEquals(day(2026, 9, 11), CoachViewModel.localEpochDay(midnightUtc, utc))
+        assertEquals(day(2026, 9, 11), CoachViewModel.localEpochDay(midnightUtc + 86_399, utc))
+        assertEquals(day(2026, 9, 12), CoachViewModel.localEpochDay(midnightUtc + 86_400, utc))
+    }
+
+    /** The zone decides the day, not the instant: the same second is two different local days either
+     *  side of a date line. A transcript is retired against the user's calendar, not UTC's. */
+    @Test
+    fun `the same instant can be two different local days`() {
+        val instant = LocalDate.of(2026, 9, 11).atStartOfDay(utc).toEpochSecond()
+        assertEquals(day(2026, 9, 11), CoachViewModel.localEpochDay(instant, utc))
+        assertEquals(day(2026, 9, 10), CoachViewModel.localEpochDay(instant, ZoneId.of("America/New_York")))
+    }
+
+    /**
+     * A local day is not always 86 400 seconds, which is why this goes through the calendar rather
+     * than dividing. On a spring-forward day the local day is 23 hours: an instant 23 hours after
+     * local midnight is already the NEXT day, and arithmetic on 86 400 would still call it the same one.
+     */
+    @Test
+    fun `a short day from daylight saving still counts as one day`() {
+        val ny = ZoneId.of("America/New_York")
+        // 2026-03-08 is the US spring-forward date: 02:00 local jumps to 03:00, so the day is 23h long.
+        val localMidnight = LocalDate.of(2026, 3, 8).atStartOfDay(ny).toEpochSecond()
+        assertEquals(day(2026, 3, 8), CoachViewModel.localEpochDay(localMidnight, ny))
+        assertEquals(day(2026, 3, 8), CoachViewModel.localEpochDay(localMidnight + 23 * 3_600 - 1, ny))
+        assertEquals(day(2026, 3, 9), CoachViewModel.localEpochDay(localMidnight + 23 * 3_600, ny))
+    }
+
+    /** The two rules together, which is how the restore path uses them: a transcript last written late
+     *  last night is stale the moment the local date rolls over, even minutes later. */
+    @Test
+    fun `a transcript written last night is stale after local midnight`() {
+        val lastNight = LocalDate.of(2026, 9, 10).atStartOfDay(utc).toEpochSecond() + 23 * 3_600
+        val lastDay = CoachViewModel.localEpochDay(lastNight, utc)
+        assertEquals(day(2026, 9, 10), lastDay)
+        assertTrue(CoachViewModel.isStaleConversation(lastDay, day(2026, 9, 11)))
+        assertFalse(CoachViewModel.isStaleConversation(lastDay, day(2026, 9, 10)))
     }
 }


### PR DESCRIPTION
Addresses the second half of #2087, reported by @bartmuskala: the morning notification arrives, and the Coach page still shows yesterday's brief, dated yesterday.

## Why the brief never appears

`CoachScreen` does this on appear:

```kotlin
vm.loadPersistedMessagesIfNeeded()    // restores yesterday's transcript from Room
vm.consumeScheduledBriefIfAny(context)
```

and the consumer opens with:

```kotlin
if (_messages.value.isNotEmpty()) return
```

Day one the transcript is empty, so the brief lands. From day two on, the restore has just repopulated it with yesterday's brief, so today's is dropped **before `consumeStoredBrief()` is even called**. The notification fires, the brief is generated and stored, and nothing shows it.

## Why the day boundary could not save it

`isStaleConversation` exists for exactly this, is wired into `send` on both platforms, and is well tested. It compares against `conversationDay`, which lives in memory.

A process restart brings that back `null`, and a null last-day is **never stale by design** (nothing sent yet cannot be). So a conversation restored from any previous day survived every boundary, including the one in `send` added to stop precisely this. The comment there describes the symptom it was meant to cure; persisting the transcript later reintroduced it across restarts.

## The fix

Every stored message already carries `createdAt`, so **the newest row dates the transcript**. No schema change, no migration, no new preference.

A transcript from a previous local day is retired by **not being restored**. The stored rows are left for the next append to replace, so nothing is deleted merely by opening the screen. Once the transcript is genuinely empty, the existing `isEmpty` gates work as written and today's brief surfaces.

Recovering the day also repairs the `send` path: a same-day restore now sets `conversationDay`, so the boundary is evaluated against a real value instead of `null`.

## Apple was losing the brief outright

Not visible from the report, since it is Android:

```swift
if let stored = CoachBriefScheduler.consumeStoredBrief() {   // clears hasUnconsumed
    coach.surfaceScheduledBrief(stored)                      // guard messages.isEmpty else { return }
}
```

The flag is cleared **before** the emptiness check rejects the text, so on Apple a brief that arrived on a day with a conversation open was consumed and thrown away, gone for good. Android checked first and so only ever failed to show one. The check now precedes the consume on both platforms.

## A consequence worth stating

On Apple, opening Coach on a new day can now reach `startBriefIfNeeded`, which generates a brief **over the network** on a bring-your-own key. It only happens when no scheduled brief is stored, because surfacing one leaves the transcript non-empty, and it is exactly what that function is for. It had been dormant since the transcript stopped emptying, so this restores its intent rather than adding a new call site.

Also worth naming: opening Coach on a new day now retires yesterday's conversation. That is not new behaviour so much as an earlier moment for it, since the first `send` of the day already wiped it.

## Not in this PR

The report's other half is that tapping the notification opens the last page rather than Coach. That is deliberate today (`appLaunchIntent`, documented as the convention every NOOP notification uses), and there is **no notification-to-screen routing anywhere in the app**: no `onNewIntent`, no intent extras, no route state to target. Building that is a separate concern and a decision about whether every notification gains a destination or only this one.

## Verification

- `CoachConversationDayTest` 11 green (5 new), full Android suite 5979 tests across 703 classes, 0 failures
- New cases pin the recovered day: an instant maps to its local day, the same instant is two different days in two zones, a 23-hour spring-forward day still counts as one day (which is why this goes through the calendar rather than dividing by 86 400), and a transcript written at 23:00 is stale after local midnight
- Swift twins pin the same composition; `localEpochDay` already had DST coverage both directions, so that is not duplicated
- Re-review found the reverse gap and closed it: Swift pinned that the **newest** row dates the transcript (so a conversation carried past midnight belongs to today and is not retired out from under the user) and Android had no twin, meaning an implementation that took the oldest row would have passed there
- `doc_comment_lint.py` and `i18n_audit.py --ci` green
- Apple is app-target Swift and does not build on this Linux box, so `CoachConversationDayTests` runs in CI on the `Strand` macOS leg
- Not exercised on a device: no notification was actually fired and tapped across a midnight boundary. The day logic is driven by injected zones and clocks, not by waiting for one.