### PR TITLE
ci: let the parity gate see main, so drift stops ambushing other PRs

### DIFF
--- a/.github/workflows/parity-governance.yml
+++ b/.github/workflows/parity-governance.yml
@@ -1,7 +1,20 @@
-# These are the scanner's own unit and repository-acceptance tests. Run the
-# multi-minute suite when its implementation, authority, tests, or workflow
-# changes; ordinary product-source changes belong to the later ledger/ratchet
-# gate, not to repeated self-testing of the scanner.
+# These are the scanner's own unit and repository-acceptance tests.
+#
+# On a PULL REQUEST, run the multi-minute suite only when its implementation,
+# authority, tests or workflow change; ordinary product-source changes belong to
+# the later ledger/ratchet gate, not to repeated self-testing of the scanner.
+#
+# On a PUSH TO MAIN, run it unconditionally. One of these tests is not about the
+# scanner at all: the repository acceptance asserts that the checked-in authority
+# still reproduces from the CURRENT product source. Product changes are exactly
+# what invalidates it, so filtering this trigger to Tools/ meant main could carry
+# stale authority indefinitely with nothing red, until some later PR touched
+# Tools/ and inherited the whole accumulated drift.
+#
+# That happened four times, and three landed on an outside contributor's PR that
+# had not caused any of it. The suite is Python-only and costs ~2.5 minutes; a
+# red main on the merge that caused the drift is the signal, and re-deriving is
+# a two-minute maintainer action. See the history in #1534.
 name: Parity Governance CI
 
 on:
@@ -15,12 +28,6 @@ on:
       - '.github/workflows/parity-governance.yml'
   push:
     branches: [main]
-    paths:
-      - 'Tools/issue_ref.py'
-      - 'Tools/parity_*.py'
-      - 'Tools/parity_*.json'
-      - 'Tools/tests/**'
-      - '.github/workflows/parity-governance.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/parity-governance.yml
+++ b/.github/workflows/parity-governance.yml
@@ -4,17 +4,22 @@
 # authority, tests or workflow change; ordinary product-source changes belong to
 # the later ledger/ratchet gate, not to repeated self-testing of the scanner.
 #
-# On a PUSH TO MAIN, run it unconditionally. One of these tests is not about the
-# scanner at all: the repository acceptance asserts that the checked-in authority
-# still reproduces from the CURRENT product source. Product changes are exactly
-# what invalidates it, so filtering this trigger to Tools/ meant main could carry
-# stale authority indefinitely with nothing red, until some later PR touched
-# Tools/ and inherited the whole accumulated drift.
+# It also runs DAILY on main. One of these tests is not about the scanner at
+# all: the repository acceptance asserts that the checked-in authority still
+# reproduces from the CURRENT product source. Product changes are what
+# invalidates it, and product changes are exactly what both filters exclude, so
+# main could carry stale authority indefinitely with nothing red until some
+# later PR touched Tools/ and inherited the whole accumulated drift.
 #
 # That happened four times, and three landed on an outside contributor's PR that
-# had not caused any of it. The suite is Python-only and costs ~2.5 minutes; a
-# red main on the merge that caused the drift is the signal, and re-deriving is
-# a two-minute maintainer action. See the history in #1534.
+# had caused none of it. The schedule finds it within a day, on main, where
+# re-deriving is a two-minute maintainer action.
+#
+# Deliberately a schedule rather than an unfiltered push: this suite is pinned
+# NOT to run on product source (see test_core_tools_filter_covers_every_
+# governance_tool_path, which asserts both filters and forbids product globs),
+# and a periodic check keeps that true. See the history in #1534.
+
 name: Parity Governance CI
 
 on:
@@ -28,6 +33,16 @@ on:
       - '.github/workflows/parity-governance.yml'
   push:
     branches: [main]
+    paths:
+      - 'Tools/issue_ref.py'
+      - 'Tools/parity_*.py'
+      - 'Tools/parity_*.json'
+      - 'Tools/tests/**'
+      - '.github/workflows/parity-governance.yml'
+  # Daily, so authority staleness is found on a schedule instead of by whoever
+  # next edits Tools/. See the header note.
+  schedule:
+    - cron: '17 4 * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## The problem

The gate was path-filtered to `Tools/` on **both** triggers. But one of its tests is not about the scanner at all:

```
test_checked_metadata_is_compact_v3_and_expands_losslessly
  self.assertEqual(self.compact_map["authority"], self.authority)
```

That asserts the checked-in authority still reproduces from the **current product source**. Product changes are exactly what invalidates it, and product changes were the one thing the filter excluded.

So main could carry stale authority indefinitely with nothing red, until some later PR touched `Tools/` and inherited the whole accumulated drift.

**Four staleness events now, and three of them landed on an outside contributor's PR that had caused none of it.** Tonight's was #2141: the same 4308 against 4310, the same hashes, failing on main, on that branch, and at `0b0d206` before any of today's merges. @bhelm's change was a comment-and-preservation follow-up that touched the contract test, and that was enough to inherit it.

## The change

A **daily schedule** on main. Drift is found within a day, on main, where re-deriving is a two-minute maintainer action, instead of weeks later on somebody else's work.

Both path filters are **untouched**.

## Why a schedule and not an unfiltered push

My first attempt removed the `push` filter so the gate would run on every merge to main. The suite's own `test_core_tools_filter_covers_every_governance_tool_path` caught it:

```python
self.assertEqual([...five paths...] * 2, governance_paths)
self.assertNotIn("'Packages/**/*.swift'", governance)
self.assertNotIn("'android/**/*.kt'", governance)
```

It pins **both** filters and forbids product globs. Not running on product source is a deliberate invariant here, not an oversight, and the `* 2` says the two triggers must agree. Overturning that to fix a staleness problem would be the wrong trade, and a periodic check keeps the invariant true while still catching drift.

So the paths stay exactly as they were and that test passes unchanged.

## What this does NOT fix

The deeper problem is untouched and worth stating plainly: **`--refresh-derived` cannot repair any of this.** It fails with `migration required` because the checked-in authority cannot be reproduced from the base, so the only route is deleting both snapshots and re-bootstrapping. That is a maintainer action no contributor can perform.

This change does not make drift repairable. It makes the maintainer the one who finds out.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / tooling

## How it was tested

`yaml.safe_load` parses the workflow and reports all four triggers. `test_core_tools_filter_covers_every_governance_tool_path` passes locally, which is the one that rejected the first attempt. The change touches `.github/workflows/parity-governance.yml`, inside the gate's own `pull_request` filter, so this PR runs the suite against itself.

Main was re-derived separately in `e1c23005` and is green, so a red result here would be about this file rather than inherited.

## Related issues

The governance design is #1534. Tonight's instance is visible on #2141.