### PR TITLE
feat(oura): add a SetFeatureMode enable control, consolidate Oura Test Centre diagnostics

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/Commands.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/Commands.swift
@@ -27,6 +27,14 @@ public enum OuraCommands {
     // client asks or whether that client is cloud-authenticated. Do not assume "off for NOOP" without
     // checking a live read.
     public static let featureRealSteps: UInt8 = 0x0B
+    // The exercise-HR (AWHR) feature id — data arrives as `0x73`/`0x74`. Server-flag-gated per
+    // OURA_PROTOCOL.md s7.1 [ring4-ble]. Per s7.5, open_oura reports this one respects a local
+    // `setFeatureMode` write on a consumer ring.
+    public static let featureExerciseHR: UInt8 = 0x03
+    // The CVA PPG sampler feature id — feeds `0x81` raw PPG. Server-flag-gated per OURA_PROTOCOL.md
+    // s7.1 [ring4-ble]. Per s7.5, open_oura reports this one respects a local `setFeatureMode` write
+    // on a consumer ring.
+    public static let featureCvaPpg: UInt8 = 0x0D
 
     // MARK: - Pre-auth / identity (unauthenticated OK)
 
@@ -159,6 +167,24 @@ public enum OuraCommands {
     /// enables anything, never writes a mode. [open_oura-feat]
     public static func realStepsReadStatus() -> OuraCommand {
         OuraCommand(label: "realsteps_status", bytes: [0x2F, 0x02, 0x20, featureRealSteps])
+    }
+
+    // MARK: - Feature-mode write (s7.5; UNVALIDATED, opt-in only)
+
+    /// Read any feature's status: `2f 02 20 <id>` — same read verb as `spo2ReadStatus`/
+    /// `realStepsReadStatus`, generalized so the feature-mode write below can re-probe after writing.
+    public static func featureReadStatus(_ feature: UInt8) -> OuraCommand {
+        OuraCommand(label: "feature_status_\(String(feature, radix: 16))", bytes: [0x2F, 0x02, 0x20, feature])
+    }
+
+    /// Write a feature's MODE: `2f 03 22 <id> <mode>`. UNVALIDATED on NOOP's own hardware — see
+    /// OURA_PROTOCOL.md s7.5: [open_oura-feat] reports this write bypassing the account gate for
+    /// several features on a consumer ring, tested there only with mode=0x01 (automatic); mode=0x00
+    /// ("off") always reverts. Gated to Test Centre / explicit user action only — nothing in
+    /// `OuraDriver`'s own flow produces this call.
+    public static func setFeatureMode(_ feature: UInt8, mode: UInt8) -> OuraCommand {
+        OuraCommand(label: "EXPERIMENT_set_feature_\(String(feature, radix: 16))_mode\(mode)",
+                    bytes: [0x2F, 0x03, 0x22, feature, mode])
     }
 
     /// The ordered live-HR enable triplet (read, enable, subscribe). The driver gates each on its ACK.

--- a/Packages/OuraProtocol/Sources/OuraProtocol/UserInfo.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/UserInfo.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+// User-info setters (opcode 0x20) and their 0x21 replies.
+//
+// EXPERIMENTAL / QUARANTINED. These are the only builders in this package that write user data to
+// the ring, and nothing in OuraDriver's flow produces them - they exist to answer one question:
+// does writing 0x20 change what tag 0x5c reports? See OuraUserInfoWrite for why that is open.
+//
+// Platform-pure value types. Facts cited per OURA_PROTOCOL.md; wire shapes per [open_oura-cheat]
+// (docs/horizon-ring3-protocol-cheatsheet.md), which records these five setters as tested-success on
+// a Ring 3 - writing ZEROS. No published capture writes a real value, which is exactly the gap.
+
+/// The `0x20` user-info fields, keyed by the `type` byte the ring echoes back in its `0x21` reply.
+///
+/// Value widths are taken from the tested request shapes in [open_oura-cheat]: gender/unit carry two
+/// value bytes, height/weight three, date-of-birth nine. The width is a FACT (the ring acked those
+/// exact lengths); the *encoding* inside those bytes is not - see `OuraUserInfoWrite`.
+public enum OuraUserInfoField: UInt8, CaseIterable, Sendable {
+    case gender = 0x02
+    case height = 0x03
+    case weight = 0x04
+    case dateOfBirth = 0x05
+    case unit = 0x06
+
+    /// Number of value bytes that follow the type byte, per the acked shapes in [open_oura-cheat].
+    public var valueByteCount: Int {
+        switch self {
+        case .gender, .unit: return 2
+        case .height, .weight: return 3
+        case .dateOfBirth: return 9
+        }
+    }
+
+    /// The label used in the strap log. Never carries the value itself.
+    public var label: String {
+        switch self {
+        case .gender: return "gender"
+        case .height: return "height"
+        case .weight: return "weight"
+        case .dateOfBirth: return "dob"
+        case .unit: return "unit"
+        }
+    }
+}
+
+/// The ring's `0x21` reply to a `0x20` write: `21 02 <type> <result>`. `result == 0` is success on
+/// every shape [open_oura-cheat] recorded.
+public struct OuraUserInfoAck: Equatable, Sendable {
+    public let field: OuraUserInfoField
+    public let result: UInt8
+    public var isSuccess: Bool { result == 0 }
+    public init(field: OuraUserInfoField, result: UInt8) { self.field = field; self.result = result }
+}
+
+/// Builders for the `0x20` user-info setters, plus the encoding candidate that maps a NOOP user
+/// profile onto them.
+///
+/// ⚠️ **The value encoding is a CANDIDATE, not a decoded fact.** Every published `0x20` write sets
+/// its field to zero, so no capture pins down the units, scale, or byte order of a non-zero value.
+/// What is known: tag `0x5c` reports height and weight as **single bytes** reading 176 and 75 - i.e.
+/// whole cm and whole kg - so a little-endian integer in cm/kg is the encoding most likely to land in
+/// those bytes. That is a hypothesis this type exists to TEST, and `writeThenVerify` documents the
+/// procedure. Do not present a write as having "set the profile" until a subsequent `0x5c` read shows
+/// the value moved.
+public enum OuraUserInfoWrite {
+    /// Build a raw `0x20` write: `20 <len> <type> <value…>`, `len` = 1 + the field's value width.
+    ///
+    /// Throws if `value` is not exactly `field.valueByteCount` bytes - the ring acked those specific
+    /// lengths and a different one is an untested shape.
+    public static func command(_ field: OuraUserInfoField, value: [UInt8]) throws -> OuraCommand {
+        guard value.count == field.valueByteCount else {
+            throw OuraUserInfoError.wrongValueWidth(field: field,
+                                                   expected: field.valueByteCount,
+                                                   got: value.count)
+        }
+        let len = UInt8(1 + value.count)
+        return OuraCommand(label: "EXPERIMENT_set_user_\(field.label)",
+                           bytes: [0x20, len, field.rawValue] + value)
+    }
+
+    /// The zero/"empty" writes recorded as tested-success in [open_oura-cheat]. Useful as the restore
+    /// step after an experiment, and as the golden shapes the tests pin.
+    public static func clear(_ field: OuraUserInfoField) -> OuraCommand {
+        // Safe by construction: the width comes from the field itself, so `command` cannot throw.
+        (try? command(field, value: [UInt8](repeating: 0, count: field.valueByteCount)))
+            ?? OuraCommand(label: "EXPERIMENT_set_user_\(field.label)", bytes: [])
+    }
+
+    /// Encode an unsigned integer little-endian into exactly `width` bytes.
+    ///
+    /// Throws if the value does not fit, rather than silently truncating - a truncated anthropometric
+    /// write would land a plausible-looking wrong number on the ring.
+    public static func encodeLE(_ value: UInt32, width: Int) throws -> [UInt8] {
+        let maxValue: UInt64 = (UInt64(1) << (8 * UInt64(width))) - 1
+        guard UInt64(value) <= maxValue else {
+            throw OuraUserInfoError.valueOutOfRange(value: value, width: width)
+        }
+        return (0..<width).map { UInt8((value >> (8 * UInt32($0))) & 0xFF) }
+    }
+
+    /// Height in whole centimetres, little-endian across the field's three bytes. CANDIDATE encoding.
+    public static func height(cm: UInt32) throws -> OuraCommand {
+        try command(.height, value: try encodeLE(cm, width: OuraUserInfoField.height.valueByteCount))
+    }
+
+    /// Weight in whole kilograms, little-endian across the field's three bytes. CANDIDATE encoding.
+    ///
+    /// Whole kg is the candidate because `0x5c` byte 1 reads 75 on a ring whose firmware default is
+    /// documented as 75 kg. If the ring instead wants grams, this write lands 62 g and `0x5c` will not
+    /// move to 62 - which is precisely the outcome that would falsify the candidate.
+    public static func weight(kg: UInt32) throws -> OuraCommand {
+        try command(.weight, value: try encodeLE(kg, width: OuraUserInfoField.weight.valueByteCount))
+    }
+
+    /// Gender as the code `0x5c` byte 2 uses: 0 male, 1 female, anything else unspecified
+    /// [open_oura-evt]. CANDIDATE encoding - that mapping is read off the *event* decoder, and nothing
+    /// proves the setter shares it.
+    public static func gender(_ code: UInt8) throws -> OuraCommand {
+        try command(.gender, value: try encodeLE(UInt32(code), width: OuraUserInfoField.gender.valueByteCount))
+    }
+
+    /// Map NOOP's `sex` string onto the `0x5c` gender code. Anything that is not male/female is
+    /// "unspecified", which is the value `bmr_schofield` documents as the both-sexes average
+    /// [open_oura-evt] - so nonbinary and unset both land on the ring's own neutral path.
+    public static func genderCode(forSex sex: String) -> UInt8 {
+        switch sex.lowercased() {
+        case "male": return 0
+        case "female": return 1
+        default: return 2
+        }
+    }
+
+    /// ⚠️ **There is no `0x20` age setter.** `0x5c` byte 0 reports age in years, but the only related
+    /// write is date-of-birth (`type 5`, nine value bytes) and no capture shows its layout. So of the
+    /// four `0x5c` fields, three have a plausible direct setter and **age does not**. This returns nil
+    /// rather than guessing a nine-byte DOB encoding; fill it in only once a capture pins the shape.
+    public static func dateOfBirthCommand(year: Int, month: Int, day: Int) -> OuraCommand? { nil }
+}
+
+/// Errors from building a user-info write. Both are programmer errors caught before any byte reaches
+/// the ring.
+public enum OuraUserInfoError: Error, Equatable, Sendable {
+    case wrongValueWidth(field: OuraUserInfoField, expected: Int, got: Int)
+    case valueOutOfRange(value: UInt32, width: Int)
+}
+
+/// Parse a `0x21` user-info reply. Returns nil for anything that is not exactly `21 02 <type> <res>`
+/// with a known type, so an unrelated `0x21` frame is never reported as an ack.
+public func parseOuraUserInfoAck(_ bytes: [UInt8]) -> OuraUserInfoAck? {
+    guard bytes.count == 4, bytes[0] == 0x21, bytes[1] == 0x02,
+          let field = OuraUserInfoField(rawValue: bytes[2]) else { return nil }
+    return OuraUserInfoAck(field: field, result: bytes[3])
+}
+
+// MARK: - Reading back what the ring reports (tag 0x5c)
+
+/// One decoded `0x5c` `user_information` record — the read-back side of the experiment.
+///
+/// The field meanings are [open_oura-evt]'s inference (`_status: inferred`), not a recovered parser,
+/// so they are reported as named bytes and nothing here treats them as authoritative. NOOP does not
+/// score or store any of it; the record exists to answer whether a `0x20` write moves these bytes.
+public struct OuraUserInfoRecord: Equatable, Sendable {
+    public let ringTimestamp: UInt32
+    public let ageYears: UInt8
+    public let weightKg: UInt8
+    public let sexCode: UInt8
+    public let heightCm: UInt8
+    /// The verbatim four payload bytes, so a log line can show what arrived even if the inferred
+    /// field split above turns out to be wrong.
+    public let raw: [UInt8]
+
+    public init(ringTimestamp: UInt32, raw: [UInt8]) {
+        self.ringTimestamp = ringTimestamp
+        self.raw = raw
+        self.ageYears  = raw.count > 0 ? raw[0] : 0
+        self.weightKg  = raw.count > 1 ? raw[1] : 0
+        self.sexCode   = raw.count > 2 ? raw[2] : 0
+        self.heightCm  = raw.count > 3 ? raw[3] : 0
+    }
+
+    /// `28 4b 02 b0` — the value every capture of this ring has produced, and the same bytes
+    /// [open_oura-evt] read off a factory-reset ring. Used only to label a log line "(defaults)".
+    public static let firmwareDefaults: [UInt8] = [0x28, 0x4B, 0x02, 0xB0]
+    public var isFirmwareDefault: Bool { raw == Self.firmwareDefaults }
+
+    /// Hex of the payload, for the strap log.
+    public var rawHex: String { raw.map { String(format: "%02x", $0) }.joined() }
+}
+
+/// The `0x5c` event tag.
+public let ouraUserInfoTag: UInt8 = 0x5C
+
+/// Scan a TLV byte buffer for `0x5c` records.
+///
+/// Walks `<tag> <len> <body…>` (where an event body is `rt:u32LE` + payload), so it works whether the
+/// caller hands over one record or a whole concatenated notification. Malformed or truncated tails
+/// stop the walk rather than throwing — this runs on every inbound notification and must never be
+/// able to break ingest.
+public func scanOuraUserInfoRecords(tlvBytes: [UInt8]) -> [OuraUserInfoRecord] {
+    var out: [OuraUserInfoRecord] = []
+    var i = 0
+    while i + 2 <= tlvBytes.count {
+        let tag = tlvBytes[i]
+        let len = Int(tlvBytes[i + 1])
+        let end = i + 2 + len
+        guard end <= tlvBytes.count else { break }
+        if tag == ouraUserInfoTag, len >= 4 {
+            let rt = UInt32(tlvBytes[i + 2]) | UInt32(tlvBytes[i + 3]) << 8
+                   | UInt32(tlvBytes[i + 4]) << 16 | UInt32(tlvBytes[i + 5]) << 24
+            out.append(OuraUserInfoRecord(ringTimestamp: rt, raw: Array(tlvBytes[(i + 6)..<end])))
+        }
+        i = end
+    }
+    return out
+}

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraFeatureModeWriteTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraFeatureModeWriteTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import OuraProtocol
+
+/// The feature-mode WRITE (`2f 03 22 <id> <mode>`) and its generalized status read (`2f 02 20 <id>`) —
+/// UNVALIDATED on NOOP's own hardware (OURA_PROTOCOL.md s7.5). These builders are pure byte construction;
+/// they carry no gate of their own, so the caller (Test Centre only, per the plan) is what keeps this
+/// off the automatic connect path.
+final class OuraFeatureModeWriteTests: XCTestCase {
+    func testFeatureReadStatusGeneralizesTheExistingSpo2AndRealStepsProbes() {
+        XCTAssertEqual(OuraCommands.featureReadStatus(OuraCommands.featureSpO2).bytes,
+                       OuraCommands.spo2ReadStatus().bytes)
+        XCTAssertEqual(OuraCommands.featureReadStatus(OuraCommands.featureRealSteps).bytes,
+                       OuraCommands.realStepsReadStatus().bytes)
+    }
+
+    func testSetFeatureModeBytesExactForSpo2AndRealSteps() {
+        XCTAssertEqual(OuraCommands.setFeatureMode(OuraCommands.featureSpO2, mode: 0x01).bytes,
+                       [0x2F, 0x03, 0x22, 0x04, 0x01])
+        XCTAssertEqual(OuraCommands.setFeatureMode(OuraCommands.featureRealSteps, mode: 0x00).bytes,
+                       [0x2F, 0x03, 0x22, 0x0B, 0x00])
+    }
+
+    func testSetFeatureModeBytesExactForExerciseHrAndCvaPpg() {
+        XCTAssertEqual(OuraCommands.setFeatureMode(OuraCommands.featureExerciseHR, mode: 0x01).bytes,
+                       [0x2F, 0x03, 0x22, 0x03, 0x01])
+        XCTAssertEqual(OuraCommands.setFeatureMode(OuraCommands.featureCvaPpg, mode: 0x00).bytes,
+                       [0x2F, 0x03, 0x22, 0x0D, 0x00])
+    }
+
+    func testSetFeatureModeSubOpIsTheEnableVerbNotTheReadVerb() {
+        // sub-op 0x22 is the SET-MODE write; 0x20 (used by featureReadStatus) is the READ. Never confuse them.
+        XCTAssertEqual(OuraCommands.setFeatureMode(OuraCommands.featureSpO2, mode: 0x01).bytes[2], 0x22)
+        XCTAssertEqual(OuraCommands.featureReadStatus(OuraCommands.featureSpO2).bytes[2], 0x20)
+    }
+}

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/UserInfoTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/UserInfoTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import OuraProtocol
+
+/// Pins the `0x20` user-info setters against the shapes [open_oura-cheat] records as tested-success
+/// on a Ring 3, and guards the encoding helpers that turn a NOOP profile into value bytes.
+final class UserInfoTests: XCTestCase {
+
+    private func hex(_ c: OuraCommand) -> String {
+        c.bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// The five zero-writes upstream actually put on a ring and got `result 0` back for. If any of
+    /// these strings changes, our builder has drifted from the only shapes known to be accepted.
+    func testClearCommandsMatchTheUpstreamTestedShapes() {
+        XCTAssertEqual(hex(OuraUserInfoWrite.clear(.gender)),      "2003020000")
+        XCTAssertEqual(hex(OuraUserInfoWrite.clear(.height)),      "200403000000")
+        XCTAssertEqual(hex(OuraUserInfoWrite.clear(.weight)),      "200404000000")
+        XCTAssertEqual(hex(OuraUserInfoWrite.clear(.unit)),        "2003060000")
+        XCTAssertEqual(hex(OuraUserInfoWrite.clear(.dateOfBirth)), "200a05000000000000000000")
+    }
+
+    /// `len` is 1 (the type byte) + the field's value width, for every field.
+    func testLengthByteCountsTypePlusValue() {
+        for field in OuraUserInfoField.allCases {
+            let bytes = OuraUserInfoWrite.clear(field).bytes
+            XCTAssertEqual(bytes[0], 0x20, "\(field) opcode")
+            XCTAssertEqual(Int(bytes[1]), 1 + field.valueByteCount, "\(field) len")
+            XCTAssertEqual(bytes[2], field.rawValue, "\(field) type")
+            XCTAssertEqual(bytes.count, 2 + 1 + field.valueByteCount, "\(field) total")
+        }
+    }
+
+    /// The candidate encoding: whole cm / whole kg, little-endian. 175 -> af 00 00, 62 -> 3e 00 00.
+    func testProfileValuesEncodeLittleEndianInWholeUnits() throws {
+        XCTAssertEqual(hex(try OuraUserInfoWrite.height(cm: 175)), "200403af0000")
+        XCTAssertEqual(hex(try OuraUserInfoWrite.weight(kg: 62)),  "2004043e0000")
+        // A value that needs a second byte must land in the second byte, not be truncated.
+        XCTAssertEqual(try OuraUserInfoWrite.encodeLE(300, width: 3), [0x2C, 0x01, 0x00])
+    }
+
+    /// Truncation would put a plausible-looking wrong number on the ring, so it must throw instead.
+    func testOverWideValueThrowsRatherThanTruncating() {
+        XCTAssertThrowsError(try OuraUserInfoWrite.encodeLE(256, width: 1)) { error in
+            XCTAssertEqual(error as? OuraUserInfoError, .valueOutOfRange(value: 256, width: 1))
+        }
+        XCTAssertEqual(try? OuraUserInfoWrite.encodeLE(255, width: 1), [0xFF])
+    }
+
+    /// A wrong-width value is an untested wire shape and must never be built.
+    func testWrongValueWidthThrows() {
+        XCTAssertThrowsError(try OuraUserInfoWrite.command(.height, value: [0x01])) { error in
+            XCTAssertEqual(error as? OuraUserInfoError,
+                           .wrongValueWidth(field: .height, expected: 3, got: 1))
+        }
+    }
+
+    /// male/female map to the `0x5c` codes; everything else takes the ring's own neutral path.
+    func testGenderCodeMapping() {
+        XCTAssertEqual(OuraUserInfoWrite.genderCode(forSex: "male"), 0)
+        XCTAssertEqual(OuraUserInfoWrite.genderCode(forSex: "female"), 1)
+        XCTAssertEqual(OuraUserInfoWrite.genderCode(forSex: "nonbinary"), 2)
+        XCTAssertEqual(OuraUserInfoWrite.genderCode(forSex: "Male"), 0, "case-insensitive")
+        XCTAssertEqual(OuraUserInfoWrite.genderCode(forSex: ""), 2, "unset is unspecified")
+    }
+
+    /// Age has no setter - the builder returns nil rather than inventing a DOB layout.
+    func testNoAgeSetterIsOfferedYet() {
+        XCTAssertNil(OuraUserInfoWrite.dateOfBirthCommand(year: 1963, month: 5, day: 27))
+    }
+
+    /// The `0x21` ack parses only its exact shape.
+    func testAckParsing() {
+        XCTAssertEqual(parseOuraUserInfoAck([0x21, 0x02, 0x03, 0x00]),
+                       OuraUserInfoAck(field: .height, result: 0))
+        XCTAssertEqual(parseOuraUserInfoAck([0x21, 0x02, 0x04, 0x07])?.isSuccess, false)
+        XCTAssertNil(parseOuraUserInfoAck([0x21, 0x02, 0x99, 0x00]), "unknown field type")
+        XCTAssertNil(parseOuraUserInfoAck([0x21, 0x02, 0x03]), "short frame")
+        XCTAssertNil(parseOuraUserInfoAck([0x2F, 0x02, 0x03, 0x00]), "not a 0x21 frame")
+    }
+
+    /// Every builder is labelled EXPERIMENT_ so a strap log never reads as routine traffic.
+    func testAllWritesAreLabelledExperiment() {
+        for field in OuraUserInfoField.allCases {
+            XCTAssertTrue(OuraUserInfoWrite.clear(field).label.hasPrefix("EXPERIMENT_"),
+                          "\(field) label: \(OuraUserInfoWrite.clear(field).label)")
+        }
+    }
+
+    // MARK: - 0x5c read-back
+
+    /// The record every capture of this ring has produced, decoded under [open_oura-evt]'s inference.
+    func testDecodesTheObservedDefaultRecord() {
+        let bytes: [UInt8] = [0x5C, 0x08, 0xFC, 0xEA, 0x5D, 0x01, 0x28, 0x4B, 0x02, 0xB0]
+        let recs = scanOuraUserInfoRecords(tlvBytes: bytes)
+        XCTAssertEqual(recs.count, 1)
+        let r = try! XCTUnwrap(recs.first)
+        XCTAssertEqual(r.ringTimestamp, 0x015D_EAFC)
+        XCTAssertEqual(r.ageYears, 40)
+        XCTAssertEqual(r.weightKg, 75)
+        XCTAssertEqual(r.sexCode, 2)
+        XCTAssertEqual(r.heightCm, 176)
+        XCTAssertEqual(r.rawHex, "284b02b0")
+        XCTAssertTrue(r.isFirmwareDefault)
+    }
+
+    /// A written-through value must read back as NOT the default - that is the experiment's readout.
+    func testANonDefaultRecordIsNotFlaggedDefault() {
+        let bytes: [UInt8] = [0x5C, 0x08, 0x00, 0x00, 0x00, 0x00, 0x3F, 0x3E, 0x00, 0xAF]
+        let r = try! XCTUnwrap(scanOuraUserInfoRecords(tlvBytes: bytes).first)
+        XCTAssertEqual([r.ageYears, r.weightKg, r.sexCode, r.heightCm], [63, 62, 0, 175])
+        XCTAssertFalse(r.isFirmwareDefault)
+    }
+
+    /// The scanner walks a concatenated notification and picks 0x5c out from among other tags.
+    func testScannerFindsTheRecordAmongOtherTags() {
+        let bytes: [UInt8] = [0x43, 0x03, 0x01, 0x02, 0x03]           // some other tag
+            + [0x5C, 0x08, 0x01, 0x00, 0x00, 0x00, 0x28, 0x4B, 0x02, 0xB0]
+            + [0x4A, 0x04, 0x00, 0x00, 0x00, 0x00]                     // and another
+        let recs = scanOuraUserInfoRecords(tlvBytes: bytes)
+        XCTAssertEqual(recs.count, 1)
+        XCTAssertEqual(recs.first?.heightCm, 176)
+    }
+
+    /// A truncated tail must stop the walk, never crash - this runs on every inbound notification.
+    func testTruncatedTailIsIgnoredNotFatal() {
+        XCTAssertEqual(scanOuraUserInfoRecords(tlvBytes: [0x5C, 0x08, 0x01, 0x02]).count, 0)
+        XCTAssertEqual(scanOuraUserInfoRecords(tlvBytes: []).count, 0)
+        XCTAssertEqual(scanOuraUserInfoRecords(tlvBytes: [0x5C]).count, 0)
+    }
+}

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -4,6 +4,7 @@ import WhoopProtocol
 import WhoopStore
 import StrandAnalytics
 import StrandImport
+import OuraProtocol
 #if os(iOS)
 import UserNotifications
 #endif
@@ -571,6 +572,7 @@ final class AppModel: ObservableObject {
             registry?.setActive(serialId)
         }
         self.sourceCoordinator = coordinator
+        bindOuraFeatureStatusMirror()
         // #814 READ SPINE (HIGH-1): drive the read side off the registry's `activeDeviceId` for the WHOLE
         // session, exactly as SourceCoordinator drives the WRITE side off the SAME publisher. A Devices-
         // screen switch/remove/re-add calls `registry.setActive` DIRECTLY (NOT through `registerDevice`), so
@@ -1164,6 +1166,27 @@ final class AppModel: ObservableObject {
     /// Combine subscriptions mirroring the live Oura source's `adoptPhase` / `needsPairing` into the two
     /// published properties above. Re-bound whenever the active Oura source changes.
     private var ouraAdoptCancellables = Set<AnyCancellable>()
+
+    /// The most recent `feature status` read-back per feature id (0x04 SpO2, 0x0b real-steps, 0x03
+    /// exercise-HR, 0x0d CVA-PPG), mirrored off the live Oura source so Test Centre's enable/disable
+    /// rows can show the ring's own current state instead of being log-only. Bound once, right after
+    /// `sourceCoordinator` is set (below) — unlike `ouraAdoptPhase` above, this isn't scoped to the
+    /// adopt wizard, so it needs to be live for any paired ring, not just one mid-adopt.
+    @Published private(set) var ouraFeatureStatuses: [Int: OuraFeatureStatus] = [:]
+    private var ouraFeatureStatusCancellable: AnyCancellable?
+
+    /// (Re)bind the feature-status mirror to whichever `OuraLiveSource` the coordinator has live, and
+    /// every later swap — same `flatMap`-over-`$ouraSource` shape as `bindOuraAdoptMirror` below.
+    private func bindOuraFeatureStatusMirror() {
+        guard let coordinator = sourceCoordinator else { return }
+        ouraFeatureStatusCancellable = coordinator.$ouraSource
+            .flatMap { source -> AnyPublisher<[Int: OuraFeatureStatus], Never> in
+                source?.$featureStatuses.eraseToAnyPublisher()
+                    ?? Just([:]).eraseToAnyPublisher()
+            }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.ouraFeatureStatuses = $0 }
+    }
 
     /// Take over a factory-reset Oura ring: grant the coordinator explicit adopt consent for THIS ring (so
     /// its live session may run the one-time key install, s3.2), register it active (which starts that live

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -112,6 +112,12 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// The live adopt outcome (see `AdoptPhase`). The wizard observes this to leave its Adopting step. Reset
     /// to `.idle` on every connect/stop/disconnect so a stale outcome never drives a transition.
     @Published public private(set) var adoptPhase: AdoptPhase = .idle
+    /// The most recent `feature status` read-back per feature id, keyed by `OuraFeatureStatus.feature`.
+    /// Updated on EVERY status frame received, independent of `loggedFeatureStatuses`'s once-per-
+    /// connection log dedup — Test Centre's enable/disable rows read this to show the ring's current
+    /// state, and a UI readout must never go stale just because the log line already printed once.
+    /// Cleared on `stop()` so a previously-paired ring's readings never bleed into a different one.
+    @Published public private(set) var featureStatuses: [Int: OuraFeatureStatus] = [:]
 
     // MARK: - BLE UUIDs (from the platform-pure OuraGatt facts)
 
@@ -321,6 +327,13 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// Feature ids whose status we have already logged this session (SpO2 0x04 / real_steps 0x0b), so the
     /// read-only feature-status diagnostic prints once per feature, not on every reconnect.
     private var loggedFeatureStatuses: Set<Int> = []
+    /// Feature ids the EXPERIMENTAL feature-mode write (`writeFeatureMode`) most recently set to mode=0
+    /// this connection. `logFeatureStatus`'s all-zero "server-gated off" label predates that write
+    /// existing — it can no longer assume all-zero means the cloud never enabled the feature, since a
+    /// self-induced disable now produces the identical bit pattern. Real-hardware confirmed 2026-09-11:
+    /// disabling SpO2 flipped mode 1→0 and the very next read logged "cloud never enabled it", which was
+    /// false — we had just enabled-then-disabled it ourselves seconds earlier.
+    private var manuallyDisabledFeatures: Set<Int> = []
     /// Product-info replies already logged this session, keyed by op+body so the #771/#772 serial/hardware
     /// capture prints each DISTINCT reply once — get_serial and get_hardware both answer under op 0x19, so a
     /// per-op guard would swallow the second (observed on-device: only the serial reached the log). Distinct
@@ -389,6 +402,17 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// ring sent, so after a full connect a hole in a decoded file can be pinned as a decode drop vs ring-side.
     /// No dedup (a re-serve is still evidence the ring re-sent it); the offline reframer collapses duplicates.
     private let rawDump: OuraRawDump?
+
+    // MARK: - 0x20 user-info write EXPERIMENT (default-off, Test Centre only)
+
+    /// The most recent `0x5c` `user_information` record this connection has seen, so a later one can be
+    /// reported as changed or unchanged rather than just printed. Never persisted, never scored.
+    private var lastUserInfoRecord: OuraUserInfoRecord?
+    /// The last `0x20` write this connection sent, if any: the field, the value bytes, and when. Set by
+    /// `writeUserInfo` and read only to caption the ack and the next `0x5c` — so the log can say which
+    /// record is the first one AFTER a write instead of leaving the reader to line up timestamps.
+    private var lastUserInfoWrite: (field: OuraUserInfoField, valueHex: String, at: Date)?
+
     /// Cached local-day formatter (the 0x50 stream is high-volume; avoid building one per record).
     private static let activityDayFormatter: DateFormatter = {
         let f = DateFormatter(); f.dateFormat = "yyyy-MM-dd"; return f   // local time zone by default
@@ -1397,6 +1421,8 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         pendingSyncTime = nil
         loggedTierBKinds.removeAll()
         loggedFeatureStatuses.removeAll()
+        manuallyDisabledFeatures.removeAll()
+        featureStatuses.removeAll()
         loggedProductInfo.removeAll()
         greenIbiAmpCount = 0
         greenIbiAmpLengths.removeAll()
@@ -1441,6 +1467,86 @@ public final class OuraLiveSource: NSObject, ObservableObject {
             log("Oura: -> \(cmd.label)")
             peripheral.writeValue(Data(cmd.bytes), for: writeCharacteristic, type: .withoutResponse)
         }
+    }
+
+    // MARK: - 0x20 user-info write EXPERIMENT
+
+    /// Log every `0x5c` `user_information` record the ring sends. ALWAYS-ON: `0x5c` is rare (at most one
+    /// per full drain, and zero in some), so this costs nothing when nothing happens and is the only
+    /// readout the write experiment has. Nothing here persists, scores, or acts on the values.
+    ///
+    /// Field names are [open_oura-evt]'s INFERENCE (`_status: inferred`), so the raw four bytes are
+    /// printed first and the named split second — if the inference is wrong, the log still carries the
+    /// evidence to re-derive it.
+    private func observeUserInfoRecords(in bytes: [UInt8]) {
+        for rec in scanOuraUserInfoRecords(tlvBytes: bytes) {
+            let changed = lastUserInfoRecord.map { $0.raw != rec.raw } ?? false
+            let sinceWrite = lastUserInfoWrite.map {
+                " | FIRST 0x5c since our \($0.field.label)=\($0.valueHex) write \(Int(Date().timeIntervalSince($0.at)))s ago"
+            } ?? ""
+            log("Oura: 0x5c user_information raw=\(rec.rawHex) rt=\(rec.ringTimestamp)"
+                + (rec.isFirmwareDefault ? " (FIRMWARE DEFAULTS)" : " (NOT the firmware defaults)")
+                + (changed ? " CHANGED from \(lastUserInfoRecord?.rawHex ?? "?")" : "")
+                + " | inferred [open_oura-evt]: age=\(rec.ageYears) weight=\(rec.weightKg)kg"
+                + " sex=\(rec.sexCode) height=\(rec.heightCm)cm" + sinceWrite)
+            lastUserInfoRecord = rec
+            // One readout per write is the experiment; keep the marker so a SECOND 0x5c in the same
+            // connection is not also captioned as "the first since the write".
+            if !sinceWrite.isEmpty { lastUserInfoWrite = nil }
+        }
+    }
+
+    /// Send one `0x20` user-info write. EXPERIMENT ONLY — reachable exclusively from the Test Centre
+    /// action; nothing in the connect flow or `OuraDriver` calls it, and it is never sent automatically.
+    ///
+    /// Returns false (and writes nothing) if the link is not ready, so the caller can say so rather than
+    /// silently appearing to have written. The value bytes are logged verbatim: this is a write to the
+    /// ring's own config, and a strap log that does not say exactly what went out is useless afterwards.
+    @discardableResult
+    func writeUserInfo(field: OuraUserInfoField, value: [UInt8]) -> Bool {
+        guard peripheral != nil, writeCharacteristic != nil else {
+            log("Oura: 0x20 user-info write SKIPPED - no connected ring / write characteristic")
+            return false
+        }
+        guard let cmd = try? OuraUserInfoWrite.command(field, value: value) else {
+            log("Oura: 0x20 user-info write REFUSED - \(value.count)B value, field \(field.label) wants \(field.valueByteCount)B")
+            return false
+        }
+        let valueHex = value.map { String(format: "%02x", $0) }.joined()
+        let frameHex = cmd.bytes.map { String(format: "%02x", $0) }.joined()
+        log("Oura: 0x20 user-info WRITE field=\(field.label) value=\(valueHex) frame=\(frameHex)"
+            + " - EXPERIMENT; last 0x5c seen this connection: \(lastUserInfoRecord?.rawHex ?? "none")")
+        lastUserInfoWrite = (field: field, valueHex: valueHex, at: Date())
+        write([cmd])
+        return true
+    }
+
+    /// Send one `2f 03 22 <id> <mode>` feature-mode write. EXPERIMENT ONLY — reachable exclusively from
+    /// the Test Centre "OURA" section; nothing in the connect flow or `OuraDriver` calls it, and it is
+    /// never sent automatically. UNVALIDATED per OURA_PROTOCOL.md s7.5.
+    ///
+    /// Clears any already-logged status for this feature first, so the read-status probe this method
+    /// also sends is guaranteed to log a fresh line — the connect-time SpO2/real_steps auto-probe (or an
+    /// earlier manual call) may have already consumed `logFeatureStatus`'s once-per-connection dedup for
+    /// this exact feature id.
+    @discardableResult
+    func writeFeatureMode(feature: UInt8, mode: UInt8) -> Bool {
+        guard peripheral != nil, writeCharacteristic != nil else {
+            log("Oura: feature-mode write SKIPPED - no connected ring / write characteristic")
+            return false
+        }
+        let cmd = OuraCommands.setFeatureMode(feature, mode: mode)
+        let frameHex = cmd.bytes.map { String(format: "%02x", $0) }.joined()
+        log("Oura: feature-mode WRITE feature=0x\(String(feature, radix: 16)) mode=\(mode) frame=\(frameHex)"
+            + " - EXPERIMENT, unvalidated on NOOP hardware (OURA_PROTOCOL.md s7.5)")
+        loggedFeatureStatuses.remove(Int(feature))
+        if mode == 0x00 {
+            manuallyDisabledFeatures.insert(Int(feature))
+        } else {
+            manuallyDisabledFeatures.remove(Int(feature))
+        }
+        write([cmd, OuraCommands.featureReadStatus(feature)])
+        return true
     }
 
     /// Advance the driver with a transition and write whatever it asks for next.
@@ -2056,19 +2162,34 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// cannot enable these offline (server ClientConfiguration gate), so a `subscription == 0` here is the
     /// honest "not a bug, it's a gate" reading. Never scored, never stored.
     private func logFeatureStatus(_ st: OuraFeatureStatus) {
+        featureStatuses[st.feature] = st
         guard loggedFeatureStatuses.insert(st.feature).inserted else { return }
         let name: String
         switch UInt8(truncatingIfNeeded: st.feature) {
         case OuraCommands.featureSpO2:      name = "SpO2 (0x04)"
         case OuraCommands.featureRealSteps: name = "real_steps (0x0b)"
         case OuraCommands.featureDaytimeHR: name = "daytime-HR (0x02)"
+        case OuraCommands.featureExerciseHR: name = "exercise-HR (0x03)"
+        case OuraCommands.featureCvaPpg:     name = "cva-ppg (0x0d)"
         default:                            name = "0x\(String(st.feature, radix: 16))"
         }
         // A gated/unavailable feature reports ALL-ZERO (mode/status/state); the streaming daytime-HR, by
         // contrast, reads mode=1 status=0x11 state=2. Flag the all-zero case as the honest "cloud never
         // enabled it" — NOT `subscription==0` alone, since daytime-HR is subscription=0 yet active.
+        //
+        // BUT all-zero is no longer proof of that: `writeFeatureMode` (s7.5) can now produce the exact
+        // same bit pattern locally. Real-hardware confirmed 2026-09-11 — disabling SpO2 flipped mode 1→0,
+        // and the unqualified "cloud never enabled it" claim below would have been false on that very
+        // read. Only make the cloud-gate claim when nothing local produced this state.
         let off = st.mode == 0 && st.status == 0 && st.state == 0
-        let gate = off ? " - INACTIVE (server-gated off; the cloud never enabled it, not emitted offline)" : ""
+        let gate: String
+        if off && manuallyDisabledFeatures.contains(st.feature) {
+            gate = " - OFF (matches the manual disable just sent this connection; not evidence of a cloud gate either way)"
+        } else if off {
+            gate = " - INACTIVE (server-gated off; the cloud never enabled it, not emitted offline)"
+        } else {
+            gate = ""
+        }
         // Name the enum fields so the log reads plainly (OURA_PROTOCOL.md s7.1 [ring4-ble]) — e.g. a gated
         // feature prints `mode=0 (off) … subscription=0 (off)`, the active daytime-HR `mode=1 (automatic)`.
         log("Oura: feature status \(name) mode=\(st.mode) (\(Self.featureModeName(st.mode))) status=\(st.status) state=\(st.state) subscription=\(st.subscription) (\(Self.subscriptionName(st.subscription)))\(gate)")
@@ -2355,6 +2476,7 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         pendingSyncTime = nil
         loggedTierBKinds.removeAll()
         loggedFeatureStatuses.removeAll()
+        manuallyDisabledFeatures.removeAll()
         loggedProductInfo.removeAll()
         greenIbiAmpCount = 0
         greenIbiAmpLengths.removeAll()
@@ -2441,6 +2563,7 @@ extension OuraLiveSource: @preconcurrency CBCentralManagerDelegate {
         pendingSyncTime = nil
         loggedTierBKinds.removeAll()
         loggedFeatureStatuses.removeAll()
+        manuallyDisabledFeatures.removeAll()
         loggedProductInfo.removeAll()
         greenIbiAmpCount = 0
         greenIbiAmpLengths.removeAll()
@@ -2571,6 +2694,20 @@ extension OuraLiveSource: @preconcurrency CBPeripheralDelegate {
            let resp = OuraFraming.parseSyncTimeResponse(syncFrame.body) {
             handleSyncTimeResponse(resp)
         }
+        // The `0x21` user-info reply (`21 02 <type> <result>`) to a `0x20` write — EXPERIMENT ONLY, and
+        // peeked the same non-destructive way as the 0x11/0x13/0x0D frames above (op 0x21 is below the
+        // event-tag range >= 0x41, so it round-trips through the TLV decoder as a harmless unknown-tag
+        // no-op). ALWAYS-ON rather than Test-Centre-gated: a 0x21 can only appear if this build wrote a
+        // 0x20, which nothing but an explicit Test Centre action does, so it costs nothing when nothing
+        // happens and is exactly the evidence that is missing otherwise. Reports only what the ring said
+        // — `result` is the ring accepting the WRITE, and says nothing about whether 0x5c moved.
+        if let ackFrame = frames.first(where: { $0.op == 0x21 }),
+           let ack = parseOuraUserInfoAck([ackFrame.op, UInt8(ackFrame.body.count)] + ackFrame.body) {
+            let sent = lastUserInfoWrite.map { " (we wrote \($0.field.label)=\($0.valueHex) \(Int(Date().timeIntervalSince($0.at)))s ago)" } ?? " (no 0x20 write recorded this connection)"
+            log("Oura: 0x20 user-info ACK field=\(ack.field.label) result=\(ack.result)"
+                + (ack.isSuccess ? " (accepted)" : " (REFUSED)") + sent
+                + " - ring accepted the write only; whether 0x5c changes is a separate read")
+        }
         // The `0x0D` GetBattery response is ALSO an outer frame (never a TLV record, s6.10), detected the
         // same non-destructive way as the 0x11 summary: its op is below the event-tag range (>= 0x41), so
         // it round-trips safely through the TLV decoder as an "unknown tag" no-op if left unfiltered. Routed
@@ -2622,6 +2759,7 @@ extension OuraLiveSource: @preconcurrency CBPeripheralDelegate {
                 if !dumpBytes.isEmpty {
                     rawDump?.record(bytes: dumpBytes)
                 }
+                observeUserInfoRecords(in: tlvBytes)
                 ingestHistory(driver.ingest(notification: tlvBytes, reassembler: reassembler))
             }
             return
@@ -2634,6 +2772,7 @@ extension OuraLiveSource: @preconcurrency CBPeripheralDelegate {
         if !dumpBytes.isEmpty {
             rawDump?.record(bytes: dumpBytes)
         }
+        observeUserInfoRecords(in: bytes)
         ingestHistory(driver.ingest(notification: bytes, reassembler: reassembler))
     }
 

--- a/Strand/Resources/Localizable.xcstrings
+++ b/Strand/Resources/Localizable.xcstrings
@@ -210533,6 +210533,180 @@
         "zh-Hans": {"stringUnit": {"state": "translated", "value": "打开趋势和读数"}},
         "zh-Hant": {"stringUnit": {"state": "translated", "value": "開啟趨勢與讀數"}}
     } },
+    "CVA PPG sampler" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CVA-PPG-Sampler"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muestreador CVA PPG"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échantillonneur CVA PPG"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Campionatore CVA PPG"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Próbkownik CVA PPG"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amostrador CVA PPG"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сэмплер CVA PPG"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CVA PPG 采样器"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CVA PPG 取樣器"
+          }
+        }
+      }
+    },
+    "Disable" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deaktivieren"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desactivar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactiver"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Disattiva"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wyłącz"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Desativar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отключить"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "停用"
+          }
+        }
+      }
+    },
+    "DOB (raw)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geburtsdatum (roh)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fecha de nacimiento (bruto)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Date de naissance (brute)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data di nascita (grezza)"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data urodzenia (surowe dane)"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data de nascimento (em bruto)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дата рождения (необработанная)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出生日期（原始）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出生日期（原始）"
+          }
+        }
+      }
+    },
     "Earlier beats cannot be scored" : { "localizations" : {
         "de": {"stringUnit": {"state": "translated", "value": "Frühere Herzschläge nicht auswertbar"}},
         "es": {"stringUnit": {"state": "translated", "value": "Los latidos anteriores no se pueden puntuar"}},
@@ -210544,6 +210718,876 @@
         "zh-Hans": {"stringUnit": {"state": "translated", "value": "早期心跳无法评分"}},
         "zh-Hant": {"stringUnit": {"state": "translated", "value": "早期心跳無法評分"}}
     } },
