### PR TITLE
sleep: a night already in hand silences the calculating banner

### DIFF
--- a/Strand/Screens/SleepView.swift
+++ b/Strand/Screens/SleepView.swift
@@ -2579,8 +2579,15 @@ func resolveSleepFreshness(hasCurrentNight: Bool, morningReady: Bool, syncing: B
                            calculating: Bool, syncedSinceDayStart: Bool,
                            syncFailed: Bool) -> SleepFreshnessStatus? {
     if syncing { return .syncing }
+    // #2108: a night already in hand outranks .calculating. It used to sit below, so `hasCurrentNight`
+    // could only silence the missing-night states and a finished night was structurally unable to
+    // silence this one: the banner said "detecting and staging the night now" directly above that same
+    // night scored, timed and staged on screen. A note that contradicts the content beside it is worse
+    // than no note, and one that is always on is read by nobody the day it matters. .syncing stays
+    // above, because data still arriving can genuinely change what is shown.
+    if hasCurrentNight { return nil }
     if calculating { return .calculating }
-    if hasCurrentNight || !morningReady { return nil }
+    if !morningReady { return nil }
     if syncFailed { return .syncFailed }
     return syncedSinceDayStart ? .notDetected : .awaitingSync
 }

--- a/StrandTests/SleepPhantomNightFallbackTests.swift
+++ b/StrandTests/SleepPhantomNightFallbackTests.swift
@@ -80,6 +80,35 @@ final class SleepPhantomNightFallbackTests: XCTestCase {
 
     // Missing-night honesty: the newest stored night may stay visible, but the status above it must say
     // whether today's night is still moving through sync/analysis or finished without a detection.
+    /// #2108: a night already in hand silences `.calculating`.
+    ///
+    /// Reported as a banner that never clears, and the screenshot showed worse: "detecting and staging
+    /// the night now" printed directly above that same night, scored, timed and staged. The ladder
+    /// checked `calculating` before `hasCurrentNight`, so a finished night could not silence it however
+    /// complete it was. This is the combination none of the cases below covered, which is why it shipped.
+    /// Twin of the Kotlin `a night already in hand silences calculating`.
+    func testFreshnessNightInHandSilencesCalculating() {
+        XCTAssertNil(resolveSleepFreshness(hasCurrentNight: true, morningReady: true, syncing: false,
+                                           calculating: true, syncedSinceDayStart: true, syncFailed: false))
+    }
+
+    /// `.syncing` deliberately still outranks a present night: data landing now can change what is shown,
+    /// where recalculating an already scored night cannot make the banner true about what is on screen.
+    /// Pinned so the fix above is not later tidied into suppressing both.
+    func testFreshnessSyncingStillShowsWithNightInHand() {
+        XCTAssertEqual(resolveSleepFreshness(hasCurrentNight: true, morningReady: true, syncing: true,
+                                             calculating: true, syncedSinceDayStart: true,
+                                             syncFailed: false), .syncing)
+    }
+
+    /// And the reorder did not silence the one state that genuinely reports work in progress: before
+    /// morning with no night detected, `.calculating` still wins over the quiet return.
+    func testFreshnessCalculatingStillShowsBeforeMorningWithNoNight() {
+        XCTAssertEqual(resolveSleepFreshness(hasCurrentNight: false, morningReady: false, syncing: false,
+                                             calculating: true, syncedSinceDayStart: false,
+                                             syncFailed: false), .calculating)
+    }
+
     func testFreshnessProgressStatesWinOverStaleHistory() {
         XCTAssertEqual(resolveSleepFreshness(hasCurrentNight: false, morningReady: true, syncing: true,
                                               calculating: true, syncedSinceDayStart: false, syncFailed: true), .syncing)

--- a/android/app/src/main/java/com/noop/ui/SleepScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/SleepScreen.kt
@@ -118,8 +118,15 @@ internal fun resolveSleepFreshness(
     syncFailed: Boolean,
 ): SleepFreshnessStatus? {
     if (syncing) return SleepFreshnessStatus.SYNCING
+    // #2108: a night already in hand outranks CALCULATING. It used to sit below, so `hasCurrentNight`
+    // could only silence the missing-night states and a finished night was structurally unable to
+    // silence this one: the banner said "detecting and staging the night now" directly above that same
+    // night scored, timed and staged on screen. A note that contradicts the content beside it is worse
+    // than no note, and one that is always on is read by nobody the day it matters. SYNCING stays above,
+    // because data still arriving can genuinely change what is shown.
+    if (hasCurrentNight) return null
     if (calculating) return SleepFreshnessStatus.CALCULATING
-    if (hasCurrentNight || !morningReady) return null
+    if (!morningReady) return null
     if (syncFailed) return SleepFreshnessStatus.SYNC_FAILED
     return if (syncedSinceDayStart) SleepFreshnessStatus.NOT_DETECTED
     else SleepFreshnessStatus.AWAITING_SYNC

--- a/android/app/src/test/java/com/noop/ui/SleepFreshnessStatusTest.kt
+++ b/android/app/src/test/java/com/noop/ui/SleepFreshnessStatusTest.kt
@@ -41,4 +41,43 @@ class SleepFreshnessStatusTest {
             resolveSleepFreshness(false, true, false, false, false, false),
         )
     }
+
+    /**
+     * #2108: a night already in hand silences CALCULATING.
+     *
+     * Reported as a banner that never goes away, and the screenshot showed worse than that: "detecting
+     * and staging the night now" printed directly above that same night, scored 82, timed 00:36 to
+     * 07:12, with its stages listed. The ladder checked `calculating` before `hasCurrentNight`, so a
+     * finished night could not silence it however complete it was. This is the combination none of the
+     * cases above covered, which is why it shipped.
+     */
+    @Test
+    fun `a night already in hand silences calculating`() {
+        assertNull(resolveSleepFreshness(true, true, false, true, true, false))
+    }
+
+    /**
+     * SYNCING deliberately still outranks a present night: data landing now can change what is shown,
+     * so that one is informative where CALCULATING is merely noisy. Pinned so the fix above is not
+     * later "tidied" into suppressing both.
+     */
+    @Test
+    fun `syncing still shows even with a night in hand`() {
+        assertEquals(
+            SleepFreshnessStatus.SYNCING,
+            resolveSleepFreshness(true, true, true, true, true, false),
+        )
+    }
+
+    /**
+     * Before morning with nothing detected yet, CALCULATING still wins over the quiet return, so the
+     * reorder did not silence the one case that genuinely reports work in progress.
+     */
+    @Test
+    fun `calculating still shows before morning when no night exists`() {
+        assertEquals(
+            SleepFreshnessStatus.CALCULATING,
+            resolveSleepFreshness(false, false, false, true, false, false),
+        )
+    }
 }


### PR DESCRIPTION
## What this PR does

Answers #2108: the Sleep page says "Calculating last night's sleep" all day, reported at 10pm.

The screenshot shows worse than a banner that overstays. It sits **directly above that same night**, scored **82**, timed `00:36 - 07:12`, stage breakdown 6h 17m, tagged ON-DEVICE. It announces work that visibly finished, on the screen showing the result.

## The cause

The priority ladder checked `calculating` before `hasCurrentNight`:

```kotlin
if (syncing) return SYNCING
if (calculating) return CALCULATING              // wins unconditionally
if (hasCurrentNight || !morningReady) return null // the have-the-night exit sits below
```

So `hasCurrentNight` could only silence the missing-night states underneath it (`SYNC_FAILED`, `NOT_DETECTED`, `AWAITING_SYNC`). A complete night was **structurally unable** to silence this one, however complete it was. In the report `hasCurrentNight` was certainly true, since the wake time was 07:12 that same day.

## The change

`hasCurrentNight` moves above `CALCULATING`, and the two conditions that used to share an exit are split so the before-morning quiet return behaves exactly as it did.

```kotlin
if (syncing) return SYNCING
if (hasCurrentNight) return null
if (calculating) return CALCULATING
if (!morningReady) return null
```

**SYNCING deliberately still outranks a present night**, pinned by a test so the fix is not later tidied into suppressing both. The two are not alike: data still landing can change what is shown, whereas a scored night being recalculated cannot make "detecting and staging the night now" true about what is on screen.

## What changed, precisely

The old order was intentional rather than an oversight, and the existing `progressStatesWinOverStaleHistory` test still passes and still means what it said. Progress states continue to outrank **stale** history, and to outrank nothing at all.

What is carved out is narrower: a **current, finished** night outranks `CALCULATING` specifically.

## Tests

The reported combination, a present night with `calculating` true, is the one case none of the five existing tests covered, which is how it shipped. Three added:

| case | pins |
|---|---|
| night in hand, calculating true | the reported bug |
| night in hand, syncing true | SYNCING still wins, so the fix cannot be over-applied |
| no night, before morning, calculating true | CALCULATING still reports genuine work |

Kotlin **8 of 8** green, from a forced run with the result XML timestamp checked against the clock and the three new names confirmed present in it.

**All three are twinned in Swift.** An earlier pass of this change pinned only the Kotlin side, which would have left the Swift ladder free to be reordered back with nothing to catch it. The twin that matters here is the ORDER itself, and a test on one platform does not guard the other.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Scope

Both platforms: the ladder is a byte-identical twin and both are reordered. The Swift `resolveSleepFreshness` lives in app-target `SleepView.swift`, which does not compile on Linux, so CI's macOS leg is what exercises it rather than me.

## Deliberately not fixed here

`analyzingHistory` is cleared only when no retry was queued:

```kotlin
val retryAlreadyQueued = analyzeAfterBackfillPending.getAndSet(false)
if (!retryAlreadyQueued) _state.update { it.copy(analyzingHistory = false) }
```

That is deliberate, so the banner spans chained passes, but it means a broken chain latches it on permanently. It is a plausible second contributor to "always", and with an empty strap log in the report there is no evidence it fired. Asserting it without that would repeat the banner's own mistake of claiming more than it can show. Worth its own issue if the banner persists after this.

## Related issues

Reported in #2108 by @bartmuskala.
