### PR TITLE
widget: retry a stress rescore that produced nothing, instead of spending the interval on it

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
@@ -476,21 +476,45 @@ class WhoopConnectionService : Service() {
                             nowMs, lastStressScoreAtMs, STRESS_RESCORE_INTERVAL_MS,
                         )
                     ) {
-                        // Stamped as soon as the interval elapses, BEFORE both the placement check and
-                        // the read. Two reasons, and the first is the one that bites: stamping inside
-                        // the placement branch would leave the gate permanently open for anyone WITHOUT
-                        // the widget, so `hasStressWidget` — which crosses into GlanceAppWidgetManager —
-                        // would run on every emission of a collector driven by live heart rate. The
-                        // second is that a slow or failing pass must not become a retry loop that reads
-                        // the day again on the very next sample.
+                        // Stamped BEFORE the placement check and the read, then CORRECTED once the
+                        // outcome is known. Stamping inside the placement branch would leave the gate
+                        // permanently open for anyone WITHOUT the widget, so `hasStressWidget` — which
+                        // crosses into GlanceAppWidgetManager — would run on every emission of a
+                        // collector driven by live heart rate; and a failing pass must not retry on the
+                        // very next sample. Both still hold.
+                        //
+                        // #2120: what did NOT hold is spending the whole interval on an attempt that
+                        // produced nothing. The placement check used to arrive here as a plain Boolean
+                        // that had already collapsed its own failure into `false`, so one Glance hiccup
+                        // read as "no widget" and the curve was skipped; `todayCurve` returns null on a
+                        // blank device id or a caught failure. Either left a placed widget blank for
+                        // fifteen minutes, and the wearer fixed it by opening the app. This now reads
+                        // the placement as a TRI-STATE and rewinds the stamp to a short retry floor for
+                        // both of those, while a settled "no widget" still keeps the full interval.
                         lastStressScoreAtMs = nowMs
-                        if (WidgetSnapshotStore.hasStressWidget(this@WhoopConnectionService)) {
+                        // Tri-state: null means the widget host did not answer, which is NOT the same
+                        // as a settled "no widget" and must not spend the interval like one.
+                        val widgetPlaced =
+                            WidgetSnapshotStore.stressWidgetPlacement(this@WhoopConnectionService)
+                        // `!= false` rather than `== true`: an UNANSWERED placement check scores anyway.
+                        // Skipping on unknown meant a device whose Glance check fails persistently never
+                        // scored at all, it just failed faster, and the widget the wearer is looking at
+                        // stayed blank. Pushing a curve nobody displays is harmless, it is stored and
+                        // unread; withholding one from a widget that IS placed is the reported bug.
+                        val curve = if (widgetPlaced != false) {
                             StressWidgetProducer.todayCurve(
                                 repo, (application as NoopApplication).activeDeviceId,
                             )
                         } else {
                             null
                         }
+                        lastStressScoreAtMs = StressWidgetProducer.stampAfterAttempt(
+                            nowMs = nowMs,
+                            producedCurve = curve != null,
+                            widgetPlaced = widgetPlaced,
+                            intervalMs = STRESS_RESCORE_INTERVAL_MS,
+                        )
+                        curve
                     } else {
                         null
                     }

--- a/android/app/src/main/java/com/noop/widget/StressWidgetProducer.kt
+++ b/android/app/src/main/java/com/noop/widget/StressWidgetProducer.kt
@@ -47,6 +47,42 @@ internal object StressWidgetProducer {
     @Volatile
     private var memo: Memo? = null
 
+    /** How soon a FAILED attempt may be retried. Short, because the widget is blank until it succeeds. */
+    const val RESCORE_RETRY_MS: Long = 60L * 1000L
+
+    /**
+     * The stamp to keep after an attempt, given what that attempt actually produced (#2120).
+     *
+     * The caller stamps BEFORE it reads, deliberately: stamping inside the placement branch would leave
+     * the gate open for everyone without the widget, so the placement check, which crosses into
+     * GlanceAppWidgetManager, would run on every emission of a collector driven by live heart rate. The
+     * cost of that choice was that an attempt producing NOTHING still spent the whole interval, so a
+     * transient miss left a placed widget blank for fifteen minutes and the wearer fixed it by opening
+     * the app. This decides what the stamp becomes once the outcome is known.
+     *
+     *  - produced a curve: keep [nowMs]. Nothing is wrong, take the full interval.
+     *  - [widgetPlaced] FALSE, a settled no: also keep [nowMs]. Producing nothing is the RIGHT answer,
+     *    and retrying sooner would re-run the placement check on a hot collector, which is precisely
+     *    what the early stamp exists to prevent.
+     *  - a placed widget whose read came back null: rewind so the next attempt is [retryMs] away rather
+     *    than a full interval. Not zero, because the other half of the caller's reasoning is that a
+     *    failing pass must not retry on the very next sample; a short floor honours both.
+     *  - [widgetPlaced] NULL, the host did not answer: rewind as well, and this is the case the report is
+     *    really about. The placement check fails closed, so a transient miss arrives as the same `false`
+     *    a settled no does, and spending the interval on it leaves a placed widget blank.
+     */
+    fun stampAfterAttempt(
+        nowMs: Long,
+        producedCurve: Boolean,
+        widgetPlaced: Boolean?,
+        intervalMs: Long,
+        retryMs: Long = RESCORE_RETRY_MS,
+    ): Long {
+        if (producedCurve || widgetPlaced == false) return nowMs
+        // Rewind so `shouldRescore` turns true again after `retryMs`, never sooner than that floor.
+        return nowMs - (intervalMs - retryMs).coerceAtLeast(0L)
+    }
+
     /**
      * Whether a background tick should rescore, given when it last did.
      *

--- a/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
+++ b/android/app/src/main/java/com/noop/widget/WidgetSnapshot.kt
@@ -147,10 +147,25 @@ object WidgetSnapshotStore {
      * send in that case, but by then the work is done, and stress is the one field whose production
      * costs a day of heart-rate rows rather than a field read.
      */
-    suspend fun hasStressWidget(context: Context): Boolean = runCatching {
+    suspend fun hasStressWidget(context: Context): Boolean = stressWidgetPlacement(context) ?: false
+
+    /**
+     * Whether a stress widget is placed, or NULL when that could not be determined (#2120).
+     *
+     * [hasStressWidget] collapses the failure into `false`, which is right for a caller deciding whether
+     * to do work: no answer means do nothing. It is wrong for a caller deciding when to try AGAIN, because
+     * "no widget is placed" and "the widget host did not answer" want opposite things. The first is a
+     * settled no; the second is a transient miss that left a placed widget blank, and the wearer sees it
+     * until something else fills it.
+     *
+     * Crossing into GlanceAppWidgetManager is what can fail here, which is exactly the crossing the
+     * caller's early stamp exists to keep off a hot collector, so the two decisions are entangled and
+     * the uncertainty has to survive the call to be acted on.
+     */
+    suspend fun stressWidgetPlacement(context: Context): Boolean? = runCatching {
         GlanceAppWidgetManager(context.applicationContext)
             .getGlanceIds(StressGlanceWidget::class.java).isNotEmpty()
-    }.getOrDefault(false)
+    }.getOrNull()
 
     fun save(context: Context, snap: WidgetSnapshot) {
         val prefs = context.getSharedPreferences(FILE, Context.MODE_PRIVATE)

--- a/android/app/src/test/java/com/noop/widget/StressWidgetBackgroundScoringTest.kt
+++ b/android/app/src/test/java/com/noop/widget/StressWidgetBackgroundScoringTest.kt
@@ -3,6 +3,7 @@ package com.noop.widget
 import com.noop.analytics.DaytimeStress
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
@@ -98,5 +99,117 @@ class StressWidgetBackgroundScoringTest {
                 DaytimeStress.isWakingHour(bucketAtHour),
             )
         }
+    }
+
+    // #2120: what the stamp becomes once the attempt's outcome is known.
+
+    /**
+     * The case the report is about: a placed widget whose read came back null. The stamp rewinds to a
+     * short retry floor, so the next emission tries again instead of the widget sitting blank for a
+     * full interval while the wearer wonders why opening the app fixes it.
+     */
+    @Test
+    fun `a placed widget whose read failed retries at the short floor`() {
+        val now = 1_000_000L
+        val stamp = StressWidgetProducer.stampAfterAttempt(
+            nowMs = now, producedCurve = false, widgetPlaced = true,
+            intervalMs = 15L * 60_000L, retryMs = 60_000L,
+        )
+        assertFalse(StressWidgetProducer.shouldRescore(now, stamp, 15L * 60_000L))
+        assertTrue(StressWidgetProducer.shouldRescore(now + 60_000L, stamp, 15L * 60_000L))
+    }
+
+    /**
+     * No widget placed is not a failure, it is the right answer, so it keeps the full interval. Retrying
+     * sooner would re-run the placement check on a collector driven by live heart rate, which is the cost
+     * the early stamp exists to avoid.
+     */
+    @Test
+    fun `no widget placed keeps the full interval`() {
+        val now = 1_000_000L
+        val stamp = StressWidgetProducer.stampAfterAttempt(
+            nowMs = now, producedCurve = false, widgetPlaced = false, intervalMs = 15L * 60_000L,
+        )
+        assertEquals(now, stamp)
+        assertFalse(StressWidgetProducer.shouldRescore(now + 60_000L, stamp, 15L * 60_000L))
+    }
+
+    /**
+     * The case the report is really about, and the one an earlier pass of this change left unfixed.
+     *
+     * The placement check fails closed, so a Glance or binder hiccup returns the same `false` a settled
+     * "no widget placed" does. Treating them alike spends the whole interval on a widget that IS placed
+     * and IS blank, which is the fifteen minutes the wearer works around by opening the app. A null
+     * placement therefore retries at the short floor, exactly as a failed read does.
+     */
+    @Test
+    fun `an unanswered placement check retries rather than spending the interval`() {
+        val now = 1_000_000L
+        val stamp = StressWidgetProducer.stampAfterAttempt(
+            nowMs = now, producedCurve = false, widgetPlaced = null,
+            intervalMs = 15L * 60_000L, retryMs = 60_000L,
+        )
+        assertFalse(StressWidgetProducer.shouldRescore(now, stamp, 15L * 60_000L))
+        assertTrue(StressWidgetProducer.shouldRescore(now + 60_000L, stamp, 15L * 60_000L))
+    }
+
+    /**
+     * And the distinction holds in the other direction: a SETTLED no keeps the full interval, so a device
+     * with no stress widget does not start re-running the placement check on a hot collector. The two
+     * cases used to be one value; this pins that they now behave differently.
+     */
+    @Test
+    fun `a settled no and an unanswered check are told apart`() {
+        val now = 1_000_000L
+        val settled = StressWidgetProducer.stampAfterAttempt(
+            nowMs = now, producedCurve = false, widgetPlaced = false, intervalMs = 15L * 60_000L,
+        )
+        val unknown = StressWidgetProducer.stampAfterAttempt(
+            nowMs = now, producedCurve = false, widgetPlaced = null, intervalMs = 15L * 60_000L,
+        )
+        assertEquals(now, settled)
+        assertNotEquals(settled, unknown)
+    }
+
+    /** A successful score keeps the full interval, which is the unchanged behaviour. */
+    @Test
+    fun `a produced curve keeps the full interval`() {
+        val now = 1_000_000L
+        val stamp = StressWidgetProducer.stampAfterAttempt(
+            nowMs = now, producedCurve = true, widgetPlaced = true, intervalMs = 15L * 60_000L,
+        )
+        assertEquals(now, stamp)
+        assertFalse(StressWidgetProducer.shouldRescore(now + 60_000L, stamp, 15L * 60_000L))
+    }
+
+    /**
+     * A retry floor longer than the interval must not rewind INTO the future, which would push the next
+     * attempt further out than doing nothing at all.
+     */
+    @Test
+    fun `a retry floor longer than the interval never delays the next attempt`() {
+        val now = 1_000_000L
+        val stamp = StressWidgetProducer.stampAfterAttempt(
+            nowMs = now, producedCurve = false, widgetPlaced = true,
+            intervalMs = 60_000L, retryMs = 15L * 60_000L,
+        )
+        assertEquals(now, stamp)
+    }
+
+    /**
+     * An unanswered placement check that then SCORES keeps the full interval, like any other success.
+     *
+     * The caller scores on unknown rather than skipping, because a device whose Glance check fails
+     * persistently would otherwise never score at all and the widget would stay blank. Once a curve
+     * exists there is nothing to retry, so the outcome, not the placement, decides the stamp.
+     */
+    @Test
+    fun `an unanswered check that still produced a curve keeps the full interval`() {
+        val now = 1_000_000L
+        val stamp = StressWidgetProducer.stampAfterAttempt(
+            nowMs = now, producedCurve = true, widgetPlaced = null, intervalMs = 15L * 60_000L,
+        )
+        assertEquals(now, stamp)
+        assertFalse(StressWidgetProducer.shouldRescore(now + 60_000L, stamp, 15L * 60_000L))
     }
 }