+    "Enable" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktivieren"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attiva"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Włącz"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ativar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включить"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用"
+          }
+        }
+      }
+    },
+    "Enables or disables SpO2 or real-steps directly via SetFeatureMode, then re-reads the feature's status. Unvalidated on NOOP's own hardware (OURA_PROTOCOL.md §7.5) — a third-party report is what these buttons exist to test." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktiviert oder deaktiviert SpO2 oder Echte Schritte direkt per SetFeatureMode und liest danach den Funktionsstatus erneut. Auf NOOPs eigener Hardware nicht validiert (OURA_PROTOCOL.md §7.5) — diese Buttons dienen dazu, einen Bericht eines Drittanbieters zu testen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activa o desactiva SpO2 o pasos reales directamente mediante SetFeatureMode y luego vuelve a leer el estado de la función. Sin validar en el hardware propio de NOOP (OURA_PROTOCOL.md §7.5); estos botones existen para probar un informe de terceros."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Active ou désactive la SpO2 ou les pas réels directement via SetFeatureMode, puis relit le statut de la fonctionnalité. Non validé sur le matériel propre de NOOP (OURA_PROTOCOL.md §7.5) — ces boutons servent à tester un rapport d'un tiers."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attiva o disattiva SpO2 o passi reali direttamente tramite SetFeatureMode, quindi rilegge lo stato della funzione. Non convalidato sull'hardware proprio di NOOP (OURA_PROTOCOL.md §7.5): questi pulsanti servono a verificare una segnalazione di terze parti."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Włącza lub wyłącza SpO2 albo rzeczywiste kroki bezpośrednio przez SetFeatureMode, a następnie ponownie odczytuje stan funkcji. Niezweryfikowane na własnym sprzęcie NOOP (OURA_PROTOCOL.md §7.5) — te przyciski służą do sprawdzenia doniesienia strony trzeciej."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ativa ou desativa SpO2 ou passos reais diretamente através de SetFeatureMode e depois volta a ler o estado da funcionalidade. Não validado no hardware próprio da NOOP (OURA_PROTOCOL.md §7.5) — estes botões existem para testar um relatório de terceiros."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включает или отключает SpO2 либо реальные шаги напрямую через SetFeatureMode, затем повторно считывает статус функции. Не проверено на собственном оборудовании NOOP (OURA_PROTOCOL.md §7.5) — эти кнопки существуют для проверки стороннего отчёта."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通过 SetFeatureMode 直接启用或停用血氧（SpO2）或真实步数，然后重新读取该功能的状态。尚未在 NOOP 自己的硬件上验证（OURA_PROTOCOL.md §7.5）——这些按钮的作用就是测试第三方的报告。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "透過 SetFeatureMode 直接啟用或停用血氧（SpO2）或真實步數，然後重新讀取該功能的狀態。尚未在 NOOP 自己的硬體上驗證（OURA_PROTOCOL.md §7.5）——這些按鈕的作用就是測試第三方的報告。"
+          }
+        }
+      }
+    },
+    "Enables or disables SpO2, real-steps, exercise HR, or the CVA PPG sampler directly via SetFeatureMode, then re-reads the feature's status. Unvalidated on NOOP's own hardware (OURA_PROTOCOL.md §7.5) — a third-party report is what these buttons exist to test. Daytime HR and resting HR are deliberately not offered here: daytime HR has its own dedicated live-HR path, and resting HR has no app-level toggle at all." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktiviert oder deaktiviert SpO2, Echte Schritte, Trainings-HF oder den CVA-PPG-Sampler direkt per SetFeatureMode und liest danach den Funktionsstatus erneut. Auf NOOPs eigener Hardware nicht validiert (OURA_PROTOCOL.md §7.5) — diese Buttons dienen dazu, einen Bericht eines Drittanbieters zu testen. Tages-HF und Ruhe-HF werden hier bewusst nicht angeboten: Tages-HF hat einen eigenen Live-HF-Pfad, und Ruhe-HF hat überhaupt keinen App-seitigen Schalter."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activa o desactiva SpO2, pasos reales, FC de ejercicio o el muestreador CVA PPG directamente mediante SetFeatureMode y luego vuelve a leer el estado de la función. Sin validar en el hardware propio de NOOP (OURA_PROTOCOL.md §7.5); estos botones existen para probar un informe de terceros. La FC diurna y la FC en reposo no se ofrecen aquí a propósito: la FC diurna tiene su propia ruta de FC en vivo, y la FC en reposo no tiene ningún interruptor a nivel de la app."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Active ou désactive la SpO2, les pas réels, la FC d'exercice ou l'échantillonneur CVA PPG directement via SetFeatureMode, puis relit le statut de la fonctionnalité. Non validé sur le matériel propre de NOOP (OURA_PROTOCOL.md §7.5) — ces boutons servent à tester un rapport d'un tiers. La FC diurne et la FC au repos ne sont volontairement pas proposées ici : la FC diurne dispose de son propre chemin de FC en direct, et la FC au repos n'a aucun interrupteur côté appli."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attiva o disattiva SpO2, passi reali, FC da esercizio o il campionatore CVA PPG direttamente tramite SetFeatureMode, quindi rilegge lo stato della funzione. Non convalidato sull'hardware proprio di NOOP (OURA_PROTOCOL.md §7.5): questi pulsanti servono a verificare una segnalazione di terze parti. La FC diurna e la FC a riposo non sono offerte qui di proposito: la FC diurna ha un proprio percorso HR live dedicato, e la FC a riposo non ha alcun interruttore lato app."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Włącza lub wyłącza SpO2, rzeczywiste kroki, tętno wysiłkowe albo próbkownik CVA PPG bezpośrednio przez SetFeatureMode, a następnie ponownie odczytuje stan funkcji. Niezweryfikowane na własnym sprzęcie NOOP (OURA_PROTOCOL.md §7.5) — te przyciski służą do sprawdzenia doniesienia strony trzeciej. Tętno dzienne i spoczynkowe są tutaj celowo pominięte: tętno dzienne ma własną, dedykowaną ścieżkę na żywo, a tętno spoczynkowe nie ma w ogóle przełącznika po stronie aplikacji."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ativa ou desativa SpO2, passos reais, FC de exercício ou o amostrador CVA PPG diretamente através de SetFeatureMode e depois volta a ler o estado da funcionalidade. Não validado no hardware próprio da NOOP (OURA_PROTOCOL.md §7.5) — estes botões existem para testar um relatório de terceiros. A FC diurna e a FC em repouso não são propositadamente oferecidas aqui: a FC diurna tem o seu próprio percurso de FC em direto, e a FC em repouso não tem qualquer interruptor ao nível da app."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включает или отключает SpO2, реальные шаги, ЧСС при нагрузке или сэмплер CVA PPG напрямую через SetFeatureMode, затем повторно считывает статус функции. Не проверено на собственном оборудовании NOOP (OURA_PROTOCOL.md §7.5) — эти кнопки существуют для проверки стороннего отчёта. Дневной ЧСС и ЧСС покоя здесь намеренно не предлагаются: у дневного ЧСС есть собственный выделенный путь в реальном времени, а у ЧСС покоя вообще нет переключателя на уровне приложения."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通过 SetFeatureMode 直接启用或停用血氧（SpO2）、真实步数、运动心率或 CVA PPG 采样器，然后重新读取该功能的状态。尚未在 NOOP 自己的硬件上验证（OURA_PROTOCOL.md §7.5）——这些按钮的作用就是测试第三方的报告。此处特意不提供日间心率和静息心率：日间心率有自己专用的实时心率通路，而静息心率完全没有应用层开关。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "透過 SetFeatureMode 直接啟用或停用血氧（SpO2）、真實步數、運動心率或 CVA PPG 取樣器，然後重新讀取該功能的狀態。尚未在 NOOP 自己的硬體上驗證（OURA_PROTOCOL.md §7.5）——這些按鈕的作用就是測試第三方的報告。此處特意不提供日間心率和靜息心率：日間心率有自己專用的即時心率路徑，而靜息心率完全沒有應用程式層級的開關。"
+          }
+        }
+      }
+    },
+    "Exercise HR" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trainings-HF"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FC de ejercicio"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FC d'exercice"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FC da esercizio"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tętno wysiłkowe"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FC de exercício"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ЧСС при нагрузке"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "运动心率"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "運動心率"
+          }
+        }
+      }
+    },
+    "Field" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feld"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Campo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Champ"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Campo"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pole"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Campo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поле"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字段"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "欄位"
+          }
+        }
+      }
+    },
+    "Frame: %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frame: %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trama: %@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trame : %@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frame: %@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rama: %@"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frame: %@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кадр: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "帧：%@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "幀：%@"
+          }
+        }
+      }
+    },
+    "Mode" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modus"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mode"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modalità"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tryb"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Режим"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模式"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模式"
+          }
+        }
+      }
+    },
+    "OURA" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OURA"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OURA"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OURA"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OURA"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OURA"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OURA"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OURA"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OURA"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OURA"
+          }
+        }
+      }
+    },
+    "Oura feature enable (experimental)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oura-Funktion aktivieren (experimentell)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activación de funciones de Oura (experimental)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activation de fonctionnalité Oura (expérimental)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Attivazione funzione Oura (sperimentale)"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Włączanie funkcji Oura (eksperymentalne)"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ativação de funcionalidade Oura (experimental)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Включение функции Oura (экспериментально)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oura 功能启用（实验性）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oura 功能啟用（實驗性）"
+          }
+        }
+      }
+    },
+    "Oura user-info write (experimental)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oura-Nutzerinfo-Schreiben (experimentell)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escritura de información de usuario de Oura (experimental)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écriture des infos utilisateur Oura (expérimental)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scrittura informazioni utente Oura (sperimentale)"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zapis danych użytkownika Oura (eksperymentalne)"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escrita de informação de utilizador Oura (experimental)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запись данных пользователя Oura (экспериментально)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oura 用户信息写入（实验性）"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oura 使用者資訊寫入（實驗性）"
+          }
+        }
+      }
+    },
+    "Real steps" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Echte Schritte"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pasos reales"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pas réels"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passi reali"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rzeczywiste kroki"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passos reais"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Реальные шаги"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "真实步数"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "真實步數"
+          }
+        }
+      }
+    },
+    "Sends %@ to the ring. This changes ring-side config. Restore with the firmware default (height 176, weight 75, sex 2) or write zeros." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sendet %@ an den Ring. Dies ändert die Konfiguration im Ring. Mit dem Firmware-Standard (Größe 176, Gewicht 75, Geschlecht 2) oder durch Schreiben von Nullen wiederherstellen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envía %@ al anillo. Esto cambia la configuración del anillo. Restaura con el valor predeterminado de fábrica (altura 176, peso 75, sexo 2) o escribiendo ceros."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoie %@ à la bague. Cela modifie la configuration côté bague. Restaurez avec la valeur par défaut du firmware (taille 176, poids 75, sexe 2) ou en écrivant des zéros."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invia %@ all'anello. Questo modifica la configurazione lato anello. Ripristina con il valore predefinito del firmware (altezza 176, peso 75, sesso 2) oppure scrivendo zeri."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wysyła %@ do pierścienia. Zmienia to konfigurację po stronie pierścienia. Przywróć wartość domyślną z firmware'u (wzrost 176, waga 75, płeć 2) lub zapisz zera."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envia %@ para o anel. Isto altera a configuração do anel. Restaure com o valor predefinido do firmware (altura 176, peso 75, sexo 2) ou escrevendo zeros."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отправляет %@ на кольцо. Это изменяет конфигурацию на стороне кольца. Восстановите значение по умолчанию из прошивки (рост 176, вес 75, пол 2) или запишите нули."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向戒指发送 %@。这会更改戒指端的配置。可通过恢复固件默认值（身高 176、体重 75、性别 2）或写入零值来还原。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向戒指傳送 %@。這會變更戒指端的設定。可透過還原韌體預設值（身高 176、體重 75、性別 2）或寫入零值來復原。"
+          }
+        }
+      }
+    },
+    "Sends %@ to the ring. Unvalidated on NOOP's own hardware (OURA_PROTOCOL.md §7.5). Mode 0x00 always reverts. Watch the strap log for the follow-up feature-status read." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sendet %@ an den Ring. Auf NOOPs eigener Hardware nicht validiert (OURA_PROTOCOL.md §7.5). Modus 0x00 stellt immer den ursprünglichen Zustand wieder her. Achte im Strap-Log auf das anschließende Feature-Status-Lesen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envía %@ al anillo. Sin validar en el hardware propio de NOOP (OURA_PROTOCOL.md §7.5). El modo 0x00 siempre revierte el cambio. Consulta el registro de la correa para ver la lectura de estado de función posterior."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoie %@ à la bague. Non validé sur le matériel propre de NOOP (OURA_PROTOCOL.md §7.5). Le mode 0x00 revient toujours à l'état initial. Consultez le journal du bracelet pour la lecture de statut de fonctionnalité qui suit."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invia %@ all'anello. Non convalidato sull'hardware proprio di NOOP (OURA_PROTOCOL.md §7.5). La modalità 0x00 ripristina sempre lo stato precedente. Controlla il log del cinturino per la successiva lettura dello stato della funzione."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wysyła %@ do pierścienia. Niezweryfikowane na własnym sprzęcie NOOP (OURA_PROTOCOL.md §7.5). Tryb 0x00 zawsze przywraca poprzedni stan. Sprawdź dziennik opaski, aby zobaczyć kolejny odczyt stanu funkcji."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envia %@ para o anel. Não validado no hardware próprio da NOOP (OURA_PROTOCOL.md §7.5). O modo 0x00 reverte sempre. Consulte o registo da pulseira para a leitura de estado da funcionalidade que se segue."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отправляет %@ на кольцо. Не проверено на собственном оборудовании NOOP (OURA_PROTOCOL.md §7.5). Режим 0x00 всегда возвращает исходное состояние. Смотрите журнал ремешка, чтобы увидеть последующее чтение статуса функции."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向戒指发送 %@。尚未在 NOOP 自己的硬件上验证（OURA_PROTOCOL.md §7.5）。模式 0x00 总是可以还原。请查看表带日志中随后的功能状态读取记录。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向戒指傳送 %@。尚未在 NOOP 自己的硬體上驗證（OURA_PROTOCOL.md §7.5）。模式 0x00 一律可以復原。請查看錶帶記錄中隨後的功能狀態讀取。"
+          }
+        }
+      }
+    },
+    "Sends %@ to the ring. Unvalidated on NOOP's own hardware (OURA_PROTOCOL.md §7.5). Watch the strap log for the follow-up feature-status read." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sendet %@ an den Ring. Auf NOOPs eigener Hardware nicht validiert (OURA_PROTOCOL.md §7.5). Achte im Strap-Log auf das anschließende Feature-Status-Lesen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envía %@ al anillo. Sin validar en el hardware propio de NOOP (OURA_PROTOCOL.md §7.5). Consulta el registro de la correa para ver la lectura de estado de función posterior."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoie %@ à la bague. Non validé sur le matériel propre de NOOP (OURA_PROTOCOL.md §7.5). Consultez le journal du bracelet pour la lecture de statut de fonctionnalité qui suit."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invia %@ all'anello. Non convalidato sull'hardware proprio di NOOP (OURA_PROTOCOL.md §7.5). Controlla il log del cinturino per la successiva lettura dello stato della funzione."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wysyła %@ do pierścienia. Niezweryfikowane na własnym sprzęcie NOOP (OURA_PROTOCOL.md §7.5). Sprawdź dziennik opaski, aby zobaczyć kolejny odczyt stanu funkcji."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envia %@ para o anel. Não validado no hardware próprio da NOOP (OURA_PROTOCOL.md §7.5). Consulte o registo da pulseira para a leitura de estado da funcionalidade que se segue."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отправляет %@ на кольцо. Не проверено на собственном оборудовании NOOP (OURA_PROTOCOL.md §7.5). Смотрите журнал ремешка, чтобы увидеть последующее чтение статуса функции."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向戒指发送 %@。尚未在 NOOP 自己的硬件上验证（OURA_PROTOCOL.md §7.5）。请查看表带日志中随后的功能状态读取记录。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向戒指傳送 %@。尚未在 NOOP 自己的硬體上驗證（OURA_PROTOCOL.md §7.5）。請查看錶帶記錄中隨後的功能狀態讀取。"
+          }
+        }
+      }
+    },
+    "Sends a SetFeatureMode write for SpO2 or real-steps, then re-reads the feature's status. Unvalidated on NOOP's own hardware (OURA_PROTOCOL.md §7.5) — a third-party report is what this button exists to test. Mode “off” always reverts." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sendet einen SetFeatureMode-Schreibbefehl für SpO2 oder Echte Schritte und liest den Funktionsstatus danach erneut. Auf NOOPs eigener Hardware nicht validiert (OURA_PROTOCOL.md §7.5) — dieser Button dient dazu, einen Bericht eines Drittanbieters zu testen. Modus „aus“ stellt immer den ursprünglichen Zustand wieder her."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envía una escritura SetFeatureMode para SpO2 o pasos reales y vuelve a leer el estado de la función. Sin validar en el hardware propio de NOOP (OURA_PROTOCOL.md §7.5); este botón existe para probar un informe de terceros. El modo \"desactivado\" siempre revierte el cambio."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoie une écriture SetFeatureMode pour la SpO2 ou les pas réels, puis relit le statut de la fonctionnalité. Non validé sur le matériel propre de NOOP (OURA_PROTOCOL.md §7.5) — ce bouton sert à tester un rapport d'un tiers. Le mode « désactivé » revient toujours à l'état initial."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Invia una scrittura SetFeatureMode per SpO2 o passi reali, quindi rilegge lo stato della funzione. Non convalidato sull'hardware proprio di NOOP (OURA_PROTOCOL.md §7.5): questo pulsante serve a verificare una segnalazione di terze parti. La modalità \"off\" ripristina sempre lo stato precedente."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wysyła zapis SetFeatureMode dla SpO2 lub rzeczywistych kroków, a następnie ponownie odczytuje stan funkcji. Niezweryfikowane na własnym sprzęcie NOOP (OURA_PROTOCOL.md §7.5) — ten przycisk służy do sprawdzenia doniesienia strony trzeciej. Tryb „off” zawsze przywraca poprzedni stan."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envia uma escrita SetFeatureMode para SpO2 ou passos reais e volta a ler o estado da funcionalidade. Não validado no hardware próprio da NOOP (OURA_PROTOCOL.md §7.5) — este botão existe para testar um relatório de terceiros. O modo \"desligado\" reverte sempre."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отправляет запись SetFeatureMode для SpO2 или реальных шагов, затем повторно считывает статус функции. Не проверено на собственном оборудовании NOOP (OURA_PROTOCOL.md §7.5) — эта кнопка существует для проверки стороннего отчёта. Режим «выкл.» всегда возвращает исходное состояние."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "发送针对血氧（SpO2）或真实步数的 SetFeatureMode 写入，然后重新读取该功能的状态。尚未在 NOOP 自己的硬件上验证（OURA_PROTOCOL.md §7.5）——此按钮的作用就是测试第三方的报告。“关闭”模式总是可以还原。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "傳送針對血氧（SpO2）或真實步數的 SetFeatureMode 寫入，然後重新讀取該功能的狀態。尚未在 NOOP 自己的硬體上驗證（OURA_PROTOCOL.md §7.5）——此按鈕的作用就是測試第三方的報告。「關閉」模式一律可以復原。"
+          }
+        }
+      }
+    },
     "This night was recorded before NOOP labelled which WHOOP 5 transport each heartbeat came from, so its intervals mix two different units with nothing stored to tell them apart. The night stays in your history, and nights recorded from now on score normally." : { "localizations" : {
         "de": {"stringUnit": {"state": "translated", "value": "Diese Nacht wurde aufgezeichnet, bevor NOOP festhielt, über welchen WHOOP-5-Übertragungsweg jeder Herzschlag kam. Ihre Intervalle mischen deshalb zwei verschiedene Einheiten, und es ist nichts gespeichert, was sie unterscheidbar macht. Die Nacht bleibt in deinem Verlauf, und ab jetzt aufgezeichnete Nächte werden normal bewertet."}},
         "es": {"stringUnit": {"state": "translated", "value": "Esta noche se registró antes de que NOOP etiquetara de qué transporte de WHOOP 5 procedía cada latido, así que sus intervalos mezclan dos unidades distintas y no hay nada guardado que permita distinguirlas. La noche permanece en tu historial y las noches registradas a partir de ahora se puntúan con normalidad."}},
@@ -210625,6 +211669,296 @@
         "zh-Hans": {"stringUnit": {"state": "translated", "value": "打开压力详情"}},
         "zh-Hant": {"stringUnit": {"state": "translated", "value": "開啟壓力詳情"}}
     } },
