### PR TITLE
doc(oura): correct the macOS pairing limitation - a factory-reset ring works fine

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,9 +307,10 @@ same rules as everything else here.
 > used only to identify that hardware. NOOP does not use, decompile, or redistribute any Oura app
 > code, and does not bypass any login, paywall, or DRM.
 
-**📱 iOS / Android only.** Pairing an Oura ring **does not work on macOS** — `connect()` is issued
-cleanly and no CoreBluetooth callback ever arrives, so it hangs silently rather than failing. This is
-reproducible and independent of the pairing method. Documented in
+**⚠️ macOS pairing needs a factory-reset ring.** Pairing an Oura ring that is still Bluetooth-bonded
+to a phone (i.e. its only prior bond is with the official Oura app) reproducibly hangs on macOS —
+`connect()` is issued cleanly and no CoreBluetooth callback ever arrives. Factory-resetting the ring
+from the official Oura app first, then pairing with NOOP on macOS, works. Documented in
 [`docs/OURA_PROTOCOL.md` §3.8](docs/OURA_PROTOCOL.md).
 
 | Input / output | Status |

--- a/docs/OURA_PROTOCOL.md
+++ b/docs/OURA_PROTOCOL.md
@@ -174,28 +174,32 @@ Before app-auth, the ring answers a small set unauthenticated: firmware (`0x08`)
 
 Treat this key like a password: it authenticates as the real Oura app against your account's ring. NOOP stores it locally the same way it stores its own provisioned key (Keychain on iOS / EncryptedSharedPreferences-Keystore on Android, §3.2) — nothing is transmitted anywhere. This recipe extracts a fact from **your own** device backup and a public schema doc; it does not touch, decompile, or redistribute any Oura app code.
 
-### 3.8 macOS pairing limitation (observed, 2026-07-29)
+### 3.8 macOS pairing needs a factory-reset ring (observed 2026-07-29, corrected 2026-09-12)
 
-Pairing an Oura ring that has never been Bluetooth-bonded to the Mac (i.e. any ring whose only prior
-bond is with the official Oura app on a phone) reproducibly fails on macOS. `CBCentralManager.connect()`
-is issued cleanly (scanning stopped first, `central.state == .poweredOn`, a valid, in-range peripheral -
-observed RSSI as good as -55), but **no CoreBluetooth delegate callback ever arrives** - not
-`didConnect`, not `didFailToConnect`. The ring never appears in System Settings ▸ Bluetooth either
-(no partial bond record is created). Ruled out: a second central holding the ring - the same failure
-reproduces with the paired phone's Bluetooth fully off. This matches CoreBluetooth's documented
-behavior that `connect()` has no built-in timeout (an unanswered connect just stays pending forever),
-so the practical symptom is a silent, permanent hang rather than an error.
+Pairing an Oura ring that is still Bluetooth-bonded to a phone (i.e. its only prior bond is with the
+official Oura app) reproducibly fails on macOS. `CBCentralManager.connect()` is issued cleanly
+(scanning stopped first, `central.state == .poweredOn`, a valid, in-range peripheral - observed RSSI
+as good as -55), but **no CoreBluetooth delegate callback ever arrives** - not `didConnect`, not
+`didFailToConnect`. The ring never appears in System Settings ▸ Bluetooth either (no partial bond
+record is created). Ruled out: a second central holding the ring - the same failure reproduces with
+the paired phone's Bluetooth fully off. This matches CoreBluetooth's documented behavior that
+`connect()` has no built-in timeout (an unanswered connect just stays pending forever), so the
+practical symptom is a silent, permanent hang rather than an error.
 
 This is a different (and apparently more total) failure surface than the already-known WHOOP 5.0/MG
 macOS limitation (see `docs/WHOOP5_DEEP_DATA.md`, "iOS / Android only on real hardware") - WHOOP 5/MG
 at least connects and discovers services, failing only at an authenticated characteristic write
 (`CBATTError` "Encryption is insufficient"). Oura's connect doesn't get that far at all. The exact
 CoreBluetooth/bluetoothd mechanism isn't diagnosed further than this (would need a low-level HCI/SMP
-trace), but the practical conclusion is the same as WHOOP 5/MG's: **treat Oura ring pairing as
-iOS/Android-only** until proven otherwise on macOS. This applies to the §3.7 Advanced-key flow as
-much as to the §3.2 factory-reset one - the limitation is at connect time, before any key is used.
-Not yet tested: whether a genuinely never-bonded-anywhere (factory-reset) ring behaves differently
-from the already-Oura-app-owned case tested here.
+trace).
+
+**Corrected 2026-09-12: a genuinely factory-reset ring pairs on macOS without issue.** The 2026-07-29
+finding above tested only an already-Oura-app-owned ring; resetting the ring from the official Oura
+app first - clearing whatever bond/pairing state the earlier phone bond left behind - then pairing
+with NOOP on macOS works. So the limitation is specifically **an existing non-Mac bond**, not macOS
+pairing in general: this applies to the §3.7 Advanced-key flow as much as to the §3.2 factory-reset
+one, since the hang is at connect time, before any key is used, but a §3.2 factory-reset performed via
+the Oura app clears it first.
 
 ---
 


### PR DESCRIPTION
## The problem

README.md and `docs/OURA_PROTOCOL.md` §3.8 both stated flatly that pairing an Oura ring **does not
work on macOS**, "reproducible and independent of the pairing method" — generalizing from a single
2026-07-29 test where the ring being paired was still Bluetooth-bonded to a phone (its only prior bond
was with the official Oura app).

Patrick's own testing shows this generalization was wrong: a ring that has been **factory-reset via
the official Oura app first** pairs on macOS without issue. The connect-hang is real, but it's scoped
to a ring still bonded elsewhere — clearing that bond (via a factory reset) resolves it. §3.8 itself
already carried an open question this closes: "Not yet tested: whether a genuinely never-bonded-
anywhere (factory-reset) ring behaves differently from the already-Oura-app-owned case tested here."

## The fix

- **README.md**: rewrites the bold summary line from "Pairing an Oura ring does not work on macOS...
  reproducible and independent of the pairing method" to "macOS pairing needs a factory-reset ring,"
  naming the actual scope (a ring still bonded to a phone) and the resolution (factory-reset via the
  Oura app, then pair with NOOP on macOS).
- **`docs/OURA_PROTOCOL.md` §3.8**: retitled to "macOS pairing needs a factory-reset ring (observed
  2026-07-29, corrected 2026-09-12)." The original hardware observation (the CoreBluetooth hang
  itself — `connect()` issued cleanly, no delegate callback ever arrives, no partial bond record) is
  kept verbatim, since that part is still accurate; only the generalization to "treat as iOS/Android-only"
  is corrected. Adds a "Corrected 2026-09-12" paragraph stating the factory-reset finding and
  resolving the section's own dangling open question.

## Verification

Docs-only change, no code touched.