### PR DESCRIPTION
## What this PR does

Answers #2120: the stress widget occasionally shows no data until the app is opened and the stress card tapped.

The original version of this was handled in #2074, by teaching the BLE service to score, since the curve used to be computed only while the app was open. This is the residue, and it has a different cause.

## The cause

The service consumes its rescore timer **before** it knows whether the attempt will produce anything:

```kotlin
lastStressScoreAtMs = nowMs                                   // timer spent here
if (WidgetSnapshotStore.hasStressWidget(this@...)) {
    StressWidgetProducer.todayCurve(repo, ...activeDeviceId)  // may return null
} else { null }
```

`STRESS_RESCORE_INTERVAL_MS` is fifteen minutes, so an attempt producing nothing leaves a placed widget blank for a quarter of an hour. Two ways that happens:

- **the placement check fails closed.** It is `runCatching { GlanceAppWidgetManager… }.getOrDefault(false)`, so a Glance or binder hiccup arrives as the same `false` a settled "no widget placed" does;
- **`todayCurve` returns null**, which it does on a blank device id or any failure caught inside it. Null means "say nothing, keep what the widget had", which for a widget that never filled is blank.

Opening the app fills it because `AppViewModel` pushes its own snapshot independently. That is the workaround being used.

## Why the stamp is not moved