+    "Write" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schreiben"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribir"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écrire"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scrivi"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zapisz"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escrever"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Записать"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "写入"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寫入"
+          }
+        }
+      }
+    },
+    "Write to ring" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An den Ring schreiben"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribir en el anillo"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écrire dans la bague"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scrivi sull'anello"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zapisz do pierścienia"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escrever no anel"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Записать в кольцо"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "写入戒指"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寫入戒指"
+          }
+        }
+      }
+    },
+    "Write to the ring?" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An den Ring schreiben?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "¿Escribir en el anillo?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écrire dans la bague ?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scrivere sull'anello?"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zapisać do pierścienia?"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escrever no anel?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Записать в кольцо?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "写入戒指？"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寫入戒指？"
+          }
+        }
+      }
+    },
+    "Write zeros" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nullen schreiben"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribir ceros"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écrire des zéros"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scrivi zeri"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zapisz zera"
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escrever zeros"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Записать нули"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "写入零值"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "寫入零值"
+          }
+        }
+      }
+    },
+    "Writes one 0x20 user-info field to the ring and logs what comes back. The ring reports 0x5c as firmware defaults (40 y, 75 kg, sex unset, 176 cm) even though your Oura app profile is correct, and the Oura app never writes it. Whether 0x20 lands in 0x5c is UNKNOWN, and so is the value encoding: try 175 for cm, then 1750 for mm. Age has no setter, only date-of-birth, whose 9-byte layout is unknown, so it is raw hex only. Tested only on Gen 3 so far — Gen 5 validation is open." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schreibt ein 0x20-Nutzerinfo-Feld an den Ring und protokolliert die Antwort. Der Ring meldet bei 0x5c die Firmware-Standardwerte (40 J, 75 kg, Geschlecht nicht gesetzt, 176 cm), obwohl dein Oura-App-Profil korrekt ist, und die Oura-App schreibt es nie. Ob 0x20 tatsächlich in 0x5c landet, ist UNBEKANNT, ebenso die Werte-Kodierung: versuche 175 für cm, dann 1750 für mm. Für das Alter gibt es keinen Setter, nur das Geburtsdatum, dessen 9-Byte-Layout unbekannt ist, also nur als Roh-Hex. Bisher nur auf Gen 3 getestet — die Validierung für Gen 5 steht noch aus."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escribe un campo de información de usuario 0x20 en el anillo y registra la respuesta. El anillo informa en 0x5c los valores predeterminados de fábrica (40 años, 75 kg, sexo sin definir, 176 cm) aunque el perfil de tu app Oura sea correcto, y la app Oura nunca lo escribe. Se DESCONOCE si 0x20 llega a 0x5c, al igual que la codificación del valor: prueba 175 para cm, luego 1750 para mm. La edad no tiene un método de escritura, solo la fecha de nacimiento, cuyo formato de 9 bytes es desconocido, así que solo se admite en hexadecimal bruto. Probado solo en Gen 3 por ahora; la validación en Gen 5 sigue pendiente."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Écrit un champ d'informations utilisateur 0x20 dans la bague et journalise la réponse. La bague indique dans 0x5c les valeurs par défaut du firmware (40 ans, 75 kg, sexe non défini, 176 cm) même si le profil de votre appli Oura est correct, et l'appli Oura ne l'écrit jamais. On ignore si 0x20 se répercute dans 0x5c, tout comme l'encodage de la valeur : essayez 175 pour les cm, puis 1750 pour les mm. L'âge n'a pas de méthode d'écriture, seulement la date de naissance, dont la structure sur 9 octets est inconnue, donc en hexadécimal brut uniquement. Testé pour l'instant uniquement sur la Gen 3 — la validation sur la Gen 5 reste à faire."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scrive un campo informazioni utente 0x20 sull'anello e registra la risposta. L'anello riporta in 0x5c i valori predefiniti del firmware (40 anni, 75 kg, sesso non impostato, 176 cm) anche se il profilo della tua app Oura è corretto, e l'app Oura non lo scrive mai. Non è NOTO se 0x20 arrivi effettivamente a 0x5c, così come non è nota la codifica del valore: prova 175 per i cm, poi 1750 per i mm. L'età non ha un setter, solo la data di nascita, il cui layout a 9 byte è sconosciuto, quindi va inserita solo come esadecimale grezzo. Finora testato solo su Gen 3 — la convalida su Gen 5 è ancora aperta."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zapisuje jedno pole informacji o użytkowniku 0x20 do pierścienia i rejestruje odpowiedź. Pierścień zgłasza w 0x5c wartości domyślne z firmware'u (40 lat, 75 kg, płeć nieustawiona, 176 cm), mimo że profil w aplikacji Oura jest poprawny, a aplikacja Oura nigdy go nie zapisuje. Czy 0x20 trafia do 0x5c, NIE WIADOMO, podobnie jak kodowanie wartości: spróbuj 175 dla cm, potem 1750 dla mm. Wiek nie ma settera, jest tylko data urodzenia, której 9-bajtowy układ jest nieznany, więc tylko surowy hex. Do tej pory testowane tylko na Gen 3 — walidacja na Gen 5 pozostaje otwarta."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Escreve um campo de informação de utilizador 0x20 no anel e regista o que é devolvido. O anel comunica em 0x5c os valores predefinidos do firmware (40 anos, 75 kg, sexo não definido, 176 cm) mesmo que o perfil da sua app Oura esteja correto, e a app Oura nunca o escreve. Se 0x20 chega a 0x5c é DESCONHECIDO, tal como a codificação do valor: experimente 175 para cm, depois 1750 para mm. A idade não tem escrita própria, apenas a data de nascimento, cujo esquema de 9 bytes é desconhecido, por isso é só em hexadecimal em bruto. Testado apenas em Gen 3 até agora — a validação em Gen 5 está em aberto."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Записывает одно поле пользовательской информации 0x20 на кольцо и регистрирует ответ. Кольцо сообщает в 0x5c значения по умолчанию из прошивки (40 лет, 75 кг, пол не задан, 176 см), даже если профиль в приложении Oura указан верно, а приложение Oura никогда его не записывает. НЕИЗВЕСТНО, попадает ли 0x20 в 0x5c, как и кодировка значения: попробуйте 175 для см, затем 1750 для мм. У возраста нет метода записи, есть только дата рождения, 9-байтовый формат которой неизвестен, поэтому только необработанный hex. Пока проверено только на Gen 3 — проверка на Gen 5 ещё предстоит."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向戒指写入一个 0x20 用户信息字段并记录返回内容。即使你的 Oura App 中的个人资料是正确的，戒指在 0x5c 中报告的仍是固件默认值（40 岁、75 公斤、性别未设置、176 厘米），且 Oura App 从不写入该字段。0x20 是否真的写入了 0x5c 尚不清楚，数值的编码方式也不清楚：先尝试厘米值 175，再尝试毫米值 1750。年龄没有写入方式，只能通过出生日期写入，其 9 字节的结构尚不清楚，因此只能使用原始十六进制。目前仅在 Gen 3 上测试过——Gen 5 的验证仍待完成。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "向戒指寫入一個 0x20 使用者資訊欄位並記錄傳回內容。即使你的 Oura App 中的個人資料正確無誤，戒指在 0x5c 中回報的仍是韌體預設值（40 歲、75 公斤、性別未設定、176 公分），且 Oura App 從不寫入該欄位。0x20 是否真的寫入了 0x5c 目前尚不清楚，數值的編碼方式也不清楚：先嘗試公分值 175，再嘗試公釐值 1750。年齡沒有寫入方式，只能透過出生日期寫入，其 9 位元組的結構尚不清楚，因此只能使用原始十六進位。目前僅在 Gen 3 上測試過——Gen 5 的驗證仍待完成。"
+          }
+        }
+      }
+    },
     "On: your charge, rest, HRV and workouts are sent to the provider, each workout with its sport, duration, distance and heart rate." : { "localizations" : {
         "de": {"stringUnit": {"state": "translated", "value": "An: Ladung, Erholung, HRV und Workouts gehen an den Anbieter, jedes Workout mit Sportart, Dauer, Distanz und Herzfrequenz."}},
         "en": {"stringUnit": {"state": "translated", "value": "On: your charge, rest, HRV and workouts are sent to the provider, each workout with its sport, duration, distance and heart rate."}},

--- a/Strand/Screens/TestCentreView.swift
+++ b/Strand/Screens/TestCentreView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import StrandDesign
 import StrandAnalytics
 import StrandImport
+import OuraProtocol
 import PolarProtocol
 import WhoopStore
 import WhoopProtocol
@@ -68,6 +69,78 @@ struct TestCentreView: View {
     @AppStorage(AppModel.ouraOnsetKeyingKey) private var ouraOnsetKeying = false
     private var ouraPaired: Bool { model.deviceRegistry?.devices.contains { $0.brand == "Oura" } ?? false }
 
+    /// The profile the 0x20 write experiment prefills from. Values are OVERRIDABLE in the field below:
+    /// the encoding is unverified, so the point is to try 175 (cm) and then 1750 (mm) without a rebuild.
+    @EnvironmentObject var profile: ProfileStore
+
+    // 0x20 user-info write EXPERIMENT (see OuraUserInfoWrite). Nothing here fires automatically.
+    @State private var userInfoField: OuraUserInfoField = .height
+    @State private var userInfoValueText = ""
+    @State private var userInfoRawHex = ""
+    @State private var showUserInfoConfirm = false
+
+    /// The value bytes the current selection would send, or nil when the entry is not usable yet.
+    /// Raw-hex mode is how the date-of-birth (age) path is probed: there is no age setter and no capture
+    /// pins the 9-byte type-5 layout, so a guess must be typed deliberately, never offered as "Age".
+    private var userInfoValueBytes: [UInt8]? {
+        if userInfoField == .dateOfBirth {
+            let cleaned = userInfoRawHex.filter { !$0.isWhitespace }
+            guard cleaned.count == userInfoField.valueByteCount * 2 else { return nil }
+            var out: [UInt8] = []
+            var idx = cleaned.startIndex
+            while idx < cleaned.endIndex {
+                let next = cleaned.index(idx, offsetBy: 2)
+                guard let b = UInt8(cleaned[idx..<next], radix: 16) else { return nil }
+                out.append(b); idx = next
+            }
+            return out
+        }
+        guard let n = UInt32(userInfoValueText.trimmingCharacters(in: .whitespaces)) else { return nil }
+        return try? OuraUserInfoWrite.encodeLE(n, width: userInfoField.valueByteCount)
+    }
+
+    /// The exact frame that would go on the wire, so it can be read BEFORE sending.
+    private var userInfoFramePreview: String {
+        guard let v = userInfoValueBytes, let cmd = try? OuraUserInfoWrite.command(userInfoField, value: v) else {
+            return "enter a value"
+        }
+        return cmd.bytes.map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Prefill from the NOOP profile when the field changes. Sex maps through the 0x5c gender code.
+    private func prefillUserInfoValue() {
+        switch userInfoField {
+        case .height: userInfoValueText = String(Int(profile.heightCm.rounded()))
+        case .weight: userInfoValueText = String(Int(profile.weightKg.rounded()))
+        case .gender: userInfoValueText = String(OuraUserInfoWrite.genderCode(forSex: profile.sex))
+        case .unit:   userInfoValueText = "0"
+        case .dateOfBirth: userInfoValueText = ""
+        }
+    }
+
+    // Feature-mode write EXPERIMENT (see OuraCommands.setFeatureMode, OURA_PROTOCOL.md s7.5). Nothing
+    // here fires automatically. Scoped to SpO2 / real-steps / exercise-HR / CVA-PPG-sampler — the
+    // features [open_oura-feat]'s local-write evidence actually covers — and mode off/automatic only,
+    // the only mode value that evidence covers. Daytime HR and resting HR are deliberately excluded:
+    // daytime HR already has its own dedicated live-HR enable path (different mode value, 0x03
+    // connected_live, wired into wear detection — don't duplicate it here), and resting HR has no
+    // app-level toggle at all per OURA_PROTOCOL.md s7.1 (firmware-computed, no SetFeatureMode target).
+    //
+    // One Enable/Disable button PER feature (not a shared feature+mode picker pair): the combined
+    // picker made it easy to write the wrong feature by forgetting the other picker was still on its
+    // last selection. A disable round-trip (Off, confirm the ring actually reports off, then Automatic
+    // to restore) is also the only test available on a ring whose features are already
+    // account-unlocked, since a plain enable is a no-op there (2026-09-11 hardware run).
+    private struct PendingFeatureWrite: Identifiable {
+        let feature: UInt8
+        let mode: UInt8
+        var id: String { "\(feature)-\(mode)" }
+        var framePreview: String {
+            OuraCommands.setFeatureMode(feature, mode: mode).bytes.map { String(format: "%02x", $0) }.joined()
+        }
+    }
+    @State private var pendingFeatureWrite: PendingFeatureWrite?
+
     // Section 4: Experimental algorithms. Bound to the SAME PuffinExperiment keys the Android card writes, so
     // the platforms stay in lockstep. The PPG-HR sub-lag interpolation variant and the HRV-readiness readout,
     // both default OFF.
@@ -93,6 +166,7 @@ struct TestCentreView: View {
                 diagnosticToolsCard.staggeredAppear(index: 1)
                 if is5MG { rawDataCollectorCard.staggeredAppear(index: 2) }
                 if is5MG { fiveMGProtocolDiagnosticsCard.staggeredAppear(index: 3) }
+                if ouraPaired { ouraCard.staggeredAppear(index: 2) }
                 exportCard.staggeredAppear(index: 2)
                 experimentalAlgorithmsCard.staggeredAppear(index: 3)
             }
@@ -321,22 +395,207 @@ struct TestCentreView: View {
                     }
                     .tint(StrandPalette.accent)
                 }
-
-                // #1284 residual 3: experimental Oura onset keying, only when an Oura ring is paired.
-                if ouraPaired {
-                    Divider().overlay(StrandPalette.hairline)
-                    Toggle(isOn: $ouraOnsetKeying) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Oura onset keying (experimental)").font(StrandFont.body)
-                            Text("Keys each Oura sleep night on its stable 0x49 onset and suppresses duplicate re-serves at the source, instead of the shipped end-anchored persist (#1284). Off by default — a hardware-validation toggle. Watch the strap log for \u{201C}onset-key(#1284)\u{201D} lines.")
-                                .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-                    }
-                    .tint(StrandPalette.accent)
-                }
             }
         }
