### PR TITLE
fix(oura): refuse the #1284 onset rekey when the assembler's own clip never bound

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/SleepSessionDedup.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/SleepSessionDedup.swift
@@ -139,6 +139,28 @@ public enum SleepSessionDedup {
         return ((onsetUnixSeconds + g / 2) / g) * g
     }
 
+    /// Guards the onset rekey against `OuraHypnogramBurst.codesWithTimes`'s own safety net: that
+    /// assembler silently falls back to the UNCLIPPED lay when clipping to the ring's `0x49` onset
+    /// would empty the burst entirely (a mis-paired window's onset landing after every real code) —
+    /// "so a mis-paired window can never empty the night." The caller has no signal that fallback
+    /// fired, and blindly re-keying `startTs` to that onset anyway wrote a NEGATIVE-DURATION session
+    /// (item 22, 2026-09-12: `startTs` 16 min after its own `endTs` on a 2-minute nap, because the
+    /// matched `0x49` window's onset was ~16 min later than the only two codes the ring actually wrote).
+    ///
+    /// A clip that genuinely bound leaves `mapped.startTs >= onset` by construction — the surviving
+    /// codes are exactly those with `ts >= onset`, so the first one can only sit at or after it. A clip
+    /// the fallback ignored leaves `mapped.startTs < onset` just as reliably, since EVERY written code
+    /// was earlier than onset (that is precisely why clipping to it would have emptied the burst).
+    /// Also rejects the rarer case where 30 s grid-rounding pushes a nearly-adjacent onset to or past
+    /// `endTs`, which would otherwise mint a zero/negative-duration session on its own.
+    ///
+    /// Returns the keyed start to bank, or `nil` to keep `mapped.startTs` unchanged (no rekey).
+    public static func safeKeyedStart(onset: Int, mapped: CachedSleepSession) -> Int? {
+        guard onset <= mapped.startTs else { return nil }
+        let keyed = keyedStart(onsetUnixSeconds: onset)
+        return keyed < mapped.endTs ? keyed : nil
+    }
+
     /// Decide, at persist time, whether a freshly reconstructed `candidate` night should be banked and
     /// which already-stored rows it supersedes — the generation-side twin of the `dedupe` heal, so a
     /// duplicate is suppressed BEFORE it is banked (closing the window where the wrong night shows until

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/SleepSessionDedupTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/SleepSessionDedupTests.swift
@@ -272,6 +272,42 @@ final class SleepSessionDedupTests: XCTestCase {
         XCTAssertEqual(SleepSessionDedup.keyedStart(onsetUnixSeconds: 1234, gridSeconds: 0), 1234)   // grid clamp ≥1 = identity
     }
 
