### PR TITLE
fix(oura): never write GetProductInfo replies into the raw diagnostics sidecar

### DIFF
--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -168,9 +168,24 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// is already the full parse of `bytes`): computes the `tail` `rawDumpBytes` needs from `frames`
     /// itself, rather than duplicating that arithmetic at the call site. Kept CoreBluetooth-free and
     /// `nonisolated static` so it is testable directly, the same as `rawDumpBytes`.
+    ///
+    /// CORRECTION (PR #2090 review, ryanbr, self-caught 6 minutes after suggesting the tail in the first
+    /// place): appending the tail unconditionally would put the serial BACK. When the frame split across
+    /// notifications is itself a GetProductInfo reply, `parseOuterFrames` stops right at it, so the
+    /// unconsumed remainder starts with `0x19` and continues straight into the ASCII serial - exactly
+    /// what this whole PR exists to keep out. The refinement that gets both: append the remainder only
+    /// when its first byte is NOT a `productInfoResponseOps` op. An ordinary split frame (any other op)
+    /// keeps full fidelity; a split product-info frame drops its (however partial) tail along with the
+    /// rest of it, same as a complete one does.
     nonisolated static func rawDumpBytes(fromNotification bytes: [UInt8], frames: [OuraOuterFrame]) -> [UInt8] {
         let consumedLength = frames.reduce(0) { $0 + 2 + $1.body.count }
-        let tail = consumedLength < bytes.count ? Array(bytes[consumedLength...]) : []
+        var tail: [UInt8] = []
+        if consumedLength < bytes.count {
+            let remainder = Array(bytes[consumedLength...])
+            if let leadOp = remainder.first, !productInfoResponseOps.contains(leadOp) {
+                tail = remainder
+            }
+        }
         return rawDumpBytes(frames, appending: tail)
     }
 

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -149,9 +149,29 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// frame body. Found via a #2075 reporter's attachment, whose `oura-raw.jsonl` carried a stable
     /// 16-digit identifier this way, unredacted, into a public issue. Never touches decode: only what
     /// `rawDump?.record` sees changes.
-    nonisolated static func rawDumpBytes(_ frames: [OuraOuterFrame]) -> [UInt8] {
+    ///
+    /// `tail` (PR #2090 review, ryanbr): `frames` only covers what `OuraFraming.parseOuterFrames` fully
+    /// consumed — it silently drops an incomplete trailing frame (`guard i + total <= bytes.count else {
+    /// break }`), which is ORDINARY, not rare: the Reassembler exists precisely because notifications
+    /// split mid-frame. A caller reconstructing the sidecar from `frames` alone therefore loses that
+    /// unconsumed remainder — e.g. `41 02 AA BB 42 05 01 02` parses one complete frame and silently drops
+    /// `42 05 01 02`. For a sidecar whose whole purpose is exact wire bytes, that is a real loss, so a
+    /// caller that reconstructs from `frames` (rather than recording the original notification bytes
+    /// verbatim) must pass whatever `bytes` remained past the frames it parsed.
+    nonisolated static func rawDumpBytes(_ frames: [OuraOuterFrame], appending tail: [UInt8] = []) -> [UInt8] {
         frames.filter { !productInfoResponseOps.contains($0.op) }
               .flatMap { [$0.op, UInt8($0.body.count)] + $0.body }
+              + tail
+    }
+
+    /// Convenience for the whole-notification case (the "no secure frame" branch below, where `frames`
+    /// is already the full parse of `bytes`): computes the `tail` `rawDumpBytes` needs from `frames`
+    /// itself, rather than duplicating that arithmetic at the call site. Kept CoreBluetooth-free and
+    /// `nonisolated static` so it is testable directly, the same as `rawDumpBytes`.
+    nonisolated static func rawDumpBytes(fromNotification bytes: [UInt8], frames: [OuraOuterFrame]) -> [UInt8] {
+        let consumedLength = frames.reduce(0) { $0 + 2 + $1.body.count }
+        let tail = consumedLength < bytes.count ? Array(bytes[consumedLength...]) : []
+        return rawDumpBytes(frames, appending: tail)
     }
 
     /// Local-time formatter for logging a decoded date/time next to a raw ring-tick cursor value, so a
@@ -2574,8 +2594,11 @@ extension OuraLiveSource: @preconcurrency CBPeripheralDelegate {
             }
             return
         }