The early stamp is deliberate and both of its reasons still hold:

1. stamping inside the placement branch would leave the gate open for everyone WITHOUT the widget, so the check, which crosses into `GlanceAppWidgetManager`, would run on every emission of a collector driven by live heart rate;
2. a failing pass must not retry on the very next sample.

So it stays where it is and is **corrected** once the outcome is known, which is something the caller learns a few lines later and previously discarded.

## The four outcomes

| outcome | stamp | why |
|---|---|---|
| produced a curve | full interval | unchanged |
| settled "no widget placed" | full interval | producing nothing is RIGHT; retrying would re-run the check on a hot collector |
| placed widget, read returned null | rewind to a 60s floor | the reported case |
| placement unknown | scores anyway; rewind only if it produced nothing | also the reported case, and the one an earlier pass missed |

An unanswered check **scores** rather than skipping. Retrying sooner was not enough on its own: a device whose placement check fails persistently would retry every minute and never score, leaving the widget just as blank with a faster spin. Pushing a curve nobody displays is harmless, it is stored and unread; withholding one from a widget that IS placed is the reported bug. A settled no still skips, so a device without the widget pays nothing.

## The tri-state, and why it is load-bearing

That last row needed the placement check to stop collapsing its failure into `false`. It now returns `Boolean?`, and `hasStressWidget` keeps its old shape by delegating with `?: false`. This service is migrated to the tri-state, since it is the caller that has to act on the uncertainty; the other caller, the #2111 foreground gate in `AppViewModel`, still uses `hasStressWidget` and is behaviourally untouched.