+    /// Item 22, 2026-09-12: a real captured negative-duration nap. Two written codes span
+    /// 14:24:17→14:26:17 (`mapped`), but the closest-matched `0x49` window's onset landed at
+    /// ~14:41:xx — ~16 min AFTER `mapped.endTs` — because `codesWithTimes`'s own clip-would-empty
+    /// fallback had silently returned the unclipped burst. The unguarded `keyedStart` call rounded
+    /// that onset to exactly 14:42:00 and wrote it as `startTs`, 943 s after `endTs`. `safeKeyedStart`
+    /// must refuse the rekey here and return nil (keep `mapped.startTs` unchanged).
+    func testSafeKeyedStartRefusesTheItem22NegativeDurationRegression() {
+        let mappedStart = 1_789_215_857   // 14:24:17 local — matches the captured stagesJSON
+        let mappedEnd = 1_789_215_977     // 14:26:17 local
+        let mismatchedOnset = 1_789_216_910   // ~14:41:50 — the mis-paired window's onset, after endTs
+        let mapped = session(start: mappedStart, end: mappedEnd)
+        XCTAssertNil(SleepSessionDedup.safeKeyedStart(onset: mismatchedOnset, mapped: mapped))
+    }
+
+    /// The ordinary, intended case: the assembler's clip genuinely bound, so the onset sits at or
+    /// just before the first surviving code (a few epochs, per `persistHypnogramBurst`'s own doc
+    /// comment) — `safeKeyedStart` should key `startTs` to the rounded onset as designed.
+    func testSafeKeyedStartAppliesTheRekeyWhenTheClipGenuinelyBound() {
+        let onset = 1_789_215_800   // precedes mapped.startTs, as a bound clip guarantees
+        let mapped = session(start: 1_789_215_857, end: 1_789_215_977)
+        let keyed = SleepSessionDedup.safeKeyedStart(onset: onset, mapped: mapped)
+        XCTAssertEqual(keyed, SleepSessionDedup.keyedStart(onsetUnixSeconds: onset))
+        XCTAssertLessThan(keyed!, mapped.endTs)
+    }
+
+    /// A second, smaller-magnitude failure mode `safeKeyedStart` also has to catch: the onset passes
+    /// the first guard (`onset <= mapped.startTs`, so the clip genuinely bound), but 30 s grid-rounding
+    /// pushes it to or past `endTs` on a very short (20 s) session — refuse rather than mint a
+    /// zero/negative-duration session.
+    func testSafeKeyedStartRefusesWhenRoundingWouldReachOrPassEndTs() {
+        let mapped = session(start: 1_000_000, end: 1_000_020)   // 20 s session
+        let onset = 999_995   // <= mapped.startTs (clip bound), but keyedStart(999_995, 60) = 1_000_020 == endTs
+        XCTAssertEqual(SleepSessionDedup.keyedStart(onsetUnixSeconds: onset), mapped.endTs)
+        XCTAssertNil(SleepSessionDedup.safeKeyedStart(onset: onset, mapped: mapped))
+    }
+
     func testPlanBankSameBucketFullerStoredRowSuppressesAPartialReserve() {
         // F1 regression: a partial re-drain keyed to the SAME bucket (same PK) as a fuller banked night must
         // be SUPPRESSED — the upsert would otherwise replace the fuller night's stages by PK. `existing` is

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -961,9 +961,13 @@ public final class OuraLiveSource: NSObject, ObservableObject {
             // startTs on the ROUNDED onset (stable across the ring's re-serves) rather than the end-anchored
             // first-code time — so re-serves of one night share a PK and the displayed bedtime is the true
             // onset. The completeness guard in the persist closure then suppresses/replaces any duplicate.
+            // `safeKeyedStart` refuses the rekey when `sleepStart` didn't actually bind in the assembler's
+            // own clip (item 22, 2026-09-12: a mis-paired 0x49 window otherwise wrote a startTs 16 min
+            // AFTER its own endTs) — see its doc comment for why `onset <= mapped.startTs` is the exact test.
             let session: CachedSleepSession = {
-                guard onsetKeying(), let onset = sleepStart else { return mapped }
-                return mapped.withStartTs(SleepSessionDedup.keyedStart(onsetUnixSeconds: onset))
+                guard onsetKeying(), let onset = sleepStart,
+                      let keyed = SleepSessionDedup.safeKeyedStart(onset: onset, mapped: mapped) else { return mapped }
+                return mapped.withStartTs(keyed)
             }()
             let start = session.startTs
             // #1284 residual 3: log when this persist lands wholly inside — or overlapping — a session already

--- a/android/app/src/main/java/com/noop/analytics/SleepSessionDedup.kt
+++ b/android/app/src/main/java/com/noop/analytics/SleepSessionDedup.kt
@@ -154,6 +154,32 @@ object SleepSessionDedup {
         return ((onsetUnixSeconds + g / 2) / g) * g
     }
 
+    /**
+     * Guards the onset rekey against `OuraHypnogramBurst.codesWithTimes`'s own safety net: that
+     * assembler silently falls back to the UNCLIPPED lay when clipping to the ring's `0x49` onset
+     * would empty the burst entirely (a mis-paired window's onset landing after every real code) —
+     * "so a mis-paired window can never empty the night." The caller has no signal that fallback
+     * fired, and blindly re-keying startTs to that onset anyway wrote a NEGATIVE-DURATION session
+     * (item 22, 2026-09-12: startTs 16 min after its own endTs on a 2-minute nap, because the matched
+     * 0x49 window's onset was ~16 min later than the only two codes the ring actually wrote).
+     *
+     * A clip that genuinely bound leaves `mapped.startTs >= onset` by construction — the surviving
+     * codes are exactly those with `ts >= onset`, so the first one can only sit at or after it. A clip
+     * the fallback ignored leaves `mapped.startTs < onset` just as reliably, since EVERY written code
+     * was earlier than onset (that is precisely why clipping to it would have emptied the burst). Also
+     * rejects the rarer case where 30 s grid-rounding pushes a nearly-adjacent onset to or past endTs,
+     * which would otherwise mint a zero/negative-duration session on its own.
+     *
+     * Returns the keyed start to bank, or null to keep the mapped `startTs` unchanged (no rekey).
+     * Takes plain bounds rather than a session type so it works against either platform's
+     * pre-persist mapping shape (`com.noop.oura.OuraSleepSession` here, `CachedSleepSession` in Swift).
+     */
+    fun safeKeyedStart(onset: Long, mappedStartTs: Long, mappedEndTs: Long): Long? {
+        if (onset > mappedStartTs) return null
+        val keyed = keyedStart(onset)
+        return if (keyed < mappedEndTs) keyed else null
+    }
+
     /** The bank decision, mirroring the Swift twin. */
     data class BankPlan(val bank: Boolean, val supersededStarts: List<Long>)
 

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -834,9 +834,15 @@ class OuraLiveSource(
             // startTs on the ROUNDED onset (stable across the ring's re-serves) rather than the end-anchored
             // first-code time — so re-serves of one night share a PK and the bedtime is the true onset. The
             // completeness guard in the persist closure then suppresses/replaces any duplicate.
+            // safeKeyedStart refuses the rekey when `sleepStart` didn't actually bind in the assembler's own
+            // clip (item 22, 2026-09-12: a mis-paired 0x49 window otherwise wrote a startTs 16 min AFTER its
+            // own endTs) — see its doc comment for why `onset <= mapped.startTs` is the exact test.
             val onset = sleepStart
-            val session = if (onsetKeying() && onset != null) {
-                mapped.copy(startTs = com.noop.analytics.SleepSessionDedup.keyedStart(onset))
+            val keyed = onset?.let {
+                com.noop.analytics.SleepSessionDedup.safeKeyedStart(it, mapped.startTs, mapped.endTs)
+            }
+            val session = if (onsetKeying() && keyed != null) {
+                mapped.copy(startTs = keyed)
             } else {
                 mapped
             }

--- a/android/app/src/test/java/com/noop/analytics/SleepSessionDedupTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/SleepSessionDedupTest.kt
@@ -288,6 +288,45 @@ class SleepSessionDedupTest {
         assertEquals(1234L, SleepSessionDedup.keyedStart(1234L, 0L))   // grid clamp >=1 = identity
     }
 
+    // Item 22, 2026-09-12: a real captured negative-duration nap. Two written codes span
+    // 14:24:17->14:26:17 (mapped), but the closest-matched 0x49 window's onset landed at ~14:41:xx —
+    // ~16 min AFTER mapped.endTs — because codesWithTimes's own clip-would-empty fallback had
+    // silently returned the unclipped burst. The unguarded keyedStart call rounded that onset to
+    // exactly 14:42:00 and wrote it as startTs, 943 s after endTs. safeKeyedStart must refuse the
+    // rekey here and return null (keep mapped.startTs unchanged).
+    @Test
+    fun safeKeyedStart_refusesTheItem22NegativeDurationRegression() {
+        val mappedStart = 1_789_215_857L   // 14:24:17 local — matches the captured stagesJSON
+        val mappedEnd = 1_789_215_977L     // 14:26:17 local
+        val mismatchedOnset = 1_789_216_910L   // ~14:41:50 — the mis-paired window's onset, after endTs
+        assertEquals(null, SleepSessionDedup.safeKeyedStart(mismatchedOnset, mappedStart, mappedEnd))
+    }
+
+    // The ordinary, intended case: the assembler's clip genuinely bound, so the onset sits at or just
+    // before the first surviving code — safeKeyedStart should key startTs to the rounded onset.
+    @Test
+    fun safeKeyedStart_appliesTheRekeyWhenTheClipGenuinelyBound() {
+        val onset = 1_789_215_800L   // precedes mapped.startTs, as a bound clip guarantees
+        val mappedStart = 1_789_215_857L
+        val mappedEnd = 1_789_215_977L
+        val keyed = SleepSessionDedup.safeKeyedStart(onset, mappedStart, mappedEnd)
+        assertEquals(SleepSessionDedup.keyedStart(onset), keyed)
+        assertTrue(keyed!! < mappedEnd)
+    }
+
+    // A second, smaller-magnitude failure mode safeKeyedStart also has to catch: the onset passes the
+    // first guard (onset <= mappedStartTs, so the clip genuinely bound), but 30 s grid-rounding pushes
+    // it to or past endTs on a very short (20 s) session — refuse rather than mint a
+    // zero/negative-duration session.
+    @Test
+    fun safeKeyedStart_refusesWhenRoundingWouldReachOrPassEndTs() {
+        val mappedStart = 1_000_000L
+        val mappedEnd = 1_000_020L   // 20 s session
+        val onset = 999_995L   // <= mappedStart (clip bound), but keyedStart(999_995, 60) = 1_000_020 == endTs
+        assertEquals(mappedEnd, SleepSessionDedup.keyedStart(onset))
+        assertEquals(null, SleepSessionDedup.safeKeyedStart(onset, mappedStart, mappedEnd))
+    }
+
     @Test
     fun planBank_sameBucketFullerStoredRow_suppressesAPartialReserve() {
         // F1 regression: a partial re-drain at the SAME keyed PK as a fuller banked night must be suppressed.


### PR DESCRIPTION
## The bug

A midday capture's Sleep screen showed a nap row displayed as **"14:42-14:26" / "0m"** (start later
than end), and the day's MAIN SLEEP + NAP(S) no longer summed to TOTAL — short by exactly 16 minutes.
The DB confirmed a real negative-duration `sleepSession` row: `startTs` 2026-09-12 14:42:00 local,
`endTs` 14:26:17 local (`endTs - startTs = -943s`). The row's `stagesJSON` (a real 2-minute
`wake`→`light` micro-segment) was internally consistent with `endTs`, but `startTs` — the row's own
primary-key field — had nothing to do with the decoded content.

Root cause: `OuraHypnogramBurst.codesWithTimes` (`Packages/OuraProtocol`) has a safety net — when
clipping the burst's codes to the ring's `0x49` onset would empty the burst entirely (a mis-paired
nearby window's onset landing after every real code), it silently falls back to the **unclipped** lay,
"so a mis-paired window can never empty the night." That's correct for the codes themselves, but the
caller (`OuraLiveSource.persistHypnogramBurst`) has no signal that fallback fired, and unconditionally
re-keys the session's `startTs` to that same (irrelevant) onset anyway via the #1284 residual-3
onset-keying feature (`SleepSessionDedup.keyedStart`). On the captured row: two written codes at
14:24-14:26, and the closest-matched `0x49` window's onset was ~16 minutes *after* them — exactly the
signature of a clip that never bound.

## The fix

New pure, unit-tested `SleepSessionDedup.safeKeyedStart` (Swift + Kotlin twin) only applies the rekey
when:

1. `onset <= mapped.startTs` — true by construction whenever the clip actually bound (the surviving
   codes are exactly those with `ts >= onset`, so the first one can only sit at or after it), false
   whenever the fallback silently returned the unclipped lay (every written code was earlier than
   onset, which is precisely why clipping to it would have emptied the burst); **and**
2. the rounded result stays `< mapped.endTs` — also catches the much rarer, smaller-magnitude case
   where plain 30s grid-rounding alone could push a nearly-adjacent onset to or past `endTs` on a very
   short session.

Both `OuraLiveSource.swift`/`.kt` call sites now route through it instead of calling `keyedStart`
directly. When the guard declines, `mapped.startTs` (the end-anchored, always-consistent value) is
kept unchanged — the existing, correct fallback behavior.

## Scope: both platforms, one commit

`SleepSessionDedup` is package-level (`Packages/WhoopStore`) with a byte-identical Kotlin twin
(`android/…/analytics/SleepSessionDedup.kt`) per the parity contract; the two call sites are app-target
Swift (`Strand/BLE/OuraLiveSource.swift`) with the matching Kotlin twin
(`android/…/ble/OuraLiveSource.kt`).

## Verification

- Swift `WhoopStore` package: `swift test` — **31/31** `SleepSessionDedupTests` green, including 3 new
  tests: a byte-for-byte reproduction of this exact regression's captured numbers, the ordinary
  clip-bound case still rekeying correctly, and the smaller 30s-rounding-overshoot edge case.
- macOS `Strand`: `xcodebuild … build` `BUILD SUCCEEDED` + `StrandTests` **1751/0** (1 pre-existing
  skip) — this is app-target Swift, so verified via `xcodebuild … test`, not just `swift test`.
- Android: `compileFullDebugKotlin` clean + `testFullDebugUnitTest` **6043/7 failed**, all 7
  independently reconfirmed **pre-existing** (2 `RecoveryDriversTest` float-rounding + 2
  `StandardHrSensorFormatTest` + 3 `TodayExplainabilityTest`, none in a touched file); 3 new
  `SleepSessionDedupTest` cases green.
- Also cherry-picked onto `integration/oura-full` and re-verified there end to end as part of that
  branch's 2026-09-12 rebase onto `upstream/main`: Swift WhoopProtocol 704 · OuraProtocol 246 ·
  WhoopStore 571 · StrandAnalytics 1975 · StrandImport 296 · StrandDesign 86, 0 failures; `StrandTests`
  1775/0; Android tests 6063/7 pre-existing-failed.
- **Not yet hardware-validated against a fresh occurrence.** The already-captured bad row (this fix's
  own motivating example) predates the fix and is NOT retroactively repaired by it — this is a
  persistence-time guard against writing a *new* bad row, not a data migration. Owed: a future
  short/daytime Oura session (ideally one that hits the same closest-window mis-pairing) confirming no
  new negative-duration row appears.