### PR TITLE
today(android): shape a hosted card clip from what it actually renders

### DIFF
--- a/android/app/src/main/java/com/noop/ui/HostedCards.kt
+++ b/android/app/src/main/java/com/noop/ui/HostedCards.kt
@@ -134,6 +134,30 @@ val HostedCard.destination: HostedDestination
     }
 
 /**
+ * Whether the card's content OPENS with a bare section header instead of filling its slot with a card.
+ *
+ * The Today host wraps every card in a rounded clip so the tap ripple respects the card's corners. That
+ * is right for a card that fills the slot, and wrong for these: their first pixel is header TEXT at the
+ * slot's top-left, and an 18dp corner cuts hardest at y=0, so the radius ate the first glyph of the
+ * overline ("LAST NIGHT" rendering as "AST NIGHT", #2109). The clip is shaped from this instead.
+ *
+ * Read the card's FIRST EMISSION, following any delegation: NIGHT_DETAIL looks like it opens with a grid
+ * and actually opens with `MetricGrid`, whose own first child is a header. A shallow look at the host
+ * composable misses that one.
+ *
+ * Listed rather than defaulted, for the same reason [destination] is: the `when` is exhaustive, so a card
+ * added later cannot silently inherit a shape that clips its title. The failure this guards is quiet, a
+ * heading that is merely slightly wrong, which is exactly the kind nobody files twice.
+ */
+val HostedCard.leadsWithSectionHeader: Boolean
+    get() = when (this) {
+        HostedCard.SLEEP_MARKS, HostedCard.ASLEEP_DURATION, HostedCard.STAGES_VS_TYPICAL,
+        HostedCard.NIGHT_DETAIL, HostedCard.SLEEP_DEBT, HostedCard.STAGES -> true
+        HostedCard.HOURS_VS_NEEDED, HostedCard.CONSISTENCY, HostedCard.STRESS_TODAY,
+        HostedCard.TREND_HRV, HostedCard.TREND_RESTING_HR, HostedCard.TREND_EFFORT -> false
+    }
+
+/**
  * The card's display title, localized. The enum's [title] field stays the English source-of-truth default
  * (used for logging/comparisons); the UI reads this so the editor shows a translated title. Enum
  * constructors can't call [stringResource], so resolution happens here at the render site. Mirrors iOS,

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -3630,12 +3630,32 @@ private fun HostedCardsSection(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    // Clipped to the card's own radius BEFORE the click. `NoopCard` clips itself, but
-                    // the ripple draws on this wrapper, so without matching the shape here it would wash
-                    // square corners over a rounded card. `Metrics.cardRadius` is the right figure
-                    // because every hosted card renders through `NoopCard`: the 26dp liquid-hero
-                    // surface `ChartCard` can wear is hero-only, and none of these opt into it.
-                    .clip(RoundedCornerShape(Metrics.cardRadius))
+                    // Clipped BEFORE the click. `NoopCard` clips itself, but the ripple draws on this
+                    // wrapper, so without matching the shape here it would wash square corners over a
+                    // rounded card. `Metrics.cardRadius` is the right figure: the 26dp liquid-hero surface
+                    // `ChartCard` can wear is hero-only, and none of these opt into it.
+                    //
+                    // This used to read "because every hosted card renders through NoopCard", and that was
+                    // the bug (#2109). Six of them open with a bare section header instead, and the clip
+                    // was cutting its first glyph. The shape is asked for per card now.
+                    .clip(
+                        // #2109: shaped from the card's own opening, not assumed. A card that FILLS this
+                        // slot wants the full radius. A card that opens with a bare section header does
+                        // not: its first pixel is heading text at the top-left, where an 18dp corner cuts
+                        // hardest at y=0, and the radius clipped the overline's first glyph ("LAST NIGHT"
+                        // read as "AST NIGHT"). Square the TOP corners for those and keep the bottom
+                        // rounded, because the slot's bottom edge IS the inner card's bottom edge and a
+                        // square ripple there would wash its corners, which is the defect the clip was
+                        // added for in the first place.
+                        if (card.leadsWithSectionHeader) {
+                            RoundedCornerShape(
+                                topStart = 0.dp, topEnd = 0.dp,
+                                bottomStart = Metrics.cardRadius, bottomEnd = Metrics.cardRadius,
+                            )
+                        } else {
+                            RoundedCornerShape(Metrics.cardRadius)
+                        }
+                    )
                     .then(if (open != null) Modifier.clickable(onClick = open) else Modifier),
             ) {
             when (card) {

--- a/android/app/src/test/java/com/noop/ui/HostedCardShapeTest.kt
+++ b/android/app/src/test/java/com/noop/ui/HostedCardShapeTest.kt
@@ -1,0 +1,66 @@
+package com.noop.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Which hosted cards open with a bare section header, and therefore must not wear a top-rounded clip.
+ *
+ * #2109: the Today host clipped every card slot to the card radius, on the premise that every hosted card
+ * fills its slot with a `NoopCard`. Six do not. They open with a bare `SectionHeader`, whose text sits at
+ * the slot's top-left, exactly where an 18dp corner cuts hardest, so the overline lost its first glyph and
+ * "LAST NIGHT" rendered as "AST NIGHT".
+ *
+ * Pinned because the failure is quiet. A clipped heading still renders, still reads almost right, and is
+ * the kind of wrong nobody files twice. The `when` behind [leadsWithSectionHeader] is exhaustive, so a new
+ * card cannot silently inherit a shape; this pins the ANSWERS, so changing one is a deliberate edit to a
+ * test rather than a side effect of editing a composable.
+ */
+class HostedCardShapeTest {
+
+    /** The six whose first pixel is heading text rather than a card surface. NIGHT_DETAIL is the one a
+     *  shallow reading misses: its header lives inside the `MetricGrid` it delegates to. */
+    @Test
+    fun `the cards that open with a bare section header are pinned`() {
+        assertEquals(
+            listOf(
+                HostedCard.SLEEP_MARKS,
+                HostedCard.ASLEEP_DURATION,
+                HostedCard.STAGES_VS_TYPICAL,
+                HostedCard.NIGHT_DETAIL,
+                HostedCard.SLEEP_DEBT,
+                HostedCard.STAGES,
+            ),
+            HostedCard.entries.filter { it.leadsWithSectionHeader },
+        )
+    }
+
+    /** The rest fill their slot with their own rounded surface, so the full radius is right for them. */
+    @Test
+    fun `the cards that fill their slot with a card are pinned`() {
+        assertEquals(
+            listOf(
+                HostedCard.HOURS_VS_NEEDED,
+                HostedCard.CONSISTENCY,
+                HostedCard.STRESS_TODAY,
+                HostedCard.TREND_HRV,
+                HostedCard.TREND_RESTING_HR,
+                HostedCard.TREND_EFFORT,
+            ),
+            HostedCard.entries.filterNot { it.leadsWithSectionHeader },
+        )
+    }
+
+    /**
+     * Every card is classified. Trivially true while the `when` is exhaustive, and the point is that it
+     * STAYS trivially true: if someone converts that `when` to an `else` branch, a card added afterwards
+     * would quietly take the default, which is the shape that clips a heading.
+     */
+    @Test
+    fun `every card is accounted for on exactly one side`() {
+        val header = HostedCard.entries.filter { it.leadsWithSectionHeader }
+        val filled = HostedCard.entries.filterNot { it.leadsWithSectionHeader }
+        assertEquals(HostedCard.entries.size, header.size + filled.size)
+        assertEquals(emptyList<HostedCard>(), header.intersect(filled.toSet()).toList())
+    }
+}


