### PR TITLE
Describe what DayOwnerSource.candidatePriorities actually returns (#2026)

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
+++ b/android/app/src/main/java/com/noop/analytics/IntelligenceEngine.kt
@@ -153,8 +153,15 @@ object IntelligenceEngine {
      * in by the UI scoring pass. Mirrors the Swift IntelligenceEngine.resolveDayOwner read-through (1B-4).
      */
     interface DayOwnerSource {
-        /** Non-archived paired devices, each as a [DayOwnerResolver.Candidate] WITHOUT its hasData flag
-         *  resolved yet (priority only: 0 = active strap, 1 = other live straps, 2 = imports). */
+        /** EVERY paired device, each as a [DayOwnerResolver.Candidate] WITHOUT its hasData flag resolved
+         *  yet (priority only: 0 = active strap, 1 = other live straps, 2 = whole-day imports,
+         *  3 = activity files (#137), 4 = archived).
+         *
+         *  Archived rows ARE included, because one list feeds two consumers here: [resolveDayOwner] and
+         *  the day-cycle/step engines, and the latter keep archived rows as read-only historical
+         *  candidates. Swift builds the two separately, and its day-owner half drops archived outright
+         *  (`IntelligenceEngine.resolveDayOwner`), so for a day covered only by a removed strap the two
+         *  platforms can name a different owner. Which rule is the intended one is open in #2026. */
         suspend fun candidatePriorities(): List<Pair<String, Int>>
 
         /** A locked owner override for [day] from the dayOwnership table, or null. Wins outright. */


### PR DESCRIPTION
Comment only, no behaviour change. Split out of #2026 so the contract stops describing a filter that is not there, while the actual question in that issue stays open.

## What was wrong

`IntelligenceEngine.DayOwnerSource.candidatePriorities` documented itself as:

> Non-archived paired devices, each as a [DayOwnerResolver.Candidate] WITHOUT its hasData flag resolved yet (priority only: 0 = active strap, 1 = other live straps, 2 = imports).

Its only implementation, `RegistryDayOwnerSource`, maps over `registry.all()` and assigns five priorities, archived included:

```kotlin
val priority = when {
    d.id == activeId -> 0
    d.status == DeviceStatus.archived.name -> 4
    d.sourceKind == SourceKind.activityFile.name -> 3
    isImport -> 2
    else -> 1
}
```

So the contract understated the range (3 and 4 are missing) and, more importantly, claimed a non-archived filter the Android side does not apply.

## Why the wording is there

It matches the Swift `IntelligenceEngine.resolveDayOwner`, which really does filter (`Strand/Data/IntelligenceEngine.swift:2910`, `devices.filter { $0.status != .archived }`). On Android one list serves two consumers, `resolveDayOwner` and the day-cycle/step engines, and `RegistryDayOwnerSource`'s own note keeps archived rows deliberately as read-only historical candidates, so the list cannot simply drop them.

Worth noting the cycle half already agrees across platforms: Swift builds a separate list at `IntelligenceEngine.swift:1952` with the same five priorities in the same order.

## Scope

The comment now states what the method returns and points at #2026 for the open question, which is whether the day-owner path should exclude archived the way Swift does. No code change, so nothing is pre-empted either way.

## Verification

- `python3 Tools/doc_comment_lint.py` — OK, no new detached doc comments (2155 files).
- `./gradlew compileFullDebugKotlin` — BUILD SUCCESSFUL (3m 9s); the remaining warnings are pre-existing and in other files.
- No Swift change, so the Apple side is untouched.