### PR TITLE
illness: ask the app whether it could score, not the stored rows

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/Analytics.kt
+++ b/android/app/src/main/java/com/noop/analytics/Analytics.kt
@@ -82,25 +82,24 @@ object IllnessWatch {
      */
     fun evaluate(days: List<DailyMetric>): String? {
         if (days.size < 14) return null
+        // #2130: this banner asserts strain from the same physiology Charge is scored on. When the app
+        // produced no Charge ANYWHERE in the window it is about to compare, it has already said it cannot
+        // judge that physiology, and a warning drawn from it contradicts its own verdict.
+        //
+        // The window's own values cannot tell you this. They are the STORED daily rows, which stay dense
+        // and healthy-looking while the engine's freshly computed series is starved: a device in #2130
+        // read "HRV -51%" off a stored base of ~35.7ms while Charge sat at `nilScore
+        // reason=hrvBaselineNotUsable, hrvNValid=2, need nValid>=4` on every one of 21 nights. Folding
+        // the stored rows, as an earlier revision did, asks the wrong series and passes.
+        //
+        // Deliberately the whole banner, not the HRV flag alone: it takes two flags to raise, and the
+        // other three are drawn from the same scoring pass. A month without a single Charge is not a
+        // state to be issuing health warnings from.
+        if (days.takeLast(31).none { it.recovery != null }) return null
 
         val recent = days.takeLast(2)
         // ~28 days ending 3 days ago: take the last 31, drop the most recent 3.
         val base = days.takeLast(31).dropLast(3)
-        // Whether a signal's window is fit to accuse the recent one (#2130). The Swift twin folds this
-        // SAME window through `Baselines.foldHistory` and refuses the signal unless the state is usable;
-        // here it was a plain mean, which is happy with ONE value and gated nothing.
-        //
-        // Folding rather than counting is the point: it is the statistic Charge is scored against, so
-        // the banner and the score can no longer hold two different baselines for one metric.
-        //
-        // Values rather than a helper because a named local function is a declaration the parity ledger
-        // counts, and this file is inside its scan.
-        val rhrBaseUsable = Baselines.metricCfg["resting_hr"]?.let { cfg ->
-            Baselines.foldHistory(base.map { it.restingHr?.toDouble() }, cfg).usable
-        } == true
-        val hrvBaseUsable = Baselines.metricCfg["hrv"]?.let { cfg ->
-            Baselines.foldHistory(base.map { it.avgHrv }, cfg).usable
-        } == true
 
         fun mean(vals: List<Double>): Double? =
             if (vals.isEmpty()) null else vals.sum() / vals.size.toDouble()
@@ -116,17 +115,15 @@ object IllnessWatch {
         run {
             val r = rm { it.restingHr?.toDouble() }
             val b = bm { it.restingHr?.toDouble() }
-            if (r != null && b != null && rhrBaseUsable && r >= b + 5) {
+            if (r != null && b != null && r >= b + 5) {
                 flags.add("resting HR +${(r - b).roundToInt()} bpm")
             }
         }
 
         run {
-            // The sparsest of the four: the over-count gate withholds whole nights (#1118), so HRV is
-            // the likeliest to have been resting on a cold-start baseline.
             val r = rm { it.avgHrv }
             val b = bm { it.avgHrv }
-            if (r != null && b != null && b > 0 && hrvBaseUsable && r <= b * 0.80) {
+            if (r != null && b != null && b > 0 && r <= b * 0.80) {
                 flags.add("HRV −${((1 - r / b) * 100).roundToInt()}%")
             }
         }

--- a/android/app/src/test/java/com/noop/analytics/AnalyticsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/AnalyticsTest.kt
@@ -84,6 +84,7 @@ class AnalyticsTest {
         avgHrv: Double? = null,
         skinTempDevC: Double? = null,
         respRateBpm: Double? = null,
+        recovery: Double? = 60.0,
     ): DailyMetric = DailyMetric(
         deviceId = "test",
         day = d,
@@ -91,6 +92,7 @@ class AnalyticsTest {
         avgHrv = avgHrv,
         skinTempDevC = skinTempDevC,
         respRateBpm = respRateBpm,
+        recovery = recovery,
     )
 
     @Test
@@ -109,40 +111,34 @@ class AnalyticsTest {
     }
 
     /**
-     * #2130: a signal may not accuse the recent window off a baseline the app would not otherwise use.
+     * #2130: no Charge anywhere in the window means no banner from it.
      *
-     * 31 days of history, but HRV on only 2 of the baseline nights, so its fold is CALIBRATING and
-     * `usable` is false. That is the field case verbatim (`hrvNValid=2, need nValid>=4`). Deliberately
-     * below the seed rather than at it: 4 valid nights would be provisional by count and rejected only
-     * for staleness, which would leave the test passing for a reason it does not name.
-     *
-     * RHR is dense and drops hard, so the RHR flag still fires; HRV must not, which leaves one flag and
-     * no banner. The recent pair carries HRV, so this pins the BASELINE rather than merely "no data".
+     * The device that reported this had flags firing off a STORED base of dense, healthy-looking values
+     * while the engine scored `nilScore reason=hrvBaselineNotUsable` on all 21 nights. The window's own
+     * values cannot reveal that, which is why this asks the app's verdict instead: two flags that would
+     * otherwise raise, and no scored day, so nothing is claimed.
      */
     @Test
-    fun illness_unusableHrvBaselineCannotRaiseAnHrvFlag() {
+    fun illness_noScoredChargeInTheWindowRaisesNothing() {
         val baseline = (0 until 31).map {
-            day(
-                "2026-01-%02d".format(it + 1),
-                restingHr = 50,
-                avgHrv = if (it < 2) 60.0 else null,
-                skinTempDevC = 0.0,
-                respRateBpm = 14.0,
-            )
+            day("2026-01-%02d".format(it + 1), restingHr = 50, avgHrv = 60.0, skinTempDevC = 0.0,
+                respRateBpm = 14.0, recovery = null)
         }
         val recent = listOf(
-            day("2026-02-01", restingHr = 58, avgHrv = 20.0, skinTempDevC = 0.0, respRateBpm = 14.0),
-            day("2026-02-02", restingHr = 58, avgHrv = 20.0, skinTempDevC = 0.0, respRateBpm = 14.0),
+            day("2026-02-01", restingHr = 58, avgHrv = 20.0, skinTempDevC = 0.0, respRateBpm = 14.0,
+                recovery = null),
+            day("2026-02-02", restingHr = 58, avgHrv = 20.0, skinTempDevC = 0.0, respRateBpm = 14.0,
+                recovery = null),
         )
         assertNull(
-            "one flag is not a banner, and a calibrating HRV fold is not a baseline",
+            "a month without a single Charge is not a state to issue health warnings from",
             IllnessWatch.evaluate(baseline + recent),
         )
     }
 
-    /** The same day shape, but with a fold that IS usable, still raises both flags. */
+    /** The same day shape on an app that IS scoring still raises, so the guard is not a blanket mute. */
     @Test
-    fun illness_usableHrvBaselineStillRaisesTheHrvFlag() {
+    fun illness_aScoringAppStillRaisesTheSameFlags() {
         val baseline = (0 until 31).map {
             day("2026-01-%02d".format(it + 1), restingHr = 50, avgHrv = 60.0, skinTempDevC = 0.0, respRateBpm = 14.0)
         }
@@ -152,7 +148,7 @@ class AnalyticsTest {
         )
         val msg = IllnessWatch.evaluate(baseline + recent)
         assertNotNull(msg)
-        assertTrue("the HRV flag is what the unusable case withholds", msg!!.contains("HRV"))
+        assertTrue("the HRV flag is what the unscored case withholds", msg!!.contains("HRV"))
     }
 
     @Test


### PR DESCRIPTION
## The gate merged for #2130 did nothing, and this removes it

Build 495 carried it. The banner came back **byte-identical**, same `-51%`.

**Two things are called the HRV baseline and they are not the same list.**

- `IntelligenceEngine` folds `hrvSeq`, this pass's **freshly computed** nightly values. That is where `hrvNValid=2` comes from.
- `IllnessWatch` folds `base.map { it.avgHrv }`, the **stored** daily rows. Those stay dense and healthy-looking: `minNightsSeed` is 4 and `staleDays` is 14, so a window holding ten stored values with a three-night gap folds to `PROVISIONAL` and is `usable`.

So the gate passed and changed nothing. I read one number and wrote the other.

The fold is **removed**, not kept beside a second one. It cannot see staleness, which is the whole substance of #2130, and leaving it would mean this file carried two baselines for one metric in order to address a bug about carrying two baselines for one metric.

## What the window cannot tell you, the app's own verdict can

```kotlin
if (days.takeLast(31).none { it.recovery != null }) return null
```

When no Charge was produced anywhere in the span this is about to compare, the app has already said it cannot judge this physiology. A warning drawn from the same inputs contradicts its own verdict. On the reporting device that is `nilScore reason=hrvBaselineNotUsable` on **all 21 nights**, while the banner asserted strain from them.

Deliberately the whole banner rather than the HRV flag alone: it takes two flags to raise and the other three come off the same scoring pass, so gating one would only change which pair fires.

## The trade, stated

A user whose Charge is nil for a month loses illness warnings entirely. That is the intent rather than a side effect: if the app cannot score a single day's recovery, it is not in a position to tell someone their body looks strained. It is also not a silent state, since Charge itself is visibly absent.

This is a proxy for "the HRV baseline is not usable" rather than that verdict directly. The direct route needs `ProfileBaselines` out of the engine, which never leaves it today, and that is a larger change than this warrants. The proxy is faithful: `hrvBaselineNotUsable` is one of the reasons Charge is nil, and the others are equally good reasons not to fire.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

`AnalyticsTest`: **18 tests, 0 failures**, forced with `--rerun-tasks`, XML timestamp checked against the clock.

The two that pinned the removed fold are **replaced rather than deleted**: one asserts two otherwise-raising flags stay silent with no scored day, the other that the same shape on a scoring app still raises, so the guard is not a blanket mute. The `day` helper now defaults a recovery, which is what a fixture for a working app should have looked like all along.

Net 7 fewer lines than before, one guard instead of two folds, no new declarations, ledger unchanged.

**Predicted and not yet confirmed:** the banner should be absent on the next build for the reporting device. The last prediction of mine on this was wrong, which is why the rule is now pinned to a number visible in its own log rather than to my reading of a fold.

## Related issues

#2130. See also #1118, why that device scores no Charge at all.