### PR TITLE
fix(oura): mask an Oura serial in the log redactors, both platforms

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/OuraSerialIdentity.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraSerialIdentity.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// What may be written to a SHAREABLE strap log for an Oura ring's serial (#2092).
+///
+/// Mirrors `WhoopSerialIdentity.logSafe`'s shape exactly (same 3-character prefix + `…`) so a masked
+/// WHOOP serial and a masked Oura serial read identically in a shared log — the reader should not need
+/// to know which brand a masked id came from to trust it is masked.
+///
+/// Kept as its OWN type rather than a shared call into `WhoopSerialIdentity`: Oura's serial identity has
+/// its own home (`ExperimentalBrand.oura`'s `idPrefix`, `SourceCoordinator.adoptOuraSerial`) and does not
+/// share WHOOP's `adoptedId`/`mayAdopt`/`isAlreadyAdopted` machinery — only the LOG-SAFETY shape is
+/// common, not the identity model. Kotlin twin: `OuraSerialIdentity`.
+public enum OuraSerialIdentity {
+    /// The one place the Oura id namespace is spelled, matching `ExperimentalBrand.oura.idPrefix` and
+    /// `DeviceBrandCatalog`'s `"oura"` entry — kept here too so `LiveState.redactPii`'s Oura rule and this
+    /// masking function agree on the prefix without importing the brand catalog into a pure package.
+    public static let idPrefix = "oura"
+
+    /// Never log `"\(idPrefix)-\(serial)"` (or the bare serial) directly — only this.
+    public static func logSafe(serial: String?) -> String {
+        guard let raw = serial?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else { return "?" }
+        return String(raw.uppercased().prefix(3)) + "…"
+    }
+}

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraSerialIdentityTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraSerialIdentityTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import WhoopStore
+
+final class OuraSerialIdentityTests: XCTestCase {
+    func testLogSafeNeverLeaksTheFullSerial() {
+        XCTAssertEqual(OuraSerialIdentity.logSafe(serial: "2H3B2405003655"), "2H3…")
+        XCTAssertEqual(OuraSerialIdentity.logSafe(serial: "2038082631034041"), "203…")
+        XCTAssertEqual(OuraSerialIdentity.logSafe(serial: nil), "?")
+        XCTAssertEqual(OuraSerialIdentity.logSafe(serial: "  "), "?")
+        XCTAssertFalse(OuraSerialIdentity.logSafe(serial: "2H3B2405003655").contains("2405003655"))
+    }
+
+    func testLogSafeUppercasesAndTrims() {
+        XCTAssertEqual(OuraSerialIdentity.logSafe(serial: "  2h3b2405003655  "), "2H3…")
+    }
+
+    func testIdPrefixMatchesTheBrandCatalog() {
+        XCTAssertEqual(OuraSerialIdentity.idPrefix, "oura")
+    }
+}

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -971,6 +971,18 @@ public final class LiveState: ObservableObject {
         out = out.replacingOccurrences(
             of: "whoop-([A-Za-z0-9]{3})[A-Za-z0-9-]{3,}",
             with: "whoop-$1…", options: .regularExpression)
+        // #2092: an Oura device id (`oura-<serial>`) is the same #1303 gap for the OTHER brand — neither
+        // rule above catches it, since the prefix isn't "whoop-". Exact same shape (3-character prefix +
+        // `…`, matching `OuraSerialIdentity.logSafe`) and the same `-noop`-suffix-preserving pair, since
+        // `DeviceRegistryStore.computedSuffix` is brand-agnostic — an Oura device gets a `oura-<serial>
+        // -noop` sibling the same way a WHOOP strap does. Applied AFTER the WHOOP rules but that ordering
+        // is not load-bearing: the two prefixes never overlap. Kotlin twin in `redactStrapLogPii`.
+        out = out.replacingOccurrences(
+            of: "oura-([A-Za-z0-9]{3})[A-Za-z0-9-]{3,}(-noop)",
+            with: "oura-$1…$2", options: .regularExpression)
+        out = out.replacingOccurrences(
+            of: "oura-([A-Za-z0-9]{3})[A-Za-z0-9-]{3,}",
+            with: "oura-$1…", options: .regularExpression)
         // The account holder's NAME, as WHOOP writes it into the advertised local name. WHOOP names a
         // strap "<FirstName>'s Whoop" by default and the scan path logs that name on every discovery, so
         // the shareable log (#445) we ask people to attach to public issues carried a real person's name.

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -139,8 +139,21 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// so a misframed/garbage reply can never mint a bogus `oura-<serial>` identity (#771 honest-data guard).
     /// The captured Gen3 serial "2H3B2405003655" (14 chars) passes; the hardware id "BLB_03" (underscore) does
     /// not — but it is already routed to the generation path before this is reached.
-    private static func isPlausibleSerial(_ s: String) -> Bool {
+    nonisolated private static func isPlausibleSerial(_ s: String) -> Bool {
         (8...24).contains(s.count) && s.allSatisfy { $0.isLetter || $0.isNumber }
+    }
+
+    /// What the product-info reply log line (below) may show (#2092): a serial page identifies the
+    /// ring's owner, so only its SHAPE is logged, via `OuraSerialIdentity.logSafe` — the same 3-character
+    /// prefix `WhoopSerialIdentity.logSafe` uses for a WHOOP serial (#1303). A hardware-generation page
+    /// ("BLB_03", never `isPlausibleSerial`) identifies no one and is still logged in full; either way a
+    /// masked value still confirms the decode happened, which is all this line exists to do. Masks BOTH
+    /// halves — logging a masked `ascii` beside the unmasked `hex` would still leak the serial encoded.
+    /// `nonisolated static` and free of the log call itself, so it is testable without CoreBluetooth.
+    nonisolated static func logSafeProductInfo(hex: String, ascii: String,
+                                               decoded: String?) -> (hex: String, ascii: String) {
+        guard let decoded, isPlausibleSerial(decoded) else { return (hex, ascii) }
+        return ("<serial>", OuraSerialIdentity.logSafe(serial: decoded))
     }
 
     /// Re-encode outer frames for the raw diagnostics sidecar, dropping `productInfoResponseOps` —
@@ -2575,12 +2588,16 @@ extension OuraLiveSource: @preconcurrency CBPeripheralDelegate {
             let hex = frame.body.map { String(format: "%02x", $0) }.joined(separator: " ")
             guard loggedProductInfo.insert("\(frame.op):\(hex)").inserted else { continue }
             let ascii = String(bytes: frame.body.map { (0x20...0x7e).contains($0) ? $0 : 0x2e }, encoding: .ascii) ?? ""
-            log("Oura: product-info reply op=0x\(String(format: "%02x", frame.op)) (\(frame.body.count)B) raw: \(hex) | ascii: \(ascii)")
+            // #2092: decode BEFORE logging (was after) so the log line can tell a serial page from a
+            // hardware page — decode itself is unchanged, only reordered.
+            let decoded = OuraDecoders.productInfoString(frame.body)
+            let safe = Self.logSafeProductInfo(hex: hex, ascii: ascii, decoded: decoded)
+            log("Oura: product-info reply op=0x\(String(format: "%02x", frame.op)) (\(frame.body.count)B) raw: \(safe.hex) | ascii: \(safe.ascii)")
             // The two GetProductInfo pages both arrive under op 0x19; tell them apart by content:
             //  • hardware page ("BLB_03") → resolves a generation → correct the model (#772).
             //  • serial page ("2H3B2405003655", no "_NN" gen marker) → the ring's STABLE identity → surface it
             //    so the app can re-point this device onto its `oura-<serial>` id (#771).
-            if let str = OuraDecoders.productInfoString(frame.body) {
+            if let str = decoded {
                 if let gen = OuraRingGen.from(hardwareId: str) {
                     if gen != ringGen {
                         log("Oura: generation from hardware id \(str) is \(gen.displayName) (was \(ringGen.displayName)) - correcting model")

--- a/StrandTests/HeaderRedactionTests.swift
+++ b/StrandTests/HeaderRedactionTests.swift
@@ -54,4 +54,35 @@ final class HeaderRedactionTests: XCTestCase {
         let line = "  device id=my-whoop status=ACTIVE brand=WHOOP model=WHOOP 4.0 lastSeen=3h 10m ago"
         XCTAssertEqual(LiveState.redactPii(line), line)
     }
+
+    /// #2092: the same gap as #1303 above, for the OTHER brand. An Oura ring's adopted id is
+    /// `oura-<serial>`, and none of the WHOOP-shaped rules match a different literal prefix, so this
+    /// header line leaked the ring's serial verbatim until the twin `oura-` rule was added.
+    func testAnAdoptedOuraSerialIdIsMasked() {
+        let line = "  device id=oura-2H3B2405003655 status=ACTIVE brand=Oura model=Oura Ring 3 lastSeen=1h ago"
+        let safe = LiveState.redactPii(line)
+        XCTAssertFalse(safe.contains("2405003655"), "serial survived: \(safe)")
+        XCTAssertTrue(safe.contains("oura-2H3…"), "three-character prefix should remain: \(safe)")
+    }
+
+    /// The `-noop` computed-sibling suffix is brand-agnostic (`DeviceRegistryStore.computedSuffix`), so
+    /// it must survive the Oura mask exactly as it does the WHOOP one.
+    func testTheComputedSiblingMarkerSurvivesForOuraToo() {
+        XCTAssertEqual(LiveState.redactPii("Days: oura-2H3B2405003655-noop=25"), "Days: oura-2H3…-noop=25")
+    }
+
+    /// An all-digit serial (this repo's own #2075/#2090 evidence: "2038082631034041") must mask the same
+    /// as an alphanumeric one — the rule keys on the "oura-" prefix, not on the serial containing a letter.
+    func testAnAllDigitOuraSerialIsMaskedToo() {
+        let line = "adopted stable serial id oura-2038082631034041 (was oura-5C4C0BF8-2DF6-1B3A-18D0-3DF0B3590148)"
+        let safe = LiveState.redactPii(line)
+        XCTAssertFalse(safe.contains("2038082631034041"), "serial survived: \(safe)")
+        XCTAssertTrue(safe.contains("oura-203…"), "three-character prefix should remain: \(safe)")
+        // The PROVISIONAL id in the same line is a CB-UUID, already caught by the earlier UUID rule.
+        XCTAssertFalse(safe.contains("5C4C0BF8-2DF6-1B3A-18D0-3DF0B3590148"), "provisional UUID survived: \(safe)")
+    }
+
+    func testAnIdTooShortToBeAnOuraSerialIsUntouched() {
+        XCTAssertEqual(LiveState.redactPii("id=oura-ABCDE"), "id=oura-ABCDE")
+    }
 }

--- a/StrandTests/OuraLiveSourceProductInfoLogRedactionTests.swift
+++ b/StrandTests/OuraLiveSourceProductInfoLogRedactionTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import Strand
+
+/// #2092, route 1: the product-info reply log line printed `ascii: <serial>` in the clear — neither
+/// `LiveState.redactPii` rule matches a bare, unprefixed serial (by design: a shape-only rule would mask
+/// ordinary prose), and the hex half was only masked by `redactHexDump`'s accident of matching a
+/// letter-led alnum run, which an all-digit serial (this repo's own #2075/#2090 evidence) never
+/// triggers. `OuraLiveSource.logSafeProductInfo` is the fix: computed right where the code already knows
+/// (via `isPlausibleSerial`) whether a decoded string IS a serial, so it can mask deliberately instead of
+/// relying on an unrelated heuristic to get lucky.
+final class OuraLiveSourceProductInfoLogRedactionTests: XCTestCase {
+
+    func testASerialPageIsMaskedInBothHexAndAscii() {
+        let serial = "2H3B2405003655"
+        let hex = Array(serial.utf8).map { String(format: "%02x", $0) }.joined(separator: " ")
+        let safe = OuraLiveSource.logSafeProductInfo(hex: hex, ascii: serial, decoded: serial)
+        XCTAssertEqual(safe.hex, "<serial>")
+        XCTAssertEqual(safe.ascii, "2H3…")
+        XCTAssertFalse(safe.ascii.contains("2405003655"))
+    }
+
+    /// This repo's own evidence (#2075's attachment): an all-digit serial with no letter to anchor a
+    /// letter-required heuristic on. Must mask the same as an alphanumeric one.
+    func testAnAllDigitSerialPageIsMaskedToo() {
+        let serial = "2038082631034041"
+        let hex = Array(serial.utf8).map { String(format: "%02x", $0) }.joined(separator: " ")
+        let safe = OuraLiveSource.logSafeProductInfo(hex: hex, ascii: serial, decoded: serial)
+        XCTAssertEqual(safe.hex, "<serial>")
+        XCTAssertEqual(safe.ascii, "203…")
+    }
+
+    /// A hardware-generation page ("BLB_03") identifies no one - never `isPlausibleSerial` because of the
+    /// underscore - and must survive in full: masking it would throw away a real diagnostic for nothing.
+    func testAHardwarePageIsLoggedInFull() {
+        let hex = Array("BLB_03".utf8).map { String(format: "%02x", $0) }.joined(separator: " ")
+        let safe = OuraLiveSource.logSafeProductInfo(hex: hex, ascii: "BLB_03", decoded: "BLB_03")
+        XCTAssertEqual(safe.hex, hex)
+        XCTAssertEqual(safe.ascii, "BLB_03")
+    }
+
+    /// A frame that failed to decode at all (nil) has nothing to mask and nothing to leak; pass through.
+    func testANilDecodeIsLeftAlone() {
+        let safe = OuraLiveSource.logSafeProductInfo(hex: "00 01", ascii: "..", decoded: nil)
+        XCTAssertEqual(safe.hex, "00 01")
+        XCTAssertEqual(safe.ascii, "..")
+    }
+}

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -1562,12 +1562,15 @@ class OuraLiveSource(
                     val ascii = String(CharArray(frame.body.size) { i ->
                         val b = frame.body[i]; if (b in 0x20..0x7e) b.toChar() else '.'
                     })
-                    log("Oura: product-info reply op=0x%02x (%dB) raw: %s | ascii: %s".format(frame.op, frame.body.size, hex, ascii))
+                    // #2092: decode BEFORE logging (was after) so the log line can tell a serial page from
+                    // a hardware page - decode itself is unchanged, only reordered.
+                    val str = OuraDecoders.productInfoString(frame.body)
+                    val (safeHex, safeAscii) = logSafeProductInfo(hex, ascii, str)
+                    log("Oura: product-info reply op=0x%02x (%dB) raw: %s | ascii: %s".format(frame.op, frame.body.size, safeHex, safeAscii))
                     // The two GetProductInfo pages both arrive under op 0x19; tell them apart by content:
                     //  • hardware page ("BLB_03") -> resolves a generation -> correct the model (#772).
                     //  • serial page ("2H3B2405003655", no "_NN" gen marker) -> the ring's STABLE identity ->
                     //    surface it so the app can re-point onto its `oura-<serial>` id (#771).
-                    val str = OuraDecoders.productInfoString(frame.body)
                     if (str != null) {
                         val gen = OuraRingGen.fromHardwareId(str)
                         if (gen != null) {
@@ -2162,6 +2165,18 @@ class OuraLiveSource(
          *  Twin of Swift's `isPlausibleSerial`. */
         private fun isPlausibleSerial(s: String): Boolean =
             s.length in 8..24 && s.all { it.isLetterOrDigit() }
+
+        /** What the product-info reply log line (below) may show (#2092): a serial page identifies the
+         *  ring's owner, so only its SHAPE is logged, via [com.noop.data.OuraSerialIdentity.logSafe] -
+         *  the same 3-character prefix [com.noop.data.WhoopSerialIdentity.logSafe] uses for a WHOOP
+         *  serial (#1303). A hardware-generation page ("BLB_03", never [isPlausibleSerial]) identifies no
+         *  one and is still logged in full; either way a masked value still confirms the decode happened,
+         *  which is all this line exists to do. Masks BOTH halves - logging a masked ascii beside the
+         *  unmasked hex would still leak the serial encoded. Twin of Swift's `logSafeProductInfo`. */
+        internal fun logSafeProductInfo(hex: String, ascii: String, decoded: String?): Pair<String, String> {
+            if (decoded == null || !isPlausibleSerial(decoded)) return hex to ascii
+            return "<serial>" to com.noop.data.OuraSerialIdentity.logSafe(decoded)
+        }
         private const val SET_AUTH_KEY_OK = 0x00
 
         /** Generate a fresh cryptographically-random 16-byte install key as unsigned bytes 0..255

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -11870,6 +11870,16 @@ private val PII_ADOPTED_ID_NOOP_RE = Regex("whoop-([A-Za-z0-9]{3})[A-Za-z0-9-]{3
 private val PII_ADOPTED_ID_RE = Regex("whoop-([A-Za-z0-9]{3})[A-Za-z0-9-]{3,}")
 
 /**
+ * #2092: an Oura device id (`oura-<serial>`) is the same #1303 gap as [PII_ADOPTED_ID_RE], for the OTHER
+ * brand. Neither WHOOP rule above matches it, since the prefix isn't "whoop-". Exact same shape (3-char
+ * prefix + "…", matching [com.noop.data.OuraSerialIdentity.logSafe]) and the same `-noop`-suffix
+ * pair, since the computed-sibling suffix is brand-agnostic — an Oura device gets a `oura-<serial>-noop`
+ * sibling the same way a WHOOP strap does.
+ */
+private val PII_OURA_ADOPTED_ID_NOOP_RE = Regex("oura-([A-Za-z0-9]{3})[A-Za-z0-9-]{3,}(-noop)")
+private val PII_OURA_ADOPTED_ID_RE = Regex("oura-([A-Za-z0-9]{3})[A-Za-z0-9-]{3,}")
+
+/**
  * Builds the 9-byte WHOOP 4.0 SET_ALARM_TIME (cmd 66) payload.
  * Layout: `[0x01] + u32 LE epoch + [0x00, 0x00]` subseconds + `[0x00, 0x00]` haptic-mode field.
  *
@@ -12108,6 +12118,10 @@ internal fun redactStrapLogPii(s: String): String = try {
         // for an adopted id. The -noop form runs before the general one so the sibling suffix survives.
         .replace(PII_ADOPTED_ID_NOOP_RE, "whoop-$1…$2")
         .replace(PII_ADOPTED_ID_RE, "whoop-$1…")
+        // #2092: the Oura twin of the two rules above. Order vs. the WHOOP pair is not load-bearing - the
+        // two prefixes never overlap.
+        .replace(PII_OURA_ADOPTED_ID_NOOP_RE, "oura-$1…$2")
+        .replace(PII_OURA_ADOPTED_ID_RE, "oura-$1…")
         // Last: the name rule keys on literal text no earlier rule produces or consumes, so it neither
         // masks a substitution marker nor depends on one.
         .replace(PII_DEVICE_NAME_RE, "<name>$1")

--- a/android/app/src/main/java/com/noop/data/OuraSerialIdentity.kt
+++ b/android/app/src/main/java/com/noop/data/OuraSerialIdentity.kt
@@ -1,0 +1,25 @@
+package com.noop.data
+
+/**
+ * What may be written to a SHAREABLE strap log for an Oura ring's serial (#2092). Byte-parity twin of
+ * Swift `OuraSerialIdentity`.
+ *
+ * Mirrors [WhoopSerialIdentity.logSafe]'s shape exactly (same 3-character prefix + "…") so a masked
+ * WHOOP serial and a masked Oura serial read identically in a shared log — the reader should not need to
+ * know which brand a masked id came from to trust it is masked.
+ *
+ * Kept as its OWN type rather than a shared call into [WhoopSerialIdentity]: Oura's serial identity has
+ * its own home and does not share WHOOP's `adoptedId`/`mayAdopt`/`isAlreadyAdopted` machinery — only the
+ * LOG-SAFETY shape is common, not the identity model.
+ */
+object OuraSerialIdentity {
+    /** The one place the Oura id namespace is spelled — matches the brand catalog's "oura" entry. */
+    const val ID_PREFIX = "oura"
+
+    /** Never log "$ID_PREFIX-$serial" (or the bare serial) directly — only this. */
+    fun logSafe(serial: String?): String {
+        val raw = serial?.trim().orEmpty()
+        if (raw.isEmpty()) return "?"
+        return raw.uppercase().take(3) + "…"
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/OuraLiveSourceProductInfoLogRedactionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/OuraLiveSourceProductInfoLogRedactionTest.kt
@@ -1,0 +1,47 @@
+package com.noop.ble
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * #2092, route 1: the product-info reply log line printed `ascii: <serial>` in the clear - neither
+ * `redactStrapLogPii` rule matches a bare, unprefixed serial (by design: a shape-only rule would mask
+ * ordinary prose), and the hex half was only masked by `redactHexDumpPii`'s accident of matching a
+ * letter-led alnum run, which an all-digit serial (this repo's own #2075/#2090 evidence) never triggers.
+ * `OuraLiveSource.logSafeProductInfo` is the fix: computed right where the code already knows (via
+ * `isPlausibleSerial`) whether a decoded string IS a serial, so it can mask deliberately instead of
+ * relying on an unrelated heuristic to get lucky. Swift twin: `OuraLiveSourceProductInfoLogRedactionTests`.
+ */
+class OuraLiveSourceProductInfoLogRedactionTest {
+
+    @Test fun `a serial page is masked in both hex and ascii`() {
+        val serial = "2H3B2405003655"
+        val hex = serial.toByteArray().joinToString(" ") { "%02x".format(it) }
+        val (safeHex, safeAscii) = OuraLiveSource.logSafeProductInfo(hex, serial, serial)
+        assertEquals("<serial>", safeHex)
+        assertEquals("2H3…", safeAscii)
+        assertFalse(safeAscii.contains("2405003655"))
+    }
+
+    @Test fun `an all-digit serial page is masked too`() {
+        val serial = "2038082631034041"
+        val hex = serial.toByteArray().joinToString(" ") { "%02x".format(it) }
+        val (safeHex, safeAscii) = OuraLiveSource.logSafeProductInfo(hex, serial, serial)
+        assertEquals("<serial>", safeHex)
+        assertEquals("203…", safeAscii)
+    }
+
+    @Test fun `a hardware page is logged in full`() {
+        val hex = "BLB_03".toByteArray().joinToString(" ") { "%02x".format(it) }
+        val (safeHex, safeAscii) = OuraLiveSource.logSafeProductInfo(hex, "BLB_03", "BLB_03")
+        assertEquals(hex, safeHex)
+        assertEquals("BLB_03", safeAscii)
+    }
+
+    @Test fun `a null decode is left alone`() {
+        val (safeHex, safeAscii) = OuraLiveSource.logSafeProductInfo("00 01", "..", null)
+        assertEquals("00 01", safeHex)
+        assertEquals("..", safeAscii)
+    }
+}

--- a/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
+++ b/android/app/src/test/java/com/noop/ble/PiiRedactionTest.kt
@@ -117,6 +117,37 @@ class PiiRedactionTest {
         assertEquals("id=whoop-ABC…", redactStrapLogPii("id=whoop-ABCDEF"))
     }
 
+    /**
+     * #2092: the same gap as #1303 above, for the OTHER brand. An Oura ring's adopted id is
+     * `oura-<serial>`, and none of the WHOOP-shaped rules match a different literal prefix.
+     */
+    @Test fun masksAnAdoptedOuraSerialDeviceId() {
+        val out = redactStrapLogPii("device id=oura-2H3B2405003655 status=ACTIVE brand=Oura")
+        assertEquals("device id=oura-2H3… status=ACTIVE brand=Oura", out)
+        assertFalse("the serial must not survive anywhere", out.contains("2405003655"))
+    }
+
+    @Test fun keepsTheComputedSiblingMarkerForOuraToo() {
+        assertEquals("Days: oura-2H3…-noop=25",
+                     redactStrapLogPii("Days: oura-2H3B2405003655-noop=25"))
+    }
+
+    /** An all-digit serial (this repo's own #2075/#2090 evidence) must mask the same as an alphanumeric
+     *  one - the rule keys on the "oura-" prefix, not on the serial containing a letter. The PROVISIONAL
+     *  id in the same line is `oura-<MAC address>` on Android (`AddDeviceWizard.kt`), already caught by
+     *  the existing MAC rule - not a UUID as on iOS/macOS. */
+    @Test fun masksAnAllDigitOuraSerialToo() {
+        val line = "adopted stable serial id oura-2038082631034041 (was oura-AA:BB:CC:DD:EE:FF)"
+        val out = redactStrapLogPii(line)
+        assertFalse("serial survived: $out", out.contains("2038082631034041"))
+        assertEquals(true, out.contains("oura-203…"))
+        assertFalse("provisional MAC survived: $out", out.contains("AA:BB:CC:DD:EE:FF"))
+    }
+
+    @Test fun ignoresOuraIdsTooShortToBeASerial() {
+        assertEquals("id=oura-ABCDE", redactStrapLogPii("id=oura-ABCDE"))
+    }
+
     @Test fun leavesModelNamesAndPlainTextAlone() {
         // "WHOOP 4.0" is a dotted model name, not a serial — must not be scrubbed.
         assertEquals("Auto-reconnecting to your saved WHOOP 4.0…",

--- a/android/app/src/test/java/com/noop/data/OuraSerialIdentityTest.kt
+++ b/android/app/src/test/java/com/noop/data/OuraSerialIdentityTest.kt
@@ -1,0 +1,24 @@
+package com.noop.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class OuraSerialIdentityTest {
+
+    @Test fun logSafeNeverLeaksTheFullSerial() {
+        assertEquals("2H3…", OuraSerialIdentity.logSafe("2H3B2405003655"))
+        assertEquals("203…", OuraSerialIdentity.logSafe("2038082631034041"))
+        assertEquals("?", OuraSerialIdentity.logSafe(null))
+        assertEquals("?", OuraSerialIdentity.logSafe("  "))
+        assertFalse(OuraSerialIdentity.logSafe("2H3B2405003655").contains("2405003655"))
+    }
+
+    @Test fun logSafeUppercasesAndTrims() {
+        assertEquals("2H3…", OuraSerialIdentity.logSafe("  2h3b2405003655  "))
+    }
+
+    @Test fun idPrefixMatchesTheBrandCatalog() {
+        assertEquals("oura", OuraSerialIdentity.ID_PREFIX)
+    }
+}


### PR DESCRIPTION
Addresses #2092.

Neither `LiveState.redactPii` (Swift) nor `redactStrapLogPii` (Kotlin) had any Oura-aware rule — every rule was WHOOP-shaped. An Oura serial reached shareable logs by two routes PR #2090 didn't cover (that one fixed only the raw sidecar):

1. The product-info reply log line printed `ascii: <serial>` in the clear.
2. Any line printing an adopted `oura-<serial>` device id carried it verbatim — the same #1303 gap as  WHOOP's `whoop-<SERIAL>`, never extended to Oura.

Shape follows #1303 exactly, both platforms: new `OuraSerialIdentity.logSafe` (3-char prefix, mirroring `WhoopSerialIdentity.logSafe`), a `oura-<serial>`/`oura-<serial>-noop` rule pair in both redactors, and the product-info log line now masks deliberately via `isPlausibleSerial` instead of relying on `redactHexDump`'s accidental letter-anchored heuristic (which an all-digit serial never triggers).

New tests both platforms. Verified: Swift `StrandTests` 1743/0 + macOS build; Kotlin `compileFullDebugKotlin` clean + `testFullDebugUnitTest` (7 pre-existing failures, independently reconfirmed against plain `upstream/main`, none in a touched file).

Not covered: the already-public #2075 attachment isn't retroactively scrubbed by this.