-        // No secure frame in this notification: treat the whole value as TLV record bytes.
-        let dumpBytes = Self.rawDumpBytes(frames)
+        // No secure frame in this notification: treat the whole value as TLV record bytes. `frames` was
+        // parsed from this WHOLE notification (line ~2495), so `rawDumpBytes(fromNotification:frames:)`
+        // appends whatever incomplete trailing frame `parseOuterFrames` had to leave behind (PR #2090
+        // review) — otherwise the sidecar silently loses exactly the wire bytes it exists to preserve.
+        let dumpBytes = Self.rawDumpBytes(fromNotification: bytes, frames: frames)
         if !dumpBytes.isEmpty {
             rawDump?.record(bytes: dumpBytes)
         }

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -143,6 +143,17 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         (8...24).contains(s.count) && s.allSatisfy { $0.isLetter || $0.isNumber }
     }
 
+    /// Re-encode outer frames for the raw diagnostics sidecar, dropping `productInfoResponseOps` —
+    /// a GetProductInfo reply's body IS the ring's serial/hardware string in plain ASCII, and the
+    /// sidecar's redaction pass only ever masks the JSON envelope's `deviceId`, never bytes inside a
+    /// frame body. Found via a #2075 reporter's attachment, whose `oura-raw.jsonl` carried a stable
+    /// 16-digit identifier this way, unredacted, into a public issue. Never touches decode: only what
+    /// `rawDump?.record` sees changes.
+    nonisolated static func rawDumpBytes(_ frames: [OuraOuterFrame]) -> [UInt8] {
+        frames.filter { !productInfoResponseOps.contains($0.op) }
+              .flatMap { [$0.op, UInt8($0.body.count)] + $0.body }
+    }
+
     /// Local-time formatter for logging a decoded date/time next to a raw ring-tick cursor value, so a
     /// number like "1178203" reads as an actual date instead of an opaque tick count. Logging only.
     private static let cursorDateFormatter: DateFormatter = {
@@ -2552,16 +2563,22 @@ extension OuraLiveSource: @preconcurrency CBPeripheralDelegate {
             }
             // Any non-secure outer frames in the same notification are TLV records; fall through to decode.
             // The 0x25 ack (if any) is consumed above, so it never reaches here.
-            let tlvBytes = frames.filter { $0.op != OuraFraming.secureSessionOp && $0.op != Self.setAuthKeyRespOp }
-                                 .flatMap { [$0.op, UInt8($0.body.count)] + $0.body }
+            let nonSecureFrames = frames.filter { $0.op != OuraFraming.secureSessionOp && $0.op != Self.setAuthKeyRespOp }
+            let tlvBytes = nonSecureFrames.flatMap { [$0.op, UInt8($0.body.count)] + $0.body }
             if !tlvBytes.isEmpty {
-                rawDump?.record(bytes: tlvBytes)
+                let dumpBytes = Self.rawDumpBytes(nonSecureFrames)
+                if !dumpBytes.isEmpty {
+                    rawDump?.record(bytes: dumpBytes)
+                }
                 ingestHistory(driver.ingest(notification: tlvBytes, reassembler: reassembler))
             }
             return
         }
         // No secure frame in this notification: treat the whole value as TLV record bytes.
-        rawDump?.record(bytes: bytes)
+        let dumpBytes = Self.rawDumpBytes(frames)
+        if !dumpBytes.isEmpty {
+            rawDump?.record(bytes: dumpBytes)
+        }
         ingestHistory(driver.ingest(notification: bytes, reassembler: reassembler))
     }
 

--- a/Strand/System/TestBundleAssembler.swift
+++ b/Strand/System/TestBundleAssembler.swift
@@ -34,14 +34,33 @@ enum TestBundleAssembler {
         "oura-raw.jsonl", "oura-ibihr.jsonl", "oura-activity.jsonl",
     ]
 
