### PR TITLE
Name the config field that dropped the day cache

### DIFF
--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -92,7 +92,11 @@ final class IntelligenceEngine: ObservableObject {
     /// Kept beside the reader rather than at the construction site so that site stays a plain value list.
     /// The cost is that the two must stay in step, which `changedConfigField` refuses to guess about when
     /// they are not. Kotlin twin: `IntelligenceEngine.DAY_CACHE_CONFIG_FIELDS`.
-    static let dayCacheConfigFields: [String] = [
+    ///
+    /// `nonisolated` for the same reason the reader below is: the engine is @MainActor, so a plain
+    /// `static let` inherits that isolation, and neither a nonisolated function nor a synchronous test
+    /// could then touch it. `[String]` is Sendable, so sharing it is safe.
+    nonisolated static let dayCacheConfigFields: [String] = [
         "hrvBaseline", "rhrBaseline", "age", "sex", "stepTicksPerStep", "maxHROverride",
         "tzOffset", "sleepNeedHours", "sleepConsistency", "habitualMidsleep",
         "experimentalSleepV2", "motionAwareWake", "deepHrvWindow", "spo2CandidateDisplay",

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -87,6 +87,41 @@ final class IntelligenceEngine: ObservableObject {
     /// potentially stale and the whole cache is dropped. Empty until the first pass.
     private var dayScanCacheConfigSig = ""
 
+    /// Names of the config-signature fields, in the exact order `dayCacheConfigSig` builds them.
+    ///
+    /// Kept beside the reader rather than at the construction site so that site stays a plain value list.
+    /// The cost is that the two must stay in step, which `changedConfigField` refuses to guess about when
+    /// they are not. Kotlin twin: `IntelligenceEngine.DAY_CACHE_CONFIG_FIELDS`.
+    static let dayCacheConfigFields: [String] = [
+        "hrvBaseline", "rhrBaseline", "age", "sex", "stepTicksPerStep", "maxHROverride",
+        "tzOffset", "sleepNeedHours", "sleepConsistency", "habitualMidsleep",
+        "experimentalSleepV2", "motionAwareWake", "deepHrvWindow", "spo2CandidateDisplay",
+        "effortMethod", "dayCycleMode",
+    ]
+
+    /// Which config field(s) moved between two signatures, for the `configDropped` tally.
+    ///
+    /// `configDropped` said a 21-day re-score happened because the pass-global config changed, and stopped
+    /// there. A field log pointed at a rolling BASELINE as the likeliest mover, but naming it from the
+    /// outside is a guess; this names it from the data.
+    ///
+    /// Never guesses: "first" on the first drop of a process, because the signature starts EMPTY rather
+    /// than nil and there is nothing to diff against, and "unknown" when the two signatures do not have
+    /// the field count this list describes, because a mislabelled field sends a reader somewhere the data
+    /// never pointed.
+    ///
+    /// `nonisolated` because it is a pure function of its arguments: the engine is @MainActor, and without
+    /// this the rule would inherit that isolation and could not be driven from a synchronous test.
+    /// Kotlin twin: `IntelligenceEngine.changedConfigField`.
+    nonisolated static func changedConfigField(previous: String, current: String) -> String {
+        if previous.isEmpty { return "first" }
+        let a = previous.split(separator: "|", omittingEmptySubsequences: false)
+        let b = current.split(separator: "|", omittingEmptySubsequences: false)
+        guard a.count == b.count, b.count == dayCacheConfigFields.count else { return "unknown" }
+        let moved = b.indices.filter { a[$0] != b[$0] }.map { dayCacheConfigFields[$0] }
+        return moved.isEmpty ? "none" : moved.joined(separator: "+")
+    }
+
     /// Who supplies the dashboard headline for a By-Day row. The By-Day card always shows NOOP's OWN
     /// on-device numbers, but the WHOLE-DASHBOARD value for the same day can come from an IMPORTED row
     /// that won the per-day merge (imports win field-by-field over computed , see Repository.mergeDaily).
@@ -895,6 +930,9 @@ final class IntelligenceEngine: ObservableObject {
         // trailing delay. So this fires once per completed backfill, not once per chunk. That coalescing is
         // load-bearing for the cache — removing it would reintroduce the #1402 storm in a form no signature
         // change can fix.
+        // Field names live in `dayCacheConfigFields`, in this exact order. Kept there rather than here so
+        // the construction stays a plain value list, and `changedConfigField` refuses to guess when the
+        // two fall out of step.
         let dayCacheConfigSig = [
             String(describing: baselines1.hrv),
             String(describing: baselines1.restingHR),
@@ -918,7 +956,10 @@ final class IntelligenceEngine: ObservableObject {
         // #2073: recorded, because a dropped cache leaves no entry to compare and the miss tally would
         // otherwise stay silent on the very case it exists to explain.
         var dayCacheConfigDropped = false
+        var dayCacheConfigMoved = ""
         if dayCacheConfigSig != dayScanCacheConfigSig {
+            dayCacheConfigMoved = Self.changedConfigField(previous: dayScanCacheConfigSig,
+                                                          current: dayCacheConfigSig)
             dayScanCache.removeAll()
             dayScanCacheConfigSig = dayCacheConfigSig
             dayCacheConfigDropped = true
@@ -955,7 +996,7 @@ final class IntelligenceEngine: ObservableObject {
             var dayCacheMissBy: [String: Int] = [:]
             // #2073: a cache dropped wholesale leaves NO entry to compare, so without this the tally would
             // stay silent and the line would read reused=0/21 with nothing saying why.
-            if dayCacheConfigDropped { dayCacheMissBy["configDropped"] = 1 }
+            if dayCacheConfigDropped { dayCacheMissBy["configDropped(\(dayCacheConfigMoved))"] = 1 }
             // #1538: per-phase cost tally. `prep` brackets the nine windowed store reads plus the
             // session matching that sits between them and `analyzeDay`; `score` brackets `analyzeDay`
             // itself. Emitted once per pass beside the reuse line.

--- a/Strand/Data/IntelligenceEngine.swift
+++ b/Strand/Data/IntelligenceEngine.swift
@@ -931,8 +931,9 @@ final class IntelligenceEngine: ObservableObject {
         // load-bearing for the cache — removing it would reintroduce the #1402 storm in a form no signature
         // change can fix.
         // Field names live in `dayCacheConfigFields`, in this exact order. Kept there rather than here so
-        // the construction stays a plain value list, and `changedConfigField` refuses to guess when the
-        // two fall out of step.
+        // the construction stays a plain value list. Add or reorder here and add or reorder there:
+        // `changedConfigField` refuses to name anything when the counts disagree, but it cannot see a
+        // REORDER, which would quietly label the wrong field.
         let dayCacheConfigSig = [
             String(describing: baselines1.hrv),
             String(describing: baselines1.restingHR),

--- a/StrandTests/DayCacheConfigFieldTests.swift
+++ b/StrandTests/DayCacheConfigFieldTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import Strand
+
+/// Swift twin of the Kotlin `DayCacheConfigFieldTest`: which config field dropped the day cache.
+///
+/// #2073 made a wholesale drop visible (`configDropped`), and a field log on build 487 showed it firing
+/// for real: `reused=0/21 missBy=absent:21,configDropped:1`, against a healthy pass that reuses 20 of 21
+/// and misses only today. The expensive passes cost up to 35 s of prep and 22 s of scoring, so which
+/// field moved is the difference between a config the user actually changed and a value that drifts on
+/// its own.
+///
+/// The signature is a plain "|"-joined value list, and the field NAMES live beside the reader rather than
+/// the construction, which on the Kotlin side keeps them off a bytecode ratchet. That split is the risk
+/// pinned here: a reader that guessed an index would name the wrong field and send someone hunting a bug
+/// that is not there, which is worse than saying nothing.
+final class DayCacheConfigFieldTests: XCTestCase {
+
+    /// A signature with one value per known field, so a changed index has a name to resolve to.
+    private func fullSig(_ mutate: (inout [String]) -> Void = { _ in }) -> String {
+        var v = (0..<IntelligenceEngine.dayCacheConfigFields.count).map { "v\($0)" }
+        mutate(&v)
+        return v.joined(separator: "|")
+    }
+
+    func testTheMovedFieldIsNamed() {
+        XCTAssertEqual(
+            IntelligenceEngine.changedConfigField(previous: fullSig(), current: fullSig { $0[0] = "moved" }),
+            "hrvBaseline"
+        )
+    }
+
+    /// The field log's leading suspicion was a rolling baseline, which is index 0 and 1. Naming them
+    /// apart is the whole point: one is HRV drifting, the other resting heart rate.
+    func testTheTwoBaselinesAreToldApart() {
+        XCTAssertEqual(
+            IntelligenceEngine.changedConfigField(previous: fullSig(), current: fullSig { $0[1] = "moved" }),
+            "rhrBaseline"
+        )
+        XCTAssertEqual(
+            IntelligenceEngine.changedConfigField(previous: fullSig(), current: fullSig { $0[15] = "moved" }),
+            "dayCycleMode"
+        )
+    }
+
+    /// Several at once happens on a settings change that touches more than one knob.
+    func testSeveralMoversAreAllNamed() {
+        let after = fullSig { $0[0] = "a"; $0[14] = "b" }
+        XCTAssertEqual(IntelligenceEngine.changedConfigField(previous: fullSig(), current: after),
+                       "hrvBaseline+effortMethod")
+    }
+
+    /// The signature starts EMPTY rather than nil, so the first drop of a process has nothing to diff
+    /// against. Reporting that as "unknown" would describe a shape mismatch that never happened.
+    func testTheFirstDropOfAProcessSaysFirst() {
+        XCTAssertEqual(IntelligenceEngine.changedConfigField(previous: "", current: fullSig()), "first")
+    }
+
+    /// The names and the construction can fall out of step, because they live apart. When they do, this
+    /// refuses to name anything rather than resolve an index against a list that no longer describes it.
+    /// A wrong field name is worse than none: a diagnostic asserting what it cannot attribute.
+    func testAShapeMismatchIsRefusedRatherThanGuessed() {
+        XCTAssertEqual(IntelligenceEngine.changedConfigField(previous: "a|b", current: "a|c"), "unknown")
+        XCTAssertEqual(IntelligenceEngine.changedConfigField(previous: fullSig(), current: "a"), "unknown")
+    }
+
+    /// Equal signatures never reach the caller, but the helper still answers honestly if they do.
+    func testAnUnchangedSignatureNamesNothing() {
+        XCTAssertEqual(IntelligenceEngine.changedConfigField(previous: fullSig(), current: fullSig()), "none")
+    }
+
+    /// The two platforms must describe the same fields in the same order, or the same drop is reported
+    /// as two different causes depending on which phone the reporter happens to hold.
+    func testTheFieldListMatchesTheKotlinTwin() {
+        XCTAssertEqual(IntelligenceEngine.dayCacheConfigFields, [
+            "hrvBaseline", "rhrBaseline", "age", "sex", "stepTicksPerStep", "maxHROverride",
+            "tzOffset", "sleepNeedHours", "sleepConsistency", "habitualMidsleep",
+            "experimentalSleepV2", "motionAwareWake", "deepHrvWindow", "spo2CandidateDisplay",
+            "effortMethod", "dayCycleMode",
+        ])
+    }
+}

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -2871,7 +2871,42 @@ object IntelligenceEngine {
         return if (dayStart < nowLocalMidnight) nextMidnight else minOf(nextMidnight, now)
     }
 
-    /** Drop the whole day cache when the pass-global config changed, recording that it happened (#2073).
+    /** Names of the config-signature fields, in the exact order `dayCacheConfigSig` builds them.
+     *
+     *  Kept beside the reader rather than at the construction site on purpose: that site sits inside
+     *  `analyzeRecentOnCpu`, which is on a JaCoCo bytecode ratchet, so labelling it there would spend
+     *  budget to say something only this diagnostic needs. The cost is that the two must stay in step,
+     *  which [changedConfigField] refuses to guess about when they are not. */
+    internal val DAY_CACHE_CONFIG_FIELDS: List<String> = listOf(
+        "hrvBaseline", "rhrBaseline", "age", "sex", "stepTicksPerStep", "maxHROverride",
+        "tzOffset", "sleepNeedHours", "sleepConsistency", "habitualMidsleep",
+        "experimentalSleepV2", "motionAwareWake", "deepHrvWindow", "spo2CandidateDisplay",
+        "effortMethod", "dayCycleMode",
+    )
+
+    /** Which config field(s) changed between two signatures, for the `configDropped` tally.
+     *
+     *  `configDropped` says a 21-day re-score happened because the pass-global config moved, and stops
+     *  exactly there: a field log pointed at a rolling BASELINE as the likeliest mover, but naming it
+     *  from the outside is a guess. This names the mover from the data.
+     *
+     *  Never guesses: "first" on the first drop of a process, and "unknown" when the two
+     *  signatures do not have the field count this list describes, because a mislabelled field would send
+     *  a reader somewhere the data never pointed. */
+    internal fun changedConfigField(previous: String, current: String): String {
+        // The field starts EMPTY, not null, so the very first drop of a process has nothing to diff
+        // against. That is "first", not "unknown": naming it unknown would report a shape mismatch that
+        // never happened and send a reader looking for a bug in the signature.
+        if (previous.isEmpty()) return "first"
+        val a = previous.split('|')
+        val b = current.split('|')
+        if (a.size != b.size || b.size != DAY_CACHE_CONFIG_FIELDS.size) return "unknown"
+        val moved = b.indices.filter { a[it] != b[it] }.map { DAY_CACHE_CONFIG_FIELDS[it] }
+        return if (moved.isEmpty()) "none" else moved.joinToString("+")
+    }
+
+    /** Drop the whole day cache when the pass-global config changed, recording that it happened (#2073)
+     *  and WHICH field moved.
      *
      *  The recording is the point. A dropped cache leaves NO entry to compare, so the miss tally below
      *  would stay silent and the line would read `reused=0/21` with nothing saying why, which is the exact
@@ -2879,9 +2914,10 @@ object IntelligenceEngine {
      *  inline branch that used to sit in the scoring method rather than adding to it. */
     private fun dropDayCacheIfConfigChanged(configSig: String) {
         if (configSig == dayScanCacheConfigSig) return
+        val moved = changedConfigField(dayScanCacheConfigSig, configSig)
         dayScanCache = HashMap()
         dayScanCacheConfigSig = configSig
-        dayCacheMissBy["configDropped"] = 1
+        dayCacheMissBy["configDropped($moved)"] = 1
     }
 
     /** The cached scan for [day] when it is still reusable, else null, tallying WHY it was not (#2073).

--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -833,6 +833,10 @@ object IntelligenceEngine {
         // 2 s (#755). So this fires once per completed backfill, not once per chunk. That coalescing is
         // load-bearing for the cache — removing it would reintroduce the #1402 storm in a form no signature
         // change can fix.
+        // Field names live in [DAY_CACHE_CONFIG_FIELDS], in this exact order, so that this stays a plain
+        // value list and costs the bytecode ratchet nothing. Add or reorder here and add or reorder there:
+        // [changedConfigField] refuses to name anything when the counts disagree, but it cannot see a
+        // REORDER, which would quietly label the wrong field.
         val dayCacheConfigSig = listOf(
             baselines1.hrv.toString(), baselines1.restingHR.toString(),
             profile.age.toString(), profile.sex.toString(), profile.stepTicksPerStep.toString(),

--- a/android/app/src/test/java/com/noop/analytics/DayCacheConfigFieldTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DayCacheConfigFieldTest.kt
@@ -1,0 +1,94 @@
+package com.noop.analytics
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Which config field dropped the day cache.
+ *
+ * #2073 made a wholesale drop visible (`configDropped`), and a field log on build 487 showed it firing
+ * for real: `reused=0/21 missBy=absent:21,configDropped:1`, against a healthy pass that reuses 20 of 21
+ * and misses only today. The expensive passes cost up to 35 s of prep and 22 s of scoring, so which field
+ * moved is the difference between a config the user actually changed and a value that drifts on its own.
+ *
+ * The signature is a plain "|"-joined value list built inside `analyzeRecentOnCpu`, which sits on a JaCoCo
+ * bytecode ratchet, so the field NAMES live beside the reader instead. That split is the risk this pins:
+ * a reader that guessed an index would name the wrong field and send someone hunting a bug that is not
+ * there, which is worse than saying nothing.
+ */
+class DayCacheConfigFieldTest {
+
+    private fun sig(vararg values: String) = values.joinToString("|")
+
+    /** A signature with one field per name, so a changed index has a name to resolve to. */
+    private fun fullSig(mutate: (MutableList<String>) -> Unit = {}): String {
+        val v = MutableList(IntelligenceEngine.DAY_CACHE_CONFIG_FIELDS.size) { "v$it" }
+        mutate(v)
+        return v.joinToString("|")
+    }
+
+    @Test
+    fun `the moved field is named`() {
+        val before = fullSig()
+        val after = fullSig { it[0] = "moved" }
+        assertEquals("hrvBaseline", IntelligenceEngine.changedConfigField(before, after))
+    }
+
+    /** The field log's leading suspicion was a rolling baseline, which is index 0 and 1. Naming them
+     *  apart is the whole point: one is HRV drifting, the other resting heart rate. */
+    @Test
+    fun `the two baselines are told apart`() {
+        assertEquals("rhrBaseline",
+            IntelligenceEngine.changedConfigField(fullSig(), fullSig { it[1] = "moved" }))
+        assertEquals("dayCycleMode",
+            IntelligenceEngine.changedConfigField(fullSig(), fullSig { it[15] = "moved" }))
+    }
+
+    /** Several at once happens on a settings change that touches more than one knob. */
+    @Test
+    fun `several movers are all named`() {
+        val after = fullSig { it[0] = "a"; it[14] = "b" }
+        assertEquals("hrvBaseline+effortMethod",
+            IntelligenceEngine.changedConfigField(fullSig(), after))
+    }
+
+    /** The signature starts EMPTY rather than null, so the first drop of a process has nothing to diff
+     *  against. Reporting that as "unknown" would describe a shape mismatch that never happened. */
+    @Test
+    fun `the first drop of a process says first`() {
+        assertEquals("first", IntelligenceEngine.changedConfigField("", fullSig()))
+    }
+
+    /**
+     * The names and the construction site can fall out of step, because they live apart. When they do,
+     * this refuses to name anything rather than resolve an index against a list that no longer describes
+     * it. A wrong field name is worse than none: it is a diagnostic asserting what it cannot attribute.
+     */
+    @Test
+    fun `a shape mismatch is refused rather than guessed`() {
+        assertEquals("unknown", IntelligenceEngine.changedConfigField(sig("a", "b"), sig("a", "c")))
+        assertEquals("unknown", IntelligenceEngine.changedConfigField(fullSig(), sig("a")))
+    }
+
+    /** The two platforms must describe the same fields in the same order, or the same drop is reported
+     *  as two different causes depending on which phone the reporter happens to hold. Pinned on BOTH
+     *  sides, because a list pinned on one is free to drift on the other. */
+    @Test
+    fun `the field list matches the Swift twin`() {
+        assertEquals(
+            listOf(
+                "hrvBaseline", "rhrBaseline", "age", "sex", "stepTicksPerStep", "maxHROverride",
+                "tzOffset", "sleepNeedHours", "sleepConsistency", "habitualMidsleep",
+                "experimentalSleepV2", "motionAwareWake", "deepHrvWindow", "spo2CandidateDisplay",
+                "effortMethod", "dayCycleMode",
+            ),
+            IntelligenceEngine.DAY_CACHE_CONFIG_FIELDS,
+        )
+    }
+
+    /** Equal signatures never reach the caller, but the helper still answers honestly if they do. */
+    @Test
+    fun `an unchanged signature names nothing`() {
+        assertEquals("none", IntelligenceEngine.changedConfigField(fullSig(), fullSig()))
+    }
+}

--- a/android/app/src/test/java/com/noop/analytics/DayCacheMissReasonTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DayCacheMissReasonTest.kt
@@ -79,9 +79,12 @@ class DayCacheMissReasonTest {
     fun `the causes with no key to compare still have names`() {
         // Both are produced by the engine rather than by missReason, so this pins the vocabulary the
         // reader will see rather than the function's branches.
-        val tokens = setOf("none", "shape", "owner", "hr", "rrAlias5", "streams", "absent", "configDropped")
+        // `configDropped` carries the field that moved, e.g. `configDropped(hrvBaseline)`, so the bare
+        // token is a prefix rather than the whole key. See [DayCacheConfigFieldTest].
+        val tokens = setOf("none", "shape", "owner", "hr", "rrAlias5", "streams", "absent",
+                           "configDropped(<field>)")
         assertTrue(tokens.contains("absent"))
-        assertTrue(tokens.contains("configDropped"))
+        assertTrue(tokens.any { it.startsWith("configDropped") })
     }
 
     @Test


### PR DESCRIPTION
A strap log from build 487 showed the day-cache drop firing for real:

```
reused=0/21  missBy=absent:21,configDropped:1     the expensive passes
reused=20/21 missBy=hr                            the healthy ones
analyzeRecent cost prep=35307ms score=7329ms
analyzeRecent cost prep=23359ms score=21609ms
```

A healthy pass reuses 20 of 21 days and re-scores only today. A dropped one re-scores all 21 and costs up to 45 seconds. So which field moved is the difference between a config the user actually changed and a value that drifts on its own.

`configDropped` stopped at "the pass-global config moved". This names the field from the data.

**Which is worth having for a narrower reason than I first wrote.** #1538 already went looking, and the signature's own comment records the answer: `baselines1` shifts with any night, and so do `sleepNeedHours`, `sleepConsistency` and `habitualMidsleepSec`, the last three through a feedback loop from the previous pass's own banked sessions. It states plainly that this is **correct invalidation rather than churn to be quantized away**, and that what keeps it affordable is the coalescing on both platforms.

So the value is not "hunt the baseline". It is separating a drop that is SUPPOSED to happen from one that is not, and spotting a burst of drops naming a habitual-sleep field, which is the signature of the coalescing having failed and is the #1402 storm shape.

## Why the names live beside the reader

The signature is built inside `analyzeRecentOnCpu`, which sits on a JaCoCo bytecode ratchet. Labelling it at the construction site would spend that budget to say something only this diagnostic needs, so the name list lives next to the code that reads it.

Verified rather than assumed: `analyzeRecentOnCpu instrumented Code length=55595 budget=55700`, unchanged by this PR.

## What it refuses to do

The cost of that split is that the list and the construction can fall out of step. When they do, the reader answers `unknown` rather than resolving an index against a list that no longer describes it. A wrong field name is worse than none, because it sends a reader hunting a bug that is not there, which is the rule this repo already applies to every other diagnostic.

`first` is distinguished for the same reason: the signature starts EMPTY rather than nil, so the first drop of a process has nothing to diff against, and reporting that as a shape mismatch would describe something that never happened.

## Parity

Both platforms pin the field list literally. A list pinned on one side alone is free to drift on the other, and the same drop would then be reported as two different causes depending on which phone the reporter is holding.

## What this is NOT

It does not make the drop less frequent, and must not. Quantising a baseline in the signature is explicitly the wrong answer per the analysis above: a night going from half-loaded to complete really does change what every day should be scored against, and the swings are large rather than drift.

## A residual, stated

A count mismatch between the field list and the construction is caught and named `unknown`. A **reorder** is not, and would quietly label the wrong field. Both construction sites now carry that warning, because it is the one failure mode the guard cannot see.

## Found by re-review

- **The framing, not the code.** I first wrote this as though a rolling baseline were an open suspicion. #1538 had already settled it, and the signature's own comment says so. Corrected above, because left standing it would have sent the next reader to quantize something already considered and rejected.
- **The field list would not have compiled.** The engine is `@MainActor`, so a plain `static let` inherits that isolation, while `changedConfigField` is `nonisolated` and the Swift twin test is synchronous. `nonisolated static let` is the established shape here (`JournalCatalog.starterQuestions`, `Repository.logicalDayRolloverHour`). The CI legs that would have caught it were cancelled by a push, so it had not been compiled anywhere at the time.
- **A stale vocabulary token.** The sibling `DayCacheMissReasonTest` still documented a bare `configDropped` the engine no longer emits.

## Verification

- `DayCacheConfigFieldTest` 7 green; full Android suite 5987 tests, 0 failures
- `IntelligenceEngineJacocoBudgetTest` green, byte length unchanged
- Swift twin mirrors all seven cases; it is app-target and runs in CI on the `Strand` macOS leg
- `doc_comment_lint.py` and `i18n_audit.py --ci` green
- Diagnostic only: no scoring path, no stored value, and no behaviour changes.