### PR TITLE
probe: let a re-arm clear the refusal latch it could never reach

### DIFF
--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -173,24 +173,18 @@ class PuffinExperiment(
                 prefs.all.keys
                     .filter { it.startsWith(UNBONDED_PROBE_INCONCLUSIVE_LINKS_KEY_PREFIX) }
                     .forEach { e.remove(it) }
-            }
-            e.apply()
-            // #2135: the refusal latch is the one retirement reason the sweep above cannot reach, because
-            // it lives in NoopPrefs rather than this file. #1804 could set it FALSELY off the probe's own
-            // local teardown, so a strap latched before that change stayed retired through every re-arm
-            // while the stalled-link diagnostic kept suggesting one. Swept by the same prefix rule, on the
-            // other file, and only on the same off-to-on edge.
-            if (rearms) {
-                runCatching {
-                    noopPrefs?.let { np ->
-                        val ne = np.edit()
-                        np.all.keys
-                            .filter { it.startsWith(UNBONDED_OFFLOAD_REFUSED_KEY_PREFIX) }
-                            .forEach { ne.remove(it) }
-                        ne.apply()
-                    }
+                // #2135: and the refusal latch, the one retirement reason a sweep of THIS file cannot
+                // reach. Same prefix rule, same edge, other file, because it is written at connect time
+                // with a device in hand and so cannot live here.
+                noopPrefs?.let { np ->
+                    val ne = np.edit()
+                    np.all.keys
+                        .filter { it.startsWith(UNBONDED_OFFLOAD_REFUSED_KEY_PREFIX) }
+                        .forEach { ne.remove(it) }
+                    ne.apply()
                 }
             }
+            e.apply()
         }
 
     /**

--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -16,7 +16,12 @@ import android.content.SharedPreferences
  * The macOS app stored this in `UserDefaults` under the key `noopPuffinExperiments`; the Android
  * equivalent is [SharedPreferences]. The same key name is reused for parity.
  */
-class PuffinExperiment(private val prefs: SharedPreferences) {
+class PuffinExperiment(
+    private val prefs: SharedPreferences,
+    /** NoopPrefs, where the per-strap refusal latch lives. Null in tests that touch only this file's own
+     *  switches; a re-arm then clears the budgets and leaves the latch, which is the pre-#2135 behaviour. */
+    private val noopPrefs: SharedPreferences? = null,
+) {
 
     /** True if the user opted in to the WHOOP 5/MG protocol probes (default false). */
     var isEnabled: Boolean
@@ -170,6 +175,22 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
                     .forEach { e.remove(it) }
             }
             e.apply()
+            // #2135: the refusal latch is the one retirement reason the sweep above cannot reach, because
+            // it lives in NoopPrefs rather than this file. #1804 could set it FALSELY off the probe's own
+            // local teardown, so a strap latched before that change stayed retired through every re-arm
+            // while the stalled-link diagnostic kept suggesting one. Swept by the same prefix rule, on the
+            // other file, and only on the same off-to-on edge.
+            if (rearms) {
+                runCatching {
+                    noopPrefs?.let { np ->
+                        val ne = np.edit()
+                        np.all.keys
+                            .filter { it.startsWith(UNBONDED_OFFLOAD_REFUSED_KEY_PREFIX) }
+                            .forEach { ne.remove(it) }
+                        ne.apply()
+                    }
+                }
+            }
         }
 
     /**
@@ -181,6 +202,11 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
      * written to `NoopPrefs` and swept from `noop_experiments`, re-enabling the switch would clear nothing
      * and the probe would stay retired forever, silently. Keeping the budget on the object that owns the
      * switch makes that drift unrepresentable rather than merely documented.
+     *
+     * The refusal latch could not move here, being written at connect time with a device in hand, and it
+     * is exactly the "retired forever, silently" case this paragraph warns about: #2135. The setter is
+     * now handed `NoopPrefs` as well and sweeps the latch by its own prefix, so both files are reachable
+     * from the one place the intent is unambiguous.
      *
      * Unreadable prefs read as 0 — the probe's other gates bound it, and a prefs failure must not be the
      * thing that keeps a spent budget spent.
@@ -315,6 +341,9 @@ class PuffinExperiment(private val prefs: SharedPreferences) {
         const val KEY_MOTION_AWARE_WAKE = "noopMotionAwareWake"
 
         fun from(context: Context): PuffinExperiment =
-            PuffinExperiment(context.getSharedPreferences(PREFS, Context.MODE_PRIVATE))
+            PuffinExperiment(
+                context.getSharedPreferences(PREFS, Context.MODE_PRIVATE),
+                context.getSharedPreferences(com.noop.ui.NoopPrefs.NAME, Context.MODE_PRIVATE),
+            )
     }
 }

--- a/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
+++ b/android/app/src/main/java/com/noop/ble/PuffinExperiment.kt
@@ -18,9 +18,10 @@ import android.content.SharedPreferences
  */
 class PuffinExperiment(
     private val prefs: SharedPreferences,
-    /** NoopPrefs, where the per-strap refusal latch lives. Null in tests that touch only this file's own
-     *  switches; a re-arm then clears the budgets and leaves the latch, which is the pre-#2135 behaviour. */
-    private val noopPrefs: SharedPreferences? = null,
+    /** NoopPrefs, where the per-strap refusal latch lives. Required, not defaulted: a caller that omitted
+     *  it would silently re-arm into the very state #2135 is about, and [from] is the only construction
+     *  site there is, so nothing is served by making it skippable. */
+    private val noopPrefs: SharedPreferences,
 ) {
 
     /** True if the user opted in to the WHOOP 5/MG protocol probes (default false). */
@@ -176,13 +177,11 @@ class PuffinExperiment(
                 // #2135: and the refusal latch, the one retirement reason a sweep of THIS file cannot
                 // reach. Same prefix rule, same edge, other file, because it is written at connect time
                 // with a device in hand and so cannot live here.
-                noopPrefs?.let { np ->
-                    val ne = np.edit()
-                    np.all.keys
-                        .filter { it.startsWith(UNBONDED_OFFLOAD_REFUSED_KEY_PREFIX) }
-                        .forEach { ne.remove(it) }
-                    ne.apply()
-                }
+                val ne = noopPrefs.edit()
+                noopPrefs.all.keys
+                    .filter { it.startsWith(UNBONDED_OFFLOAD_REFUSED_KEY_PREFIX) }
+                    .forEach { ne.remove(it) }
+                ne.apply()
             }
             e.apply()
         }