+    /// `oura-raw.jsonl` is the ONE sidecar whose payload is nothing but hex (`OuraRawDumpLine.encode`) —
+    /// `oura-ibihr.jsonl`/`oura-activity.jsonl` encode DECODED numeric fields, so `LiveState.redactHexDump`'s
+    /// byte-run heuristic below never sees a hex blob long enough to false-positive on. Only `raw` needs the
+    /// exemption `redactEntries` applies via this set.
+    private static let rawHexSidecarNames: Set<String> = ["oura-raw.jsonl"]
+
     /// Re-run the redaction sink over every entry. Text entries are decoded as UTF-8, scrubbed via the same
     /// LiveState.redactPii used by the live sink, and re-encoded. A non-UTF-8 entry (none today) passes
     /// through untouched rather than risk corrupting binary. meta.json and report.txt have no PII shapes so
     /// they pass through byte-identical; raw-capture is where the embedded serials live.
+    ///
+    /// `oura-raw.jsonl` skips the `redactPii` sweep entirely (see `rawHexSidecarNames`) — its `hex` field is
+    /// the ring's UNDECODED TLV bytes, and `redactPii`'s `redactHexDump` helper (built for #1833: a WHOOP
+    /// serial hiding as ASCII inside a hex-dumped console line) decodes hex back to bytes and masks any 9+
+    /// byte run that spells alnum ASCII starting with a letter. Every Oura record is nothing but such runs,
+    /// so that heuristic fires on ordinary sensor bytes and on the `0x43`/`0x61` debug-text channel (ASCII by
+    /// design) — found 2026-09-11 via a real user capture: 38 of 3112 lines had bytes silently replaced with
+    /// `•` placeholders that are not even valid hex, breaking any offline tool that reframes the file. The
+    /// actual identity leak this heuristic was hoped to also catch here — the ring's SERIAL, arriving in
+    /// plain digits via a `0x18`/`0x19` GetProductInfo reply — is invisible to it anyway (no letter in an
+    /// all-numeric run), and is instead filtered at the SOURCE by `OuraLiveSource.rawDumpBytes` before the
+    /// frame ever reaches this file. The `deviceId` field mask below still runs unconditionally, so the one
+    /// piece of identity `oura-raw.jsonl`'s JSON envelope carries is still scrubbed.
     static func redactEntries(_ entries: [FileExport.BundleEntry]) -> [FileExport.BundleEntry] {
         entries.map { entry in
             guard let text = String(data: entry.data, encoding: .utf8) else { return entry }
-            var scrubbed = LiveState.redactPii(text)
+            var scrubbed = rawHexSidecarNames.contains(entry.name) ? text : LiveState.redactPii(text)
             // #572 follow-up: field-aware deviceId mask for the Oura sidecars (see `ouraSidecarNames`). Runs
             // AFTER redactPii, so it catches a non-canonical id that the dash-anchored UUID rule misses; on an
             // already-canonical id redactPii turned into `<device>`, this is a no-op. Key-anchored to

--- a/StrandTests/OuraLiveSourceRawDumpRedactionTests.swift
+++ b/StrandTests/OuraLiveSourceRawDumpRedactionTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+import OuraProtocol
+@testable import Strand
+
+/// `OuraLiveSource.rawDumpBytes` is what actually reaches `oura-raw.jsonl` — the sidecar's own
+/// redaction pass only ever masks the JSON envelope's `deviceId`, never bytes inside a frame body.
+/// A `0x18`/`0x19` GetProductInfo reply's body IS the ring's serial/hardware string in plain ASCII
+/// (found via a user's own capture, which carried a stable 16-digit identifier into a public GitHub
+/// issue attachment this way). These pin that the raw sidecar never sees that frame, while every
+/// other frame — including ones that happen to share a notification with it — is untouched.
+final class OuraLiveSourceRawDumpRedactionTests: XCTestCase {
+    private func encoded(_ frames: [OuraOuterFrame]) -> [UInt8] {
+        frames.flatMap { [$0.op, UInt8($0.body.count)] + $0.body }
+    }
+
+    func testProductInfoRequestAndResponseAreBothDropped() {
+        let serial = Array("2038082631034041".utf8)
+        let frames = [OuraOuterFrame(op: 0x18, body: [0x08, 0x00, 0x10]),
+                      OuraOuterFrame(op: 0x19, body: serial)]
+        XCTAssertEqual(OuraLiveSource.rawDumpBytes(frames), [])
+    }
+
+    func testAnOrdinaryFrameIsUnaffected() {
+        let frames = [OuraOuterFrame(op: 0x5D, body: [0x01, 0x02, 0x03])]
+        XCTAssertEqual(OuraLiveSource.rawDumpBytes(frames), encoded(frames))
+    }
+
+    func testOnlyTheProductInfoFrameIsStrippedOutOfAMixedNotification() {
+        let hr = OuraOuterFrame(op: 0x80, body: [0x42])
+        let productInfo = OuraOuterFrame(op: 0x19, body: Array("COR_08".utf8))
+        let battery = OuraOuterFrame(op: 0x0D, body: [0x64])
+        XCTAssertEqual(OuraLiveSource.rawDumpBytes([hr, productInfo, battery]), encoded([hr, battery]))
+    }
+}

--- a/StrandTests/OuraLiveSourceRawDumpRedactionTests.swift
+++ b/StrandTests/OuraLiveSourceRawDumpRedactionTests.swift
@@ -31,4 +31,28 @@ final class OuraLiveSourceRawDumpRedactionTests: XCTestCase {
         let battery = OuraOuterFrame(op: 0x0D, body: [0x64])
         XCTAssertEqual(OuraLiveSource.rawDumpBytes([hr, productInfo, battery]), encoded([hr, battery]))
     }
+
+    /// PR #2090 review (ryanbr): `parseOuterFrames` silently drops an incomplete trailing frame
+    /// (`guard i + total <= bytes.count else { break }`) — ordinary, not rare, since the Reassembler
+    /// exists precisely because notifications split mid-frame. A caller reconstructing the sidecar from
+    /// `frames` alone therefore loses that unconsumed remainder. Reproduces the exact worked example from
+    /// the review: `41 02 AA BB 42 05 01 02` parses ONE complete frame (`41 02 AA BB`, 4 bytes) and leaves
+    /// `42 05 01 02` (4 of the claimed 7 body bytes) unconsumed - `rawDumpBytes(fromNotification:frames:)`
+    /// must still carry it into the sidecar, verbatim, appended after the (filtered) complete frames.
+    func testIncompleteTrailingFrameSurvivesAsATailNotAsALoss() {
+        let bytes: [UInt8] = [0x41, 0x02, 0xAA, 0xBB, 0x42, 0x05, 0x01, 0x02]
+        let frames = OuraFraming.parseOuterFrames(bytes)
+        XCTAssertEqual(frames, [OuraOuterFrame(op: 0x41, body: [0xAA, 0xBB])], "sanity: only one frame parses")
+        let dump = OuraLiveSource.rawDumpBytes(fromNotification: bytes, frames: frames)
+        XCTAssertEqual(dump, bytes, "the unconsumed tail must survive verbatim, not be dropped")
+    }
+
+    /// The same convenience function must still drop a product-info frame when the notification parses
+    /// cleanly with nothing left over (the ordinary case, no tail to preserve).
+    func testNotificationConvenienceStillStripsProductInfoWithNoTrailingPartial() {
+        let serial = Array("2038082631034041".utf8)
+        let bytes: [UInt8] = [0x19, UInt8(serial.count)] + serial
+        let frames = OuraFraming.parseOuterFrames(bytes)
+        XCTAssertEqual(OuraLiveSource.rawDumpBytes(fromNotification: bytes, frames: frames), [])
+    }
 }

--- a/StrandTests/OuraLiveSourceRawDumpRedactionTests.swift
+++ b/StrandTests/OuraLiveSourceRawDumpRedactionTests.swift
@@ -55,4 +55,23 @@ final class OuraLiveSourceRawDumpRedactionTests: XCTestCase {
         let frames = OuraFraming.parseOuterFrames(bytes)
         XCTAssertEqual(OuraLiveSource.rawDumpBytes(fromNotification: bytes, frames: frames), [])
     }
+
+    func testSplitProductInfoFrameTailIsDroppedNotAppended() {
+        let partialSerial = Array("2H3B2405003655".utf8) // 14 of the 20 bytes the header claims
+        let bytes: [UInt8] = [0x41, 0x02, 0xAA, 0xBB, 0x19, 0x14] + partialSerial
+        let frames = OuraFraming.parseOuterFrames(bytes)
+        XCTAssertEqual(frames, [OuraOuterFrame(op: 0x41, body: [0xAA, 0xBB])], "sanity: only one frame parses")
+        let dump = OuraLiveSource.rawDumpBytes(fromNotification: bytes, frames: frames)
+        XCTAssertEqual(dump, [0x41, 0x02, 0xAA, 0xBB], "the split product-info tail must be dropped whole")
+        XCTAssertFalse(String(decoding: dump, as: UTF8.self).contains("2H3B2405003655"))
+    }
+
+    /// The same guard applies to a bare one-byte remainder (just the op, not even a length byte yet) -
+    /// the review's "a one-byte remainder is fine to test the same way" note.
+    func testOneByteProductInfoOpRemainderIsDropped() {
+        let bytes: [UInt8] = [0x41, 0x02, 0xAA, 0xBB, 0x18]
+        let frames = OuraFraming.parseOuterFrames(bytes)
+        let dump = OuraLiveSource.rawDumpBytes(fromNotification: bytes, frames: frames)
+        XCTAssertEqual(dump, [0x41, 0x02, 0xAA, 0xBB])
+    }
 }

