### PR TITLE
diag: say whether a device R-R beats were never banked or were refused by the unit policy

### DIFF
--- a/Packages/StrandAnalytics/Sources/StrandAnalytics/UniversalTrace.swift
+++ b/Packages/StrandAnalytics/Sources/StrandAnalytics/UniversalTrace.swift
@@ -18,6 +18,37 @@ import Foundation
 
 public enum UniversalTrace {
 
+    /// The R-R transport line: what a device has banked versus what its unit policy can actually score.
+    ///
+    /// #2117: a WHOOP 5 window is pinned to one transport, and a window holding no beat on a scorable
+    /// channel reads back EMPTY rather than falling back. Everything derived from beats then goes blank
+    /// (HRV, respiratory rate) while heart-rate-derived values carry on, which is what a wearer reports
+    /// as "HRV stopped working". The analyzer cannot explain it: handed nothing, it honestly says
+    /// nInput=0 and has no way to know whether the strap banked nothing or banked beats the policy
+    /// refused.
+    ///
+    /// These two facts separate those cases, and the store already computes both. Rides every export for
+    /// the same reason the clock-drift line does: the wearer who needs it is the one who did not know to
+    /// turn a mode on. Returns nil for a device the policy does not apply to, so a WHOOP 4 export is
+    /// unchanged.
+    ///
+    /// Twin of Kotlin `ConnectionTrace.rrTransportLine`.
+    public static func rrTransportLine(strictWhoop5: Bool,
+                                       firstRecordedUnix: Int?,
+                                       firstScorableUnix: Int?) -> String? {
+        guard strictWhoop5 else { return nil }
+        guard let firstRecordedUnix else { return "rrTransport recorded=none scorable=none" }
+        let recorded = "recorded=\(ConnectionTrace.isoDate(firstRecordedUnix))"
+        guard let firstScorableUnix else {
+            // Beats on disk, none the policy will score: the whole history predates transport labelling
+            // or sits on an excluded channel. This is the state that blanks every night at once.
+            return "rrTransport \(recorded) scorable=none unscorableHistory=yes"
+        }
+        let gapDays = max(0, Int((Double(firstScorableUnix - firstRecordedUnix) / 86_400).rounded()))
+        return "rrTransport \(recorded) scorable=\(ConnectionTrace.isoDate(firstScorableUnix)) "
+            + "unscorableHistory=\(gapDays > 0 ? "yes" : "no") gapDays=\(gapDays)"
+    }
+
     /// The universal strap-clock line: the strap's newest banked-record timestamp vs wall clock, with a
     /// FUTURE-DATE flag (the tell of a wandering / un-clocked RTC), the optional banked span in days, and the
     /// firmware record-layout version the strap hands over. One line, tagged `.universal` by the caller, so

--- a/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
+++ b/Packages/StrandAnalytics/Tests/StrandAnalyticsTests/ConnectionReadoutTests.swift
@@ -300,3 +300,66 @@ final class ConnectionReadoutTests: XCTestCase {
         XCTAssertEqual(ConnectionReadout.lastFrameLabel(lastFrameUnix: nil, nowUnix: 1_002), "no frames yet")
     }
 }