--- a/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
+++ b/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
@@ -277,10 +277,16 @@ internal fun unbondedProbeSupersedesLine(explicitBondOptedIn: Boolean): String =
         else "") +
         " (#1635, experimental)"
 
+/** Prefix of every persisted refusal latch, so opting back in can clear them all without knowing which
+ *  straps carry one (#2135). Same reason [UNBONDED_PROBE_SILENT_LINKS_KEY_PREFIX] is a constant, and the
+ *  key below is built FROM it so the writer and the sweeper cannot drift apart. */
+internal const val UNBONDED_OFFLOAD_REFUSED_KEY_PREFIX = "noop.unbondedOffloadRefused."
+
 /** Persisted key for "this strap refused the unbonded puffin subscriptions". Per device and lowercased,
  *  for the same reason [firmwarePrefKey] is. */
 internal fun unbondedOffloadRefusedPrefKey(peripheralId: String?): String? =
-    peripheralId?.trim()?.takeIf { it.isNotEmpty() }?.let { "noop.unbondedOffloadRefused.${it.lowercase()}" }
+    peripheralId?.trim()?.takeIf { it.isNotEmpty() }
+        ?.let { UNBONDED_OFFLOAD_REFUSED_KEY_PREFIX + it.lowercase() }
 
 /**
  * Does writing [PuffinExperiment.unbondedOffload] hand every strap's silence budget back?

--- a/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
@@ -704,4 +704,21 @@ class UnbondedOffloadProbeTest {
         assertTrue(line!!, line.contains("inconclusive-link budget is spent"))
         assertTrue(line, line.contains("our own stack"))
     }
+
+    /**
+     * #2135: the key a refusal is WRITTEN under must be reachable by the prefix a re-arm sweeps.
+     *
+     * The two drifting apart is the whole bug: the sweep cleared the two budgets, the latch kept its own
+     * spelling in another file, and the probe stayed retired through every re-arm while the diagnostic
+     * kept suggesting one. Building the key from the prefix makes that unrepresentable; this pins it.
+     */
+    @Test
+    fun aRefusalKeyIsReachableByTheRearmSweep() {
+        val key = unbondedOffloadRefusedPrefKey("AA:BB:CC:DD:EE:FF")
+        assertNotNull(key)
+        assertTrue(
+            "a refusal latch the re-arm cannot sweep is a retirement with no way out",
+            key!!.startsWith(UNBONDED_OFFLOAD_REFUSED_KEY_PREFIX),
+        )
+    }
 }


