### PR TITLE
fix(oura): don't reset the history resume cursor to 0 on a stale replay the ring's own clock disproves as a reboot

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraHistoryDrain.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraHistoryDrain.swift
@@ -20,6 +20,18 @@ public struct OuraHistoryDrain: Sendable, Equatable {
     /// A healthy full pull finishes in ~1-2 min; past this something upstream is wrong — stop, keep the
     /// banked progress, and let the periodic re-fetch try again later.
     public static let maxDrainSeconds: TimeInterval = 300
+    /// The ring's clock tick rate (OURA_PROTOCOL.md s5.5: 100 ms/tick by default). Used only by
+    /// `anchorsAreContinuous` below, never by ring-time -> UTC conversion (that stays in `OuraDriver`).
+    public static let ringTicksPerSecond: Double = 10
+    /// Ordinary jitter tolerance for `anchorsAreContinuous` (#2097): how far the ring's clock may appear
+    /// to fall behind wall-clock across a gap before it counts as a real power-cycle pause rather than
+    /// anchor-receipt latency noise (BLE round-trip variance on the two receipt timestamps). A genuine
+    /// power-cycle pause is measured in minutes (13m41s observed on one dead-battery reboot) — nowhere
+    /// close to this margin, so it stays generous without risking a false "continuous" read.
+    public static let anchorContinuityMaxPauseSeconds: Double = 20
+    /// Minimum wall-clock gap `anchorsAreContinuous` will judge; below this a few seconds of receipt-
+    /// latency noise would dominate the rate measurement, so the check declines rather than guessing.
+    public static let anchorContinuityMinGapSeconds: Double = 30
 
     private var minBytesLeftSeen: UInt32 = .max
     private var stallCount = 0
@@ -101,12 +113,41 @@ public struct OuraHistoryDrain: Sendable, Equatable {
 
     /// The cursor to persist at drain end, given the current cursor and whether `maxStoredRingTime`
     /// resolves under the CURRENT anchor. A reboot (`sawPreResumeData`) resets to 0 (honest full pull next
-    /// connect); otherwise the cursor advances to `maxStoredRingTime` only if it moved forward AND
-    /// resolves. Unchanged in every other case.
-    public func resumeCursorAtDrainEnd(currentCursor: UInt32, resolvesUnderAnchor: Bool) -> UInt32 {
-        if sawPreResumeData { return 0 }
+    /// connect) UNLESS `anchorConfirmsContinuity` says the ring's own clock never paused (#2097) — in
+    /// that case the stale replay came from something other than a power-cycle (observed: a second BLE
+    /// client serving the ring in between), so it is treated like ordinary stale data: discarded, cursor
+    /// left to the same forward-only-if-resolving rule as any other drain. Otherwise the cursor advances
+    /// to `maxStoredRingTime` only if it moved forward AND resolves; unchanged in every other case.
+    public func resumeCursorAtDrainEnd(currentCursor: UInt32, resolvesUnderAnchor: Bool,
+                                        anchorConfirmsContinuity: Bool = false) -> UInt32 {
+        if sawPreResumeData, !anchorConfirmsContinuity { return 0 }
         if maxStoredRingTime > currentCursor, resolvesUnderAnchor { return maxStoredRingTime }
         return currentCursor
+    }
+
+    /// Whether two `0x13 SyncTime` anchors observed across a connect-to-connect gap are consistent with
+    /// the ring's clock having ticked continuously the whole time — i.e. NOT a genuine power-cycle (#2097).
+    ///
+    /// `OuraHistoryDrain.sawPreResumeData` alone cannot tell a real ring reboot from a second BLE client
+    /// (e.g. the Oura app) having served the ring in between and left NOOP's resume cursor looking stale:
+    /// both produce the identical "a stored sample is older than where we sought" signature. But a real
+    /// power-cycle does not reset the ring's free-running tick counter toward zero — it PAUSES it while
+    /// the ring is off (measured: a dead-battery reboot lost 13m41s of ticks against wall-clock, bracketed
+    /// by two sub-second no-charge controls) — so comparing elapsed ring-ticks against elapsed wall-clock
+    /// across the gap distinguishes the two: continuous ticking means nothing paused the ring's clock.
+    ///
+    /// Declines to judge (returns `false`, the safe default that keeps today's "treat as reboot"
+    /// behavior) when the gap is too short to measure meaningfully, or when `current` somehow precedes
+    /// `previous` in ring-ticks (never observed; not a continuity claim either way).
+    public static func anchorsAreContinuous(previous: (ringTicks: UInt32, unixSeconds: Int64),
+                                             current: (ringTicks: UInt32, unixSeconds: Int64)) -> Bool {
+        let wallDelta = Double(current.unixSeconds - previous.unixSeconds)
+        guard wallDelta >= anchorContinuityMinGapSeconds, current.ringTicks >= previous.ringTicks else {
+            return false
+        }
+        let ringSeconds = Double(current.ringTicks - previous.ringTicks) / ringTicksPerSecond
+        let fellBehindBy = wallDelta - ringSeconds
+        return fellBehindBy <= anchorContinuityMaxPauseSeconds
     }
 
     /// Sanitize a cursor loaded from persistence: a value above the plausibility ceiling is pre-fix

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraHistoryDrainTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraHistoryDrainTests.swift
@@ -104,6 +104,74 @@ final class OuraHistoryDrainTests: XCTestCase {
                        "a reboot forces 0 (full pull) even if a forward sample also arrived")
     }
 
+    // MARK: #2097 - a SyncTime anchor confirming clock continuity overrides the reboot reset
+
+    func testAnchorConfirmsContinuityKeepsCursorInsteadOfFullReset() {
+        var d = OuraHistoryDrain()
+        d.noteStoredRingTime(500, resumeCursorAtFetchStart: 1000) // stale sample -> sawPreResumeData
+        XCTAssertTrue(d.sawPreResumeData)
+        XCTAssertEqual(d.resumeCursorAtDrainEnd(currentCursor: 1000, resolvesUnderAnchor: true,
+                                                 anchorConfirmsContinuity: true), 1000,
+                       "continuity confirmed (#2097): not a reboot - discard the stale replay, keep the cursor")
+    }
+
+    func testAnchorConfirmsContinuityStillAdvancesOnRealForwardProgress() {
+        var d = OuraHistoryDrain()
+        d.noteStoredRingTime(3_453_828, resumeCursorAtFetchStart: 1000) // forward...
+        d.noteStoredRingTime(500, resumeCursorAtFetchStart: 1000)       // ...plus a stale replay
+        XCTAssertTrue(d.sawPreResumeData)
+        XCTAssertEqual(d.resumeCursorAtDrainEnd(currentCursor: 1000, resolvesUnderAnchor: true,
+                                                 anchorConfirmsContinuity: true), 3_453_828,
+                       "continuity confirmed: genuine forward progress still commits normally")
+    }
+
+    func testAnchorContinuityDefaultsToOldRebootBehaviorWhenOmitted() {
+        var d = OuraHistoryDrain()
+        d.noteStoredRingTime(500, resumeCursorAtFetchStart: 1000)
+        XCTAssertEqual(d.resumeCursorAtDrainEnd(currentCursor: 1000, resolvesUnderAnchor: true), 0,
+                       "omitting anchorConfirmsContinuity must not change today's behavior")
+    }
+
+    // MARK: #2097 - anchorsAreContinuous (the SyncTime anchor comparison itself)
+
+    func testAnchorsAreContinuousOnTheReal20260911N2Gap() {
+        // The witnessed n=2 occurrence: 12:29:26 -> 14:00:02 local, 5436s wall, 54357 ring ticks
+        // (~9.999 ticks/s) spanning the Oura-app handoff. The ring's clock never paused.
+        let previous = (ringTicks: UInt32(42_236_951), unixSeconds: Int64(0))
+        let current = (ringTicks: UInt32(42_291_308), unixSeconds: Int64(5436))
+        XCTAssertTrue(OuraHistoryDrain.anchorsAreContinuous(previous: previous, current: current))
+    }
+
+    func testAnchorsAreContinuousDetectsARealPause() {
+        // A genuine power-cycle: ticks paused for 821s (matches the measured 13m41s dead-battery
+        // reboot) somewhere inside a 3600s wall-clock gap.
+        let previous = (ringTicks: UInt32(1_000_000), unixSeconds: Int64(0))
+        let tickedSeconds = 3600 - 821
+        let current = (ringTicks: UInt32(1_000_000) + UInt32(tickedSeconds * 10), unixSeconds: Int64(3600))
+        XCTAssertFalse(OuraHistoryDrain.anchorsAreContinuous(previous: previous, current: current))
+    }
+
+    func testAnchorsAreContinuousToleratesOrdinaryJitter() {
+        // 5s of receipt-latency noise across an otherwise-continuous gap must not false-positive as a
+        // pause (well under anchorContinuityMaxPauseSeconds).
+        let previous = (ringTicks: UInt32(1_000_000), unixSeconds: Int64(0))
+        let current = (ringTicks: UInt32(1_000_000 + 3_000), unixSeconds: Int64(305)) // 305s wall, 300s ticked
+        XCTAssertTrue(OuraHistoryDrain.anchorsAreContinuous(previous: previous, current: current))
+    }
+
+    func testAnchorsAreContinuousDeclinesOnTooShortAGap() {
+        let previous = (ringTicks: UInt32(1_000_000), unixSeconds: Int64(0))
+        let current = (ringTicks: UInt32(1_000_100), unixSeconds: Int64(10)) // below the 30s minimum
+        XCTAssertFalse(OuraHistoryDrain.anchorsAreContinuous(previous: previous, current: current),
+                       "too short a gap to judge - declines rather than guessing")
+    }
+
+    func testAnchorsAreContinuousDeclinesWhenTicksWentBackward() {
+        let previous = (ringTicks: UInt32(1_000_000), unixSeconds: Int64(0))
+        let current = (ringTicks: UInt32(999_000), unixSeconds: Int64(100)) // never observed; decline, not confirm
+        XCTAssertFalse(OuraHistoryDrain.anchorsAreContinuous(previous: previous, current: current))
+    }
+
     // MARK: loaded-cursor sanitize + reset
 
     func testSanitizeLoadedCursor() {

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -614,6 +614,19 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// The cursor we resumed FROM at the start of the current fetch — passed into `drain.noteStoredRingTime`
     /// so a real stored sample OLDER than it flags a genuine ring reboot (clock reset / seek ignored).
     private var resumeCursorAtFetchStart: UInt32 = 0
+    /// The SyncTime anchor persisted from the END of the PREVIOUS connection to this ring (#2097), loaded
+    /// fresh at the start of THIS session — never an anchor this session itself adopts. Compared against
+    /// `currentSyncAnchor` in `commitResumeCursor` to tell a genuine ring reboot from a second BLE client
+    /// (e.g. the Oura app) having served the ring in between: `sawPreResumeData` alone cannot, since both
+    /// produce the same "stored sample older than the fetch cursor" signature. `nil` on a first-ever
+    /// connect to this ring, or when no previous session ever adopted an anchor — the comparison then
+    /// simply declines and today's "treat as reboot" behavior stands.
+    private var previousSyncAnchor: (ringTicks: UInt32, unixSeconds: Int64)?
+    /// The SyncTime anchor THIS session has adopted (freshest wins, mirroring `OuraDriver.adoptSyncTimeAnchor`),
+    /// persisted via `OuraSyncAnchorStore` for the NEXT connection to compare against as its own
+    /// `previousSyncAnchor`. `nil` until `adoptSyncTimeAnchor(deviceTimestamp:status:receivedAt:source:)`
+    /// first succeeds this session.
+    private var currentSyncAnchor: (ringTicks: UInt32, unixSeconds: Int64)?
     /// Wall-clock start of the current drain; `drain`'s deadline guard force-stops one running too long.
     private var drainStartedAt: Date?
     /// The cursor the LAST GetEvents request was issued at — the `start` of open_oura's progress test
@@ -777,17 +790,28 @@ public final class OuraLiveSource: NSObject, ObservableObject {
 
     /// Commit the durable resume cursor at drain end. Only a cursor that (a) moved forward, (b) is below
     /// the plausibility ceiling, and (c) resolves to a real time under the CURRENT anchor is persisted;
-    /// a reboot (`sawPreResumeData`) resets to 0 so next connect does an honest full pull.
+    /// a reboot (`sawPreResumeData`) resets to 0 so next connect does an honest full pull — UNLESS the
+    /// ring's own SyncTime anchor proves its clock never paused across the gap (#2097:
+    /// `OuraHistoryDrain.anchorsAreContinuous`), in which case the stale replay is treated like ordinary
+    /// stale data instead (dropped; cursor follows the same forward-only-if-resolving rule as any other
+    /// drain) rather than forcing a full re-pull of the ring's entire history.
     private func commitResumeCursor(drainCompleted: Bool) {
         let how = drainCompleted ? "caught up (bytes_left 0)" : "stopped early"
         let resolves = drain.maxStoredRingTime > 0
             && (driver?.unixSeconds(forRingTimestamp: drain.maxStoredRingTime) != nil)
-        let newCursor = drain.resumeCursorAtDrainEnd(currentCursor: historyCursor, resolvesUnderAnchor: resolves)
-        if drain.sawPreResumeData {
+        let anchorConfirmsContinuity = drain.sawPreResumeData && syncAnchorsConfirmContinuity()
+        let newCursor = drain.resumeCursorAtDrainEnd(currentCursor: historyCursor, resolvesUnderAnchor: resolves,
+                                                      anchorConfirmsContinuity: anchorConfirmsContinuity)
+        if drain.sawPreResumeData, !anchorConfirmsContinuity {
             log("Oura: history \(how) but the ring served data older than cursor \(resumeCursorAtFetchStart) - clock reset/seek ignored; next connect does a full pull")
             historyCursor = 0
             OuraHistoryCursorStore.save(0, deviceId: deviceId)
-        } else if newCursor != historyCursor {
+            return
+        }
+        if drain.sawPreResumeData {
+            log("Oura: history \(how) but the ring served data older than cursor \(resumeCursorAtFetchStart) - the ring's own SyncTime clock never paused across the gap, so this is a second BLE client's serve position, not a reboot (#2097); discarding the stale replay instead of a full re-pull")
+        }
+        if newCursor != historyCursor {
             historyCursor = newCursor
             OuraHistoryCursorStore.save(newCursor, deviceId: deviceId)
             log("Oura: history \(how) - resume cursor advanced to \(historyCursor) [\(describeCursor(historyCursor))]")
@@ -796,6 +820,17 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         } else {
             log("Oura: history \(how) (resume cursor unchanged \(historyCursor) [\(describeCursor(historyCursor))])")
         }
+    }
+
+    /// Whether this drain's `sawPreResumeData` flag should be trusted as a genuine ring reboot, or
+    /// whether the ring's own clock proves otherwise (#2097). Requires BOTH a previous-session anchor
+    /// (persisted by an earlier connect) and an anchor THIS session adopted; either missing means there
+    /// is nothing to compare, so this declines (`false`) and the existing reboot handling stands — the
+    /// safe default when the ring was never anchored before (first pairing) or never got anchored again
+    /// this session (e.g. the drain finished before any 0x13 SyncTime reply resolved).
+    private func syncAnchorsConfirmContinuity() -> Bool {
+        guard let previous = previousSyncAnchor, let current = currentSyncAnchor else { return false }
+        return OuraHistoryDrain.anchorsAreContinuous(previous: previous, current: current)
     }
 
     /// The 0x49 window in `windows` whose envelope ring-time is nearest `rt` and within `tolerance` ticks,
@@ -2387,6 +2422,11 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
             log("Oura: persisted resume cursor \(loadedCursor) exceeds the plausibility ceiling (pre-fix garbage) - full pull")
             OuraHistoryCursorStore.save(0, deviceId: deviceId)
         }
+        // The anchor from whatever session last adopted one — loaded BEFORE this session gets a chance to
+        // adopt its own, so `commitResumeCursor` can compare the two (#2097). `currentSyncAnchor` starts
+        // nil each session; nothing carries a stale in-memory anchor into a fresh connect.
+        previousSyncAnchor = OuraSyncAnchorStore.read(deviceId: deviceId)
+        currentSyncAnchor = nil
         peripheral.discoverServices([Self.service])
     }
 
@@ -2659,6 +2699,11 @@ extension OuraLiveSource: @preconcurrency CBPeripheralDelegate {
             loggedAnchor = true
             log("Oura: UTC anchor from SyncTime response (0x13) \(source) - device rt \(rt) [\(unit), raw \(raw), status \(status)] = its receipt time; no 0x42 needed this session")
         }
+        // The freshest pair this session has adopted (mirrors `driver.adoptSyncTimeAnchor` always
+        // overwriting), kept for `commitResumeCursor`'s continuity check and persisted so the NEXT
+        // connection can compare against it as its own `previousSyncAnchor` (#2097).
+        currentSyncAnchor = (ringTicks: rt, unixSeconds: receivedAt)
+        OuraSyncAnchorStore.save(ringTicks: rt, unixSeconds: receivedAt, deviceId: deviceId)
         drainPendingAnchorEvents()
         drainPendingHypnogramBursts()
         return true
@@ -2785,5 +2830,37 @@ enum OuraHistoryCursorStore {
     /// Store the advanced cursor for `deviceId`.
     static func save(_ cursor: UInt32, deviceId: String) {
         UserDefaults.standard.set(Int(cursor), forKey: key(deviceId: deviceId))
+    }
+}
+
+// MARK: - Oura SyncTime anchor persistence (#2097)
+
+/// Persists the Oura ring's `0x13 SyncTime` (ring-ticks, wall-clock) anchor pair across connects, so a
+/// later connection can check whether the ring's own clock ran continuously since the last one —
+/// distinguishing a genuine power-cycle from a second BLE client (e.g. the Oura app) having served the
+/// ring in between, which otherwise looks identical to `OuraHistoryDrain.sawPreResumeData`
+/// (`OuraHistoryDrain.anchorsAreContinuous` does the actual comparison; this type only persists the
+/// inputs). Not sensitive — an opaque clock pairing, not a credential — so plain `UserDefaults`, same
+/// reasoning as `OuraHistoryCursorStore`.
+enum OuraSyncAnchorStore {
+    private static func ticksKey(deviceId: String) -> String { "com.noop.oura.syncAnchorTicks.\(deviceId)" }
+    private static func secondsKey(deviceId: String) -> String { "com.noop.oura.syncAnchorSeconds.\(deviceId)" }
+
+    /// The persisted anchor for `deviceId`, or nil if none is stored yet (a ring never anchored before,
+    /// or an install that predates this feature).
+    static func read(deviceId: String) -> (ringTicks: UInt32, unixSeconds: Int64)? {
+        let defaults = UserDefaults.standard
+        guard let ticksRaw = defaults.object(forKey: ticksKey(deviceId: deviceId)) as? Int,
+              let secondsRaw = defaults.object(forKey: secondsKey(deviceId: deviceId)) as? Int else {
+            return nil
+        }
+        return (ringTicks: UInt32(clamping: ticksRaw), unixSeconds: Int64(secondsRaw))
+    }
+
+    /// Store the freshest anchor for `deviceId`.
+    static func save(ringTicks: UInt32, unixSeconds: Int64, deviceId: String) {
+        let defaults = UserDefaults.standard
+        defaults.set(Int(ringTicks), forKey: ticksKey(deviceId: deviceId))
+        defaults.set(Int(unixSeconds), forKey: secondsKey(deviceId: deviceId))
     }
 }

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -499,6 +499,28 @@ class OuraLiveSource(
     /** Where this fetch sought from (reboot detection floor); armed per drain. */
     private var resumeCursorAtFetchStart = 0L
 
+    /**
+     * The SyncTime anchor persisted from the END of the PREVIOUS connection to this ring (#2097),
+     * loaded fresh at the start of THIS session — never an anchor this session itself adopts. Compared
+     * against [currentSyncAnchorTicks]/[currentSyncAnchorUnixSeconds] in `commitResumeCursor` to tell a
+     * genuine ring reboot from a second BLE client (e.g. the Oura app) having served the ring in
+     * between: [OuraHistoryDrain.sawPreResumeData] alone cannot, since both produce the same "stored
+     * sample older than the fetch cursor" signature. Null on a first-ever connect to this ring, or when
+     * no previous session ever adopted an anchor — the comparison then declines and the existing
+     * "treat as reboot" behavior stands.
+     */
+    private var previousSyncAnchorTicks: Long? = null
+    private var previousSyncAnchorUnixSeconds: Long? = null
+
+    /**
+     * The SyncTime anchor THIS session has adopted (freshest wins, mirroring
+     * [OuraDriver.adoptSyncTimeAnchor]), persisted via [OuraSyncAnchorStore] for the NEXT connection to
+     * compare against as its own previous anchor. Null until `adoptSyncTimeAnchor` first succeeds this
+     * session.
+     */
+    private var currentSyncAnchorTicks: Long? = null
+    private var currentSyncAnchorUnixSeconds: Long? = null
+
     /** Wall-clock start of the current drain; feeds the deadline guard. */
     private var drainStartedAtMs: Long? = null
 
@@ -687,19 +709,32 @@ class OuraLiveSource(
     /**
      * Commit the durable resume cursor at drain end. Only a cursor that (a) moved forward, (b) is
      * below the plausibility ceiling, and (c) resolves to a real time under the CURRENT anchor is
-     * persisted; a reboot (`sawPreResumeData`) resets to 0 so next connect does an honest full pull.
+     * persisted; a reboot (`sawPreResumeData`) resets to 0 so next connect does an honest full pull —
+     * UNLESS the ring's own SyncTime anchor proves its clock never paused across the gap (#2097:
+     * [OuraHistoryDrain.anchorsAreContinuous]), in which case the stale replay is treated like ordinary
+     * stale data instead (dropped; cursor follows the same forward-only-if-resolving rule as any other
+     * drain) rather than forcing a full re-pull of the ring's entire history.
      */
     private fun commitResumeCursor(drainCompleted: Boolean) {
         val how = if (drainCompleted) "caught up (bytes_left 0)" else "stopped early"
         val resolves = drain.maxStoredRingTime > 0 &&
             driver?.unixSeconds(forRingTimestamp = drain.maxStoredRingTime) != null
-        val newCursor = drain.resumeCursorAtDrainEnd(historyCursor, resolves)
-        if (drain.sawPreResumeData) {
+        val anchorConfirmsContinuity = drain.sawPreResumeData && syncAnchorsConfirmContinuity()
+        val newCursor = drain.resumeCursorAtDrainEnd(historyCursor, resolves, anchorConfirmsContinuity)
+        if (drain.sawPreResumeData && !anchorConfirmsContinuity) {
             log("Oura: history $how but the ring served data older than cursor $resumeCursorAtFetchStart" +
                 " - clock reset/seek ignored; next connect does a full pull")
             historyCursor = 0
             OuraHistoryCursorStore.save(appContext, deviceId, 0)
-        } else if (newCursor != historyCursor) {
+            return
+        }
+        if (drain.sawPreResumeData) {
+            log("Oura: history $how but the ring served data older than cursor $resumeCursorAtFetchStart" +
+                " - the ring's own SyncTime clock never paused across the gap, so this is a second BLE" +
+                " client's serve position, not a reboot (#2097); discarding the stale replay instead of" +
+                " a full re-pull")
+        }
+        if (newCursor != historyCursor) {
             historyCursor = newCursor
             OuraHistoryCursorStore.save(appContext, deviceId, newCursor)
             log("Oura: history $how - resume cursor advanced to $historyCursor")
@@ -709,6 +744,20 @@ class OuraLiveSource(
         } else {
             log("Oura: history $how (resume cursor unchanged $historyCursor)")
         }
+    }
+
+    /**
+     * Whether this drain's `sawPreResumeData` flag should be trusted as a genuine ring reboot, or
+     * whether the ring's own clock proves otherwise (#2097). Requires BOTH a previous-session anchor
+     * (persisted by an earlier connect) and an anchor THIS session adopted; either missing means there
+     * is nothing to compare, so this declines (`false`) and the existing reboot handling stands.
+     */
+    private fun syncAnchorsConfirmContinuity(): Boolean {
+        val prevTicks = previousSyncAnchorTicks ?: return false
+        val prevSeconds = previousSyncAnchorUnixSeconds ?: return false
+        val curTicks = currentSyncAnchorTicks ?: return false
+        val curSeconds = currentSyncAnchorUnixSeconds ?: return false
+        return OuraHistoryDrain.anchorsAreContinuous(prevTicks, prevSeconds, curTicks, curSeconds)
     }
 
     /**
@@ -875,6 +924,12 @@ class OuraLiveSource(
             log("Oura: UTC anchor from SyncTime response (0x13) $source - device rt $rt [$unit, " +
                 "raw $raw, status $status] = its receipt time; no 0x42 needed this session")
         }
+        // The freshest pair this session has adopted (mirrors `d.adoptSyncTimeAnchor` always
+        // overwriting), kept for `commitResumeCursor`'s continuity check and persisted so the NEXT
+        // connection can compare against it as its own previous anchor (#2097).
+        currentSyncAnchorTicks = rt
+        currentSyncAnchorUnixSeconds = receivedAt
+        OuraSyncAnchorStore.save(appContext, deviceId, rt, receivedAt)
         drainPendingAnchorEvents()
         drainPendingHypnogramBursts()
         return true
@@ -1035,6 +1090,14 @@ class OuraLiveSource(
             log("Oura: persisted resume cursor $loadedCursor exceeds the plausibility ceiling (pre-fix garbage) - full pull")
             OuraHistoryCursorStore.save(appContext, deviceId, 0)
         }
+        // The anchor from whatever session last adopted one — loaded BEFORE this session gets a chance
+        // to adopt its own, so `commitResumeCursor` can compare the two (#2097). The current-session
+        // anchor starts null each session; nothing carries a stale in-memory anchor into a fresh connect.
+        val loadedAnchor = OuraSyncAnchorStore.read(appContext, deviceId)
+        previousSyncAnchorTicks = loadedAnchor?.first
+        previousSyncAnchorUnixSeconds = loadedAnchor?.second
+        currentSyncAnchorTicks = null
+        currentSyncAnchorUnixSeconds = null
         // connectGatt can throw (SecurityException if BLUETOOTH_CONNECT was revoked mid-session,
         // IllegalArgumentException on a stale device) - never let that crash the app; a failed start
         // simply leaves the previous source in place (mirrors [StandardHrSource]).
@@ -2236,5 +2299,48 @@ object OuraHistoryCursorStore {
     /** Store the advanced cursor for [deviceId]. */
     fun save(ctx: Context, deviceId: String, cursor: Long) {
         runCatching { prefs(ctx).edit().putLong(prefKey(deviceId), cursor and 0xFFFF_FFFFL).apply() }
+    }
+}
+
+// MARK: - Oura SyncTime anchor persistence (#2097)
+
+/**
+ * Persists the Oura ring's `0x13 SyncTime` (ring-ticks, wall-clock) anchor pair across connects, so a
+ * later connection can check whether the ring's own clock ran continuously since the last one —
+ * distinguishing a genuine power-cycle from a second BLE client (e.g. the Oura app) having served the
+ * ring in between, which otherwise looks identical to [OuraHistoryDrain.sawPreResumeData]
+ * ([OuraHistoryDrain.anchorsAreContinuous] does the actual comparison; this object only persists the
+ * inputs). Kotlin twin of Swift's `OuraSyncAnchorStore`. Not sensitive — an opaque clock pairing, not a
+ * credential — so plain [SharedPreferences], same reasoning as [OuraHistoryCursorStore].
+ */
+object OuraSyncAnchorStore {
+    private const val FILE_NAME = "noop_oura_sync_anchor"
+    private const val TICKS_KEY_PREFIX = "sync_anchor_ticks_"
+    private const val SECONDS_KEY_PREFIX = "sync_anchor_seconds_"
+
+    private fun prefs(ctx: Context): SharedPreferences =
+        ctx.applicationContext.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE)
+
+    /** The persisted anchor for [deviceId] as (ringTicks, unixSeconds), or null if none is stored yet
+     *  (a ring never anchored before, or an install that predates this feature). */
+    fun read(ctx: Context, deviceId: String): Pair<Long, Long>? = runCatching {
+        val p = prefs(ctx)
+        val ticksKey = "$TICKS_KEY_PREFIX$deviceId"
+        val secondsKey = "$SECONDS_KEY_PREFIX$deviceId"
+        if (!p.contains(ticksKey) || !p.contains(secondsKey)) {
+            null
+        } else {
+            p.getLong(ticksKey, 0L) to p.getLong(secondsKey, 0L)
+        }
+    }.getOrNull()
+
+    /** Store the freshest anchor for [deviceId]. */
+    fun save(ctx: Context, deviceId: String, ringTicks: Long, unixSeconds: Long) {
+        runCatching {
+            prefs(ctx).edit()
+                .putLong("$TICKS_KEY_PREFIX$deviceId", ringTicks and 0xFFFF_FFFFL)
+                .putLong("$SECONDS_KEY_PREFIX$deviceId", unixSeconds)
+                .apply()
+        }
     }
 }

--- a/android/app/src/main/java/com/noop/oura/OuraHistoryDrain.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraHistoryDrain.kt
@@ -114,11 +114,19 @@ class OuraHistoryDrain {
     /**
      * The cursor to persist at drain end, given the current cursor and whether [maxStoredRingTime]
      * resolves under the CURRENT anchor. A reboot ([sawPreResumeData]) resets to 0 (honest full pull
-     * next connect); otherwise the cursor advances to [maxStoredRingTime] only if it moved forward AND
-     * resolves. Unchanged in every other case.
+     * next connect) UNLESS [anchorConfirmsContinuity] says the ring's own clock never paused (#2097) —
+     * in that case the stale replay came from something other than a power-cycle (observed: a second
+     * BLE client serving the ring in between), so it is treated like ordinary stale data: discarded,
+     * cursor left to the same forward-only-if-resolving rule as any other drain. Otherwise the cursor
+     * advances to [maxStoredRingTime] only if it moved forward AND resolves; unchanged in every other
+     * case.
      */
-    fun resumeCursorAtDrainEnd(currentCursor: Long, resolvesUnderAnchor: Boolean): Long {
-        if (sawPreResumeData) return 0
+    fun resumeCursorAtDrainEnd(
+        currentCursor: Long,
+        resolvesUnderAnchor: Boolean,
+        anchorConfirmsContinuity: Boolean = false,
+    ): Long {
+        if (sawPreResumeData && !anchorConfirmsContinuity) return 0
         if (maxStoredRingTime > currentCursor && resolvesUnderAnchor) return maxStoredRingTime
         return currentCursor
     }
@@ -145,5 +153,56 @@ class OuraHistoryDrain {
          */
         fun sanitizeLoadedCursor(persisted: Long): Long =
             if (persisted in 0..MAX_PLAUSIBLE_RESUME_TICKS) persisted else 0
+
+        /** The ring's clock tick rate (OURA_PROTOCOL.md s5.5: 100 ms/tick by default). Used only by
+         *  [anchorsAreContinuous], never by ring-time -> UTC conversion (that stays in [OuraDriver]). */
+        const val RING_TICKS_PER_SECOND = 10.0
+
+        /**
+         * Ordinary jitter tolerance for [anchorsAreContinuous] (#2097): how far the ring's clock may
+         * appear to fall behind wall-clock across a gap before it counts as a real power-cycle pause
+         * rather than anchor-receipt latency noise (BLE round-trip variance on the two receipt
+         * timestamps). A genuine power-cycle pause is measured in minutes (13m41s observed on one
+         * dead-battery reboot) — nowhere close to this margin, so it stays generous without risking a
+         * false "continuous" read.
+         */
+        const val ANCHOR_CONTINUITY_MAX_PAUSE_SECONDS = 20.0
+
+        /** Minimum wall-clock gap [anchorsAreContinuous] will judge; below this a few seconds of
+         *  receipt-latency noise would dominate the rate measurement, so it declines rather than
+         *  guessing. */
+        const val ANCHOR_CONTINUITY_MIN_GAP_SECONDS = 30.0
+
+        /**
+         * Whether two `0x13 SyncTime` anchors observed across a connect-to-connect gap are consistent
+         * with the ring's clock having ticked continuously the whole time — i.e. NOT a genuine
+         * power-cycle (#2097). Byte-identical twin of Swift's `OuraHistoryDrain.anchorsAreContinuous`.
+         *
+         * [sawPreResumeData] alone cannot tell a real ring reboot from a second BLE client (e.g. the
+         * Oura app) having served the ring in between and left our resume cursor looking stale: both
+         * produce the identical "a stored sample is older than where we sought" signature. But a real
+         * power-cycle does not reset the ring's free-running tick counter toward zero — it PAUSES it
+         * while the ring is off (measured: a dead-battery reboot lost 13m41s of ticks against
+         * wall-clock) — so comparing elapsed ring-ticks against elapsed wall-clock across the gap
+         * distinguishes the two: continuous ticking means nothing paused the ring's clock.
+         *
+         * Declines to judge (returns `false`, the safe default that keeps the "treat as reboot"
+         * behavior) when the gap is too short to measure meaningfully, or when [current] somehow
+         * precedes [previous] in ring-ticks (never observed; not a continuity claim either way).
+         */
+        fun anchorsAreContinuous(
+            previousRingTicks: Long,
+            previousUnixSeconds: Long,
+            currentRingTicks: Long,
+            currentUnixSeconds: Long,
+        ): Boolean {
+            val wallDelta = (currentUnixSeconds - previousUnixSeconds).toDouble()
+            if (wallDelta < ANCHOR_CONTINUITY_MIN_GAP_SECONDS || currentRingTicks < previousRingTicks) {
+                return false
+            }
+            val ringSeconds = (currentRingTicks - previousRingTicks).toDouble() / RING_TICKS_PER_SECOND
+            val fellBehindBy = wallDelta - ringSeconds
+            return fellBehindBy <= ANCHOR_CONTINUITY_MAX_PAUSE_SECONDS
+        }
     }
 }

--- a/android/app/src/test/java/com/noop/oura/OuraHistoryDrainTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraHistoryDrainTest.kt
@@ -115,6 +115,103 @@ class OuraHistoryDrainTest {
         )
     }
 
+    // MARK: #2097 - a SyncTime anchor confirming clock continuity overrides the reboot reset
+
+    @Test
+    fun testAnchorConfirmsContinuityKeepsCursorInsteadOfFullReset() {
+        val d = OuraHistoryDrain()
+        d.noteStoredRingTime(500, resumeCursorAtFetchStart = 1000) // stale sample -> sawPreResumeData
+        assertTrue(d.sawPreResumeData)
+        assertEquals(
+            "continuity confirmed (#2097): not a reboot - discard the stale replay, keep the cursor",
+            1000L,
+            d.resumeCursorAtDrainEnd(currentCursor = 1000, resolvesUnderAnchor = true, anchorConfirmsContinuity = true),
+        )
+    }
+
+    @Test
+    fun testAnchorConfirmsContinuityStillAdvancesOnRealForwardProgress() {
+        val d = OuraHistoryDrain()
+        d.noteStoredRingTime(3_453_828, resumeCursorAtFetchStart = 1000) // forward...
+        d.noteStoredRingTime(500, resumeCursorAtFetchStart = 1000)       // ...plus a stale replay
+        assertTrue(d.sawPreResumeData)
+        assertEquals(
+            "continuity confirmed: genuine forward progress still commits normally",
+            3_453_828L,
+            d.resumeCursorAtDrainEnd(currentCursor = 1000, resolvesUnderAnchor = true, anchorConfirmsContinuity = true),
+        )
+    }
+
+    @Test
+    fun testAnchorContinuityDefaultsToOldRebootBehaviorWhenOmitted() {
+        val d = OuraHistoryDrain()
+        d.noteStoredRingTime(500, resumeCursorAtFetchStart = 1000)
+        assertEquals(
+            "omitting anchorConfirmsContinuity must not change today's behavior",
+            0L, d.resumeCursorAtDrainEnd(currentCursor = 1000, resolvesUnderAnchor = true),
+        )
+    }
+
+    // MARK: #2097 - anchorsAreContinuous (the SyncTime anchor comparison itself)
+
+    @Test
+    fun testAnchorsAreContinuousOnTheReal20260911N2Gap() {
+        // The witnessed n=2 occurrence: 12:29:26 -> 14:00:02 local, 5436s wall, 54357 ring ticks
+        // (~9.999 ticks/s) spanning the Oura-app handoff. The ring's clock never paused.
+        assertTrue(
+            OuraHistoryDrain.anchorsAreContinuous(
+                previousRingTicks = 42_236_951L, previousUnixSeconds = 0L,
+                currentRingTicks = 42_291_308L, currentUnixSeconds = 5436L,
+            ),
+        )
+    }
+
+    @Test
+    fun testAnchorsAreContinuousDetectsARealPause() {
+        // A genuine power-cycle: ticks paused for 821s (matches the measured 13m41s dead-battery
+        // reboot) somewhere inside a 3600s wall-clock gap.
+        val tickedSeconds = 3600 - 821
+        assertFalse(
+            OuraHistoryDrain.anchorsAreContinuous(
+                previousRingTicks = 1_000_000L, previousUnixSeconds = 0L,
+                currentRingTicks = 1_000_000L + tickedSeconds * 10L, currentUnixSeconds = 3600L,
+            ),
+        )
+    }
+
+    @Test
+    fun testAnchorsAreContinuousToleratesOrdinaryJitter() {
+        // 5s of receipt-latency noise across an otherwise-continuous gap must not false-positive as a
+        // pause (well under ANCHOR_CONTINUITY_MAX_PAUSE_SECONDS).
+        assertTrue(
+            OuraHistoryDrain.anchorsAreContinuous(
+                previousRingTicks = 1_000_000L, previousUnixSeconds = 0L,
+                currentRingTicks = 1_003_000L, currentUnixSeconds = 305L, // 305s wall, 300s ticked
+            ),
+        )
+    }
+
+    @Test
+    fun testAnchorsAreContinuousDeclinesOnTooShortAGap() {
+        assertFalse(
+            "too short a gap to judge - declines rather than guessing",
+            OuraHistoryDrain.anchorsAreContinuous(
+                previousRingTicks = 1_000_000L, previousUnixSeconds = 0L,
+                currentRingTicks = 1_000_100L, currentUnixSeconds = 10L, // below the 30s minimum
+            ),
+        )
+    }
+
+    @Test
+    fun testAnchorsAreContinuousDeclinesWhenTicksWentBackward() {
+        assertFalse(
+            OuraHistoryDrain.anchorsAreContinuous(
+                previousRingTicks = 1_000_000L, previousUnixSeconds = 0L,
+                currentRingTicks = 999_000L, currentUnixSeconds = 100L, // never observed; decline, not confirm
+            ),
+        )
+    }
+
     // MARK: in-session continuation cursor (open_oura drain_events `progressed`)
 
     @Test


### PR DESCRIPTION
## The bug

`OuraHistoryDrain.noteStoredRingTime` sets `sawPreResumeData = true` the instant a stored history
sample's ring-time is older than the cursor the current fetch resumed from
(`OuraHistoryDrain.swift:77`). `commitResumeCursor` treats that flag as an unambiguous ring reboot and
resets the durable resume cursor to `0` (`OuraLiveSource.swift:786` on `main`), so the next connect
does an "honest full pull" of the ring's **entire** banked history — observed walking ~47-49 days back
to `2026-07-24`.

That's a deliberate, tested design and it's doing exactly what it was built to do *given its premise*.
The premise is wrong sometimes: the single-stale-sample signal can't distinguish a genuine power-cycle
from a much cheaper explanation — a second BLE client (the Oura app) connected to the ring in between
and left its own serve position somewhere NOOP's cursor doesn't recognize. Two occurrences on file,
n=2 with a **witnessed** repro (Patrick: connect NOOP → launch Oura app without BT permission yet →
grant BT permission → let the Oura app's own drain finish → revoke permission → back to NOOP), confirm
this is the real trigger, not a fluke.

**Evidence the ring didn't actually reboot in n=2:** every connect logs a `0x13 SyncTime` anchor
pairing the ring's tick counter with host wall-clock. Pulling all 21 logged in that session and
computing `Δticks/Δwallclock` for every consecutive pair gives a steady **9.97-10.05 ticks/s**
throughout — including the exact interval spanning the Oura-app handoff (5436s wall / 54357 ticks =
**9.999/s**). A genuine power-cycle doesn't zero the ring's clock, it *pauses* it (documented
elsewhere: a dead-battery reboot lost 13m41s against wall-clock), so a real reboot would show that
ratio dropping across the gap. It didn't, anywhere, right up to the guard firing.

## The fix

Cross-check the ring's own clock before trusting `sawPreResumeData` as a reboot, instead of resetting
on that signal alone:

- **`OuraHistoryDrain.anchorsAreContinuous`** (new, pure, Swift + Kotlin twin): compares two
  `(ringTicks, unixSeconds)` SyncTime anchors and returns whether the ring's clock ticked
  continuously across the gap. Declines to judge (safe default) below a 30s gap or if ticks somehow
  went backward; flags >20s of fall-behind as a real pause (generous vs. the 13m41s measured real
  case, tight vs. the <1s jitter measured in clean captures).
- **`OuraHistoryDrain.resumeCursorAtDrainEnd`** gains an `anchorConfirmsContinuity` parameter
  (default `false` — omitting it reproduces today's behavior exactly, all existing tests pass
  unchanged): `sawPreResumeData` only forces the cursor to `0` when continuity is **not** confirmed.
  When it is, the stale replay is simply discarded (store-side dedup already handles that safely —
  see the `dup-gen`/`onset-key suppressed` lines in the n=2 capture) and the cursor follows the same
  forward-only-if-resolving rule as any other drain.
- **`OuraSyncAnchorStore`** (new, mirrors `OuraHistoryCursorStore`'s exact shape — UserDefaults on
  Apple, `SharedPreferences` on Android, keyed by `deviceId`): persists the freshest SyncTime anchor
  across connects, since the anchor itself lives only as ephemeral `OuraDriver` instance state
  (cleared every disconnect). Loaded at connect *before* this session gets to adopt its own anchor
  (`previousSyncAnchor`); this session's own anchor, once adopted, is kept (`currentSyncAnchor`) and
  persisted at the same call site for the *next* connect to compare against.
- New log line distinguishes "not a reboot, second client, cursor kept" from the existing "clock
  reset/seek ignored, full pull" wording, which is otherwise untouched.

**On the no-stored-anchor case** (first-ever connect to a ring, or an install predating this store):
`syncAnchorsConfirmContinuity()` returns `false` and today's reboot-forces-0 behavior stands,
unchanged. In the witnessed n=2 repro specifically, NOOP's own process relaunched mid-handoff (a
`"previous app session … rolled"` log-rotation marker sits right in the gap) — the store is
UserDefaults/SharedPreferences-backed precisely so it survives that, unlike the anchor itself.

## Scope: both platforms, one commit

`OuraHistoryDrain` is package-level (`Packages/OuraProtocol`) and has a byte-identical Kotlin twin
(`android/…/oura/OuraHistoryDrain.kt`) per the parity contract; the wiring
(`previousSyncAnchor`/`currentSyncAnchor`, `OuraSyncAnchorStore`, `commitResumeCursor`'s new branch)
is app-target Swift (`Strand/BLE/OuraLiveSource.swift`) with the matching Kotlin twin
(`android/…/ble/OuraLiveSource.kt`).

## Verification

- Swift `OuraProtocol` package: **217/0** (27 in `OuraHistoryDrainTests`, incl. the real 2026-09-11
  gap as a continuous-clock regression case and a synthetic 821s pause, matching the measured 13m41s
  dead-battery reboot, as the still-caught real-reboot case).
- macOS `Strand`: `BUILD SUCCEEDED` + `StrandTests` **1735/0** (1 pre-existing skip) — this is
  app-target Swift, so verified via `xcodebuild … test`, not just `swift test`.
- Android: `compileFullDebugKotlin` clean + `testFullDebugUnitTest` **5995/7 failed**, all 7
  independently reconfirmed **pre-existing** (2 `RecoveryDriversTest` float-rounding + 2
  `StandardHrSensorFormatTest` + 3 `TodayExplainabilityTest`, none in a touched file); new
  `OuraHistoryDrainTest` **26/26**.
- Also cherry-picked onto `integration/oura-full` (`0849ff056`, zero conflicts) and re-verified there
  end to end: Swift `OuraProtocol` 242/0, `StrandTests` 1767/0 (same count as that branch's prior
  verified pass), Android tests 6026/7 pre-existing-failed.
- **Not yet hardware-validated.** The phone build still runs the pre-fix tip. Owed before this is
  fully closed: flash the fixed build and repeat the exact 5-step handoff to confirm the cursor is
  kept instead of reset on a real strap.