### PR DESCRIPTION
## What this PR does

Answers #2109, where a hosted card's title renders masked on Today, seen on the Sleep "Stages" card. The reporter adds "Might occur with others as well." It does: **six of the ten hosted cards**.

## The cause

The Today host wraps every hosted card in one rounded clip so the tap ripple respects the card's corners:

```kotlin
.clip(RoundedCornerShape(Metrics.cardRadius))   // 18.dp
```

The comment justified that shape with *"because every hosted card renders through `NoopCard`"*, and that premise is the bug. Six hosted cards do not fill their slot with a card. They open with a bare section header:

```kotlin
SectionHeader("Stages", overline = "Last night", trailing = m.clockLabel)
```

That text sits at the slot's top-left, which is exactly where an 18dp corner cuts hardest, at y=0. The radius took the overline's first glyph, so "LAST NIGHT" rendered as "AST NIGHT".

## Which cards

| opens with a bare header | fills its slot with a card |
|---|---|
| SLEEP_MARKS | HOURS_VS_NEEDED |
| ASLEEP_DURATION | CONSISTENCY |
| STAGES_VS_TYPICAL | STRESS_TODAY |
| **NIGHT_DETAIL** | TREND_HRV |
| SLEEP_DEBT | TREND_RESTING_HR |
| **STAGES** (reported) | TREND_EFFORT |