--- a/StrandTests/TestBundleAssemblerTests.swift
+++ b/StrandTests/TestBundleAssemblerTests.swift
@@ -124,6 +124,38 @@ final class TestBundleAssemblerTests: XCTestCase {
         XCTAssertTrue(out.contains("\"hex\":\"\(hex)\""), "the raw hex bytes must survive redaction intact")
     }
 
+    /// 2026-09-11: the test above only proves the raw `hex` field survives for a payload that happens to
+    /// avoid `redactHexDump`'s WHOOP-serial heuristic (its bytes never decode to a 9+ byte run of unbroken
+    /// alnum ASCII starting with a letter). A real capture's `0x80` live-HR/IBI and `0x43`/`0x61` debug-text
+    /// channels routinely produce exactly that shape by coincidence or by design (found 2026-09-11 in a
+    /// user's #2075 attachment: 38 of 3112 `oura-raw.jsonl` lines had bytes silently replaced with `•` — not
+    /// even valid hex — because they matched the WHOOP-serial shape this heuristic was built to catch on a
+    /// console hex dump, e.g. "WHOOP 4C1594026"). This pins that `oura-raw.jsonl` is now exempt from that
+    /// sweep while its `deviceId` is still masked.
+    func testRawSidecarSurvivesTheWhoopSerialHeuristicFalsePositive() {
+        let ringId = "5C4C0BF8-2DF6-1B3A-18D0-3DF0B3590148"
+        // 0x43 op, header-ish non-alnum bytes, then an UNBROKEN 9-byte letter-led alnum run ("SN1234567") -
+        // exactly what `redactHexDump` masks in a WHOOP console hex dump, coincidentally reachable by any
+        // Oura frame whose bytes happen to fall in that ASCII range.
+        let header = "e5a30000"
+        let payload = Array("SN1234567".utf8).map { String(format: "%02x", $0) }.joined()
+        let bodyLen = (header.count + payload.count) / 2
+        let hex = "43" + String(format: "%02x", bodyLen) + header + payload
+        let line = "{\"schema\":1,\"deviceId\":\"\(ringId)\",\"utc\":1,\"iso\":\"2026-09-11T00:00:00Z\",\"hex\":\"\(hex)\"}"
+        let out = String(data: TestBundleAssembler.redactEntries(
+            [FileExport.BundleEntry(name: "oura-raw.jsonl", data: Data(line.utf8))]).first!.data, encoding: .utf8)!
+        XCTAssertTrue(out.contains("\"hex\":\"\(hex)\""),
+                       "the debug-text frame must survive byte-for-byte, got: \(out)")
+        XCTAssertFalse(out.contains(ringId), "the ring UUID must still be scrubbed")
+        XCTAssertTrue(out.contains("\"deviceId\":\"<device>\""), "the ring id must still be masked to <device>")
+        // A sibling non-raw sidecar (decoded fields, no hex blob) is unaffected by this exemption and still
+        // rides the general `redactPii` sweep — the exemption is scoped to `raw` alone.
+        let ibiLine = "{\"schema\":1,\"deviceId\":\"\(ringId)\",\"hr\":60}"
+        let ibiOut = String(data: TestBundleAssembler.redactEntries(
+            [FileExport.BundleEntry(name: "oura-ibihr.jsonl", data: Data(ibiLine.utf8))]).first!.data, encoding: .utf8)!
+        XCTAssertFalse(ibiOut.contains(ringId))
+    }
+
     /// #572 follow-up: the field-aware `deviceId` mask closes the gap the canonical-only contract left — a
     /// DASHLESS (or truncated) ring id, which the dash-anchored UUID rule can't match and would otherwise
     /// leak verbatim, is still masked to `<device>`, and the raw `hex` capture is STILL untouched (the mask