+    }
+
+    // MARK: - Section 2b: Oura (consolidated; only when an Oura ring is paired)
+
+    @ViewBuilder private var ouraCard: some View {
+        NoopCard {
+            VStack(alignment: .leading, spacing: NoopMetrics.space3) {
+                Text("OURA")
+                    .font(StrandFont.overline).tracking(StrandFont.overlineTracking)
+                    .foregroundStyle(StrandPalette.textSecondary)
+
+                // #1284 residual 3: experimental Oura onset keying.
+                Toggle(isOn: $ouraOnsetKeying) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Oura onset keying (experimental)").font(StrandFont.body)
+                        Text("Keys each Oura sleep night on its stable 0x49 onset and suppresses duplicate re-serves at the source, instead of the shipped end-anchored persist (#1284). Off by default — a hardware-validation toggle. Watch the strap log for \u{201C}onset-key(#1284)\u{201D} lines.")
+                            .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .tint(StrandPalette.accent)
+
+                Divider().overlay(StrandPalette.hairline)
+                ouraUserInfoWriteBlock
+
+                Divider().overlay(StrandPalette.hairline)
+                ouraEnableFeatureBlock
+            }
+        }
+    }
+
+    /// The 0x20 user-info WRITE experiment. EXPERIMENTAL, manual, one field at a time.
+    ///
+    /// This is the only control in NOOP that writes user data to a ring. It exists to answer one
+    /// question: does a 0x20 write change what tag 0x5c reports? Nothing calls it automatically, and
+    /// deliberately NOT on connect: the value encoding is unverified, an automatic write would destroy
+    /// the clean before-state the readout depends on, and the connect/bond window is the app's most
+    /// fragile path (#1635). Read the strap log for the WRITE line, the 0x20 ACK, and the next 0x5c.
+    @ViewBuilder
+    private var ouraUserInfoWriteBlock: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Oura user-info write (experimental)").font(StrandFont.body)
+            Text("Writes one 0x20 user-info field to the ring and logs what comes back. The ring reports 0x5c as firmware defaults (40 y, 75 kg, sex unset, 176 cm) even though your Oura app profile is correct, and the Oura app never writes it. Whether 0x20 lands in 0x5c is UNKNOWN, and so is the value encoding: try 175 for cm, then 1750 for mm. Age has no setter, only date-of-birth, whose 9-byte layout is unknown, so it is raw hex only. Tested only on Gen 3 so far — Gen 5 validation is open.")
+                .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Picker("Field", selection: $userInfoField) {
+                Text("Height").tag(OuraUserInfoField.height)
+                Text("Sex").tag(OuraUserInfoField.gender)
+                Text("Weight").tag(OuraUserInfoField.weight)
+                Text("DOB (raw)").tag(OuraUserInfoField.dateOfBirth)
+            }
+            .pickerStyle(.segmented)
+            .onChange(of: userInfoField) { _ in prefillUserInfoValue() }
+
+            if userInfoField == .dateOfBirth {
+                TextField("18 hex chars (9 bytes)", text: $userInfoRawHex)
+                    .font(StrandFont.body).textFieldStyle(.roundedBorder)
+            } else {
+                TextField("value", text: $userInfoValueText)
+                    .font(StrandFont.body).textFieldStyle(.roundedBorder)
+            }
+
+            Text("Frame: \(userInfoFramePreview)")
+                .font(StrandFont.caption).foregroundStyle(StrandPalette.textSecondary)
+
+            HStack(spacing: 12) {
+                Button("Write to ring") { showUserInfoConfirm = true }
+                    .disabled(userInfoValueBytes == nil)
+                Button("Write zeros") {
+                    _ = model.sourceCoordinator?.ouraSource?.writeUserInfo(
+                        field: userInfoField,
+                        value: [UInt8](repeating: 0, count: userInfoField.valueByteCount))
+                }
+            }
+            .font(StrandFont.body).tint(StrandPalette.accent)
+        }
+        .onAppear { if userInfoValueText.isEmpty { prefillUserInfoValue() } }
+        .alert("Write to the ring?", isPresented: $showUserInfoConfirm) {
+            Button("Cancel", role: .cancel) { }
+            Button("Write", role: .destructive) {
+                guard let v = userInfoValueBytes else { return }
+                if model.sourceCoordinator?.ouraSource?.writeUserInfo(field: userInfoField, value: v) != true {
+                    infoTitle = "Not written"
+                    infoMessage = "No connected Oura ring. Connect the ring, then try again."
+                    showInfo = true
+                }
+            }
+        } message: {
+            Text("Sends \(userInfoFramePreview) to the ring. This changes ring-side config. Restore with the firmware default (height 176, weight 75, sex 2) or write zeros.")
+        }
+    }
+
+    /// The `SetFeatureMode` WRITE experiment (`2f 03 22 <id> <mode>`) — hardware-CONFIRMED 2026-09-11:
+    /// disabling then re-enabling SpO2 flipped `mode` `1→0→1`, reproduced both directions on a real
+    /// Gen 3 ring. `docs/OURA_PROTOCOL.md` s7.5 still marks the account-gate-bypass claim itself
+    /// unvalidated (this ring was already cloud-entitled), but the write mechanism itself is proven.
+    /// Scoped to SpO2 / real-steps / exercise-HR / CVA-PPG-sampler, mode off/automatic only — daytime
+    /// HR and resting HR are deliberately excluded (see the state-var comment above).
+    ///
+    /// Each row shows the ring's OWN last-known status live (mirrored via `AppModel.ouraFeatureStatuses`
+    /// off `OuraLiveSource.featureStatuses`) — originally log-only, changed after the same hardware run
+    /// made clear that reading the strap log for every check was the wrong tradeoff for a control meant
+    /// to be poked repeatedly. The strap log still carries the WRITE line and the 0x23 ACK either way.
+    ///
+    /// One Enable/Disable button PER feature — see the state-var comment above for why this replaced
+    /// a shared feature+mode picker pair.
+    @ViewBuilder
+    private var ouraEnableFeatureBlock: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Oura feature enable (experimental)").font(StrandFont.body)
+            Text("Enables or disables SpO2, real-steps, exercise HR, or the CVA PPG sampler directly via SetFeatureMode, then re-reads the feature's status. Unvalidated on NOOP's own hardware (OURA_PROTOCOL.md \u{00A7}7.5) — a third-party report is what these buttons exist to test. Daytime HR and resting HR are deliberately not offered here: daytime HR has its own dedicated live-HR path, and resting HR has no app-level toggle at all.")
+                .font(StrandFont.caption).foregroundStyle(StrandPalette.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            ouraFeatureEnableRow(label: "SpO2", feature: OuraCommands.featureSpO2)
+            ouraFeatureEnableRow(label: "Real steps", feature: OuraCommands.featureRealSteps)
+            ouraFeatureEnableRow(label: "Exercise HR", feature: OuraCommands.featureExerciseHR)
+            ouraFeatureEnableRow(label: "CVA PPG sampler", feature: OuraCommands.featureCvaPpg)
+        }
+        .alert("Write to the ring?", isPresented: Binding(
+            get: { pendingFeatureWrite != nil },
+            set: { if !$0 { pendingFeatureWrite = nil } }
+        ), presenting: pendingFeatureWrite) { pending in
+            Button("Cancel", role: .cancel) { }
+            Button("Write", role: .destructive) {
+                if model.sourceCoordinator?.ouraSource?.writeFeatureMode(feature: pending.feature, mode: pending.mode) != true {
+                    infoTitle = "Not written"
+                    infoMessage = "No connected Oura ring. Connect the ring, then try again."
+                    showInfo = true
+                }
+            }
+        } message: { pending in
+            Text("Sends \(pending.framePreview) to the ring. Unvalidated on NOOP's own hardware (OURA_PROTOCOL.md \u{00A7}7.5). Watch the strap log for the follow-up feature-status read.")
+        }
+    }
+
+    @ViewBuilder
+    private func ouraFeatureEnableRow(label: LocalizedStringKey, feature: UInt8) -> some View {
+        HStack(spacing: 12) {
+            Text(label).font(StrandFont.body)
+            Spacer()
+            Text(ouraFeatureStatusLabel(feature))
+                .font(StrandFont.caption)
+                .foregroundStyle(ouraFeatureStatusIsOn(feature) ? StrandPalette.statusPositive : StrandPalette.textTertiary)
+            Button("Enable") { pendingFeatureWrite = PendingFeatureWrite(feature: feature, mode: 0x01) }
+            Button("Disable") { pendingFeatureWrite = PendingFeatureWrite(feature: feature, mode: 0x00) }
+        }
+        .tint(StrandPalette.accent)
+    }
+
+    /// The ring's own last-known status for this feature, mirrored live off `OuraLiveSource` (never a
+    /// guess from what we last SENT — see the 2026-09-11 hardware run where a self-induced disable had
+    /// to be told apart from a genuine cloud gate). "Unknown" until the connect-time auto-probe (SpO2/
+    /// real-steps) or an explicit Enable/Disable has produced at least one read-back this connection.
+    /// `mode` is what Enable/Disable actually controls, so it drives BOTH the primary label and the
+    /// color — a real 2026-09-11 hardware run showed SpO2 correctly enabled (`mode=automatic`) read as
+    /// "still off" because the label led with `status` instead, and `status=0`'s word ("off") sat right
+    /// next to the Enable/Disable buttons, reading as a second, contradicting toggle. `status` is real
+    /// and worth showing (SpO2 samples periodically, not continuously, so `status=0` "idle" is its
+    /// NORMAL resting state even while enabled) but only as a silent-by-default qualifier, in vocabulary
+    /// that cannot be mistaken for another on/off switch — "active"/"searching"/etc, never "on"/"off".
+    private func ouraFeatureStatusLabel(_ feature: UInt8) -> String {
+        guard let st = model.ouraFeatureStatuses[Int(feature)] else { return String(localized: "Unknown") }
+        let mode = ouraFeatureModeLabel(st.mode)
+        guard let qualifier = ouraFeatureStatusQualifier(st.status) else { return mode }
+        return "\(mode) \u{00B7} \(qualifier)"
+    }
+
+    private func ouraFeatureModeLabel(_ mode: Int) -> String {
+        switch mode {
+        case 0: return String(localized: "Off")
+        case 1: return String(localized: "Automatic")
+        case 2: return String(localized: "Requested")
+        case 3: return String(localized: "Connected live")
+        default: return String(localized: "Unknown")
+        }
+    }
+
+    /// nil for status=0 ("idle") — the expected resting state for an ENABLED feature between samples,
+    /// not worth a qualifier every time. Non-nil only when the ring reports something beyond that.
+    private func ouraFeatureStatusQualifier(_ status: Int) -> String? {
+        switch status {
+        case 0: return nil
+        case 1: return String(localized: "active")
+        case 2: return String(localized: "searching")
+        case 3: return String(localized: "no PPG")
+        case 4: return String(localized: "cold")
+        case 5: return String(localized: "movement")
+        case 6: return String(localized: "identifying")
+        default: return String(localized: "unknown")
+        }
+    }
+
+    /// Colors the row on `mode` (what Enable/Disable controls), not `status` (a transient sampling
+    /// detail) — see the doc comment on `ouraFeatureStatusLabel` for why conflating the two misled a
+    /// real hardware test into reading a correctly-enabled SpO2 as still off.
+    private func ouraFeatureStatusIsOn(_ feature: UInt8) -> Bool {
+        model.ouraFeatureStatuses[Int(feature)]?.mode == 1
     }
 
     // MARK: - Section 3: Export and auto-export (manual Report + scheduled export)

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -1226,7 +1226,17 @@ NOOP ships a **read-only** probe that asks the ring to report a feature's own st
 
 - **Shipped probes:** `spo2_status` (`2f 02 20 04`) and `realsteps_status` (`2f 02 20 0b`), sent once after `get_battery` on each connect; logged once per feature, never stored or scored.
 - **All-zero = server-gated OFF.** A gated/unavailable feature reads back `mode=0 status=0 state=0 subscription=0`. Contrast the *streaming* daytime-HR (`0x02`), which reads `mode=1 status=0x11 state=2` — so **all-zero mode/status/state is the gated signature**, not `subscription==0` alone (daytime-HR is `subscription=0` yet active).
