### PR TITLE
illness: a handful of stored nights is not a baseline

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/Analytics.kt
+++ b/android/app/src/main/java/com/noop/analytics/Analytics.kt
@@ -74,6 +74,20 @@ object Zones {
  * is a UI concern, so this pure function omits it. Callers decide whether to run it.
  */
 object IllnessWatch {
+
+    /**
+     * Valid nights a signal's baseline window must carry before it may accuse the recent one.
+     *
+     * `mean` returns a figure from a SINGLE value, so without this a lone stored night is a "baseline".
+     * The respiration flag has always required it; #2130 found HRV and resting HR going without, on a
+     * device where HRV survives on 2 nights in 21 because the over-count gate withholds the rest (#1118).
+     *
+     * This does NOT make the comparison sound. The window still averages whatever was stored, including
+     * values a later engine would no longer produce, which is the substance of #2130 and needs the
+     * baseline-trust flag iOS already gates on. This only stops the thinnest version of it.
+     */
+    private const val MIN_BASELINE_NIGHTS = 10
+
     /**
      * Evaluate the [days] history (oldest -> newest). Returns a human-readable banner
      * message when 2+ anomaly flags fire, otherwise null.
@@ -99,17 +113,25 @@ object IllnessWatch {
         val flags = mutableListOf<String>()
 
         run {
+            // #2130: the same "enough valid baseline nights" rule the respiration flag below already
+            // applies. `mean` is happy with ONE value, so without this a single stored night can serve
+            // as the baseline a wearer's resting HR is judged against.
+            val rhrBase = base.mapNotNull { it.restingHr?.toDouble() }
             val r = rm { it.restingHr?.toDouble() }
             val b = bm { it.restingHr?.toDouble() }
-            if (r != null && b != null && r >= b + 5) {
+            if (r != null && b != null && rhrBase.size >= MIN_BASELINE_NIGHTS && r >= b + 5) {
                 flags.add("resting HR +${(r - b).roundToInt()} bpm")
             }
         }
 
         run {
+            // #2130: same guard, and it matters more here. HRV is the sparsest of the four, since the
+            // over-count gate withholds whole nights (#1118), so its baseline is the likeliest of them
+            // to have been resting on a handful of stored values.
+            val hrvBase = base.mapNotNull { it.avgHrv }
             val r = rm { it.avgHrv }
             val b = bm { it.avgHrv }
-            if (r != null && b != null && b > 0 && r <= b * 0.80) {
+            if (r != null && b != null && b > 0 && hrvBase.size >= MIN_BASELINE_NIGHTS && r <= b * 0.80) {
                 flags.add("HRV −${((1 - r / b) * 100).roundToInt()}%")
             }
         }
@@ -132,7 +154,7 @@ object IllnessWatch {
             val r = rm { it.respRateBpm }
             val b = bm { it.respRateBpm }
             val plausible = { v: Double -> v in 8.0..25.0 }
-            if (r != null && b != null && respBase.size >= 10 &&
+            if (r != null && b != null && respBase.size >= MIN_BASELINE_NIGHTS &&
                 plausible(r) && plausible(b) && r >= b + 2.5
             ) {
                 flags.add("respiration up")

--- a/android/app/src/main/java/com/noop/analytics/Analytics.kt
+++ b/android/app/src/main/java/com/noop/analytics/Analytics.kt
@@ -86,19 +86,15 @@ object IllnessWatch {
         val recent = days.takeLast(2)
         // ~28 days ending 3 days ago: take the last 31, drop the most recent 3.
         val base = days.takeLast(31).dropLast(3)
-        // Whether a signal's baseline window is fit to accuse the recent one (#2130).
+        // Whether a signal's window is fit to accuse the recent one (#2130). The Swift twin folds this
+        // SAME window through `Baselines.foldHistory` and refuses the signal unless the state is usable;
+        // here it was a plain mean, which is happy with ONE value and gated nothing.
         //
-        // The Swift twin of this window already does exactly this: `AppModel.applyIllnessSignal` folds
-        // the SAME `suffix(31).dropLast(3)` through `Baselines.foldHistory` and refuses the signal
-        // outright unless the state is usable. Android was taking a plain mean instead, which is happy
-        // with ONE stored value, so a lone night could be the baseline a wearer was accused against, and
-        // no gate stood between a cold-start baseline and a health warning.
+        // Folding rather than counting is the point: it is the statistic Charge is scored against, so
+        // the banner and the score can no longer hold two different baselines for one metric.
         //
-        // Folding rather than counting matters: it is the same statistic Charge is scored against, so
-        // the banner and the score can no longer hold two different baselines for one metric. On the
-        // device in #2130 they held 35.7ms and 19.71ms at the same moment.
-        // Resolved as values, not as a helper: a named local function is a declaration the parity ledger
-        // counts, and this file's Kotlin half is inside its scan.
+        // Values rather than a helper because a named local function is a declaration the parity ledger
+        // counts, and this file is inside its scan.
         val rhrBaseUsable = Baselines.metricCfg["resting_hr"]?.let { cfg ->
             Baselines.foldHistory(base.map { it.restingHr?.toDouble() }, cfg).usable
         } == true

--- a/android/app/src/main/java/com/noop/analytics/Analytics.kt
+++ b/android/app/src/main/java/com/noop/analytics/Analytics.kt
@@ -86,11 +86,25 @@ object IllnessWatch {
         val recent = days.takeLast(2)
         // ~28 days ending 3 days ago: take the last 31, drop the most recent 3.
         val base = days.takeLast(31).dropLast(3)
-        // Valid nights a signal's window must carry before it may accuse the recent one. `mean` returns
-        // a figure from a SINGLE value, so without this a lone stored night is a "baseline" (#2130).
-        // A local, not a named constant: promoting it adds parity-ledger debt for a detail of one
-        // function. It does not make the comparison SOUND, which is the rest of #2130.
-        val minBaselineNights = 10
+        // Whether a signal's baseline window is fit to accuse the recent one (#2130).
+        //
+        // The Swift twin of this window already does exactly this: `AppModel.applyIllnessSignal` folds
+        // the SAME `suffix(31).dropLast(3)` through `Baselines.foldHistory` and refuses the signal
+        // outright unless the state is usable. Android was taking a plain mean instead, which is happy
+        // with ONE stored value, so a lone night could be the baseline a wearer was accused against, and
+        // no gate stood between a cold-start baseline and a health warning.
+        //
+        // Folding rather than counting matters: it is the same statistic Charge is scored against, so
+        // the banner and the score can no longer hold two different baselines for one metric. On the
+        // device in #2130 they held 35.7ms and 19.71ms at the same moment.
+        // Resolved as values, not as a helper: a named local function is a declaration the parity ledger
+        // counts, and this file's Kotlin half is inside its scan.
+        val rhrBaseUsable = Baselines.metricCfg["resting_hr"]?.let { cfg ->
+            Baselines.foldHistory(base.map { it.restingHr?.toDouble() }, cfg).usable
+        } == true
+        val hrvBaseUsable = Baselines.metricCfg["hrv"]?.let { cfg ->
+            Baselines.foldHistory(base.map { it.avgHrv }, cfg).usable
+        } == true
 
         fun mean(vals: List<Double>): Double? =
             if (vals.isEmpty()) null else vals.sum() / vals.size.toDouble()
@@ -104,22 +118,19 @@ object IllnessWatch {
         val flags = mutableListOf<String>()
 
         run {
-            // Guarded like the respiration flag below, which has always required it.
-            val rhrBase = base.mapNotNull { it.restingHr?.toDouble() }
             val r = rm { it.restingHr?.toDouble() }
             val b = bm { it.restingHr?.toDouble() }
-            if (r != null && b != null && rhrBase.size >= minBaselineNights && r >= b + 5) {
+            if (r != null && b != null && rhrBaseUsable && r >= b + 5) {
                 flags.add("resting HR +${(r - b).roundToInt()} bpm")
             }
         }
 
         run {
             // The sparsest of the four: the over-count gate withholds whole nights (#1118), so HRV is
-            // the likeliest to have been resting on a handful of stored values.
-            val hrvBase = base.mapNotNull { it.avgHrv }
+            // the likeliest to have been resting on a cold-start baseline.
             val r = rm { it.avgHrv }
             val b = bm { it.avgHrv }
-            if (r != null && b != null && b > 0 && hrvBase.size >= minBaselineNights && r <= b * 0.80) {
+            if (r != null && b != null && b > 0 && hrvBaseUsable && r <= b * 0.80) {
                 flags.add("HRV −${((1 - r / b) * 100).roundToInt()}%")
             }
         }
@@ -142,7 +153,7 @@ object IllnessWatch {
             val r = rm { it.respRateBpm }
             val b = bm { it.respRateBpm }
             val plausible = { v: Double -> v in 8.0..25.0 }
-            if (r != null && b != null && respBase.size >= minBaselineNights &&
+            if (r != null && b != null && respBase.size >= 10 &&
                 plausible(r) && plausible(b) && r >= b + 2.5
             ) {
                 flags.add("respiration up")

--- a/android/app/src/main/java/com/noop/analytics/Analytics.kt
+++ b/android/app/src/main/java/com/noop/analytics/Analytics.kt
@@ -74,20 +74,6 @@ object Zones {
  * is a UI concern, so this pure function omits it. Callers decide whether to run it.
  */
 object IllnessWatch {
-
-    /**
-     * Valid nights a signal's baseline window must carry before it may accuse the recent one.
-     *
-     * `mean` returns a figure from a SINGLE value, so without this a lone stored night is a "baseline".
-     * The respiration flag has always required it; #2130 found HRV and resting HR going without, on a
-     * device where HRV survives on 2 nights in 21 because the over-count gate withholds the rest (#1118).
-     *
-     * This does NOT make the comparison sound. The window still averages whatever was stored, including
-     * values a later engine would no longer produce, which is the substance of #2130 and needs the
-     * baseline-trust flag iOS already gates on. This only stops the thinnest version of it.
-     */
-    private const val MIN_BASELINE_NIGHTS = 10
-
     /**
      * Evaluate the [days] history (oldest -> newest). Returns a human-readable banner
      * message when 2+ anomaly flags fire, otherwise null.
@@ -100,6 +86,11 @@ object IllnessWatch {
         val recent = days.takeLast(2)
         // ~28 days ending 3 days ago: take the last 31, drop the most recent 3.
         val base = days.takeLast(31).dropLast(3)
+        // Valid nights a signal's window must carry before it may accuse the recent one. `mean` returns
+        // a figure from a SINGLE value, so without this a lone stored night is a "baseline" (#2130).
+        // A local, not a named constant: promoting it adds parity-ledger debt for a detail of one
+        // function. It does not make the comparison SOUND, which is the rest of #2130.
+        val minBaselineNights = 10
 
         fun mean(vals: List<Double>): Double? =
             if (vals.isEmpty()) null else vals.sum() / vals.size.toDouble()
@@ -113,25 +104,22 @@ object IllnessWatch {
         val flags = mutableListOf<String>()
 
         run {
-            // #2130: the same "enough valid baseline nights" rule the respiration flag below already
-            // applies. `mean` is happy with ONE value, so without this a single stored night can serve
-            // as the baseline a wearer's resting HR is judged against.
+            // Guarded like the respiration flag below, which has always required it.
             val rhrBase = base.mapNotNull { it.restingHr?.toDouble() }
             val r = rm { it.restingHr?.toDouble() }
             val b = bm { it.restingHr?.toDouble() }
-            if (r != null && b != null && rhrBase.size >= MIN_BASELINE_NIGHTS && r >= b + 5) {
+            if (r != null && b != null && rhrBase.size >= minBaselineNights && r >= b + 5) {
                 flags.add("resting HR +${(r - b).roundToInt()} bpm")
             }
         }
 
         run {
-            // #2130: same guard, and it matters more here. HRV is the sparsest of the four, since the
-            // over-count gate withholds whole nights (#1118), so its baseline is the likeliest of them
-            // to have been resting on a handful of stored values.
+            // The sparsest of the four: the over-count gate withholds whole nights (#1118), so HRV is
+            // the likeliest to have been resting on a handful of stored values.
             val hrvBase = base.mapNotNull { it.avgHrv }
             val r = rm { it.avgHrv }
             val b = bm { it.avgHrv }
-            if (r != null && b != null && b > 0 && hrvBase.size >= MIN_BASELINE_NIGHTS && r <= b * 0.80) {
+            if (r != null && b != null && b > 0 && hrvBase.size >= minBaselineNights && r <= b * 0.80) {
                 flags.add("HRV −${((1 - r / b) * 100).roundToInt()}%")
             }
         }
@@ -154,7 +142,7 @@ object IllnessWatch {
             val r = rm { it.respRateBpm }
             val b = bm { it.respRateBpm }
             val plausible = { v: Double -> v in 8.0..25.0 }
-            if (r != null && b != null && respBase.size >= MIN_BASELINE_NIGHTS &&
+            if (r != null && b != null && respBase.size >= minBaselineNights &&
                 plausible(r) && plausible(b) && r >= b + 2.5
             ) {
                 flags.add("respiration up")

--- a/android/app/src/test/java/com/noop/analytics/AnalyticsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AnalyticsTest.kt
@@ -109,19 +109,23 @@ class AnalyticsTest {
     }
 
     /**
-     * #2130: a signal may not accuse the recent window off a handful of stored nights.
+     * #2130: a signal may not accuse the recent window off a baseline the app would not otherwise use.
      *
-     * 31 days of history, but HRV present on only 4 of the baseline nights. RHR is dense and drops hard,
-     * so the RHR flag still fires; HRV must not, which leaves one flag and no banner. The recent pair
-     * carries HRV, so this pins the BASELINE requirement rather than merely "no data".
+     * 31 days of history, but HRV on only 2 of the baseline nights, so its fold is CALIBRATING and
+     * `usable` is false. That is the field case verbatim (`hrvNValid=2, need nValid>=4`). Deliberately
+     * below the seed rather than at it: 4 valid nights would be provisional by count and rejected only
+     * for staleness, which would leave the test passing for a reason it does not name.
+     *
+     * RHR is dense and drops hard, so the RHR flag still fires; HRV must not, which leaves one flag and
+     * no banner. The recent pair carries HRV, so this pins the BASELINE rather than merely "no data".
      */
     @Test
-    fun illness_sparseHrvBaselineCannotRaiseAnHrvFlag() {
+    fun illness_unusableHrvBaselineCannotRaiseAnHrvFlag() {
         val baseline = (0 until 31).map {
             day(
                 "2026-01-%02d".format(it + 1),
                 restingHr = 50,
-                avgHrv = if (it < 4) 60.0 else null,
+                avgHrv = if (it < 2) 60.0 else null,
                 skinTempDevC = 0.0,
                 respRateBpm = 14.0,
             )
@@ -131,14 +135,14 @@ class AnalyticsTest {
             day("2026-02-02", restingHr = 58, avgHrv = 20.0, skinTempDevC = 0.0, respRateBpm = 14.0),
         )
         assertNull(
-            "one flag is not a banner, and a 4-night HRV history is not a baseline",
+            "one flag is not a banner, and a calibrating HRV fold is not a baseline",
             IllnessWatch.evaluate(baseline + recent),
         )
     }
 
-    /** The same day shape, but with a DENSE HRV baseline, still raises both flags. */
+    /** The same day shape, but with a fold that IS usable, still raises both flags. */
     @Test
-    fun illness_denseHrvBaselineStillRaisesTheHrvFlag() {
+    fun illness_usableHrvBaselineStillRaisesTheHrvFlag() {
         val baseline = (0 until 31).map {
             day("2026-01-%02d".format(it + 1), restingHr = 50, avgHrv = 60.0, skinTempDevC = 0.0, respRateBpm = 14.0)
         }
@@ -148,7 +152,7 @@ class AnalyticsTest {
         )
         val msg = IllnessWatch.evaluate(baseline + recent)
         assertNotNull(msg)
-        assertTrue("the HRV flag is what the sparse case withholds", msg!!.contains("HRV"))
+        assertTrue("the HRV flag is what the unusable case withholds", msg!!.contains("HRV"))
     }
 
     @Test

--- a/android/app/src/test/java/com/noop/analytics/AnalyticsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AnalyticsTest.kt
@@ -108,6 +108,49 @@ class AnalyticsTest {
         assertNull(IllnessWatch.evaluate(days))
     }
 
+    /**
+     * #2130: a signal may not accuse the recent window off a handful of stored nights.
+     *
+     * 31 days of history, but HRV present on only 4 of the baseline nights. RHR is dense and drops hard,
+     * so the RHR flag still fires; HRV must not, which leaves one flag and no banner. The recent pair
+     * carries HRV, so this pins the BASELINE requirement rather than merely "no data".
+     */
+    @Test
+    fun illness_sparseHrvBaselineCannotRaiseAnHrvFlag() {
+        val baseline = (0 until 31).map {
+            day(
+                "2026-01-%02d".format(it + 1),
+                restingHr = 50,
+                avgHrv = if (it < 4) 60.0 else null,
+                skinTempDevC = 0.0,
+                respRateBpm = 14.0,
+            )
+        }
+        val recent = listOf(
+            day("2026-02-01", restingHr = 58, avgHrv = 20.0, skinTempDevC = 0.0, respRateBpm = 14.0),
+            day("2026-02-02", restingHr = 58, avgHrv = 20.0, skinTempDevC = 0.0, respRateBpm = 14.0),
+        )
+        assertNull(
+            "one flag is not a banner, and a 4-night HRV history is not a baseline",
+            IllnessWatch.evaluate(baseline + recent),
+        )
+    }
+
+    /** The same day shape, but with a DENSE HRV baseline, still raises both flags. */
+    @Test
+    fun illness_denseHrvBaselineStillRaisesTheHrvFlag() {
+        val baseline = (0 until 31).map {
+            day("2026-01-%02d".format(it + 1), restingHr = 50, avgHrv = 60.0, skinTempDevC = 0.0, respRateBpm = 14.0)
+        }
+        val recent = listOf(
+            day("2026-02-01", restingHr = 58, avgHrv = 20.0, skinTempDevC = 0.0, respRateBpm = 14.0),
+            day("2026-02-02", restingHr = 58, avgHrv = 20.0, skinTempDevC = 0.0, respRateBpm = 14.0),
+        )
+        val msg = IllnessWatch.evaluate(baseline + recent)
+        assertNotNull(msg)
+        assertTrue("the HRV flag is what the sparse case withholds", msg!!.contains("HRV"))
+    }
+
     @Test
     fun illness_twoFlagsRaisesBanner() {
         // 31 calm days, then 2 strained recent days appended (33 total).


### PR DESCRIPTION
## What this does

The strain banner judged the last 2 days against a ~28 day window using a **plain mean of stored values**, with no gate of any kind. `mean` is happy with one value, so a single stored night could be the baseline a wearer was accused against.

It now folds that window through `Baselines.foldHistory` with the metric's cfg and withholds the flag unless the state is **usable** , which is what the Swift twin has always done.

## Parity, which overturned the first version of this PR

I originally wrote that iOS has no `IllnessWatch` and that this was not a parity gap. That was wrong. `AppModel.applyIllnessSignal` builds the same windows, down to the comment:

```swift
let base = Array(days.suffix(31).dropLast(3))    // ~28 days ending 3 days ago
let state = Baselines.foldHistory(base.map(kp), cfg: cfg)
guard state.usable else { return (SignalReading(zIllnessward: 0, present: false), false) }
```

So the gap was never "Android has an extra engine". It is that **Android held a second baseline for a metric the score already has one for**, while iOS reuses the score's. On the device in #2130 those two read **35.7ms** and **19.71ms** at the same moment, and the banner quoted the one nothing gated.

`Baselines.foldHistory(...).usable` needs nothing from the caller and is already idiomatic here (`IntelligenceEngine.kt` does exactly this for skin temp), so my earlier claim in #2130 that this needed fold state plumbed through the ViewModel was also wrong, and is corrected there.

## This reaches the reported case

The first revision used a minimum-valid-nights count. That cannot tell a stale stored value from a fresh one, and would **not** have silenced the reported banner. This does: that device's HRV baseline is calibrating on 2 valid nights, so the fold is not usable, the HRV flag is withheld, and one flag is not a banner.

Respiration keeps its own `>= 10` and its plausibility bounds, untouched. Its rationale is RSA-specific and it is not part of this report.

## Ledger

Three findings in this PR, all the same lesson: in a scanned file a new declaration is never free.

- an object-level `const` took Kotlin constants 840 to 841;
- a named local `fun` took Kotlin functions 2440 to 2441;
- a local `val` is invisible to the scan, which is what the check resolves into now.

The governance gate is path-filtered to `Tools/parity_*`, so each of those would have gone green here and failed a later unrelated PR. Counts verified back at main's 2440 / 840 / 208.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

`AnalyticsTest`: **18 tests, 0 failures**, forced with `--rerun-tasks`, XML timestamp checked against the clock.

Two new ones, written as a pair so the assertion lands on the baseline rather than on absence:

- a sparse HRV history cannot raise an HRV flag **even though the recent pair carries HRV**, which leaves one flag and therefore no banner;
- the same day shape with a dense history still raises it.

## Related issues

Raised in #2130. See also #2131 (Android's `baselineTrusted` counting nights with any vital rather than testing trust, in the other engine), #1118 (why HRV nights are scarce here) and #2126 (the same stale-versus-fresh fault in the recovery baseline).