### PR DESCRIPTION
## The bug

`oura-raw.jsonl` — the raw BLE frame sidecar a Test Centre export bundles alongside `report.txt` —
logs every outer frame verbatim as `{"schema":1,"deviceId":"...","utc":...,"hex":"..."}`. The bundle's
redaction pass (`TestBundleAssembler.redactEntries`, `meta.redaction = "v2"`) only ever masks the JSON
envelope's `deviceId` field; it never looks inside a frame's `hex` payload.

A `0x18` GetProductInfo request / `0x19` reply pair is exactly the protocol's serial/hardware-string
exchange (OURA_PROTOCOL.md §4.1: request offset `08 00 10` = serial). NOOP already asks for it on
every connect (`get_hardware` in the log) to resolve the ring's stable id and generation. So every
capture that includes so much as one reconnect carries the ring's serial number in plain ASCII inside
`oura-raw.jsonl` — invisible in the readable parts of `report.txt`, only found by hex-decoding the
sidecar frame by frame.

This isn't hypothetical: a Ring 5 user's diagnostics zip attached to #2075 has 14 reconnects, and all
14 logged the identical 16-digit string via `0x19` — sitting unredacted in a bundle attached to a
**public** GitHub issue. The bug-report template's own checklist tells reporters to leave out "strap
serial, account email, raw export" — this reporter had no way to know it was in there.