-- **2026-07-20 Gen 3 capture:** both SpO2 (`0x04`) and real_steps (`0x0b`) returned all-zero — confirming §7.1 on live hardware. No local `setFeatureMode` can flip these; the gate is the Oura cloud `ClientConfiguration`, not the ring or NOOP.
+- **2026-07-20 Gen 3 capture:** both SpO2 (`0x04`) and real_steps (`0x0b`) returned all-zero — confirming §7.1 on live hardware. **Correction (2026-09-11): the claim that formerly stood here — "no local `setFeatureMode` can flip these" — was never actually tested.** NOOP has only ever sent the read probe (`2f 02 20 <id>`); it has never sent the enable write (`2f 03 22 <id> <mode>`), so the ring's response to that write on a gate-OFF NOOP ring is genuinely unknown, not confirmed-impossible. See §7.5 for the contradicting evidence.
+
+### 7.5 Local `setFeatureMode` enable — reported to bypass the account gate for some features (UNVALIDATED, not sent by NOOP) [open_oura-feat]
+
+`docs/ring-features.md` [open_oura-feat] reports that, on a **consumer Ring 5** with `real_steps`/`exercise_hr`/`cva_ppg`/`experimental` all reading server-gated OFF, sending the write `2f 03 22 <id> 01` (mode → automatic) directly over BLE — **with no paid membership and no server-side entitlement change** — returned success and the features stayed AUTOMATIC (verified there with a follow-up `feature-status` read). Only `research_data` (`0x01`) was rejected outright, and `raw_data` (`0x12`) accepted the mode write but its RData sampler still refused to configure (`INVALID_SUBTAG`) — so the local write does not universally defeat every entitlement, but it worked for 4 of the 5 features NOOP's §3.7 Advanced-key/paid-membership path was written to unlock.
+
+**What this does and doesn't tell us:**
+- It contradicts the §7.4 claim above at least for `real_steps`/`exercise_hr`/`cva_ppg`/`experimental` — the gate for those is not purely an Oura-cloud `ClientConfiguration` check; the ring itself will honor a local mode write regardless.
+- **SpO2 (`0x04`) is not covered by this evidence.** On the source ring, SpO2 already read AUTOMATIC by default before any write was sent — the experiment never demonstrated forcing SpO2 from a gate-OFF state, which is the case NOOP's own 2026-07-20 capture is actually in. Whether `2f 03 22 04 01` flips a gate-OFF SpO2 ring is untested by both projects.
+- The wire bytes (`2f 03 22 <id> <mode>` → `2f 03 23 <id> <status>`) are independently verifiable over BLE and are already cited into §7.1 from [ring4-ble]/[open_oura-feat]; only the *outcome of actually sending it on a gated ring* is new here. The *rationale* `ring-features.md` gives for why this works (`FeatureDefinitions.*` server-flag names, the `b0.smali` enable sequence) is attributed there to decompiled-app analysis and is cited here as background only — NOOP implements neither that code nor those literals.
+- **UNVALIDATED, not wired into NOOP**, and NOOP still does not send this write (§7.4 remains a read-only probe). Confirming this on NOOP's own hardware — including whether it moves a gate-OFF SpO2 ring — is open work; see the Test Centre proposal tracked alongside this doc.
 
 ---
 


