### PR TITLE
stress: reduce each baseline day as it is read, instead of holding thirty at once

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeBaselines.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/DaytimeBaselines.swift
@@ -118,12 +118,28 @@ public extension DaytimeStress {
     /// the scorer honestly runs HR-only rather than z-scoring against a 1–2-day, untrustworthy HRV
     /// baseline — the whole-baseline grain of the per-hour graceful-nil already in `rawScore`.
     static func foldDaytimeBaselines(days: [DaytimeDayStreams]) -> (hr: BaselineState, rmssd: BaselineState?) {
+        foldAggregates(days.map {
+            dayDaytimeAggregate(hr: $0.hr, rr: $0.rr, tzOffsetSeconds: $0.tzOffsetSeconds)
+        })
+    }
+
+    /// The same fold, taking days already reduced to their `dayDaytimeAggregate` pair.
+    ///
+    /// This exists so a CALLER can reduce each day as it reads it and let that day's raw samples go,
+    /// instead of holding thirty days of them at once (#2107). A day collapses to two `Double?`s here and
+    /// its streams are never read again, so keeping them alive bought nothing and cost a heap: thirty days
+    /// of a worn 5.0 is millions of sample objects, which is how a 256MB Android heap ran out.
+    ///
+    /// `foldDaytimeBaselines(days:)` is now literally this with the reduction done eagerly, so the
+    /// streaming caller and the list caller cannot drift apart: there is one fold, reached two ways.
+    /// Twin of Kotlin `DaytimeBaselines.foldAggregates`.
+    static func foldAggregates(_ aggregates: [(hr: Double?, rmssd: Double?)])
+        -> (hr: BaselineState, rmssd: BaselineState?) {
         var hrAggs: [Double?] = []
         var rmssdAggs: [Double?] = []
-        hrAggs.reserveCapacity(days.count)
-        rmssdAggs.reserveCapacity(days.count)
-        for d in days {
-            let agg = dayDaytimeAggregate(hr: d.hr, rr: d.rr, tzOffsetSeconds: d.tzOffsetSeconds)
+        hrAggs.reserveCapacity(aggregates.count)
+        rmssdAggs.reserveCapacity(aggregates.count)
+        for agg in aggregates {
             hrAggs.append(agg.hr)
             rmssdAggs.append(agg.rmssd)
         }
@@ -138,7 +154,16 @@ public extension DaytimeStress {
     /// unchanged default). This is the single graceful-degradation gate: a cold start, or a trailing
     /// window that is all sparse/imported days, keeps EXACTLY today's pre-existing day-relative behaviour.
     static func scoringMode(history days: [DaytimeDayStreams]) -> ScoringMode {
-        let baselines = foldDaytimeBaselines(days: days)
+        scoringModeFromAggregates(days.map {
+            dayDaytimeAggregate(hr: $0.hr, rr: $0.rr, tzOffsetSeconds: $0.tzOffsetSeconds)
+        })
+    }
+
+    /// `scoringMode(history:)` for days already reduced to aggregates. See `foldAggregates` for why
+    /// (#2107). Named rather than overloaded, so the twin stays findable by name from either side.
+    /// Twin of Kotlin `DaytimeBaselines.scoringModeFromAggregates`.
+    static func scoringModeFromAggregates(_ aggregates: [(hr: Double?, rmssd: Double?)]) -> ScoringMode {
+        let baselines = foldAggregates(aggregates)
         guard baselines.hr.usable else { return .dayRelative }
         // RMSSD stays out of the LIVE score until it has its own validation pass — see
         // `DaytimeStress.daytimeRMSSDScoringEnabled`. The baseline is still folded above (so the

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeBaselinesTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/DaytimeBaselinesTests.swift
@@ -87,6 +87,41 @@ final class DaytimeBaselinesTests: XCTestCase {
 
     // MARK: - Fold trailing history
 
+    /// #2107: reducing each day as it is read must produce EXACTLY the list fold's answer.
+    ///
+    /// The caller used to hold thirty days of raw streams to compute sixty numbers, which exhausted the
+    /// heap. It now reduces per day and keeps only the aggregates. That is only safe if the two routes
+    /// agree, so this pins them together rather than trusting that one delegates to the other today.
+    func testReducingPerDayMatchesFoldingTheWholeList() {
+        let days = (0..<12).map {
+            DaytimeStress.DaytimeDayStreams(hr: flatDayHR($0, bpm: 65 + ($0 % 3)), rr: [],
+                                            tzOffsetSeconds: 0)
+        }
+        let viaList = DaytimeStress.foldDaytimeBaselines(days: days)
+        let viaAggregates = DaytimeStress.foldAggregates(days.map {
+            DaytimeStress.dayDaytimeAggregate(hr: $0.hr, rr: $0.rr, tzOffsetSeconds: $0.tzOffsetSeconds)
+        })
+        XCTAssertEqual(viaList.hr.baseline, viaAggregates.hr.baseline, accuracy: 0)
+        XCTAssertEqual(viaList.hr.usable, viaAggregates.hr.usable)
+        XCTAssertEqual(viaList.rmssd?.baseline, viaAggregates.rmssd?.baseline)
+
+        // And the same for the mode the screen actually asks for.
+        let modeViaList = DaytimeStress.scoringMode(history: days)
+        let modeViaAggregates = DaytimeStress.scoringModeFromAggregates(days.map {
+            DaytimeStress.dayDaytimeAggregate(hr: $0.hr, rr: $0.rr, tzOffsetSeconds: $0.tzOffsetSeconds)
+        })
+        XCTAssertEqual(modeViaList, modeViaAggregates)
+    }
+
+    /// An unworn day contributes no aggregate either way. Pinned because the caller SKIPS such days
+    /// before reducing (it never reads their R-R), so the two routes must still line up when the day
+    /// list and the aggregate list have different lengths in the caller's loop.
+    func testAnEmptyDayReducesToNothingOnBothRoutes() {
+        let empty = DaytimeStress.dayDaytimeAggregate(hr: [], rr: [], tzOffsetSeconds: 0)
+        XCTAssertNil(empty.hr)
+        XCTAssertNil(empty.rmssd)
+    }
+
     func testFoldConvergesHRBaselineToThePersonalDaytimeFloor() {
         // Twelve identical days whose P10 daytime HR is exactly 65 → the EWMA center converges to 65 and
         // the baseline is usable (12 ≥ minNightsSeed). No R-R anywhere → RMSSD baseline is nil.

--- a/Strand/Screens/StressView.swift
+++ b/Strand/Screens/StressView.swift
@@ -160,8 +160,14 @@ struct StressView: View {
     /// fold itself is O(days).
     private func daytimeScoringMode(startOfToday: Date) async -> DaytimeStress.ScoringMode {
         let cal = Calendar.current
-        var days: [DaytimeStress.DaytimeDayStreams] = []
-        days.reserveCapacity(Self.baselineHistoryDays)
+        // #2107: keep each day's AGGREGATE, never its streams. This used to accumulate 30 x
+        // DaytimeDayStreams, each holding up to 200,000 HR plus 200,000 R-R samples, and hand the lot to
+        // the fold. The fold's first act is to reduce a day to two Doubles, so all that was ever wanted
+        // from thirty days was sixty numbers; holding the samples alive to produce them is what exhausted
+        // a 256MB heap on the Android twin and crashed it with an OutOfMemoryError. Reducing here lets
+        // each day's samples be released at the end of its own iteration.
+        var aggregates: [(hr: Double?, rmssd: Double?)] = []
+        aggregates.reserveCapacity(Self.baselineHistoryDays)
         // Oldest → newest so the EWMA fold replays the history in order.
         for back in stride(from: Self.baselineHistoryDays, through: 1, by: -1) {
             guard let dayStart = cal.date(byAdding: .day, value: -back, to: startOfToday),
@@ -172,9 +178,11 @@ struct StressView: View {
             let dayHR = await repo.hrSamples(from: from, to: to, limit: 200_000)
             guard !dayHR.isEmpty else { continue }   // unworn day — no floor to learn, skip the R-R read
             let dayRR = await repo.rrIntervals(from: from, to: to, limit: 200_000)
-            days.append(.init(hr: dayHR, rr: dayRR, tzOffsetSeconds: dayTz))
+            aggregates.append(
+                DaytimeStress.dayDaytimeAggregate(hr: dayHR, rr: dayRR, tzOffsetSeconds: dayTz)
+            )
         }
-        return DaytimeStress.scoringMode(history: days)
+        return DaytimeStress.scoringModeFromAggregates(aggregates)
     }
 
     /// Recompute the cached `StressModel` only when (repo.days, storedSeries)

--- a/android/app/src/main/java/com/noop/analytics/DaytimeBaselines.kt
+++ b/android/app/src/main/java/com/noop/analytics/DaytimeBaselines.kt
@@ -136,11 +136,24 @@ object DaytimeBaselines {
      * scorer honestly runs HR-only rather than z-scoring against a 1–2-day, untrustworthy HRV
      * baseline — the whole-baseline grain of the per-hour graceful-null already in rawScore.
      */
-    fun foldDaytimeBaselines(days: List<DaytimeDayStreams>): DaytimeBaselineStates {
-        val hrAggs = ArrayList<Double?>(days.size)
-        val rmssdAggs = ArrayList<Double?>(days.size)
-        for (d in days) {
-            val agg = dayDaytimeAggregate(d.hr, d.rr, d.tzOffsetSeconds)
+    fun foldDaytimeBaselines(days: List<DaytimeDayStreams>): DaytimeBaselineStates =
+        foldAggregates(days.map { dayDaytimeAggregate(it.hr, it.rr, it.tzOffsetSeconds) })
+
+    /**
+     * The same fold, taking days already reduced to their [DayAggregate] pair.
+     *
+     * This exists so a CALLER can reduce each day as it reads it and let that day's raw samples go,
+     * instead of holding thirty days of them at once (#2107). A day collapses to two Doubles here and
+     * its streams are never read again, so keeping them alive bought nothing and cost a heap: thirty
+     * days of a worn 5.0 is millions of sample objects, which is how a 256MB heap ran out.
+     *
+     * [foldDaytimeBaselines] is now literally this with the reduction done eagerly, so the streaming
+     * caller and the list caller cannot drift apart: there is one fold, reached two ways.
+     */
+    fun foldAggregates(aggregates: List<DayAggregate>): DaytimeBaselineStates {
+        val hrAggs = ArrayList<Double?>(aggregates.size)
+        val rmssdAggs = ArrayList<Double?>(aggregates.size)
+        for (agg in aggregates) {
             hrAggs.add(agg.hr)
             rmssdAggs.add(agg.rmssd)
         }
@@ -157,8 +170,13 @@ object DaytimeBaselines {
      * a cold start, or a trailing window that is all sparse/imported days, keeps EXACTLY today's
      * pre-existing day-relative behaviour.
      */
-    fun scoringMode(days: List<DaytimeDayStreams>): DaytimeStress.ScoringMode {
-        val baselines = foldDaytimeBaselines(days)
+    fun scoringMode(days: List<DaytimeDayStreams>): DaytimeStress.ScoringMode =
+        scoringModeFromAggregates(days.map { dayDaytimeAggregate(it.hr, it.rr, it.tzOffsetSeconds) })
+
+    /** [scoringMode] for days already reduced to aggregates. See [foldAggregates] for why (#2107).
+     *  Twin of Swift `DaytimeStress.scoringModeFromAggregates`. */
+    fun scoringModeFromAggregates(aggregates: List<DayAggregate>): DaytimeStress.ScoringMode {
+        val baselines = foldAggregates(aggregates)
         if (!baselines.hr.usable) return DaytimeStress.ScoringMode.DayRelative
         // RMSSD stays out of the LIVE score until it has its own validation pass — see
         // DaytimeStress.daytimeRMSSDScoringEnabled. The baseline is still folded above (so the

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -216,7 +216,8 @@ private suspend fun loadDaytimeStress(vm: AppViewModel, personalBaseline: Boolea
  * today's intraday read: BaselineRelative once there's enough real worn daytime-HR history for a usable
  * baseline, else DayRelative (the unchanged default). Reads each past day's raw HR once (bounded per
  * day) via [vm].repo; unworn days (no HR) are skipped without an R-R read. Faithful twin of the iOS
- * StressView.daytimeScoringMode. [todayLocalDay] is today's date in [zone].
+ * StressView.daytimeScoringMode. [todayLocalDay] is today's date in [zone]. Each day is reduced
+ * to its aggregate as it is read (#2107), so only the aggregates are retained, never the streams.
  */
 private suspend fun daytimeScoringMode(
     vm: AppViewModel,
@@ -225,7 +226,13 @@ private suspend fun daytimeScoringMode(
 ): DaytimeStress.ScoringMode {
     // 30 mirrors the app's other rolling baselines (nightly resting-HR / HRV) and the iOS baselineHistoryDays.
     val baselineHistoryDays = 30
-    val days = ArrayList<DaytimeBaselines.DaytimeDayStreams>(baselineHistoryDays)
+    // #2107: keep each day's AGGREGATE, never its streams. This used to accumulate 30 x
+    // DaytimeDayStreams, each holding up to 200,000 HR plus 200,000 R-R samples, and hand the lot to
+    // the fold. The fold's first act is to reduce a day to two Doubles, so all that was ever wanted
+    // from thirty days was sixty numbers; holding the samples alive to produce them is what exhausted
+    // a 256MB heap on a worn 5.0 and crashed the app with an OutOfMemoryError. Reducing here lets each
+    // day's samples become garbage at the end of its own iteration.
+    val aggregates = ArrayList<DaytimeBaselines.DayAggregate>(baselineHistoryDays)
     // Oldest → newest so the EWMA fold replays the history in order.
     for (back in baselineHistoryDays downTo 1) {
         val window = stressLocalDayWindow(todayLocalDay.minusDays(back.toLong()), zone)
@@ -242,15 +249,11 @@ private suspend fun daytimeScoringMode(
             window.toEpochSecondInclusive,
             limit = 200_000,
         )
-        days.add(
-            DaytimeBaselines.DaytimeDayStreams(
-                hr = dayHr,
-                rr = dayRr,
-                tzOffsetSeconds = window.offsetSeconds.toLong(),
-            ),
+        aggregates.add(
+            DaytimeBaselines.dayDaytimeAggregate(dayHr, dayRr, window.offsetSeconds.toLong()),
         )
     }
-    return DaytimeBaselines.scoringMode(days)
+    return DaytimeBaselines.scoringModeFromAggregates(aggregates)
 }
 
 // MARK: - Loaded content

--- a/android/app/src/test/java/com/noop/analytics/DaytimeBaselinesTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/DaytimeBaselinesTest.kt
@@ -242,4 +242,51 @@ class DaytimeBaselinesTest {
             assertNull("flag off: RMSSD is held out of the live score despite a usable baseline", mode.rmssd)
         }
     }
+
+    /**
+     * #2107: reducing each day as it is read must produce EXACTLY the list fold's answer.
+     *
+     * The screen used to hold thirty days of raw streams to compute sixty numbers, which exhausted a
+     * 256MB heap and crashed with an OutOfMemoryError. It now reduces per day and keeps only the
+     * aggregates. That is only safe if the two routes agree, so this pins them together rather than
+     * trusting that one delegates to the other today. Twin of the Swift
+     * `testReducingPerDayMatchesFoldingTheWholeList`.
+     */
+    @Test
+    fun `reducing per day matches folding the whole list`() {
+        val days = (0 until 12).map {
+            DaytimeBaselines.DaytimeDayStreams(
+                hr = flatDayHr(it, 65 + (it % 3)),
+                rr = emptyList(),
+                tzOffsetSeconds = 0L,
+            )
+        }
+        val viaList = DaytimeBaselines.foldDaytimeBaselines(days)
+        val viaAggregates = DaytimeBaselines.foldAggregates(
+            days.map { DaytimeBaselines.dayDaytimeAggregate(it.hr, it.rr, it.tzOffsetSeconds) },
+        )
+        assertEquals(viaList.hr.baseline, viaAggregates.hr.baseline, 0.0)
+        assertEquals(viaList.hr.usable, viaAggregates.hr.usable)
+        assertEquals(viaList.rmssd?.baseline, viaAggregates.rmssd?.baseline)
+
+        // And the same for the mode the screen actually asks for.
+        assertEquals(
+            DaytimeBaselines.scoringMode(days),
+            DaytimeBaselines.scoringModeFromAggregates(
+                days.map { DaytimeBaselines.dayDaytimeAggregate(it.hr, it.rr, it.tzOffsetSeconds) },
+            ),
+        )
+    }
+
+    /**
+     * An unworn day contributes no aggregate either way. Pinned because the caller SKIPS such days
+     * before reducing (it never reads their R-R), so the two routes must still line up when the day
+     * list and the aggregate list have different lengths in the caller's loop.
+     */
+    @Test
+    fun `an empty day reduces to nothing on both routes`() {
+        val empty = DaytimeBaselines.dayDaytimeAggregate(emptyList(), emptyList(), 0L)
+        assertNull(empty.hr)
+        assertNull(empty.rmssd)
+    }
 }


### PR DESCRIPTION
## What this PR does

Answers #2107: three OutOfMemoryErrors from 11.6.0, all at the same 256MB ceiling, twice on main and once on a coroutine thread. The failing allocations are 16 and 32 bytes, so those frames are where the heap finally ran out, not where it went.

Fixed on **both platforms**, because the Swift original and its Kotlin twin have the same shape.

## The cause

`daytimeScoringMode` built the personal daytime baseline by loading thirty days of raw streams and keeping every one alive until the end:

```kotlin
val days = ArrayList<DaytimeDayStreams>(30)
for (back in 30 downTo 1) {
    val dayHr = repo.hrSamplesUnion(..., limit = 200_000)
    if (dayHr.isEmpty()) continue
    val dayRr = repo.rrIntervalsUnion(..., limit = 200_000)
    days.add(DaytimeDayStreams(hr = dayHr, rr = dayRr, ...))   // every day kept alive
}
return DaytimeBaselines.scoringMode(days)
```

The doc said "bounded per day", and per day it was. Nothing bounded the aggregate. For a 5.0 worn all day that is on the order of **five million sample objects retained at once**, which is how a 256MB heap runs out.

What makes it plainly wrong rather than merely expensive is what the fold does with them. Its first act is:

```kotlin
val agg = dayDaytimeAggregate(d.hr, d.rr, d.tzOffsetSeconds)   // -> (hr: Double?, rmssd: Double?)
```

A day collapses to **two Doubles** and its streams are never read again. Thirty days of samples were being held to produce sixty numbers.

## Why it matches the report

- *"Go to trends. Wait."*: sixty sequential queries.
- *"All of a sudden it hangs"*: GC thrash as the heap fills.
- OOM on two different threads: the heap is exhausted globally, which is why the failing allocations are tiny.
- *"Trend chart ... was not shown. It all of a sudden appeared"*: the slow load finally landing.

## On "stress page" versus "trends"

The report's title says stress page and its repro says trends, which is worth reconciling rather than
waving at. Trends has no memory sink: it works entirely from per-day rows (`daysMerged`,
`resolvedSeries`), loads no raw samples, and even years of history is a couple of thousand rows. It
cannot exhaust a 256MB heap.

The stress baseline path is the only place in the app that retains millions of objects, which makes the
sequence coherent: the load starts on Stress, the wearer moves to Trends, and the exhausted heap kills
whatever allocates next. That is exactly the shape of the three traces, two on main during layout and
one on a background coroutine, each failing on an allocation of 16 or 32 bytes.

Consistent with, not proven. A device confirmation is still what would settle it.

## The change

Each day is reduced as it is read, so its samples become collectable at the end of its own iteration and only the aggregates are retained.

```kotlin
aggregates.add(DaytimeBaselines.dayDaytimeAggregate(dayHr, dayRr, tz))
...
return DaytimeBaselines.scoringModeFromAggregates(aggregates)
```

The fold gained an aggregate-taking entry point on each side, and the stream-taking one is now literally that with the reduction done eagerly:

```kotlin
fun foldDaytimeBaselines(days: List<DaytimeDayStreams>): DaytimeBaselineStates =
    foldAggregates(days.map { dayDaytimeAggregate(it.hr, it.rr, it.tzOffsetSeconds) })
```

One fold reached two ways, so the streaming caller and the list caller cannot drift apart. The Swift side uses the same NAMES rather than an overload, so the twins stay findable by grep from either platform.

## Scope, stated honestly

This removes the thirty-times multiplier, **not** the whole allocation. Peak retention becomes one day's streams: today's HR plus R-R plus gravity, held together for `analyze`, `StressIndex` and `HrvFreqDomain`, on the order of tens of megabytes. That is survivable where thirty days was not, but it is a reduction rather than a guarantee, and a device with a smaller heap and a very dense day could still be tight.

The path is **opt-in and default off** (#463 personal baseline), so only wearers who enabled it could hit this. On an unpatched build, turning it off is the workaround.

**Deliberately not touched**: the unbounded stored-stress read a few lines above, which pulls the whole history with an open date range. It is one row per day rather than per sample, it is a different concern, and `StressRawReadScopeTest` pins that exact call, so it wants its own change.

## Two consequences worth stating

**The stream-taking entry points are now test-only.** `foldDaytimeBaselines(days:)` and
`scoringMode(history:)` have no production callers left on either platform. They are kept deliberately:
they are the reference route the equivalence test compares against, which is what proves this refactor
did not change behaviour, and several existing tests build readable day-stream fixtures through them.
Deleting them would leave one route and nothing to check it against.

**The parity ledger's baseline drifts because of this.** Running `Tools/parity_ledger.py` after this
change reports `test-only-callsite` drift in `Packages/StrandAnalytics` and `android/analytics`. It
also reports drift in `Packages/OuraProtocol`, which this branch does not touch: that one arrived with
#2105. Nothing is red today, because the parity workflow is path-filtered to `Tools/parity_*` and
product-source enforcement is deferred, but the checked-in baseline is stale on main and will fail the
next change that touches that tooling. It wants a regeneration, which is its own commit rather than
this one.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

A test on each platform pins the two routes to identical baselines and an identical `ScoringMode`, and pins that an unworn day reduces to nothing either way, because the caller skips those before reducing so the two lists differ in length in its loop.

- **Swift** `DaytimeBaselinesTests`: 14 tests, 0 failures (12 before, plus 2). Run on Linux against a snapshot-enabled SQLite built per `docs/BUILD.md`, checksum verified.
- **Android** `DaytimeBaselinesTest`: 14 tests, 0 failures (12 before, plus 2). `DaytimeStressTest` 21/0 and `StressRawReadScopeTest` 2/0, the last of which scans `StressScreen.kt`'s source and pins the exact device-aware read calls I edited around. Forced with `--rerun-tasks` after `syncRoomSchemaSnapshot` in its own invocation, because the first attempt produced the known FAILED-then-UP-TO-DATE flip-flop and that green was not real. XML timestamps confirmed newer than the source edit.
- `StrandAnalytics` package builds clean.

**`StressView.swift` is app-target and does not compile locally**, so the Swift caller edit is covered by CI's `build (Strand, macOS)` leg rather than by me. It is a two-line change in the same shape as the Kotlin one, but I would rather name the gap than imply I verified it.

**Not reproduced on a device.** The diagnosis is from the stack traces and the code; nobody has confirmed the crash stops. @bartmuskala is the person who can, and confirming the personal-baseline toggle was on would also confirm the diagnosis.

## Related issues

Reported in #2107 by @bartmuskala.