Without it the **primary** reported cause stays unfixed. An earlier pass of this change treated an unanswered check as a settled no and left the fifteen minutes exactly where they were, while looking correct in every test. Collapsing "I could not tell" into "no" is fine for a caller deciding whether to do work, and wrong for a caller deciding when to try again.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

- `StressWidgetBackgroundScoringTest`: **13 tests, 0 failures** (7 before, plus 6). Forced with `--rerun-tasks` after `syncRoomSchemaSnapshot` in its own invocation, with the result XML timestamp checked against the clock, because a stale XML from an earlier run reads exactly like a pass.
- The six pin all four outcomes, that a settled no and an unanswered check are told apart, and that a retry floor longer than the interval never rewinds into the future and pushes the next attempt further out than doing nothing.
- `compileFullDebugKotlin` clean. `Tools/doc_comment_lint.py` passes.
- No scoring change: the curve itself, its inputs and its gating are untouched. Only WHEN a failed attempt may be retried moves.

**Not confirmed on a device.** The timer decision is unit-testable; the end-to-end behaviour is not. It wants a placed stress widget with the service running, observing that a blank widget recovers on the next heart-rate emission rather than at the next fifteen-minute boundary.

## Scope

Android only. The stress widget and this service are Android surfaces with no Apple twin.

**Deliberately not in here:** whether the placement check should fail closed at all. It is load-bearing in two places now, here and in the foreground path after #2111, and a false negative is silent in both. This PR makes the uncertainty visible to the one caller that must act on it, rather than changing the default for every caller.

## Related issues

Reported in #2120.