## The fix

`OuraLiveSource.productInfoResponseOps` (`{0x18, 0x19}`) already exists and is already used, right
before both `rawDump?.record` call sites, to intercept these frames for serial/generation parsing. This
adds one filtering step — `OuraLiveSource.rawDumpBytes(_:)` — that re-encodes a notification's outer
frames for the sidecar with `productInfoResponseOps` dropped, and calls it at both sites instead of
recording the frames/bytes verbatim:

- the secure-session branch now filters the frame list it already builds (`nonSecureFrames`) before
  handing it to `rawDump?.record`, instead of after;
- the non-secure-session fallback (`rawDump?.record(bytes: bytes)`) now reconstructs from `frames`
  through the same filter rather than writing the raw notification bytes untouched.

**Decode is completely unaffected** — `driver.ingest`, `observeUserInfoRecords`, and the existing
serial/generation-parsing loop all still see every frame exactly as before. Only what reaches
`oura-raw.jsonl` changes. If a notification's frames are *entirely* product-info (the common case,
since the reply usually arrives alone), nothing is written for that notification at all rather than an
empty record.

## Scope: Apple only, and that's not a parity gap

Android has **no raw-capture writer** at all — confirmed by grep across
`android/app/src/main/java/com/noop`; only decoded sidecars exist there (`OuraActivityDump.kt`,
`OuraCvaPpgDump.kt`, `OuraMotionDump.kt`, `OuraRealStepsDump.kt`), none of which carry raw frame bytes.
`TestBundleAssembler.kt`'s redaction has no `deviceId`/Oura-specific masking either, because there's
nothing Oura-raw to mask. So there is nothing to fix on the Android side — this diagnostics format
simply doesn't exist there.

## Also worth knowing (not part of this PR)

The already-public attachment on #2075 still carries the serial in the clear — this PR stops new
captures from doing the same, it doesn't retroactively scrub what's already on GitHub. Whether to ask
GitHub to remove that specific attachment, or contact the reporter, is a separate call for whoever
triages that issue.

## Verification

Pure frame-filtering logic (`rawDumpBytes` is `nonisolated static`, no CoreBluetooth involved), covered
by 3 new unit tests in `StrandTests/OuraLiveSourceRawDumpRedactionTests.swift`: a product-info-only
notification is dropped entirely, an ordinary frame is untouched, and a mixed notification keeps every
frame except the product-info one. All 3 pass.

- macOS `Strand`: `BUILD SUCCEEDED`; `StrandTests/OuraLiveSourceRawDumpRedactionTests` 3/3 passing.
- iOS `NOOPiOS`: `BUILD SUCCEEDED` (compile-only, per this repo's usual iOS-leg coverage).
- Not hardware-validated — nothing here touches the BLE connection path, only what a diagnostic export
  writes to disk after the fact.