+
+/// #2117: the R-R transport line, which separates "banked nothing" from "banked beats the policy refused".
+final class UniversalTraceRRTransportTests: XCTestCase {
+
+    /// A device the WHOOP 5 unit policy does not govern says nothing at all, so a WHOOP 4 export is
+    /// byte-unchanged by this line existing.
+    func testANonStrictDeviceEmitsNothing() {
+        XCTAssertNil(UniversalTrace.rrTransportLine(strictWhoop5: false, firstRecordedUnix: 1_750_000_000,
+                                                    firstScorableUnix: nil))
+    }
+
+    /// The state that blanks every night at once: beats on disk, none the policy will score. This is the
+    /// one worth recognising at a glance, because it looks identical to "no data" from the analyzer's side.
+    func testBeatsOnDiskButNoneScorableIsNamed() {
+        let line = UniversalTrace.rrTransportLine(strictWhoop5: true, firstRecordedUnix: 1_750_000_000,
+                                                  firstScorableUnix: nil)
+        XCTAssertNotNil(line)
+        XCTAssertTrue(line!.contains("scorable=none"))
+        XCTAssertTrue(line!.contains("unscorableHistory=yes"))
+    }
+
+    /// A strap that has never banked a beat is a DIFFERENT report from one whose beats were refused, and
+    /// the line must not blur them: no "unscorableHistory" claim when there is no history to be unscorable.
+    func testNoHistoryAtAllIsNotReportedAsUnscorable() {
+        let line = UniversalTrace.rrTransportLine(strictWhoop5: true, firstRecordedUnix: nil,
+                                                  firstScorableUnix: nil)
+        XCTAssertEqual(line, "rrTransport recorded=none scorable=none")
+        XCTAssertFalse(line!.contains("unscorableHistory"))
+    }
+
+    /// Partly scorable: the gap is what says how much history was refused, and it is the number that
+    /// distinguishes "upgraded last week" from "lost a year".
+    func testAPartlyScorableHistoryReportsTheGapInDays() {
+        let line = UniversalTrace.rrTransportLine(strictWhoop5: true, firstRecordedUnix: 1_750_000_000,
+                                                  firstScorableUnix: 1_750_000_000 + 30 * 86_400)
+        XCTAssertNotNil(line)
+        XCTAssertTrue(line!.contains("unscorableHistory=yes"))
+        XCTAssertTrue(line!.contains("gapDays=30"))
+    }
+
+    /// The WHOLE line, byte for byte, with the identical literal pinned on the Kotlin side.
+    ///
+    /// The other cases here assert fragments, which would let the two platforms drift on anything a
+    /// `contains` does not look at: field order, spacing, or the shared date format. A report is diffed
+    /// across platforms, so the line has to be the same line, not merely the same facts.
+    func testTheWholeLineIsPinnedByteForByte() {
+        XCTAssertEqual(
+            UniversalTrace.rrTransportLine(strictWhoop5: true, firstRecordedUnix: 1_750_000_000,
+                                           firstScorableUnix: 1_752_592_000),
+            "rrTransport recorded=2025-06-15 15:06:40 scorable=2025-07-15 15:06:40 unscorableHistory=yes gapDays=30"
+        )
+    }
+
+    /// Fully scorable from the first beat: nothing was refused, and the line must say so plainly rather
+    /// than leaving a reader to infer it from a missing field.
+    func testAFullyScorableHistorySaysSo() {
+        let line = UniversalTrace.rrTransportLine(strictWhoop5: true, firstRecordedUnix: 1_750_000_000,
+                                                  firstScorableUnix: 1_750_000_000)
+        XCTAssertNotNil(line)
+        XCTAssertTrue(line!.contains("unscorableHistory=no"))
+        XCTAssertTrue(line!.contains("gapDays=0"))
+    }
+}

--- a/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/DeviceRegistryStore.swift
@@ -23,9 +23,23 @@ public struct DeviceRegistryStore: Sendable {
         }
     }
 
+    /// The one query that answers "which strap is active".
+    ///
+    /// Shared rather than retyped because the answer is load-bearing beyond this accessor: the WHOOP 5
+    /// R-R policy resolves a legacy `my-whoop` alias through it, so this decides whose unit rules a
+    /// wearer's older history is judged by. Two copies of that could drift into disagreeing about which
+    /// strap a night belongs to, and the Android twin already keeps it in exactly one place
+    /// (`DeviceRegistryDao`).
+    ///
+    /// `LIMIT 1` with no `ORDER BY` is deliberate but only safe because single-active is an invariant
+    /// the writers maintain (demote every active row, then promote one, in that order). If two rows were
+    /// ever active at once the pick would be arbitrary, so the invariant is what makes this total, not
+    /// the query.
+    static let activeDeviceIdSQL = "SELECT id FROM pairedDevice WHERE status = 'active' LIMIT 1"
+
     public func activeDeviceId() throws -> String? {
         try dbQueue.read { db in
-            try String.fetchOne(db, sql: "SELECT id FROM pairedDevice WHERE status = 'active' LIMIT 1")
+            try String.fetchOne(db, sql: Self.activeDeviceIdSQL)
         }
     }
 