### PR DESCRIPTION
## What was wrong

Turning "Try history sync without pairing" off and on cleared the probe's two budgets and left the refusal latch untouched. The latch is written to `NoopPrefs` at connect time with a device in hand; the setter sweeps `noop_experiments` with none, and said so itself:

> The setter above clears these by prefix because it has no device in hand, and a sweep can only reach its own prefs file.

`unbondedProbeRetired` short-circuits on the refusal alone:

```kotlin
previouslyRefused -> "retired for this strap: a refusal is latched"
```

So a latched strap stayed retired through every re-arm, while the stalled-link diagnostic kept suggesting the one action that could not help.

## Why it matters rather than being a curiosity

**#1804** set that latch **falsely**, off the probe's own local teardown. Its change landed 2026-09-07 and stops new false latches; it does nothing for a strap already carrying one.

On the device this came from, the probe was the sole route to history, since a 5/MG never bonds (#1635) and backfill is gated off for the whole link. Gravity ran to **20,647** samples on 2026-08-26 and to **zero** from 2026-08-29, and with it went sleep staging, REM, skin temperature and the stress motion gate.

## The change

The setter now receives `NoopPrefs` as well and sweeps the latch by its own prefix, on the same off-to-on edge as the budgets, so both files are reachable from the one place the intent is unambiguous. The latch could not simply move to the experiment's own file: it is written at connect time and the setter has no device.

The key is now built FROM that prefix rather than spelling it a second time, which is what the bug was: a writer and a sweeper that could disagree about the same string.

`noopPrefs` is a REQUIRED parameter, not a defaulted one. An omitted default would re-arm into exactly the state this fixes, and `from(context)` is the only construction of `PuffinExperiment` in the repo, so nothing was served by making it skippable.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

`UnbondedOffloadProbeTest`: **51 tests, 0 failures**, forced with `--rerun-tasks`, XML timestamp checked against the clock.

One new test, pinning the only part that can silently regress: a refusal key must start with the prefix a re-arm sweeps. The sweep and the writer drifting apart IS the defect, and building the key from the constant makes it unrepresentable rather than merely documented.

Verified by hand rather than assumed: the refusal is both read and written through `NoopPrefs.NAME`, so the sweep targets the file that actually holds it; both toggle sites (Test Centre and Settings) build through `PuffinExperiment.from(context)`; and the DIS identity read keeps its own separate latch, untouched.

The sweep itself is a `SharedPreferences` write, which these tests do not fake; the file's existing style is pure functions tested directly, and adding a prefs harness for three lines would cost more than it protects.

**Not confirmed on a device.** The wearer-visible check is whether a latched 5/MG resumes banking gravity after toggling the switch.

## Scope

Android only, stated precisely: **`PuffinExperiment` itself IS a twin** and the two platforms deliberately share defaults key names (`PuffinExperiment.defaultsKey` and siblings, per `TestCentre.swift`'s migration note). What has no counterpart is the `unbondedOffload` switch and everything under it: no `unbondedOffload`, no probe budgets and no refusal latch exist in Swift.

Worth recording, since it is the reason the neighbouring latch was left alone: the unbonded **DIS** read DOES have a Swift twin (`BLEManager.unbondedDisReadDelay`). Clearing that one on this switch would have been a one-sided change to a paired concept, on top of being the wrong switch.

Swift defers backfill on an unbonded strap the same way (`Backfiller.swift:53`), it simply has no probe to work around it, so an iOS 5/MG meets the same wall with no escape hatch at all. That is a feature-level gap rather than this PR's business.

`com/noop/ble` sits outside the parity ledger's scan, so the new constant carries no ledger debt.

This does not change WHEN a refusal is latched, only whether a deliberate re-arm can clear one. Whether a refusal should be permanently unclearable at all is the open question left on #2135.

## Related issues

Raised in #2135. See also #1804 (the false latch), #1635 (why a 5/MG has no other route to its history) and #2127 (the gravity gap this produced on one device).