Classifying these needs each card's FIRST EMISSION, followed through any delegation. **NIGHT_DETAIL is the one a shallow reading misses**: the host composable renders a metric grid, and the header lives inside the `MetricGrid` it delegates to. An earlier pass of this change had it on the wrong side, which would have left one of the six still clipped while a test asserted it was fine. The property's doc names that trap.

## The fix

The shape is asked for per card rather than assumed. Cards that fill their slot keep the full radius. Cards that open with a header get square **top** corners and keep the bottom rounded, because the slot's bottom edge IS the inner card's bottom edge, and squaring that would wash the ripple over its corners, which is the defect the clip was added for. Dropping the clip outright would have traded this bug for that one.

Which cards those are is **data**, an exhaustive `when` sitting beside the existing `destination` mapping and justified the same way that one is: a card added later cannot silently inherit a shape that clips its title, because the compiler asks.

```kotlin
val HostedCard.leadsWithSectionHeader: Boolean
    get() = when (this) {
        SLEEP_MARKS, ASLEEP_DURATION, STAGES_VS_TYPICAL,
        NIGHT_DETAIL, SLEEP_DEBT, STAGES -> true
        HOURS_VS_NEEDED, CONSISTENCY, STRESS_TODAY,
        TREND_HRV, TREND_RESTING_HR, TREND_EFFORT -> false
    }
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- New `HostedCardShapeTest`: 3 tests, pinning both sides of the partition and their disjointness. Run forced with `--no-build-cache --rerun-tasks` after deleting the stale result XML, because an earlier invocation produced the UP-TO-DATE flip-flop and its green was not real. The genuine run reports `tests="3" skipped="0" failures="0" errors="0"`.
- The third test exists for a specific reason: the exhaustive `when` is what makes a new card safe today, so it guards against someone converting it to an `else` branch, after which a new card would silently take the heading-clipping shape.
- `./gradlew compileFullDebugKotlin` clean.
- `Tools/doc_comment_lint.py` passes.
- No BLE, storage or analytics path is touched.

**Not confirmed on a device.** The mechanism and the card list are verified in code, but the visual is inferred: the screenshot in #2109 has the reporter's own annotation over the very glyph in question. A look on a phone, or a second screenshot without the marker, would close that gap.

## Scope and parity

Android only, and structurally so. iOS wraps hosted cards in `NavigationLink(value: route) { hostedCard(for: card) }.buttonStyle(.plain)` with no corner shaping at all, so there is nothing there to clip a heading and no twin to write. Same conclusion as #2113, for the same reason.

## Related issues

Reported in #2109 by @bartmuskala.