### PR TITLE
fix(android): skip stress scoring without a widget

### DIFF
--- a/android/app/src/main/java/com/noop/ui/AppViewModel.kt
+++ b/android/app/src/main/java/com/noop/ui/AppViewModel.kt
@@ -1051,10 +1051,15 @@ class AppViewModel(app: Application) : AndroidViewModel(app) {
                     // widget reads the anchor here (the notification's honest-null contract lives in the
                     // service), keeping the two symmetric.
                     val anchorRow = widgetAnchorRow(days, logicalKey, localKey)
-                    // #2040: today's stress curve for the stress widget. Self-gating on a cheap HR
-                    // fingerprint, so an idle tick costs one indexed COUNT and no rows; null when
-                    // there is no device to read, which leaves whatever curve is stored alone.
-                    val stressCurve = com.noop.widget.StressWidgetProducer.todayCurve(repo, activeStrapId)
+                    // #2040: today's stress curve for the stress widget. Do not even fingerprint the
+                    // day's HR when nobody has placed one; scoring is the only expensive widget field.
+                    // Null also leaves whatever curve is already stored alone, so a newly placed widget
+                    // fills on the next pass without disturbing the other widget snapshots.
+                    val stressCurve = if (WidgetSnapshotStore.hasStressWidget(appContext)) {
+                        com.noop.widget.StressWidgetProducer.todayCurve(repo, activeStrapId)
+                    } else {
+                        null
+                    }
                     WidgetSnapshotStore.push(
                         appContext,
                         WidgetSnapshot(

--- a/android/app/src/test/java/com/noop/widget/StressWidgetBackgroundScoringTest.kt
+++ b/android/app/src/test/java/com/noop/widget/StressWidgetBackgroundScoringTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.File
 
 /**
  * The stress widget's two blank states, and the gate that stops it staying blank.
@@ -19,6 +20,27 @@ import org.junit.Test
  */
 class StressWidgetBackgroundScoringTest {
     private val interval = 15L * 60L * 1000L
+
+    @Test
+    fun foregroundProducerChecksPlacementBeforeScoring() {
+        var root = File(System.getProperty("user.dir") ?: ".").canonicalFile
+        var source: String? = null
+        repeat(4) {
+            val candidate = File(root, "android/app/src/main/java/com/noop/ui/AppViewModel.kt")
+            if (candidate.isFile && source == null) source = candidate.readText()
+            root = root.parentFile ?: root
+        }
+        val viewModel = source
+            ?: error("AppViewModel.kt not found - this test must not pass by default")
+        val foregroundProducer = Regex(
+            """val\s+stressCurve\s*=\s*if\s*\(WidgetSnapshotStore\.hasStressWidget\(appContext\)\)\s*\{\s*com\.noop\.widget\.StressWidgetProducer\.todayCurve"""
+        )
+
+        assertTrue(
+            "AppViewModel must check for a placed stress widget before reading the day",
+            foregroundProducer.containsMatchIn(viewModel),
+        )
+    }
 
     @Test
     fun theFirstTickAfterLaunchScores() {


### PR DESCRIPTION
## What this PR does

Guards the foreground stress-widget producer with the existing placement check before it fingerprints or reads today's heart-rate data. The normal snapshot push still runs, preserving fresh scalar fields and the stored stress curve; only the unused stress scoring work is skipped when no stress widget is placed.

Adds a regression contract test for the `AppViewModel` call site.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- `./gradlew testFullDebugUnitTest`
- `./gradlew assembleFullDebug`

## Checklist

- [x] Swift package tests pass for any package I touched (not applicable; no Swift package touched)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens (not applicable; no visual change)
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Related: #2081

