### PR TITLE
fix(android): guard sleep session cache upserts

### DIFF
--- a/android/app/src/main/java/com/noop/data/Entities.kt
+++ b/android/app/src/main/java/com/noop/data/Entities.kt
@@ -396,7 +396,7 @@ data class SleepSession(
     //     Interpreter's `(sb shr 4) and 3` (H2 persist half).
     // Both nullable TEXT (no SQL DEFAULT, a Kotlin construction default never reaches the schema), so old
     // rows read back null. HONESTY: an absent signal stays null, never a fabricated zero series. Written/read
-    // through the targeted DAO methods (not the @Upsert path, which never names them and so preserves them).
+    // through targeted DAO methods; [SleepSessionUpsertPolicy] carries the stored values through cache refreshes.
     val motionJSON: String? = null,
     val sleepStateJSON: String? = null,
     // v34 (Swift WhoopStore v34-sleep-staging-sparse parity, MIGRATION_27_28). True when this night was

--- a/android/app/src/main/java/com/noop/data/SleepSessionUpsertPolicy.kt
+++ b/android/app/src/main/java/com/noop/data/SleepSessionUpsertPolicy.kt
@@ -1,0 +1,43 @@
+package com.noop.data
+
+import com.noop.analytics.HypnogramCoverage
+
+/**
+ * Decides how a cache refresh may replace an existing sleep-session row.
+ *
+ * A strap can serve the same night more than once, and a resumed drain can carry a thinner stage
+ * timeline than the row already on disk. Dropping that candidate whole keeps `endTs`, `efficiency`
+ * and `stagesJSON` describing one coherent decode. The 0/1/2 rank is the same rule the display merge
+ * uses and mirrors `WhoopStore.SleepMerge.richness`.
+ *
+ * Hand-edited bounds and stages belong to the user, so a normal refresh preserves them while still
+ * updating derived vitals and `stagingSparse`. Motion and band-state arrays have dedicated writers;
+ * they are retained on every cache refresh just as the Swift upsert leaves those columns untouched.
+ */
+internal object SleepSessionUpsertPolicy {
+    /** The accepted replacement row, or null when [candidate] is poorer than [existing]. */
+    fun merge(existing: SleepSession, candidate: SleepSession): SleepSession? {
+        if (!candidate.userEdited && !existing.userEdited &&
+            richness(candidate) < richness(existing)
+        ) {
+            return null
+        }
+
+        return candidate.copy(
+            endTs = if (existing.userEdited) existing.endTs else candidate.endTs,
+            stagesJSON = if (existing.userEdited) existing.stagesJSON else candidate.stagesJSON,
+            userEdited = existing.userEdited,
+            startTsAdjusted = if (existing.userEdited) existing.startTsAdjusted else candidate.startTsAdjusted,
+            motionJSON = existing.motionJSON,
+            sleepStateJSON = existing.sleepStateJSON,
+        )
+    }
+
+    /** 0 = no stages, 1 = stages with holes, 2 = stages covering the claimed span. */
+    fun richness(session: SleepSession): Int {
+        val stages = session.stagesJSON?.trim() ?: return 0
+        if (stages.isEmpty() || stages == "[]") return 0
+        val span = (session.endTs - session.startTs).toDouble()
+        return if (HypnogramCoverage.isHoled(stages, span)) 1 else 2
+    }
+}

--- a/android/app/src/main/java/com/noop/data/WhoopDao.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
+import androidx.room.Update
 import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
 
@@ -290,6 +291,14 @@ interface WhoopDao : DeviceRegistryDao {
     @Upsert
     suspend fun upsertSleepSessions(rows: List<SleepSession>)
 
+    /** Exact row read for the repository's transactional sleep-cache replacement guard (#1976). */
+    @Query("SELECT * FROM sleepSession WHERE deviceId = :deviceId AND startTs = :startTs")
+    suspend fun sleepSession(deviceId: String, startTs: Long): SleepSession?
+
+    /** Update an existing row after [SleepSessionUpsertPolicy] has preserved its protected fields. */
+    @Update
+    suspend fun updateSleepSession(row: SleepSession): Int
+
     /** Remove one sleep session by its full primary key (deviceId, startTs) — used by the
      *  bed/wake-time edit, which deletes then re-inserts because startTs is part of the PK. */
     @Query("DELETE FROM sleepSession WHERE deviceId = :deviceId AND startTs = :startTs")
@@ -329,8 +338,8 @@ interface WhoopDao : DeviceRegistryDao {
      * v18 (H8): write the per-epoch motion magnitudes (compact JSON array) for one session, banked beside
      * `stagesJSON` on the same row. Keyed by the IMMUTABLE detected key (deviceId, startTs). `null` clears
      * the column (no series). Port of iOS WhoopStore.persistSessionMotion (the repository encodes the array).
-     * Returns rows changed (0 when no such session). Targeted UPDATE so the @Upsert recompute/import path —
-     * which never names this column — preserves it. */
+     * Returns rows changed (0 when no such session). Targeted UPDATE owns this column;
+     * [SleepSessionUpsertPolicy] preserves it through recompute/import refreshes. */
     @Query(
         "UPDATE sleepSession SET motionJSON = :json WHERE deviceId = :deviceId AND startTs = :sessionStart"
     )

--- a/android/app/src/main/java/com/noop/data/WhoopRepository.kt
+++ b/android/app/src/main/java/com/noop/data/WhoopRepository.kt
@@ -745,7 +745,29 @@ class WhoopRepository(
     // MARK: - Server-derived caches (latest value wins on conflict)
 
     suspend fun upsertDailyMetrics(days: List<DailyMetric>) = dao.upsertDailyMetrics(days)
-    suspend fun upsertSleepSessions(sessions: List<SleepSession>) = dao.upsertSleepSessions(sessions)
+
+    /**
+     * Upsert cached sleep sessions without letting a partial re-serve replace a fuller night.
+     *
+     * The read and write share one transaction so every caller gets the same store-level guarantee.
+     * Existing hand-edited bounds/stages and the arrays owned by targeted writers are retained by
+     * [SleepSessionUpsertPolicy]; derived vitals still refresh. Mirrors WhoopStore's cache upsert.
+     */
+    suspend fun upsertSleepSessions(sessions: List<SleepSession>) {
+        if (sessions.isEmpty()) return
+        transactor.run {
+            for (candidate in sessions) {
+                val existing = dao.sleepSession(candidate.deviceId, candidate.startTs)
+                if (existing == null) {
+                    dao.insertSleepSession(candidate)
+                } else {
+                    SleepSessionUpsertPolicy.merge(existing, candidate)?.let {
+                        dao.updateSleepSession(it)
+                    }
+                }
+            }
+        }
+    }
 
     /** Delete the computed source's cached daily rows whose day-key is in [from, to] (inclusive,
      *  yyyy-MM-dd). The #277 local-day re-bucketing migration clears the computed UTC-keyed rows over
@@ -1025,8 +1047,8 @@ class WhoopRepository(
         dao.updateSleepStages(deviceId, detectedStartTs, stagesJSON)
 
     // MARK: - Per-epoch sleep analytics (v18: motionJSON / sleepStateJSON). Banked beside stagesJSON on
-    // the sleepSession row; written/read through targeted methods so the @Upsert recompute/import path
-    // (which never names these columns) preserves them. Port of iOS WhoopStore.persist/sessionMotion +
+    // the sleepSession row; written/read through targeted methods, then carried through recompute/import
+    // refreshes by SleepSessionUpsertPolicy. Port of iOS WhoopStore.persist/sessionMotion +
     // persist/sessionSleepState. HONESTY: an absent signal is stored as NULL and read back as null, never
     // a fabricated zero series; an EMPTY input array clears the column.
 
@@ -2954,23 +2976,12 @@ class WhoopRepository(
             return out
         }
 
-        /** True when the session carries a non-empty stage payload; null, "", and "[]" carry none.
-         *  Twin of WhoopStore.SleepMerge.hasStages. */
-        private fun hasStages(s: SleepSession): Boolean {
-            val json = s.stagesJSON?.trim() ?: return false
-            return json.isNotEmpty() && json != "[]"
-        }
-
         /** How much of a night this session's stages actually describe: 2 = covers its span, 1 = present
          *  but HOLED, 0 = none. A timeline whose coverage cannot be measured (the imported minute-dict
          *  shape, which has no timestamps) is never holed, so it ranks 2 — imports keep being judged on
          *  presence exactly as they always were, and this gate cannot reach them.
          *  Twin of WhoopStore.SleepMerge.richness. */
-        private fun richness(s: SleepSession): Int {
-            if (!hasStages(s)) return 0
-            val span = (s.endTs - s.startTs).toDouble()
-            return if (com.noop.analytics.HypnogramCoverage.isHoled(s.stagesJSON, span)) 1 else 2
-        }
+        private fun richness(s: SleepSession): Int = SleepSessionUpsertPolicy.richness(s)
 
         /** A day's richness is that of its BEST session — a day with a fully-staged main night plus an
          *  unstaged nap is a staged day (#715 keeps every session of the winning day either way).

--- a/android/app/src/test/java/com/noop/data/SleepSessionUpsertPolicyTest.kt
+++ b/android/app/src/test/java/com/noop/data/SleepSessionUpsertPolicyTest.kt
@@ -1,0 +1,184 @@
+package com.noop.data
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Proxy
+
+class SleepSessionUpsertPolicyTest {
+    private val deviceId = "whoop-test"
+    private val start = 1_000L
+    private val end = 2_000L
+
+    private fun stages(from: Long, to: Long) =
+        """[{"start":$from,"end":$to,"stage":"deep"}]"""
+
+    private fun session(
+        endTs: Long = end,
+        stagesJSON: String? = stages(start, endTs),
+        userEdited: Boolean = false,
+        startTsAdjusted: Long? = null,
+        efficiency: Double? = 0.8,
+        restingHr: Int? = 55,
+        avgHrv: Double? = 60.0,
+        motionJSON: String? = "[0.1]",
+        sleepStateJSON: String? = "[2]",
+        stagingSparse: Boolean? = false,
+    ) = SleepSession(
+        deviceId = deviceId,
+        startTs = start,
+        endTs = endTs,
+        efficiency = efficiency,
+        restingHr = restingHr,
+        avgHrv = avgHrv,
+        stagesJSON = stagesJSON,
+        userEdited = userEdited,
+        startTsAdjusted = startTsAdjusted,
+        motionJSON = motionJSON,
+        sleepStateJSON = sleepStateJSON,
+        stagingSparse = stagingSparse,
+    )
+
+    @Test
+    fun poorerUneditedCandidateIsDroppedWhole() {
+        val existing = session()
+        val partial = session(
+            endTs = 3_000L,
+            stagesJSON = stages(start, start + 100L),
+            efficiency = 0.1,
+            restingHr = 99,
+            avgHrv = 1.0,
+        )
+
+        assertEquals(2, SleepSessionUpsertPolicy.richness(existing))
+        assertEquals(1, SleepSessionUpsertPolicy.richness(partial))
+        assertNull(SleepSessionUpsertPolicy.merge(existing, partial))
+    }
+
+    @Test
+    fun equallyRichRefreshReplacesDerivedFieldsButKeepsTargetedArrays() {
+        val existing = session(motionJSON = "[0.2]", sleepStateJSON = "[3]")
+        val candidate = session(
+            efficiency = 0.91,
+            restingHr = 48,
+            avgHrv = 82.0,
+            motionJSON = null,
+            sleepStateJSON = null,
+            stagingSparse = true,
+        )
+
+        val merged = SleepSessionUpsertPolicy.merge(existing, candidate)!!
+
+        assertEquals(0.91, merged.efficiency!!, 0.0)
+        assertEquals(48, merged.restingHr)
+        assertEquals(82.0, merged.avgHrv!!, 0.0)
+        assertEquals(true, merged.stagingSparse)
+        assertEquals("[0.2]", merged.motionJSON)
+        assertEquals("[3]", merged.sleepStateJSON)
+    }
+
+    @Test
+    fun refreshPreservesUserEditedBoundsStagesAndFlag() {
+        val editedStages = stages(900L, end)
+        val existing = session(
+            endTs = end + 200L,
+            stagesJSON = editedStages,
+            userEdited = true,
+            startTsAdjusted = 900L,
+            efficiency = 0.75,
+        )
+        val refresh = session(
+            endTs = end + 500L,
+            stagesJSON = null,
+            efficiency = 0.88,
+            restingHr = 50,
+            avgHrv = 72.0,
+            stagingSparse = true,
+        )
+
+        val merged = SleepSessionUpsertPolicy.merge(existing, refresh)!!
+
+        assertEquals(existing.endTs, merged.endTs)
+        assertEquals(editedStages, merged.stagesJSON)
+        assertEquals(900L, merged.startTsAdjusted)
+        assertTrue(merged.userEdited)
+        assertEquals(0.88, merged.efficiency!!, 0.0)
+        assertEquals(50, merged.restingHr)
+        assertEquals(72.0, merged.avgHrv!!, 0.0)
+        assertEquals(true, merged.stagingSparse)
+    }
+
+    @Test
+    fun repositoryReadsAndWritesTheBatchInsideOneTransaction() = runBlocking {
+        val stored = linkedMapOf<Pair<String, Long>, SleepSession>()
+        val calls = mutableListOf<String>()
+        var transactionCalls = 0
+        var inTransaction = false
+        val dao = Proxy.newProxyInstance(
+            WhoopDao::class.java.classLoader,
+            arrayOf(WhoopDao::class.java),
+        ) { _, method, args ->
+            assertTrue("${method.name} must run inside the upsert transaction", inTransaction)
+            calls += method.name
+            when (method.name) {
+                "sleepSession" -> stored[(args[0] as String) to (args[1] as Long)]
+                "insertSleepSession" -> {
+                    val row = args[0] as SleepSession
+                    stored[row.deviceId to row.startTs] = row
+                    1L
+                }
+                "updateSleepSession" -> {
+                    val row = args[0] as SleepSession
+                    stored[row.deviceId to row.startTs] = row
+                    1
+                }
+                else -> error("Unexpected DAO call: ${method.name}")
+            }
+        } as WhoopDao
+        val transactor = object : WhoopRepository.Transactor {
+            override suspend fun <R> run(block: suspend () -> R): R {
+                transactionCalls++
+                assertFalse(inTransaction)
+                inTransaction = true
+                return try {
+                    block()
+                } finally {
+                    inTransaction = false
+                }
+            }
+        }
+        val complete = session()
+        val poorer = session(endTs = 3_000L, stagesJSON = stages(start, start + 100L))
+        val refresh = session(efficiency = 0.9, restingHr = 51, motionJSON = null, sleepStateJSON = null)
+
+        WhoopRepository(dao, transactor).upsertSleepSessions(listOf(complete, poorer, refresh))
+
+        assertEquals(1, transactionCalls)
+        assertEquals(
+            listOf("sleepSession", "insertSleepSession", "sleepSession", "sleepSession", "updateSleepSession"),
+            calls,
+        )
+        assertEquals(0.9, stored.getValue(deviceId to start).efficiency!!, 0.0)
+        assertEquals(51, stored.getValue(deviceId to start).restingHr)
+        assertEquals("[0.1]", stored.getValue(deviceId to start).motionJSON)
+        assertEquals("[2]", stored.getValue(deviceId to start).sleepStateJSON)
+        assertFalse(inTransaction)
+    }
+
+    @Test
+    fun emptyBatchDoesNotOpenATransaction() = runBlocking {
+        val dao = Proxy.newProxyInstance(
+            WhoopDao::class.java.classLoader,
+            arrayOf(WhoopDao::class.java),
+        ) { _, method, _ -> error("Empty batch must not call ${method.name}") } as WhoopDao
+        val transactor = object : WhoopRepository.Transactor {
+            override suspend fun <R> run(block: suspend () -> R): R =
+                error("Empty batch must not open a transaction")
+        }
+
+        WhoopRepository(dao, transactor).upsertSleepSessions(emptyList())
+    }
+}

--- a/android/app/src/test/java/com/noop/data/Whoop5RRSqliteTest.kt
+++ b/android/app/src/test/java/com/noop/data/Whoop5RRSqliteTest.kt
@@ -78,9 +78,14 @@ class Whoop5RRSqliteTest {
                     (args[0] as List<*>).filterIsInstance<SleepSession>().forEach { sleeps[it.deviceId to it.startTs] = it }
                     Unit
                 }
+                "sleepSession" -> sleeps[(args[0] as String) to (args[1] as Long)]
                 "insertSleepSession" -> {
                     val row = args[0] as SleepSession
                     if (sleeps.putIfAbsent(row.deviceId to row.startTs, row) == null) 1L else -1L
+                }
+                "updateSleepSession" -> {
+                    val row = args[0] as SleepSession
+                    if (sleeps.replace(row.deviceId to row.startTs, row) != null) 1 else 0
                 }
                 "replaceComputedScoreWindow" -> {
                     (args[3] as List<*>).filterIsInstance<DailyMetric>().forEach { days[it.deviceId to it.day] = it }


### PR DESCRIPTION
## What this PR does

Moves Android sleep-session protection into the repository write path so every cache producer gets the same guarantees:

- reads the existing natural-key row and writes the decision in one transaction;
- drops a non-user-edited candidate when its stage timeline is less complete than the stored row;
- preserves user-edited bounds, stage data, and the `userEdited` flag during accepted refreshes;
- preserves motion and band-state arrays owned by their targeted writers while still refreshing derived vitals and `stagingSparse`;
- shares the 0/1/2 hypnogram richness policy with the existing display merge instead of maintaining a second rule.

This mirrors the established Swift `WhoopStore` behavior and closes the caller-dependent protection gap on Android.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- Focused `SleepSessionUpsertPolicyTest` and `Whoop5RRSqliteTest`
- `./gradlew testFullDebugUnitTest`
- `./gradlew assembleFullDebug`

The focused tests cover poorer-candidate rejection, accepted derived-field refreshes, preservation of user edits and targeted arrays, insert/update orchestration, and the transaction boundary. No strap hardware is involved in this persistence path.

## Checklist

- [x] Swift package tests pass for any package I touched (not applicable; no Swift package touched)
- [x] Android unit tests pass if I touched `android/` (`./gradlew testFullDebugUnitTest`)
- [x] No new build warnings introduced
- [x] UI changes use only `StrandDesign` tokens (not applicable; no UI change)
- [x] No hardcoded hex frame bytes; protocol facts live in the schema / decoders
- [x] Follows the conventions in [`docs/CONTRIBUTING.md`](../docs/CONTRIBUTING.md)
- [x] I did not commit generated output (`Strand.xcodeproj/`) or any secrets/keystores

## Related issues

Related: #1976