### PR DESCRIPTION
# What changed

- `docs/OURA_PROTOCOL.md` §7.4 no longer claims (untested) that no local write can flip the SpO2/
  real-steps gate; new §7.5 cites `Th0rgal/open_oura`'s `docs/ring-features.md` evidence that it does,
  for several features, as an unvalidated candidate — attribution only, no code/literals copied.
- `Packages/OuraProtocol/Sources/OuraProtocol/Commands.swift`: generalized `setFeatureMode(_:mode:)`
  and `featureReadStatus(_:)` builders, reusing the existing `featureSpO2`/`featureRealSteps`
  constants. `liveHREnable`/`liveHRDisable`/`spo2ReadStatus`/`realStepsReadStatus` are untouched.
- New `Packages/OuraProtocol/Tests/OuraProtocolTests/OuraFeatureModeWriteTests.swift` — pure XCTest,
  exact-byte assertions.
- `Strand/BLE/OuraLiveSource.swift`: new `writeFeatureMode(feature:mode:)`, mirroring the existing
  `writeUserInfo` write (guard/log/write shape). Clears `loggedFeatureStatuses` for the target feature
  first, so the follow-up status read it also sends is guaranteed to log even if the connect-time
  auto-probe already consumed that feature's once-per-connection dedup.
- `Strand/Screens/TestCentreView.swift`: new standalone "OURA" section (`ouraCard`), consolidating the
  onset-keying toggle and the existing user-info write block out of the generic "DIAGNOSTIC TOOLS"
  card, plus the new `ouraEnableFeatureBlock` — SpO2/real-steps picker, mode off/automatic only,
  confirm-then-write (`.alert`, `role: .destructive`, mirroring the user-info block's own pattern),
  log-only result (matches that block's own precedent — no new `@Published` readout).
- `Strand/Resources/Localizable.xcstrings`: this branch is a fresh cut off `upstream/main`, so the
  *entire* pre-existing user-info-write block's copy needed extracting too (it was never landed
  upstream) — 16 new keys total, translated for all 9 catalog locales (de/es/fr/it/pl/pt-PT/ru/
  zh-Hans/zh-Hant).

## Why reversible / why this write is safe to add

`mode=0x00` ("off") is always the next send in the same UI. Same class of write as the already-shipped
`0x20` user-info write; no destructive/DFU/factory-reset path touched. See the issue note for the
full justification.

## Verification

- `swift build && swift test` — `OuraProtocol` package: **225/225 passing**, including the 3 new tests.
- `xcodegen generate && xcodebuild -scheme Strand -destination 'platform=macOS' build` —
  **BUILD SUCCEEDED**. App-target Swift, which no default CI compiles (`app-build.yml` disabled).
- `python3 Tools/i18n_audit.py --ci upstream/main` — **clean**: no new un-extracted literals, all 4
  focus locales (de/es/fr/pt-PT) complete, zero new gaps in the non-focus ratchet, zero format
  mismatches.
- 🔴 **BLE write path — needs real-hardware validation, not done.** Compile success proves nothing
  about whether the ring actually honors the write. What to check: a ring with SpO2/real-steps
  confirmed gate-OFF via the existing read-only probe, then `writeFeatureMode` with mode=automatic,
  then re-read status — on **both a Gen 3 and a Gen 5** ring (the existing user-info write has only
  ever been validated on Gen 3; this PR's copy flags that explicitly).

## Cross-platform

Swift/macOS+iOS only. Android (`android/app/src/main/java/com/noop/ble/OuraLiveSource.kt`, the
Compose Test Centre) does not yet have the user-info-write feature this consolidates, either — porting
both is a bigger, separate follow-up, not silently dropped here.

Relates to [#2102](https://github.com/ryanbr/noop/issues/2102) (opened 2026-09-11)