### PR TITLE
stress: draw the movement marks as the stretches they are, not as dots on the axis

### DIFF
--- a/StrandTests/StressTraceTests.swift
+++ b/StrandTests/StressTraceTests.swift
@@ -178,14 +178,29 @@ final class StressTraceTests: XCTestCase {
         XCTAssertEqual(StressTrace.levelTicks(), [3, 2, 1, 0])
     }
 
-    func testTimeTicksAnchorToTheScoredHoursNotToTheDay() {
+    func testTimeTicksLabelTheAxisWhichSpansTheWholeSeries() {
         let day = [at(0, nil), at(8, 1.0), at(12, 1.5), at(16, 2.0), at(23, nil)]
-        // An evening-only day must not label its axis with a morning that was never sampled.
-        XCTAssertEqual(StressTrace.timeTicks(day), [8 * hour, 12 * hour, 16 * hour])
+        // Every renderer spreads these three evenly across the chart, and the chart spans the SERIES.
+        // Anything narrower names the wrong instant at the edge it is drawn against.
+        XCTAssertEqual(StressTrace.timeTicks(day), [0, 11 * hour + 1_800, 23 * hour])
     }
 
-    func testOneScoredHourNamesOneInstant() {
-        XCTAssertEqual(StressTrace.timeTicks([at(9, 1.0), at(10, nil)]), [9 * hour])
+    /// #2106: scored to 18:30, masked as movement until 22:00, and the axis said the day ended at 18:30.
+    /// The right-hand label is the end of the DAY, not the end of scoring, or a chart that is perfectly
+    /// current reads as one that stopped updating hours ago.
+    func testADayWhoseClosingHoursWereAllMaskedStillNamesItsTrueEnd() {
+        let day = [at(6, 1.0), at(18, 1.5), at(20, nil, moving: true), at(22, nil, moving: true)]
+        XCTAssertEqual(StressTrace.timeTicks(day).last, 22 * hour)
+    }
+
+    func testOneInstantNamesOneInstant() {
+        // The renderers hide a lone label, so this is what keeps a one-point day from showing a stray.
+        XCTAssertEqual(StressTrace.timeTicks([at(9, 1.0)]), [9 * hour])
+    }
+
+    func testTwoInstantsNameBothEndsAndTheMidpointBetweenThem() {
+        XCTAssertEqual(StressTrace.timeTicks([at(9, 1.0), at(10, nil)]),
+                       [9 * hour, 9 * hour + 1_800, 10 * hour])
     }
 
     // MARK: - the snapshot's day guard

--- a/StrandTests/StressTraceTests.swift
+++ b/StrandTests/StressTraceTests.swift
@@ -78,9 +78,64 @@ final class StressTraceTests: XCTestCase {
     func testHoursMaskedAsMovementAreMarkedAndDoNotJoinTheLine() {
         let day = [at(0, 1.0), at(1, nil, moving: true), at(2, 1.0)]
         XCTAssertEqual(StressTrace.segments(day, width: 100, height: 100).count, 2)
-        let marks = StressTrace.movingMarks(day, width: 100)
-        XCTAssertEqual(marks.count, 1)
-        XCTAssertEqual(marks[0], 50, accuracy: 0.001)
+        let span = StressTrace.movingSpans(day, width: 100)[0]
+        XCTAssertEqual(span.lowerBound, 25, accuracy: 0.001)
+        XCTAssertEqual(span.upperBound, 75, accuracy: 0.001)
+    }
+
+    // #2106: contiguous masked stretches, so the marks read as regions rather than as axis ticks.
+
+    /// Adjacent masked hours become ONE span: that is the whole point, a bar under the hole it explains.
+    func testAdjacentMovingHoursJoinIntoOneSpan() {
+        let day = [at(0, 1.0), at(1, nil, moving: true), at(2, nil, moving: true), at(3, 1.5)]
+        XCTAssertEqual(StressTrace.movingSpans(day, width: 100).count, 1)
+    }
+
+    /// Separated runs stay separate, so two different stretches are not merged into one claim.
+    func testSeparatedMovingRunsStaySeparate() {
+        let day = [at(0, nil, moving: true), at(1, 1.0), at(2, nil, moving: true)]
+        XCTAssertEqual(StressTrace.movingSpans(day, width: 100).count, 2)
+    }
+
+    /// A run ending at the LAST hour still closes, rather than being dropped for want of a terminator.
+    func testARunEndingAtTheLastPointIsStillEmitted() {
+        let day = [at(0, 1.0), at(1, nil, moving: true), at(2, nil, moving: true)]
+        let spans = StressTrace.movingSpans(day, width: 100)
+        XCTAssertEqual(spans.count, 1)
+        XCTAssertEqual(spans[0].upperBound, 100, accuracy: 0.001)
+    }
+
+    /// No moving hours means no marks, so an ordinary day carries no band at all.
+    func testNoMovingHoursYieldsNoSpans() {
+        XCTAssertTrue(StressTrace.movingSpans([at(0, 1.0), at(1, 2.0)], width: 100).isEmpty)
+    }
+
+    /// A LONE masked hour is the case the geometry exists for: centre to centre it has a width of zero,
+    /// and it is the hour with no neighbours to make it obvious, so it is also the one that most needs
+    /// to be legible. It covers its own hour, half a slot either side of its centre.
+    func testALoneMovingHourSpansItsOwnHourNotAnInstant() {
+        let day = [at(0, 1.0), at(1, 1.0), at(2, nil, moving: true), at(3, 1.0), at(4, 1.0)]
+        let spans = StressTrace.movingSpans(day, width: 100)
+        XCTAssertEqual(spans.count, 1)
+        XCTAssertEqual(spans[0].lowerBound, 37.5, accuracy: 0.001)
+        XCTAssertEqual(spans[0].upperBound, 62.5, accuracy: 0.001)
+    }
+
+    /// A run covers its hours EDGE to edge, so the bar reaches past the outermost masked centres.
+    func testARunCoversItsHoursEdgeToEdge() {
+        let day = [at(0, 1.0), at(1, nil, moving: true), at(2, nil, moving: true), at(3, 1.0)]
+        let spans = StressTrace.movingSpans(day, width: 100)
+        XCTAssertEqual(spans.count, 1)
+        XCTAssertEqual(spans[0].lowerBound, 100.0 / 6.0, accuracy: 0.001)
+        XCTAssertEqual(spans[0].upperBound, 100.0 * 5.0 / 6.0, accuracy: 0.001)
+    }
+
+    /// At the ends of the day the territory stops at the data: nothing is invented past what was sampled.
+    func testARunStartingAtTheFirstHourStartsAtTheEdgeOfTheBox() {
+        let day = [at(0, nil, moving: true), at(1, 1.0), at(2, 1.0)]
+        let spans = StressTrace.movingSpans(day, width: 100)
+        XCTAssertEqual(spans.count, 1)
+        XCTAssertEqual(spans[0].lowerBound, 0, accuracy: 0.001)
     }
 
     // MARK: - the high band

--- a/StrandiOSShared/StressTrace.swift
+++ b/StrandiOSShared/StressTrace.swift
@@ -201,15 +201,27 @@ public enum StressTrace {
     /// moved with the day would make two days impossible to compare at a glance.
     public static func levelTicks() -> [Int] { [3, 2, 1, 0] }
 
-    /// The three timestamps along the bottom: first, middle and last of the SCORED data, not of the day.
+    /// The three timestamps along the bottom: first, middle and last of the SERIES.
     ///
-    /// Anchored to scored hours because a day with only an evening's signal would otherwise label its
-    /// axis with a morning that was never sampled, and the curve would sit crushed into the right-hand
-    /// end of a mostly empty chart. Fewer than three distinct instants returns what there is, so the
-    /// caller draws one label rather than three copies of it.
+    /// The series, not the scored hours, because these label the AXIS, and the axis IS the series: every
+    /// placement in this file maps x across `first.ts ... last.ts`, and every renderer spreads these
+    /// three labels evenly across that same width. Anchoring them to the scored subset instead put the
+    /// last SCORED instant at the right-hand edge, so a day whose closing hours were all masked as
+    /// movement announced that it ended when scoring stopped rather than when the day did.
+    ///
+    /// That is the second half of #2106, and it was read exactly as it was drawn: a chart running to
+    /// 22:00 labelled "18:30" at its right edge, reported as the app having stopped updating. The
+    /// trailing hours were there the whole time, masked as exertion. Only the axis disagreed.
+    ///
+    /// The rationale this replaces was that an evening-only wearer would otherwise be labelled with a
+    /// morning that was never sampled. The buckets are built FROM the samples, so the series carries no
+    /// unsampled hours to begin with, and the curve was already spread across the series either way.
+    /// The labels were the only part that ever disagreed with the geometry.
+    ///
+    /// Fewer than three distinct instants returns what there is, so the caller draws one label rather
+    /// than three copies of it.
     public static func timeTicks(_ series: [StressPoint]) -> [Int64] {
-        let scored = series.filter { $0.level != nil }
-        guard let first = scored.first?.ts, let last = scored.last?.ts else { return [] }
+        guard let first = series.first?.ts, let last = series.last?.ts else { return [] }
         if first == last { return [first] }
         let mid = first + (last - first) / 2
         return (mid == first || mid == last) ? [first, last] : [first, mid, last]

--- a/StrandiOSShared/StressTrace.swift
+++ b/StrandiOSShared/StressTrace.swift
@@ -146,17 +146,53 @@ public enum StressTrace {
         }
     }
 
-    /// X positions of the hours masked as movement, for the faint marks along the base.
+    /// The hours masked as movement, grouped into CONTIGUOUS x ranges, for the marks along the base.
     ///
-    /// Bare X centres rather than spans: the mark's thickness is a drawing decision, while WHERE the
-    /// moving hours were is a fact about the day.
-    public static func movingMarks(_ series: [StressPoint], width: CGFloat) -> [CGFloat] {
+    /// A run rather than a mark per hour, because a run says which STRETCH of the day was masked, and
+    /// that is what a reader needs when they are looking at a hole in the trace and trying to work out
+    /// what put it there. The reason it matters was reported rather than theorised: a wearer saw the
+    /// gaps, read the evenly spaced marks along the zero line as axis ticks, concluded the data itself
+    /// was missing, and asked whether continuous HRV tracking would fill them in. One bar under the
+    /// stretch it explains cannot be mistaken for a scale, because a scale does not start and stop with
+    /// the data.
+    ///
+    /// Adjacency is by POSITION in the series, not by timestamp arithmetic: the series is already the
+    /// hour grid the chart draws, so two neighbouring entries are two neighbouring hours by construction.
+    ///
+    /// A span runs edge to edge of the hours it covers, NOT centre to centre. An hour is a stretch of the
+    /// day, not an instant, and the difference is the whole case for the shape: centre to centre gives a
+    /// lone masked hour a width of zero, which is exactly the hour that most needs to be legible, since
+    /// there are no neighbours to make it obvious. Edges are the MIDPOINT to each neighbour rather than a
+    /// fixed slot, so an irregular series (a DST-long day, an hour missing from the list entirely) still
+    /// gets honest extents. At the ends of the series the territory stops at the point itself: the day's
+    /// extent is what was sampled, nothing is invented past it, and every span stays inside the box
+    /// without a clamp.
+    ///
+    /// The upper edge is floored to the lower one. On a sorted series it never binds, but the two
+    /// platforms disagree about what an inverted range means, Kotlin yielding an empty one where Swift
+    /// traps, and a twin that crashes on one side and shrugs on the other is not a twin.
+    public static func movingSpans(_ series: [StressPoint], width: CGFloat) -> [ClosedRange<CGFloat>] {
         guard let firstPoint = series.first, let lastPoint = series.last, width > 0 else { return [] }
         let t0 = firstPoint.ts
         let span = CGFloat(lastPoint.ts - t0)
-        return series.filter(\.moving).map { p in
-            span <= 0 ? 0 : CGFloat(p.ts - t0) / span * width
+        let xs = series.map { span <= 0 ? CGFloat(0) : CGFloat($0.ts - t0) / span * width }
+        let last = series.count - 1
+        func leftEdge(_ i: Int) -> CGFloat { i == 0 ? xs[0] : (xs[i - 1] + xs[i]) / 2 }
+        func rightEdge(_ i: Int) -> CGFloat { i == last ? xs[last] : (xs[i] + xs[i + 1]) / 2 }
+        var out: [ClosedRange<CGFloat>] = []
+        var runStart: Int?
+        for i in series.indices {
+            let moving = series[i].moving
+            if moving, runStart == nil { runStart = i }
+            // A run closes at the first hour that is NOT moving, and also at the end of the series, or
+            // a day whose last hours were all masked would be dropped for want of a terminator.
+            if let from = runStart, !moving || i == last {
+                let lo = leftEdge(from)
+                out.append(lo...max(rightEdge(moving ? i : i - 1), lo))
+                runStart = nil
+            }
         }
+        return out
     }
 
     /// The labels up the left edge, top-down: the top of the domain down to zero.

--- a/StrandiOSWidgets/StressWidget.swift
+++ b/StrandiOSWidgets/StressWidget.swift
@@ -98,12 +98,21 @@ private struct StressMovingMarksShape: Shape {
 
     func path(in rect: CGRect) -> Path {
         var path = Path()
-        let half: CGFloat = 3
-        for x in StressTrace.movingMarks(series, width: rect.width) {
+        // A span arrives covering its hours edge to edge, so the only width left to decide is the
+        // FLOOR, for a degenerate series with no width to spread across. It is the width the mark used
+        // to have unconditionally, kept so the smallest mark is no less visible than before.
+        let minWidth: CGFloat = 6
+        let radius = rect.height / 2
+        for span in StressTrace.movingSpans(series, width: rect.width) {
+            let lo = min(max(span.lowerBound, 0), rect.width)
+            let hi = min(max(span.upperBound, 0), rect.width)
+            // Floored by GROWING right, then left if that ran into the edge, so a mark at either end
+            // of the day keeps its width instead of being trimmed away by the box.
+            let x1 = max(hi, min(lo + minWidth, rect.width))
+            let x0 = min(lo, max(x1 - minWidth, 0))
             path.addRoundedRect(
-                in: CGRect(x: max(x - half, 0), y: rect.minY,
-                           width: min(half * 2, rect.width), height: rect.height),
-                cornerSize: CGSize(width: half, height: half),
+                in: CGRect(x: x0, y: rect.minY, width: x1 - x0, height: rect.height),
+                cornerSize: CGSize(width: radius, height: radius),
             )
         }
         return path

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -664,93 +664,100 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
                         }
                     }
                     Spacer(Modifier.width(6.dp))
-                    Canvas(
-                        modifier = Modifier
-                            .weight(1f)
-                            .height(Metrics.chartHeight),
-                    ) {
-                        val w = size.width
-                        val h = size.height
-                        if (w <= 0f || h <= 0f) return@Canvas
-                        val strokeW = 2.dp.toPx()
-                        // Reserve the bottom strip for the movement marks, and build the geometry AT the
-                        // reduced height rather than scaling it afterwards. A calm hour sits at the very
-                        // bottom of a fixed domain, so without the strip its line and the marks share a
-                        // row and read as one thing. (The widget carves the same band out of its bitmap;
-                        // computing against `chartH` here is the same idea without the second mapping
-                        // that had to be got right there.)
-                        val hasMarks = points.any { it.moving }
-                        val markBand = if (hasMarks) (strokeW * 2.5f).coerceAtMost(h / 6f) else 0f
-                        val chartH = (h - markBand).coerceAtLeast(1f)
-                        // Amber at the top through green to blue at the bottom: because the domain is
-                        // fixed, vertical position IS the level, so one shader colours every run by the
-                        // score it actually carries.
-                        val gradient = Brush.verticalGradient(listOf(tense, steady, calm),
-                                                              startY = 0f, endY = chartH)
+                    // The chart and its hour labels share ONE column, so the labels line up with the
+                    // ink they name. As siblings of the whole row they started at the card's edge
+                    // instead, shifted left of the chart by the width of the level scale (#2106).
+                    Column(modifier = Modifier.weight(1f)) {
+                        Canvas(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(Metrics.chartHeight),
+                        ) {
+                            val w = size.width
+                            val h = size.height
+                            if (w <= 0f || h <= 0f) return@Canvas
+                            val strokeW = 2.dp.toPx()
+                            // Reserve the bottom strip for the movement marks, and build the geometry AT the
+                            // reduced height rather than scaling it afterwards. A calm hour sits at the very
+                            // bottom of a fixed domain, so without the strip its line and the marks share a
+                            // row and read as one thing. (The widget carves the same band out of its bitmap;
+                            // computing against `chartH` here is the same idea without the second mapping
+                            // that had to be got right there.)
+                            val hasMarks = points.any { it.moving }
+                            val markBand = if (hasMarks) (strokeW * 2.5f).coerceAtMost(h / 6f) else 0f
+                            val chartH = (h - markBand).coerceAtLeast(1f)
+                            // Amber at the top through green to blue at the bottom: because the domain is
+                            // fixed, vertical position IS the level, so one shader colours every run by the
+                            // score it actually carries.
+                            val gradient = Brush.verticalGradient(listOf(tense, steady, calm),
+                                                                  startY = 0f, endY = chartH)
 
-                        StressTrace.segments(points, w, chartH).forEach { run ->
-                            if (run.isEmpty()) return@forEach
-                            if (run.size == 1) {
-                                // Brushed, not a flat colour: the dot has to carry the level the same way
-                                // the line does, or a lone HIGH hour would draw the calm-day green.
-                                drawCircle(brush = gradient, radius = strokeW,
-                                           center = Offset(run[0].x.coerceAtLeast(strokeW), run[0].y))
-                                return@forEach
+                            StressTrace.segments(points, w, chartH).forEach { run ->
+                                if (run.isEmpty()) return@forEach
+                                if (run.size == 1) {
+                                    // Brushed, not a flat colour: the dot has to carry the level the same way
+                                    // the line does, or a lone HIGH hour would draw the calm-day green.
+                                    drawCircle(brush = gradient, radius = strokeW,
+                                               center = Offset(run[0].x.coerceAtLeast(strokeW), run[0].y))
+                                    return@forEach
+                                }
+                                val line = Path().apply {
+                                    moveTo(run[0].x, run[0].y)
+                                    run.drop(1).forEach { lineTo(it.x, it.y) }
+                                }
+                                // Closed PER RUN, so the fill cannot spread under an hour that was never
+                                // scored and undo the gap the broken line exists to draw.
+                                val fill = Path().apply {
+                                    addPath(line)
+                                    lineTo(run.last().x, chartH)
+                                    lineTo(run[0].x, chartH)
+                                    close()
+                                }
+                                drawPath(fill, brush = gradient, alpha = StrandAlpha.chartFillSoft)
+                                drawPath(line, brush = gradient,
+                                         style = Stroke(width = strokeW, cap = StrokeCap.Round,
+                                                        join = StrokeJoin.Round))
                             }
-                            val line = Path().apply {
-                                moveTo(run[0].x, run[0].y)
-                                run.drop(1).forEach { lineTo(it.x, it.y) }
+                            // Hours in the HIGH band, dotted above the line exactly as the screen marks them.
+                            StressTrace.highPoints(points, w, chartH).forEach {
+                                drawCircle(color = tense, radius = strokeW,
+                                           center = Offset(it.x, (it.y - strokeW * 2f).coerceAtLeast(strokeW)))
                             }
-                            // Closed PER RUN, so the fill cannot spread under an hour that was never
-                            // scored and undo the gap the broken line exists to draw.
-                            val fill = Path().apply {
-                                addPath(line)
-                                lineTo(run.last().x, chartH)
-                                lineTo(run[0].x, chartH)
-                                close()
+                            // The stretches the motion gate masked: exertion raises heart rate on its own, so
+                            // the hour is marked rather than scored.
+                            // #2106: one bar per CONTIGUOUS masked stretch, not a dot per hour, and in a
+                            // colour that is not the one the axis labels use. Reported as "many gaps" by a
+                            // wearer who read the old evenly spaced tertiary dots as tick marks and asked
+                            // whether he needed to enable continuous HRV to fill them. A scale does not
+                            // start and stop with the data, so a bar sitting under the stretch it explains
+                            // cannot be read as one. The span already covers the masked hours edge to edge,
+                            // so the floor below is only for a degenerate series with no width to spread
+                            // across, not the ordinary lone-hour case. It is the WIDGET's floor, and wider
+                            // than the dot this replaced, so even that case is no less visible than before.
+                            val markY = h - markBand / 2f
+                            val markH = (markBand * 0.5f).coerceAtLeast(1f)
+                            val minMarkW = strokeW * 3f
+                            StressTrace.movingSpans(points, w).forEach { span ->
+                                val x1 = maxOf(span.endInclusive, minOf(span.start + minMarkW, w))
+                                val x0 = minOf(span.start, maxOf(x1 - minMarkW, 0f))
+                                drawRoundRect(
+                                    color = markTone,
+                                    topLeft = Offset(x0, markY - markH / 2f),
+                                    size = Size(x1 - x0, markH),
+                                    cornerRadius = CornerRadius(markH / 2f, markH / 2f),
+                                )
                             }
-                            drawPath(fill, brush = gradient, alpha = StrandAlpha.chartFillSoft)
-                            drawPath(line, brush = gradient,
-                                     style = Stroke(width = strokeW, cap = StrokeCap.Round,
-                                                    join = StrokeJoin.Round))
                         }
-                        // Hours in the HIGH band, dotted above the line exactly as the screen marks them.
-                        StressTrace.highPoints(points, w, chartH).forEach {
-                            drawCircle(color = tense, radius = strokeW,
-                                       center = Offset(it.x, (it.y - strokeW * 2f).coerceAtLeast(strokeW)))
-                        }
-                        // The stretches the motion gate masked: exertion raises heart rate on its own, so
-                        // the hour is marked rather than scored.
-                        // #2106: one bar per CONTIGUOUS masked stretch, not a dot per hour, and in a
-                        // colour that is not the one the axis labels use. Reported as "many gaps" by a
-                        // wearer who read the old evenly spaced tertiary dots as tick marks and asked
-                        // whether he needed to enable continuous HRV to fill them. A scale does not
-                        // start and stop with the data, so a bar sitting under the stretch it explains
-                        // cannot be read as one. The span already covers the masked hours edge to edge,
-                        // so the floor below is only for a degenerate series with no width to spread
-                        // across, not the ordinary lone-hour case. It is the WIDGET's floor, and wider
-                        // than the dot this replaced, so even that case is no less visible than before.
-                        val markY = h - markBand / 2f
-                        val markH = (markBand * 0.5f).coerceAtLeast(1f)
-                        val minMarkW = strokeW * 3f
-                        StressTrace.movingSpans(points, w).forEach { span ->
-                            val x1 = maxOf(span.endInclusive, minOf(span.start + minMarkW, w))
-                            val x0 = minOf(span.start, maxOf(x1 - minMarkW, 0f))
-                            drawRoundRect(
-                                color = markTone,
-                                topLeft = Offset(x0, markY - markH / 2f),
-                                size = Size(x1 - x0, markH),
-                                cornerRadius = CornerRadius(markH / 2f, markH / 2f),
-                            )
-                        }
-                    }
-                }
-
-                if (ticks.size >= 2) {
-                    Row(modifier = Modifier.fillMaxWidth()) {
-                        ticks.forEachIndexed { i, ts ->
-                            Text(pointTimeLabel(ts), style = NoopType.footnote, color = textTertiary)
-                            if (i < ticks.size - 1) Spacer(Modifier.weight(1f))
+                        // Evenly spread, which is only honest because the ticks now span the same series
+                        // the chart does. While they named the last SCORED hour, the right-hand label sat
+                        // at the right-hand edge and claimed the day ended there (#2106).
+                        if (ticks.size >= 2) {
+                            Row(modifier = Modifier.fillMaxWidth()) {
+                                ticks.forEachIndexed { i, ts ->
+                                    Text(pointTimeLabel(ts), style = NoopType.footnote, color = textTertiary)
+                                    if (i < ticks.size - 1) Spacer(Modifier.weight(1f))
+                                }
+                            }
                         }
                     }
                 }

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -609,6 +609,9 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
     val stats = remember(points) { StressTrace.stats(points) }
     val ticks = remember(points) { StressTrace.timeTicks(points) }
     val textTertiary = Palette.textTertiary
+    // #2106: the movement marks read as data, not chrome, so they take the same tone the WIDGET
+    // already uses for them rather than the tertiary one the axis labels use.
+    val markTone = Palette.textSecondary
     val calm = StressRamp.CALM
     val steady = StressRamp.STEADY
     val tense = StressRamp.TENSE
@@ -718,9 +721,24 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
                         }
                         // The stretches the motion gate masked: exertion raises heart rate on its own, so
                         // the hour is marked rather than scored.
-                        StressTrace.movingMarks(points, w).forEach {
-                            drawCircle(color = textTertiary, radius = strokeW * 0.6f,
-                                       center = Offset(it, h - markBand / 2f))
+                        // #2106: one bar per CONTIGUOUS masked stretch, not a dot per hour, and in a
+                        // colour that is not the one the axis labels use. Reported as "many gaps" by a
+                        // wearer who read the old evenly spaced tertiary dots as tick marks and asked
+                        // whether he needed to enable continuous HRV to fill them. A scale does not
+                        // start and stop with the data, so a bar that spans exactly the hole cannot be
+                        // read as one. A single masked hour still gets a mark, floored to the stroke
+                        // width so it stays visible rather than collapsing to a hairline.
+                        val markY = h - markBand / 2f
+                        val markH = (markBand * 0.5f).coerceAtLeast(1f)
+                        StressTrace.movingSpans(points, w).forEach { span ->
+                            val x0 = span.start
+                            val x1 = (span.endInclusive).coerceAtLeast(x0 + strokeW)
+                            drawRoundRect(
+                                color = markTone,
+                                topLeft = Offset(x0, markY - markH / 2f),
+                                size = Size(x1 - x0, markH),
+                                cornerRadius = CornerRadius(markH / 2f, markH / 2f),
+                            )
                         }
                     }
                 }

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -728,12 +728,14 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
                         // start and stop with the data, so a bar sitting under the stretch it explains
                         // cannot be read as one. The span already covers the masked hours edge to edge,
                         // so the floor below is only for a degenerate series with no width to spread
-                        // across, not the ordinary lone-hour case.
+                        // across, not the ordinary lone-hour case. It is the WIDGET's floor, and wider
+                        // than the dot this replaced, so even that case is no less visible than before.
                         val markY = h - markBand / 2f
                         val markH = (markBand * 0.5f).coerceAtLeast(1f)
+                        val minMarkW = strokeW * 3f
                         StressTrace.movingSpans(points, w).forEach { span ->
-                            val x0 = span.start
-                            val x1 = (span.endInclusive).coerceAtLeast(x0 + strokeW)
+                            val x1 = maxOf(span.endInclusive, minOf(span.start + minMarkW, w))
+                            val x0 = minOf(span.start, maxOf(x1 - minMarkW, 0f))
                             drawRoundRect(
                                 color = markTone,
                                 topLeft = Offset(x0, markY - markH / 2f),

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -725,9 +725,10 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
                         // colour that is not the one the axis labels use. Reported as "many gaps" by a
                         // wearer who read the old evenly spaced tertiary dots as tick marks and asked
                         // whether he needed to enable continuous HRV to fill them. A scale does not
-                        // start and stop with the data, so a bar that spans exactly the hole cannot be
-                        // read as one. A single masked hour still gets a mark, floored to the stroke
-                        // width so it stays visible rather than collapsing to a hairline.
+                        // start and stop with the data, so a bar sitting under the stretch it explains
+                        // cannot be read as one. The span already covers the masked hours edge to edge,
+                        // so the floor below is only for a degenerate series with no width to spread
+                        // across, not the ordinary lone-hour case.
                         val markY = h - markBand / 2f
                         val markH = (markBand * 0.5f).coerceAtLeast(1f)
                         StressTrace.movingSpans(points, w).forEach { span ->

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -667,7 +667,12 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
                     // The chart and its hour labels share ONE column, so the labels line up with the
                     // ink they name. As siblings of the whole row they started at the card's edge
                     // instead, shifted left of the chart by the width of the level scale (#2106).
-                    Column(modifier = Modifier.weight(1f)) {
+                    // The 10.dp is the gap the labels had as a direct child of the card's column,
+                    // carried over so moving them only changes WHERE they start, not how they sit.
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = Arrangement.spacedBy(10.dp),
+                    ) {
                         Canvas(
                             modifier = Modifier
                                 .fillMaxWidth()

--- a/android/app/src/main/java/com/noop/widget/StressGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/StressGlanceWidget.kt
@@ -266,7 +266,7 @@ private fun StressTraceImage(
     val bmp = runCatching {
         StressTraceRenderer.render(
             segments = StressTrace.segments(snap.stressSeries, wPx.toFloat(), hPx.toFloat()),
-            movingMarks = StressTrace.movingMarks(snap.stressSeries, wPx.toFloat()),
+            movingSpans = StressTrace.movingSpans(snap.stressSeries, wPx.toFloat()),
             highPoints = StressTrace.highPoints(snap.stressSeries, wPx.toFloat(), hPx.toFloat()),
             widthPx = wPx,
             heightPx = hPx,

--- a/android/app/src/main/java/com/noop/widget/StressGlanceWidget.kt
+++ b/android/app/src/main/java/com/noop/widget/StressGlanceWidget.kt
@@ -326,7 +326,8 @@ private fun StressTraceImage(
 }
 
 /**
- * The time labels under the curve: first, middle and last SCORED hour (see [StressTrace.timeTicks]).
+ * The time labels under the curve: first, middle and last instant of the SERIES (see
+ * [StressTrace.timeTicks]), which is the span the trace above is drawn across.
  *
  * Spread with weighted spacers rather than fixed gaps, so the middle label sits over the middle of the
  * chart whatever width the launcher gave the widget. Formatted through the locale's short time format,
@@ -335,7 +336,7 @@ private fun StressTraceImage(
 @Composable
 private fun StressTimeAxis(snap: WidgetSnapshot, dark: Boolean) {
     val ticks = StressTrace.timeTicks(snap.stressSeries)
-    // One scored hour names one instant, and a single label pinned to the left edge reads as a stray
+    // One instant names one instant, and a single label pinned to the left edge reads as a stray
     // rather than an axis, so the axis only appears once there is a span to label.
     if (ticks.size < 2) return
     val fmt = DateFormat.getTimeInstance(DateFormat.SHORT)

--- a/android/app/src/main/java/com/noop/widget/StressTrace.kt
+++ b/android/app/src/main/java/com/noop/widget/StressTrace.kt
@@ -165,14 +165,12 @@ object StressTrace {
     /**
      * The moving hours grouped into CONTIGUOUS x ranges, for the marks along the base (#2106).
      *
-     * Separate from [movingMarks] because the two answer different questions. Bare centres say where
-     * each masked hour was; a run says which STRETCH of the day was masked, and that is what a reader
-     * needs when they are looking at a hole in the trace and trying to work out what put it there.
-     *
-     * The reason this matters was reported rather than theorised. A wearer saw the gaps, read the
-     * evenly spaced dots along the zero line as axis ticks, and concluded the data itself was missing,
-     * asking whether continuous HRV tracking would fill them in. Adjacent hours drawn as one bar under
-     * the gap it explains cannot be mistaken for a scale, because a scale does not start and stop with
+     * A run rather than a mark per hour, because a run says which STRETCH of the day was masked, and
+     * that is what a reader needs when they are looking at a hole in the trace and trying to work out
+     * what put it there. The reason it matters was reported rather than theorised: a wearer saw the
+     * gaps, read the evenly spaced marks along the zero line as axis ticks, concluded the data itself
+     * was missing, and asked whether continuous HRV tracking would fill them in. One bar under the
+     * stretch it explains cannot be mistaken for a scale, because a scale does not start and stop with
      * the data.
      *
      * Adjacency is by POSITION in the series, not by timestamp arithmetic: the series is already the
@@ -186,6 +184,10 @@ object StressTrace {
      * from the list entirely) still gets honest extents. At the ends of the series the territory stops
      * at the point itself: the day's extent is what was sampled, and nothing is invented past it, which
      * also keeps every span inside the box without a clamp.
+     *
+     * The upper edge is floored to the lower one. On a sorted series it never binds, but the two
+     * platforms disagree about what an inverted range means, Kotlin yielding an empty one where Swift
+     * traps, and a twin that crashes on one side and shrugs on the other is not a twin.
      */
     fun movingSpans(series: List<StressPoint>, width: Float): List<ClosedFloatingPointRange<Float>> {
         if (series.isEmpty() || width <= 0f) return emptyList()
@@ -206,26 +208,12 @@ object StressTrace {
             // A run closes at the first hour that is NOT moving, and also at the end of the series, or
             // a day whose last hours were all masked would be dropped for want of a terminator.
             if (from != null && (!moving || i == last)) {
-                out.add(leftEdge(from)..rightEdge(if (moving) i else i - 1))
+                val lo = leftEdge(from)
+                out.add(lo..maxOf(rightEdge(if (moving) i else i - 1), lo))
                 runStart = null
             }
         }
         return out
-    }
-
-    /**
-     * X positions of the hours masked as movement, for the faint marks along the base.
-     *
-     * Returned as bare X centres rather than as spans: the mark's thickness is a drawing decision and
-     * belongs to the renderer, while WHERE the moving hours were is a fact about the day.
-     */
-    fun movingMarks(series: List<StressPoint>, width: Float): List<Float> {
-        if (series.isEmpty() || width <= 0f) return emptyList()
-        val t0 = series.first().ts
-        val span = (series.last().ts - t0).toFloat()
-        return series.filter { it.moving }.map { p ->
-            if (span <= 0f) 0f else (p.ts - t0) / span * width
-        }
     }
 
     /**

--- a/android/app/src/main/java/com/noop/widget/StressTrace.kt
+++ b/android/app/src/main/java/com/noop/widget/StressTrace.kt
@@ -177,21 +177,36 @@ object StressTrace {
      *
      * Adjacency is by POSITION in the series, not by timestamp arithmetic: the series is already the
      * hour grid the chart draws, so two neighbouring entries are two neighbouring hours by construction.
+     *
+     * A span runs edge to edge of the hours it covers, NOT centre to centre. An hour is a stretch of the
+     * day, not an instant, and the difference is the whole case for the change: centre to centre gives a
+     * lone masked hour a width of zero, which is exactly the hour that most needs to be legible, since
+     * there is no run of neighbours to make it obvious. Edges are taken as the MIDPOINT to each
+     * neighbour rather than as a fixed slot, so an irregular series (a DST-long day, an hour missing
+     * from the list entirely) still gets honest extents. At the ends of the series the territory stops
+     * at the point itself: the day's extent is what was sampled, and nothing is invented past it, which
+     * also keeps every span inside the box without a clamp.
      */
     fun movingSpans(series: List<StressPoint>, width: Float): List<ClosedFloatingPointRange<Float>> {
         if (series.isEmpty() || width <= 0f) return emptyList()
         val t0 = series.first().ts
         val span = (series.last().ts - t0).toFloat()
-        fun xOf(ts: Long): Float = if (span <= 0f) 0f else (ts - t0) / span * width
+        val xs = FloatArray(series.size) {
+            if (span <= 0f) 0f else (series[it].ts - t0) / span * width
+        }
+        val last = series.lastIndex
+        fun leftEdge(i: Int): Float = if (i == 0) xs[0] else (xs[i - 1] + xs[i]) / 2f
+        fun rightEdge(i: Int): Float = if (i == last) xs[last] else (xs[i] + xs[i + 1]) / 2f
         val out = ArrayList<ClosedFloatingPointRange<Float>>()
         var runStart: Int? = null
         for (i in series.indices) {
             val moving = series[i].moving
             if (moving && runStart == null) runStart = i
-            val runEnds = !moving || i == series.lastIndex
-            if (runEnds && runStart != null) {
-                val last = if (moving) i else i - 1
-                out.add(xOf(series[runStart!!].ts)..xOf(series[last].ts))
+            val from = runStart
+            // A run closes at the first hour that is NOT moving, and also at the end of the series, or
+            // a day whose last hours were all masked would be dropped for want of a terminator.
+            if (from != null && (!moving || i == last)) {
+                out.add(leftEdge(from)..rightEdge(if (moving) i else i - 1))
                 runStart = null
             }
         }

--- a/android/app/src/main/java/com/noop/widget/StressTrace.kt
+++ b/android/app/src/main/java/com/noop/widget/StressTrace.kt
@@ -225,18 +225,30 @@ object StressTrace {
     fun levelTicks(): List<Int> = listOf(3, 2, 1, 0)
 
     /**
-     * The three timestamps along the bottom: first, middle, last of the SCORED data, not of the day.
+     * The three timestamps along the bottom: first, middle and last of the SERIES.
      *
-     * Anchored to scored hours because a day that only has an evening's worth of signal would otherwise
-     * label its axis with a morning that was never sampled, and the trace would sit crushed into the
-     * right-hand end of a mostly empty chart. Fewer than three distinct instants returns what there is,
-     * so the renderer draws one label rather than three copies of it.
+     * The series, not the scored hours, because these label the AXIS, and the axis IS the series: every
+     * placement in this file maps x across `first.ts .. last.ts`, and every renderer spreads these three
+     * labels evenly across that same width. Anchoring them to the scored subset instead put the last
+     * SCORED instant at the right-hand edge, so a day whose closing hours were all masked as movement
+     * announced that it ended when scoring stopped rather than when the day did.
+     *
+     * That is the second half of #2106, and it was read exactly as it was drawn: a chart running to
+     * 22:00 labelled "18:30" at its right edge, reported as the app having stopped updating. The
+     * trailing hours were there the whole time, masked as exertion. Only the axis disagreed.
+     *
+     * The rationale this replaces was that an evening-only wearer would otherwise be labelled with a
+     * morning that was never sampled. The buckets are built FROM the samples, so the series carries no
+     * unsampled hours to begin with, and the trace was already spread across the series either way. The
+     * labels were the only part that ever disagreed with the geometry.
+     *
+     * Fewer than three distinct instants returns what there is, so the renderer draws one label rather
+     * than three copies of it.
      */
     fun timeTicks(series: List<StressPoint>): List<Long> {
-        val scored = series.filter { it.level != null }
-        if (scored.isEmpty()) return emptyList()
-        val first = scored.first().ts
-        val last = scored.last().ts
+        if (series.isEmpty()) return emptyList()
+        val first = series.first().ts
+        val last = series.last().ts
         if (first == last) return listOf(first)
         val mid = first + (last - first) / 2
         return if (mid == first || mid == last) listOf(first, last) else listOf(first, mid, last)

--- a/android/app/src/main/java/com/noop/widget/StressTrace.kt
+++ b/android/app/src/main/java/com/noop/widget/StressTrace.kt
@@ -163,6 +163,42 @@ object StressTrace {
     }
 
     /**
+     * The moving hours grouped into CONTIGUOUS x ranges, for the marks along the base (#2106).
+     *
+     * Separate from [movingMarks] because the two answer different questions. Bare centres say where
+     * each masked hour was; a run says which STRETCH of the day was masked, and that is what a reader
+     * needs when they are looking at a hole in the trace and trying to work out what put it there.
+     *
+     * The reason this matters was reported rather than theorised. A wearer saw the gaps, read the
+     * evenly spaced dots along the zero line as axis ticks, and concluded the data itself was missing,
+     * asking whether continuous HRV tracking would fill them in. Adjacent hours drawn as one bar under
+     * the gap it explains cannot be mistaken for a scale, because a scale does not start and stop with
+     * the data.
+     *
+     * Adjacency is by POSITION in the series, not by timestamp arithmetic: the series is already the
+     * hour grid the chart draws, so two neighbouring entries are two neighbouring hours by construction.
+     */
+    fun movingSpans(series: List<StressPoint>, width: Float): List<ClosedFloatingPointRange<Float>> {
+        if (series.isEmpty() || width <= 0f) return emptyList()
+        val t0 = series.first().ts
+        val span = (series.last().ts - t0).toFloat()
+        fun xOf(ts: Long): Float = if (span <= 0f) 0f else (ts - t0) / span * width
+        val out = ArrayList<ClosedFloatingPointRange<Float>>()
+        var runStart: Int? = null
+        for (i in series.indices) {
+            val moving = series[i].moving
+            if (moving && runStart == null) runStart = i
+            val runEnds = !moving || i == series.lastIndex
+            if (runEnds && runStart != null) {
+                val last = if (moving) i else i - 1
+                out.add(xOf(series[runStart!!].ts)..xOf(series[last].ts))
+                runStart = null
+            }
+        }
+        return out
+    }
+
+    /**
      * X positions of the hours masked as movement, for the faint marks along the base.
      *
      * Returned as bare X centres rather than as spans: the mark's thickness is a drawing decision and

--- a/android/app/src/main/java/com/noop/widget/StressTraceRenderer.kt
+++ b/android/app/src/main/java/com/noop/widget/StressTraceRenderer.kt
@@ -29,13 +29,13 @@ internal object StressTraceRenderer {
     /**
      * @param segments from [StressTrace.segments], already normalised into the box, each a contiguous
      *        run of scored hours
-     * @param movingMarks from [StressTrace.movingMarks], X centres of the hours masked as movement
+     * @param movingSpans from [StressTrace.movingSpans], the CONTIGUOUS stretches masked as movement
      * @return the trace, or null when there is nothing to draw or the box is degenerate, so the caller
      *         shows the empty state rather than an empty image.
      */
     fun render(
         segments: List<List<StressTrace.Pt>>,
-        movingMarks: List<Float>,
+        movingSpans: List<ClosedFloatingPointRange<Float>>,
         /** from [StressTrace.highPoints], the scored hours sitting in the high band */
         highPoints: List<StressTrace.Pt>,
         widthPx: Int,
@@ -54,7 +54,7 @@ internal object StressTraceRenderer {
         markColor: Int,
         strokePx: Float,
     ): Bitmap? {
-        if (segments.isEmpty() && movingMarks.isEmpty() && highPoints.isEmpty()) return null
+        if (segments.isEmpty() && movingSpans.isEmpty() && highPoints.isEmpty()) return null
         // The caller sized this with the shared payload budget; re-check it rather than re-decide it.
         val w = widthPx.coerceAtLeast(1)
         val h = heightPx.coerceAtLeast(1)
@@ -69,7 +69,7 @@ internal object StressTraceRenderer {
 
         // Reserve the bottom strip for the movement marks so a calm hour's line, which sits at the very
         // bottom of a fixed domain, cannot be confused with them.
-        val markBand = if (movingMarks.isEmpty()) 0f else (strokePx * 2f).coerceAtMost(h / 6f)
+        val markBand = if (movingSpans.isEmpty()) 0f else (strokePx * 2f).coerceAtMost(h / 6f)
         val chartH = (h - markBand).coerceAtLeast(1f)
 
         // Inset by the stroke so a point sitting exactly on the top or bottom edge is not shaved in half.
@@ -164,20 +164,27 @@ internal object StressTraceRenderer {
             }
         }
 
-        if (movingMarks.isNotEmpty() && markBand > 0f) {
+        if (movingSpans.isNotEmpty() && markBand > 0f) {
             val markPaint = Paint().apply {
                 isAntiAlias = true
                 color = markColor
                 style = Paint.Style.FILL
             }
-            val halfWidth = (strokePx * 1.5f).coerceAtLeast(1f)
+            // A span arrives covering its hours edge to edge, so the only width left to decide is the
+            // FLOOR, for a degenerate series with no width to spread across. It is the width the mark
+            // used to have unconditionally, kept so the smallest mark is no less visible than before.
+            val minWidth = (strokePx * 3f).coerceAtLeast(1f)
+            val radius = markBand / 2f
             val top = h - markBand
-            for (x in movingMarks) {
-                canvas.drawRoundRect(
-                    (x - halfWidth).coerceAtLeast(0f), top,
-                    (x + halfWidth).coerceAtMost(w.toFloat()), h.toFloat(),
-                    halfWidth, halfWidth, markPaint,
-                )
+            val right = w.toFloat()
+            for (span in movingSpans) {
+                val lo = span.start.coerceIn(0f, right)
+                val hi = span.endInclusive.coerceIn(0f, right)
+                // Floored by GROWING right, then left if that ran into the edge, so a mark at either
+                // end of the day keeps its width instead of being trimmed away by the box.
+                val x1 = maxOf(hi, minOf(lo + minWidth, right))
+                val x0 = minOf(lo, maxOf(x1 - minWidth, 0f))
+                canvas.drawRoundRect(x0, top, x1, h.toFloat(), radius, radius, markPaint)
             }
         }
         return bmp

--- a/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
+++ b/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
@@ -157,16 +157,34 @@ class StressTraceTest {
     }
 
     @Test
-    fun `time ticks anchor to the scored hours, not to the day`() {
+    fun `time ticks label the axis, which spans the whole series`() {
         val day = listOf(at(0, null), at(8, 1.0), at(12, 1.5), at(16, 2.0), at(23, null))
-        val ticks = StressTrace.timeTicks(day)
-        // An evening-only day must not label its axis with a morning that was never sampled.
-        assertEquals(listOf(8 * h, 12 * h, 16 * h), ticks)
+        // Every renderer spreads these three evenly across the chart, and the chart spans the SERIES.
+        // Anything narrower names the wrong instant at the edge it is drawn against.
+        assertEquals(listOf(0L, 11 * h + 1800L, 23 * h), StressTrace.timeTicks(day))
+    }
+
+    /**
+     * #2106: scored to 18:30, masked as movement until 22:00, and the axis said the day ended at 18:30.
+     * The right-hand label is the end of the DAY, not the end of scoring, or a chart that is perfectly
+     * current reads as one that stopped updating hours ago.
+     */
+    @Test
+    fun `a day whose closing hours were all masked still names its true end`() {
+        val day = listOf(at(6, 1.0), at(18, 1.5), at(20, null, moving = true), at(22, null, moving = true))
+        assertEquals(22 * h, StressTrace.timeTicks(day).last())
     }
 
     @Test
-    fun `one scored hour names one instant`() {
-        assertEquals(listOf(9 * h), StressTrace.timeTicks(listOf(at(9, 1.0), at(10, null))))
+    fun `one instant names one instant`() {
+        // The renderers hide a lone label, so this is what keeps a one-point day from showing a stray.
+        assertEquals(listOf(9 * h), StressTrace.timeTicks(listOf(at(9, 1.0))))
+    }
+
+    @Test
+    fun `two instants name both ends and the midpoint between them`() {
+        assertEquals(listOf(9 * h, 9 * h + 1800L, 10 * h),
+                     StressTrace.timeTicks(listOf(at(9, 1.0), at(10, null))))
     }
 
     // #2106: contiguous masked stretches, so the marks read as regions rather than as axis ticks.

--- a/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
+++ b/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
@@ -207,4 +207,38 @@ class StressTraceTest {
         val series = listOf(pt(0, 1.0, false), pt(3600, 2.0, false))
         assertEquals(emptyList<ClosedFloatingPointRange<Float>>(), StressTrace.movingSpans(series, 100f))
     }
+
+    /**
+     * A LONE masked hour is the case the geometry exists for: centre to centre it has a width of zero,
+     * and it is the hour with no neighbours to make it obvious, so it is also the one that most needs
+     * to be legible. It covers its own hour, half a slot either side of its centre.
+     */
+    @Test
+    fun `a lone moving hour spans its own hour, not an instant`() {
+        val series = listOf(
+            pt(0, 1.0, false), pt(3600, 1.0, false), pt(7200, null, true),
+            pt(10800, 1.0, false), pt(14400, 1.0, false),
+        )
+        val span = StressTrace.movingSpans(series, 100f).single()
+        assertEquals(37.5f, span.start, 0.01f)
+        assertEquals(62.5f, span.endInclusive, 0.01f)
+    }
+
+    /** A run covers its hours EDGE to edge, so the bar reaches past the outermost masked centres. */
+    @Test
+    fun `a run covers its hours edge to edge`() {
+        val series = listOf(
+            pt(0, 1.0, false), pt(3600, null, true), pt(7200, null, true), pt(10800, 1.0, false),
+        )
+        val span = StressTrace.movingSpans(series, 100f).single()
+        assertEquals(100f / 6f, span.start, 0.01f)
+        assertEquals(100f * 5f / 6f, span.endInclusive, 0.01f)
+    }
+
+    /** At the ends of the day the territory stops at the data: nothing is invented past what was sampled. */
+    @Test
+    fun `a run starting at the first hour starts at the edge of the box`() {
+        val series = listOf(pt(0, null, true), pt(3600, 1.0, false), pt(7200, 1.0, false))
+        assertEquals(0f, StressTrace.movingSpans(series, 100f).single().start, 0.01f)
+    }
 }

--- a/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
+++ b/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
@@ -168,4 +168,43 @@ class StressTraceTest {
     fun `one scored hour names one instant`() {
         assertEquals(listOf(9 * h), StressTrace.timeTicks(listOf(at(9, 1.0), at(10, null))))
     }
+
+    // #2106: contiguous masked stretches, so the marks read as regions rather than as axis ticks.
+
+    private fun pt(ts: Long, level: Double?, moving: Boolean) = StressPoint(ts, level, moving)
+
+    /** Adjacent masked hours become ONE span: that is the whole point, a bar under the hole it explains. */
+    @Test
+    fun `adjacent moving hours join into one span`() {
+        val series = listOf(
+            pt(0, 1.0, false), pt(3600, null, true), pt(7200, null, true), pt(10800, 1.5, false),
+        )
+        val spans = StressTrace.movingSpans(series, 100f)
+        assertEquals(1, spans.size)
+    }
+
+    /** Separated runs stay separate, so two different stretches are not merged into one claim. */
+    @Test
+    fun `separated moving runs stay separate`() {
+        val series = listOf(
+            pt(0, null, true), pt(3600, 1.0, false), pt(7200, null, true),
+        )
+        assertEquals(2, StressTrace.movingSpans(series, 100f).size)
+    }
+
+    /** A run ending at the LAST point still closes, rather than being dropped for want of a terminator. */
+    @Test
+    fun `a run ending at the last point is still emitted`() {
+        val series = listOf(pt(0, 1.0, false), pt(3600, null, true), pt(7200, null, true))
+        val spans = StressTrace.movingSpans(series, 100f)
+        assertEquals(1, spans.size)
+        assertEquals(100f, spans.first().endInclusive, 0.01f)
+    }
+
+    /** No moving hours means no marks, so an ordinary day carries no band at all. */
+    @Test
+    fun `no moving hours yields no spans`() {
+        val series = listOf(pt(0, 1.0, false), pt(3600, 2.0, false))
+        assertEquals(emptyList<ClosedFloatingPointRange<Float>>(), StressTrace.movingSpans(series, 100f))
+    }
 }

--- a/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
+++ b/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
@@ -76,9 +76,9 @@ class StressTraceTest {
     fun `hours masked as movement are marked and do not join the line`() {
         val day = listOf(at(0, 1.0), at(1, null, moving = true), at(2, 1.0))
         assertEquals(2, StressTrace.segments(day, 100f, 100f).size)
-        val marks = StressTrace.movingMarks(day, 100f)
-        assertEquals(1, marks.size)
-        assertEquals(50f, marks.single(), 0.001f)
+        val span = StressTrace.movingSpans(day, 100f).single()
+        assertEquals(25f, span.start, 0.001f)
+        assertEquals(75f, span.endInclusive, 0.001f)
     }
 
     // MARK: - the high band
@@ -171,41 +171,33 @@ class StressTraceTest {
 
     // #2106: contiguous masked stretches, so the marks read as regions rather than as axis ticks.
 
-    private fun pt(ts: Long, level: Double?, moving: Boolean) = StressPoint(ts, level, moving)
-
     /** Adjacent masked hours become ONE span: that is the whole point, a bar under the hole it explains. */
     @Test
     fun `adjacent moving hours join into one span`() {
-        val series = listOf(
-            pt(0, 1.0, false), pt(3600, null, true), pt(7200, null, true), pt(10800, 1.5, false),
-        )
-        val spans = StressTrace.movingSpans(series, 100f)
-        assertEquals(1, spans.size)
+        val day = listOf(at(0, 1.0), at(1, null, moving = true), at(2, null, moving = true), at(3, 1.5))
+        assertEquals(1, StressTrace.movingSpans(day, 100f).size)
     }
 
     /** Separated runs stay separate, so two different stretches are not merged into one claim. */
     @Test
     fun `separated moving runs stay separate`() {
-        val series = listOf(
-            pt(0, null, true), pt(3600, 1.0, false), pt(7200, null, true),
-        )
-        assertEquals(2, StressTrace.movingSpans(series, 100f).size)
+        val day = listOf(at(0, null, moving = true), at(1, 1.0), at(2, null, moving = true))
+        assertEquals(2, StressTrace.movingSpans(day, 100f).size)
     }
 
-    /** A run ending at the LAST point still closes, rather than being dropped for want of a terminator. */
+    /** A run ending at the LAST hour still closes, rather than being dropped for want of a terminator. */
     @Test
     fun `a run ending at the last point is still emitted`() {
-        val series = listOf(pt(0, 1.0, false), pt(3600, null, true), pt(7200, null, true))
-        val spans = StressTrace.movingSpans(series, 100f)
-        assertEquals(1, spans.size)
-        assertEquals(100f, spans.first().endInclusive, 0.01f)
+        val day = listOf(at(0, 1.0), at(1, null, moving = true), at(2, null, moving = true))
+        val span = StressTrace.movingSpans(day, 100f).single()
+        assertEquals(100f, span.endInclusive, 0.001f)
     }
 
     /** No moving hours means no marks, so an ordinary day carries no band at all. */
     @Test
     fun `no moving hours yields no spans`() {
-        val series = listOf(pt(0, 1.0, false), pt(3600, 2.0, false))
-        assertEquals(emptyList<ClosedFloatingPointRange<Float>>(), StressTrace.movingSpans(series, 100f))
+        assertEquals(emptyList<ClosedFloatingPointRange<Float>>(),
+                     StressTrace.movingSpans(listOf(at(0, 1.0), at(1, 2.0)), 100f))
     }
 
     /**
@@ -215,30 +207,25 @@ class StressTraceTest {
      */
     @Test
     fun `a lone moving hour spans its own hour, not an instant`() {
-        val series = listOf(
-            pt(0, 1.0, false), pt(3600, 1.0, false), pt(7200, null, true),
-            pt(10800, 1.0, false), pt(14400, 1.0, false),
-        )
-        val span = StressTrace.movingSpans(series, 100f).single()
-        assertEquals(37.5f, span.start, 0.01f)
-        assertEquals(62.5f, span.endInclusive, 0.01f)
+        val day = listOf(at(0, 1.0), at(1, 1.0), at(2, null, moving = true), at(3, 1.0), at(4, 1.0))
+        val span = StressTrace.movingSpans(day, 100f).single()
+        assertEquals(37.5f, span.start, 0.001f)
+        assertEquals(62.5f, span.endInclusive, 0.001f)
     }
 
     /** A run covers its hours EDGE to edge, so the bar reaches past the outermost masked centres. */
     @Test
     fun `a run covers its hours edge to edge`() {
-        val series = listOf(
-            pt(0, 1.0, false), pt(3600, null, true), pt(7200, null, true), pt(10800, 1.0, false),
-        )
-        val span = StressTrace.movingSpans(series, 100f).single()
-        assertEquals(100f / 6f, span.start, 0.01f)
-        assertEquals(100f * 5f / 6f, span.endInclusive, 0.01f)
+        val day = listOf(at(0, 1.0), at(1, null, moving = true), at(2, null, moving = true), at(3, 1.0))
+        val span = StressTrace.movingSpans(day, 100f).single()
+        assertEquals(100f / 6f, span.start, 0.001f)
+        assertEquals(100f * 5f / 6f, span.endInclusive, 0.001f)
     }
 
     /** At the ends of the day the territory stops at the data: nothing is invented past what was sampled. */
     @Test
     fun `a run starting at the first hour starts at the edge of the box`() {
-        val series = listOf(pt(0, null, true), pt(3600, 1.0, false), pt(7200, 1.0, false))
-        assertEquals(0f, StressTrace.movingSpans(series, 100f).single().start, 0.01f)
+        val day = listOf(at(0, null, moving = true), at(1, 1.0), at(2, 1.0))
+        assertEquals(0f, StressTrace.movingSpans(day, 100f).single().start, 0.001f)
     }
 }


### PR DESCRIPTION
## What this PR does

Answers the first half of #2106: "many gaps" in the stress chart, with the reporter asking whether he needed to enable continuous HRV tracking to fill them.

**He did not.** The gaps are already explained, and the explanation is what failed to communicate.

## Both halves of the report are the same bug

The issue raises two things, "many gaps" and "this is a screenshot from 22:38, the screenshot shows an update untill 18:30 only". They have one cause.

**The chart was never stale.** Its axis said it was. `timeTicks` named the first, middle and last *scored* instant, and every renderer spreads those three evenly across the full width, which is the **series**. On a day whose closing hours were all masked as movement, the last scored instant landed on the right-hand edge, and the chart announced that the day ended when scoring stopped.

The screenshot proves it arithmetically: 06:00 and 18:30 with **12:15** between them is exactly the midpoint of the scored span, and the movement marks continue past 18:30 to roughly x=0.97 of the width, about 22:00, where the series actually ends. The HR card in the same report runs to "Now" at a live 88 bpm with peaks to 135, so the samples were there the whole evening and it was an active one.

`HrTrace.timeTicks` has always anchored to the series. That is why the HR card on the same screen, on the same day, labelled itself correctly while the stress card claimed 18:30.

## The gaps are deliberate

An hour that is substantially ambulatory is masked as **exertion rather than scored as stress**, plus a shadow hour after it while mean HR is still elevated. The model is careful about the distinction: the hour carries `maskedForActivity` specifically so a caller can tell "masked as activity" apart from "no data", and that flag survives into the chart as `StressPoint.moving`.

Worth saying plainly for the reporter's question: HRV does not feed the live score at all today. `daytimeRMSSDScoringEnabled` is `false`, held until daytime HR+RMSSD is shown to beat the HR-only r≈0.6 ceiling. Enabling anything would not have changed a single gap.

## What the chart did with it

```kotlin
drawCircle(color = textTertiary, radius = strokeW * 0.6f,
           center = Offset(it, h - markBand / 2f))
```

One dot per masked hour, at 60% of the trace stroke, in **the colour the axis labels use**, sitting on the zero gridline. In the reporter's screenshot those dots are present under every gap: two near 07:00, two near 11:00, five after 17:00. They read as tick marks, which is what he took them for.

## The fix

- adjacent masked hours join into **one bar** instead of a mark each. A scale does not start and stop with the data, so a bar sitting under the stretch it explains cannot be mistaken for one;
- on the screen, the tone moves off the axis-label colour onto the one the widget already used.

A span runs **edge to edge of the hours it covers, not centre to centre**. An hour is a stretch of the day, not an instant, and the distinction is not cosmetic: centre to centre gives a lone masked hour a width of zero, and that is the hour that most needs to be legible, since there are no neighbours to make it obvious. Edges are the midpoint to each neighbour rather than a fixed slot, so an irregular series (a DST-long day, an hour absent from the list) still gets honest extents; at either end of the day the territory stops at the data, so nothing is invented past what was sampled and no clamp is needed.

## All four surfaces, not one

The first pass changed the Android screen alone. That was wrong, and the review that caught it is worth recording, because nothing automated would have.

Four surfaces draw these marks. Before, the three that draw any agreed on the rule; a screen-only change would have traded a two-way inconsistency for a three-way one. `StrandiOSShared/StressTrace.swift` is a real twin of the Kotlin object, pinned case for case by `StrandTests/StressTraceTests.swift`, and `movingSpans` had gone into only one half of a file whose own doc says these are the same decisions on both platforms and should not be made twice.

**`Tools/parity_ledger.py` excludes both halves** (`android/.../com/noop/widget/**` on the Kotlin side, `StrandiOS*/**` on the Swift), so this twin pair sits outside the automated scan entirely. There is no deferred ledger drift waiting to ambush a later PR, and equally no gate. The ledger run on this branch is clean.

So the span rule is ported to Swift unchanged and **both widgets move onto it**. That is a real improvement for them in its own right: three consecutive masked hours were three separate pills at hour centres, which is exactly the reading the report is about, at the size where a mark is hardest to tell from a tick.

`movingMarks` is **deleted from both platforms**. Its last caller was the widget renderer, and a pure module is precisely where an unused public function drifts.

## Two things the port itself surfaced

**The platforms disagreed about an inverted range.** Kotlin yields an empty one, Swift **traps**. Only an unsorted series can produce one and `decode` sorts, so it is not reachable today, but a twin that crashes on one side and shrugs on the other is not a twin. Both now floor the upper edge to the lower.

**The screen's floor was narrower than the dot it replaced.** With spans edge to edge the floor only fires for a degenerate series, but it was one stroke wide, so the single case that reached it came out *worse* than before the change. It now takes the widget's width, which is what the mark had unconditionally before.

## The axis

One filter removed on both platforms. Every renderer becomes correct without a layout change: an even spread is honest as soon as the ticks span what the chart spans.

The rationale being replaced was that an evening-only wearer would otherwise be labelled with a morning never sampled. The buckets are built **from** the samples, so the series carries no unsampled hours to begin with, and the trace was already mapped across the series either way. The labels were the only part that disagreed with the geometry.

Separately, the card's hour labels sat under the **card** rather than under the **chart**, shifted left by the width of the level scale, because they were a sibling of the row holding the scale and the canvas. They move into the canvas's own column, so nothing has to be kept in sync by hand.

## Scope

iOS's **screen** still draws no marks at all, and that is deliberately out of scope. `DaytimeLoadLine` takes `[DaytimeStress.HourPoint]` and rolls its own `scoredRuns` geometry rather than going through `StressTrace`, so it never sees a type carrying `moving` even though `maskedForActivity` is on the data it already receives. Giving it marks means giving it a mark band it does not have and deciding whether it should use the shared module at all. Its header comment repeats the caption's error below, too.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

`StressTraceTest`: **26 tests, 0 failures** (17 before, plus 9), forced with `--rerun-tasks` after `syncRoomSchemaSnapshot` in its own invocation, XML timestamp checked against the clock.

Four pin the grouping: adjacency joining, separated runs staying separate, a run ending at the **last** point still closing rather than being dropped for want of a terminator, and no moving hours drawing nothing. Three pin the geometry, which is the part that would quietly regress back to centres: a lone hour covering half a slot either side, a run reaching past its outermost centres, and a run at the start of the day stopping at the edge of the box.

Two more cover the axis, and two that pinned the old scored-anchored invariant are **repinned to the same shape rather than dropped**: one asserts the reported case directly, a day scored to 18:30 and masked to 22:00 whose last label must be 22:00; the other keeps a single-instant day from drawing a stray label, which is what the renderers' `size >= 2` gate relies on.

All nine are **mirrored into `StrandTests/StressTraceTests.swift`**, whose own doc promises it mirrors the Kotlin case for case, so the two suites stay level.

`compileFullDebugKotlin` clean; `Tools/parity_ledger.py` clean. The Swift half is app-target and does not build on Linux, so CI's `build (Strand, macOS)` is the compiler for it.

No scoring change anywhere: the masking, its thresholds and the curve are untouched, only how an already-computed mask is drawn.

**Not confirmed on a device.** The geometry is unit-tested; that the bars read as an explanation is the thing that actually needs a human looking at a phone, and the two widgets need a home screen.

## Deliberately not fixed here: the copy, which is the likelier culprit

Two strings say the wrong thing, and between them they answer the reporter's question incorrectly in words, which no amount of redrawing fixes.

**The caption under the chart** ends "Hours without enough data are skipped." His hours were not short of data, they were masked as ambulatory. The model works hard to keep those apart, `maskedForActivity` exists for no other reason, and the caption collapses them into the one explanation that is not his. He saw gaps, read that sentence, and asked whether continuous HRV would fill them. That sentence is also hardcoded English concatenated onto a localized string, so it is a l10n hole as well as a factual one.

**The screen's subtitle** reads "Autonomic load from HRV and resting heart rate" while `daytimeRMSSDScoringEnabled` is false, naming an input the score does not use, and it is the likelier reason the question was about HRV at all.

There is also no legend anywhere naming what a mark means, on any of the four surfaces.

All three are wording across eight locales and claims about what the score means rather than rendering bugs, so they want to be written deliberately rather than by me in passing. Happy to file them as one issue.

**The second complaint in the report is untouched**: a chart ending at 18:30 read at 22:38. The attached strap log would separate "no HR after 18:30" from "stale curve", and #2121 may already have improved it.

## Related issues

Reported in #2106 by @bartmuskala.