--- a/Packages/WhoopStore/Sources/WhoopStore/Whoop5RRReadPolicy.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/Whoop5RRReadPolicy.swift
@@ -67,7 +67,7 @@ extension WhoopStore {
             // that old ID. Resolve its active strap here so sleep edits and ordinary reads agree.
             // Physical owners and confirmed WHOOP 4 history never inherit another strap's policy.
             if !tagged && !unlabelledAliasOfWhoop5 && deviceId == "my-whoop",
-               let active = try String.fetchOne(db, sql: "SELECT id FROM pairedDevice WHERE status = 'active' LIMIT 1"),
+               let active = try String.fetchOne(db, sql: DeviceRegistryStore.activeDeviceIdSQL),
                active != deviceId {
                 tagged = try isWhoop5RRSource(db: db, deviceId: active)
             }

--- a/Strand/App/AppModel.swift
+++ b/Strand/App/AppModel.swift
@@ -250,6 +250,16 @@ final class AppModel: ObservableObject {
         live.$heartRate.sink { [weak self] _ in self?.ingestHR() }.store(in: &hrCancellables)
         live.$rr.sink { [weak self] _ in self?.ingestHR() }.store(in: &hrCancellables)
 
+        // #2117: bank the device's R-R transport facts whenever a link comes up. Shell-independent on
+        // purpose: the classic Today already reads these three for its own note, but the Liquid shell is
+        // the iOS default, and the wearer this explains is the one whose HRV silently went blank there.
+        // Two indexed MINs plus one registry read, once per connect, so it is cheap enough not to gate.
+        live.$connected.sink { [weak self] isConnected in
+            // The disconnect path clears via `clearBiometrics`, so only a link coming UP refreshes.
+            guard isConnected, let self else { return }
+            Task { await self.refreshRRTransportFacts() }
+        }.store(in: &hrCancellables)
+
         // Physical-input + wear hooks (fired live by FrameRouter).
         live.onDoubleTap = { [weak self] in self?.handleDoubleTap() }
         live.onWristChange = { [weak self] worn in self?.handleWristChange(worn) }
@@ -504,6 +514,36 @@ final class AppModel: ObservableObject {
         ble.setPauseCaptureOnPowerSave(on && PuffinExperiment.pauseHrvOnPowerSaveEnabled,
                                        thresholdPct: PuffinExperiment.powerSavingBatteryPct)
     }
+    /// #2117: resolve what this device has banked versus what its unit policy can score, and hand the
+    /// facts to `LiveState` so every Test Centre export carries the universal `rrTransport` line.
+    ///
+    /// Facts only. The judgement is `UniversalTrace.rrTransportLine`, shared byte for byte with Android.
+    /// Silent on failure: a diagnostic that cannot read its inputs says nothing rather than guessing, and
+    /// the line is simply absent from the export.
+    private func refreshRRTransportFacts() async {
+        // No store to ask: drop whatever was banked rather than leaving a previous answer standing. A
+        // diagnostic may only assert what it can attribute, and stale facts would be attributed to now.
+        guard let store = await repo.storeHandle() else {
+            live.clearRRTransport()
+            return
+        }
+        let owner = repo.deviceId
+        let strict = (try? await store.isWhoop5RRSource(deviceId: owner)) ?? false
+        // The two MINs are only ever read by a line the formatter suppresses unless this is strict, so a
+        // device the policy does not govern stops after the one registry read. That case is not
+        // hypothetical: a 4.0 in a reconnect burst (#1120) runs this repeatedly, and the timestamps would
+        // be fetched from the store queue the backfill is writing through, to be discarded every time.
+        guard strict else {
+            live.setRRTransport(strictWhoop5: false, firstRecordedUnix: nil, firstScorableUnix: nil)
+            return
+        }
+        let firstRecorded = (try? await store.firstRecordedRRTimestamp(deviceId: owner)) ?? nil
+        let firstScorable = (try? await store.firstScorableWhoop5RRTimestamp(deviceId: owner)) ?? nil
+        // AppModel is @MainActor, so this resumes on the main actor: no hop needed.
+        live.setRRTransport(strictWhoop5: strict, firstRecordedUnix: firstRecorded,
+                            firstScorableUnix: firstScorable)
+    }
+
 
     /// Tiny and guarded: with no generic strap paired the active id is "my-whoop", so the coordinator
     /// observes WHOOP-active and stays a NO-OP , the existing `scan()`/`disconnect()` WHOOP flow is

--- a/Strand/BLE/LiveState.swift
+++ b/Strand/BLE/LiveState.swift
@@ -226,6 +226,46 @@ public final class LiveState: ObservableObject {
     }
     @Published public private(set) var strapRange: StrapRange?
 
+    // MARK: - R-R transport snapshot (#2117)
+
+    /// What this device has banked versus what its unit policy can actually score.
+    ///
+    /// Banked here for the same reason `strapRange` is: the export assembler turns it into a UNIVERSAL
+    /// line that rides EVERY Test Centre report, so a wearer whose HRV went blank self-diagnoses without
+    /// having known to turn a mode on. Observability only, never gated, and cleared on disconnect so a
+    /// stale answer cannot outlive the link. nil until resolved for this session.
+    ///
+    /// The judgement lives in `UniversalTrace.rrTransportLine`, not here. This carries facts.
+    public struct RRTransport: Equatable, Sendable {
+        public var strictWhoop5: Bool
+        public var firstRecordedUnix: Int?
+        public var firstScorableUnix: Int?
+        public init(strictWhoop5: Bool, firstRecordedUnix: Int?, firstScorableUnix: Int?) {
+            self.strictWhoop5 = strictWhoop5
+            self.firstRecordedUnix = firstRecordedUnix
+            self.firstScorableUnix = firstScorableUnix
+        }
+    }
+    @Published public private(set) var rrTransport: RRTransport?
+
+    /// Bank the device's R-R transport facts. Two indexed MINs at the call site, so this is cheap enough
+    /// to refresh on connect rather than being cached across links.
+    public func setRRTransport(strictWhoop5: Bool, firstRecordedUnix: Int?, firstScorableUnix: Int?) {
+        rrTransport = RRTransport(strictWhoop5: strictWhoop5, firstRecordedUnix: firstRecordedUnix,
+                                  firstScorableUnix: firstScorableUnix)
+    }
+
+    /// Clear the banked facts. Deliberately NOT called from `clearBiometrics` the way `clearStrapRange`
+    /// is, because the two describe different things: a strap range is the STRAP's own clock, which must
+    /// not outlive the link that reported it, while these describe what OUR database holds, which stays
+    /// true after a disconnect.
+    ///
+    /// That difference decides whether the line is present when it is wanted. The wearer this exists for
+    /// is the one who notices a blank HRV, opens Test Centre and exports, and the strap is quite possibly
+    /// not connected by then. Clearing on disconnect would drop the line from precisely that export.
+    /// Re-read on each connect, so a newly banked history is picked up.
+    public func clearRRTransport() { rrTransport = nil }
+
     /// Bank the strap's reported banked-record window (from GET_DATA_RANGE). Additive observability: the
     /// universal clock-drift export line reads this. `oldest` keeps the previously-known value when this
     /// reply carries only the upper bound, so a half/short range reply never clears a good lower bound.

--- a/Strand/System/TestBundleAssembler.swift
+++ b/Strand/System/TestBundleAssembler.swift
@@ -151,8 +151,17 @@ enum TestBundleAssembler {
         //    the report body BEFORE the completeness scan so its `dayOwner`-sibling token is part of the text
         //    the guard reads. No-op when no range was ever seen this session (no strap reply yet).
         let baseReport = live.exportableLogText()
-        let universalLine = universalClockDriftLine(range: live.strapRange)
-        let reportText = universalLine.map { baseReport + "\n[universal] " + $0 } ?? baseReport
+        // #2117: both universal lines ride every export, appended in a fixed order so two reports from
+        // the same strap diff cleanly. Either may be absent (no range reported yet; a device the WHOOP 5
+        // unit policy does not govern), and an absent line is simply omitted rather than stubbed, so a
+        // WHOOP 4 report is byte-unchanged by this existing.
+        let universalLines = [
+            universalClockDriftLine(range: live.strapRange),
+            universalRRTransportLine(transport: live.rrTransport),
+        ].compactMap { $0 }
+        let reportText = universalLines.isEmpty
+            ? baseReport
+            : baseReport + universalLines.map { "\n[universal] " + $0 }.joined()
 
         // 1. report.txt: the same exportable strap log the strap-log card shares, plus the universal
         //    clock-drift line. Already redacted by the append(log:) sink, but the whole-bundle redactEntries
@@ -264,6 +273,17 @@ enum TestBundleAssembler {
     /// this session (no strap reply yet) OR only a firmware-only snapshot exists (newest==0, no real window).
     /// Pure; delegates the format to UniversalTrace so the line can never silently drift. `now` is injectable
     /// so the line is unit-testable without a live clock.
+    /// The universal R-R transport line (#2117): what the device banked versus what its unit policy can
+    /// score. nil when nothing has been resolved this session, or for a device the policy does not govern.
+    /// The judgement is `UniversalTrace.rrTransportLine`, shared byte for byte with Android; this is the
+    /// hand-off.
+    static func universalRRTransportLine(transport: LiveState.RRTransport?) -> String? {
+        guard let transport else { return nil }
+        return UniversalTrace.rrTransportLine(strictWhoop5: transport.strictWhoop5,
+                                              firstRecordedUnix: transport.firstRecordedUnix,
+                                              firstScorableUnix: transport.firstScorableUnix)
+    }
+
     static func universalClockDriftLine(range: LiveState.StrapRange?,
                                         now: Int = Int(Date().timeIntervalSince1970)) -> String? {
         guard let range, range.newestUnix > 0 else { return nil }

--- a/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
+++ b/android/app/src/main/java/com/noop/analytics/ConnectionReadout.kt
@@ -34,6 +34,25 @@ object ConnectionTrace {
 
 
     /**
+     * The R-R transport line: what a device has banked versus what its unit policy can actually score.
+     *
+     * #2117: a WHOOP 5 window is pinned to one transport, and a window holding no beat on a scorable
+     * channel reads back EMPTY rather than falling back. Everything derived from beats then goes blank
+     * (HRV, respiratory rate) while heart-rate-derived values carry on, which is what a wearer reports as
+     * "HRV stopped working". The analyzer cannot explain it: handed nothing, it honestly reports nInput=0
+     * and has no way to know whether the strap banked nothing or banked beats the policy refused.
+     *
+     * These two facts separate those cases, and the store already computes both. Rides every export for
+     * the same reason the clock-drift line does: the wearer who needs it is the one who did not know to
+     * turn a mode on. Returns null for a device the policy does not apply to, so a WHOOP 4 export is
+     * unchanged.
+     *
+     * Twin of Swift `UniversalTrace.rrTransportLine`.
+     */
+    fun rrTransportLine(
+        strictWhoop5: Boolean,
+
+    /**
      * The CLOCK-DRIFT summary line (#767 / #754 cluster): the strap-reported banked-record window
      * [oldest, newest] against the wall clock, ending in the shared clock VERDICT ([clockVerdict]):
      * FUTURE-DATED (ahead beyond [futureToleranceSeconds]), RTC-EPOCH (a never-set ~1970/71 clock, #987),
@@ -42,6 +61,23 @@ object ConnectionTrace {
      * .connection line. All timestamps are unix seconds in the same wall domain. [oldestUnix] is optional
      * (a half/short range reply gives only the upper bound). Mirrors the Swift formatter exactly.
      */
+        firstRecordedUnix: Long?,
+        firstScorableUnix: Long?,
+    ): String? {
+        if (!strictWhoop5) return null
+        if (firstRecordedUnix == null) return "rrTransport recorded=none scorable=none"
+        val recorded = "recorded=" + isoDate(firstRecordedUnix)
+        // Beats on disk, none the policy will score: the whole history predates transport labelling or
+        // sits on an excluded channel. This is the state that blanks every night at once.
+        if (firstScorableUnix == null) return "rrTransport $recorded scorable=none unscorableHistory=yes"
+        val gapDays = maxOf(
+            0L,
+            Math.round((firstScorableUnix - firstRecordedUnix).toDouble() / 86_400.0),
+        )
+        return "rrTransport $recorded scorable=" + isoDate(firstScorableUnix) +
+            " unscorableHistory=" + (if (gapDays > 0) "yes" else "no") + " gapDays=" + gapDays
+    }
+
     fun clockDriftLine(
         oldestUnix: Long?,
         newestUnix: Long,

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -7643,6 +7643,44 @@ class WhoopBleClient(
                                 )
                                 log(line, com.noop.testcentre.TestDomain.UNIVERSAL)
                             }
+                            // #2117: the R-R TRANSPORT picture, beside the clock-drift line and for the
+                            // same reason. A WHOOP 5 window is pinned to one transport, so a window with
+                            // no beat on a scorable channel reads back empty and everything beat-derived
+                            // (HRV, respiratory rate) blanks while heart-rate values carry on. The HRV
+                            // analyzer cannot explain that: handed nothing it honestly says nInput=0, with
+                            // no way to tell "banked nothing" from "banked beats the policy refused".
+                            // These two facts separate those, and the store already has both. Rides EVERY
+                            // export, because the wearer who needs it is the one who did not know to turn
+                            // a mode on. Pure formatter, no behaviour change. Twin of the Apple emit.
+                            if (testCentre.active(com.noop.testcentre.TestDomain.UNIVERSAL)) {
+                                // Three indexed reads, so OFF the BLE callback thread: this is
+                                // observability and must never sit in front of the connection path.
+                                ioScope.launch {
+                                    val rrLine = runCatching {
+                                        // The two MINs only feed a line the formatter suppresses unless
+                                        // this is strict, so a device the policy does not govern stops
+                                        // after the one registry read. Not hypothetical: a 4.0 in a
+                                        // reconnect burst (#1120) runs this repeatedly, and would other-
+                                        // wise fetch them from the store the backfill is writing through,
+                                        // to discard them every time. Twin of the Apple early-out.
+                                        if (!repository.isWhoop5RrSource(deviceId)) {
+                                            null
+                                        } else {
+                                            com.noop.analytics.ConnectionTrace.rrTransportLine(
+                                                strictWhoop5 = true,
+                                                firstRecordedUnix = repository.firstRecordedRrTs(deviceId),
+                                                firstScorableUnix =
+                                                    repository.firstScorableWhoop5RrTs(deviceId),
+                                            )
+                                        }
+                                    }.getOrNull()
+                                    // Silent when it cannot read its inputs: a diagnostic that cannot
+                                    // measure says nothing rather than guessing, so the line is absent.
+                                    if (rrLine != null) {
+                                        log(rrLine, com.noop.testcentre.TestDomain.UNIVERSAL)
+                                    }
+                                }
+                            }
                             // #1164: recompute the "strap has banked records newer than our frontier" flag
                             // so the Today Rest card can show "Pending sync" right after connect (before the
                             // first offload starts), not only after an offload completes. The frontier read

--- a/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/ConnectionReadoutTest.kt
@@ -2,6 +2,7 @@ package com.noop.analytics
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -298,5 +299,64 @@ class ConnectionReadoutTest {
     @Test fun lastFrameLabel() {
         assertEquals("12s ago", ConnectionReadout.lastFrameLabel(990L, nowUnix = 1_002L))
         assertEquals("no frames yet", ConnectionReadout.lastFrameLabel(null, nowUnix = 1_002L))
+    }
+
+    // #2117: the R-R transport line, separating "banked nothing" from "banked beats the policy refused".
+    // Byte-identical twin of the Swift UniversalTraceRRTransportTests.
+
+    /** A device the WHOOP 5 unit policy does not govern says nothing, so a WHOOP 4 export is unchanged. */
+    @Test
+    fun `a non strict device emits nothing`() {
+        assertNull(ConnectionTrace.rrTransportLine(false, 1_750_000_000L, null))
+    }
+
+    /** The state that blanks every night at once: beats on disk, none the policy will score. */
+    @Test
+    fun `beats on disk but none scorable is named`() {
+        val line = ConnectionTrace.rrTransportLine(true, 1_750_000_000L, null)
+        assertNotNull(line)
+        assertTrue(line!!.contains("scorable=none"))
+        assertTrue(line.contains("unscorableHistory=yes"))
+    }
+
+    /** A strap that never banked a beat is a DIFFERENT report from one whose beats were refused. */
+    @Test
+    fun `no history at all is not reported as unscorable`() {
+        val line = ConnectionTrace.rrTransportLine(true, null, null)
+        assertEquals("rrTransport recorded=none scorable=none", line)
+        assertFalse(line!!.contains("unscorableHistory"))
+    }
+
+    /** The gap is what says how much history was refused. */
+    @Test
+    fun `a partly scorable history reports the gap in days`() {
+        val line = ConnectionTrace.rrTransportLine(true, 1_750_000_000L, 1_750_000_000L + 30 * 86_400L)
+        assertNotNull(line)
+        assertTrue(line!!.contains("unscorableHistory=yes"))
+        assertTrue(line.contains("gapDays=30"))
+    }
+
+    /**
+     * The WHOLE line, byte for byte, with the identical literal pinned on the Swift side.
+     *
+     * The other cases assert fragments, which would let the two platforms drift on anything a `contains`
+     * does not look at: field order, spacing, or the shared date format. A report is diffed across
+     * platforms, so the line has to be the same line, not merely the same facts.
+     */
+    @Test
+    fun `the whole line is pinned byte for byte`() {
+        assertEquals(
+            "rrTransport recorded=2025-06-15 15:06:40 scorable=2025-07-15 15:06:40 unscorableHistory=yes gapDays=30",
+            ConnectionTrace.rrTransportLine(true, 1_750_000_000L, 1_752_592_000L),
+        )
+    }
+
+    /** Fully scorable from the first beat says so plainly, rather than by a missing field. */
+    @Test
+    fun `a fully scorable history says so`() {
+        val line = ConnectionTrace.rrTransportLine(true, 1_750_000_000L, 1_750_000_000L)
+        assertNotNull(line)
+        assertTrue(line!!.contains("unscorableHistory=no"))
+        assertTrue(line.contains("gapDays=0"))
     }
 }


### PR DESCRIPTION
## What this PR does

#2117: a WHOOP 5 R-R window is pinned to one transport, so a window holding no beat on a scorable channel reads back **empty** rather than falling back. Everything beat-derived then blanks (HRV, respiratory rate) while heart-rate values carry on. That is what a wearer reports as "HRV stopped working", and what sent one back to 11.5 saying they would not update again.

Refusing to score mixed-unit beats is correct. Refusing **silently** is not, and right now the app cannot say which happened.

## The diagnostic gap

Handed nothing, the HRV analyzer honestly reports `nInput=0`. It has no way to tell a strap that banked nothing from a strap whose beats the policy declined, because it only sees what it was passed. Those two want completely different fixes, and separating them has meant asking the wearer for a database export. That is why #2117 is blocked on data.

The store already computes both facts. They were loaded in exactly one place, the **classic** Today screen, which is not the iOS default, so the wearer this explains never saw them.

## The line

A universal `rrTransport` line now rides every Test Centre export, beside the clock-drift line and for the same stated reason: the wearer who needs it is the one who did not know to turn a mode on.

```
rrTransport recorded=none scorable=none                                nothing banked
rrTransport recorded=2025-06-15 scorable=none unscorableHistory=yes    banked, all refused
rrTransport recorded=2025-06-15 scorable=2025-07-15 ... gapDays=30     partly refused
rrTransport recorded=2025-06-15 scorable=2025-06-15 ... gapDays=0      nothing refused
```

The second is the one worth recognising at a glance: from every other vantage point in the app it is indistinguishable from "no data". The line is **absent entirely** for a device the policy does not govern, so a WHOOP 4 export is byte-unchanged.

## Where the judgement lives

All of it is in the pure formatter, tested on both platforms: the four states, the gap arithmetic, and the distinction the whole diagnosis turns on, that a strap which never banked a beat must NOT be reported as having unscorable history. Conflating those two would send the next reader down the wrong fork, which is the specific failure this exists to prevent.

The plumbing carries facts and decides nothing. That matters here because `AppModel`, `LiveState` and `TestBundleAssembler` are app-target Swift that I cannot compile locally, so the shape deliberately puts every decision in the layer that CI and I can both check.

## Also in here

A duplicate this investigation surfaced: `Whoop5RRReadPolicy` re-implemented `DeviceRegistryStore.activeDeviceId`'s query inline. That query decides whose unit rules a wearer's legacy history is judged by, so it is worth having once. One copy now, which is what Android already had. Documented alongside it: `LIMIT 1` with no `ORDER BY` is total only because single-active is an invariant the writers maintain (demote all, then promote one), not because the query guarantees it.

## Two asymmetries, deliberate

Each follows its own platform's precedent rather than an invented symmetry.

- **Apple** banks the facts on connect unconditionally, as `strapRange` does ("Set unconditionally, it is observability, not gated"), and the assembler builds the line at export time from that.
- **Android** emits at connect gated on an active mode, as its clock-drift line does.

The consequence on Android is worth knowing: the line rides an export only when a mode was on as the link came up, so enabling one wants a reconnect. That trap already exists for the clock-drift line; this does not make it worse, and it does not fix it either.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- **Swift** `UniversalTraceRRTransportTests`: 5 tests, 0 failures, run on Linux against a checksum-verified snapshot-enabled SQLite per `docs/BUILD.md`. Whole file 35/0 after the final edit.
- **Android** `ConnectionReadoutTest`: 27 tests, 0 failures (22 before, plus 5 twins), from a real run with the XML confirmed newer than the source edit.
- `Packages/WhoopStore` `Whoop5RR` suites: 10 tests, 0 failures, covering the read policy the SQL dedup touches.
- `compileFullDebugKotlin` clean. `Tools/doc_comment_lint.py` passes.
- No scoring path changes: no read is widened or narrowed, and no stored value moves.

**The app-target Swift is CI-verified only.** `AppModel`, `LiveState` and `TestBundleAssembler` do not build on Linux, so `build (Strand, macOS)` is what compiles them, not me.

**Not confirmed on a device**, and deliberately not presented as the answer to the underlying report. It makes the next one answerable rather than requiring a database export. Which of the three forks in #2117 applies is still open.

## Related issues

Investigated under #2117.