### PR TITLE
fix(diagnostics): Test Centre export dropped the newer Oura sidecars, and trimmed JSONL files mid-record

### DIFF
--- a/Strand/System/TestBundleAssembler.swift
+++ b/Strand/System/TestBundleAssembler.swift
@@ -103,10 +103,25 @@ enum TestBundleAssembler {
                 : 0
             guard entry.data.count > share else { return entry }
             truncated = true
-            // Keep the tail (most recent): the last `share` bytes.
-            return FileExport.BundleEntry(name: entry.name, data: Data(entry.data.suffix(share)))
+            // Keep the tail (most recent): the last `share` bytes, then snap forward to the next full
+            // JSONL line. A raw byte-count tail can (and in production did - a real export shipped
+            // oura-cva-ppg.jsonl/oura-real-steps.jsonl/oura-motion.jsonl each with a corrupted first
+            // line) land mid-record; every trimmable name is newline-delimited JSONL, so dropping the
+            // partial line at the front keeps every kept line honest.
+            return FileExport.BundleEntry(name: entry.name,
+                                          data: Self.trimToLineBoundary(entry.data.suffix(share)))
         }
         return (capped, truncated)
+    }
+
+    /// Drop bytes up to and including the first newline in `data`, so a raw byte-count tail (from
+    /// `capEntries`'s proportional trim) never starts mid-line for a newline-delimited JSONL sidecar.
+    /// Returns `data` unchanged when it contains no newline (a single very-long line, or already empty)
+    /// - never worse than the untrimmed behaviour, just not improved. Pure/testable.
+    static func trimToLineBoundary(_ data: Data) -> Data {
+        guard let newline = data.firstIndex(of: 0x0A) else { return data }
+        let start = data.index(after: newline)
+        return data.subdata(in: start..<data.endIndex)
     }
 
     // MARK: - assemble (the entrypoint behind the Report button, the Group D integration seam)

--- a/Strand/System/TestBundleAssembler.swift
+++ b/Strand/System/TestBundleAssembler.swift
@@ -14,14 +14,20 @@ enum TestBundleAssembler {
     /// The redaction stamp written into meta.json so a maintainer knows the whole-bundle scrub ran.
     static let redactionVersion = "v2"
 
+    /// The Oura Diagnostics-dir sidecar kinds the bundle attaches — the SINGLE source of truth
+    /// `normalizedOuraEntryName`/`ouraDiagnosticEntries`/`trimmableNames`/`ouraSidecarNames` all derive
+    /// from, so a new dump writer (`Strand/BLE/Oura*Dump.swift`) needs exactly one line added here to be
+    /// picked up everywhere instead of silently missing the export bundle. (Landed after `cva-ppg` and
+    /// `real-steps` shipped their writers but not their kind entry — both wrote real files on-device that
+    /// the bundler's hardcoded 3-kind list then dropped from every export.)
+    static let ouraSidecarKinds: [String] = ["raw", "ibihr", "activity", "cva-ppg", "motion", "real-steps"]
+
     /// The bundle files that may be trimmed to fit the cap (newest-tail kept). The strap-log tail and
     /// meta.json are already bounded, so only these raw research streams can blow the budget: the WHOOP
-    /// frame capture plus the Oura ring's Tier-B JSONL sidecars (raw notifications / IBI-HR / activity MET).
-    /// Everything NOT listed here is kept whole and its bytes are reserved before the trimmable group is
-    /// given the remainder. These are the NORMALIZED entry names (the ring id is dropped from the filename).
-    static let trimmableNames: Set<String> = [
-        "raw-capture.jsonl", "oura-raw.jsonl", "oura-ibihr.jsonl", "oura-activity.jsonl",
-    ]
+    /// frame capture plus the Oura ring's Tier-B JSONL sidecars (raw notifications / IBI-HR / activity MET /
+    /// CVA-PPG / motion / real-steps). Everything NOT listed here is kept whole and its bytes are reserved
+    /// before the trimmable group is given the remainder. NORMALIZED entry names (ring id dropped).
+    static let trimmableNames: Set<String> = Set(["raw-capture.jsonl"] + ouraSidecarKinds.map { "oura-\($0).jsonl" })
 
     /// #572 follow-up: the Oura Tier-B sidecars carry the ring id in a `"deviceId"` JSON field. The
     /// whole-bundle UUID scrub (`LiveState.redactPii`) masks it only when it is a CANONICAL dashed
@@ -30,9 +36,7 @@ enum TestBundleAssembler {
     /// covered, and (unlike broadening the UUID regex to dashless hex) it CANNOT touch the raw `hex` capture
     /// field, which a greedier rule would shred. Scoped to the sidecars so a non-PII logical `deviceId`
     /// (e.g. "my-whoop") elsewhere in the bundle stays readable. NORMALIZED names (ring id already dropped).
-    static let ouraSidecarNames: Set<String> = [
-        "oura-raw.jsonl", "oura-ibihr.jsonl", "oura-activity.jsonl",
-    ]
+    static let ouraSidecarNames: Set<String> = Set(ouraSidecarKinds.map { "oura-\($0).jsonl" })
 
     /// `oura-raw.jsonl` is the ONE sidecar whose payload is nothing but hex (`OuraRawDumpLine.encode`) —
     /// `oura-ibihr.jsonl`/`oura-activity.jsonl` encode DECODED numeric fields, so `LiveState.redactHexDump`'s
@@ -320,11 +324,12 @@ enum TestBundleAssembler {
     }
 
     /// Map a diagnostics filename to a NORMALIZED bundle entry name that drops the ring id, or nil when the
-    /// file is not one of the three Oura sidecars. `oura-<type>-<ringId>.jsonl` → `oura-<type>.jsonl`, which
-    /// (a) keeps the ring id out of the bundle's filenames (redaction scrubs content, never names) and
-    /// (b) lands on the `trimmableNames` set so the cap can trim it. Pure/string-only for unit testing.
+    /// file is not one of the Oura sidecars in `ouraSidecarKinds`. `oura-<type>-<ringId>.jsonl` →
+    /// `oura-<type>.jsonl`, which (a) keeps the ring id out of the bundle's filenames (redaction scrubs
+    /// content, never names) and (b) lands on the `trimmableNames` set so the cap can trim it.
+    /// Pure/string-only for unit testing.
     static func normalizedOuraEntryName(forFile filename: String) -> String? {
-        for kind in ["raw", "ibihr", "activity"] {
+        for kind in ouraSidecarKinds {
             if filename.hasPrefix("oura-\(kind)-"), filename.hasSuffix(".jsonl") {
                 return "oura-\(kind).jsonl"
             }
@@ -348,8 +353,8 @@ enum TestBundleAssembler {
             if let existing = byName[name], existing.data.count >= entry.data.count { continue }
             byName[name] = entry
         }
-        // Stable order (raw, ibihr, activity) so the bundle listing is deterministic.
-        return ["oura-raw.jsonl", "oura-ibihr.jsonl", "oura-activity.jsonl"].compactMap { byName[$0] }
+        // Stable order (ouraSidecarKinds order) so the bundle listing is deterministic.
+        return ouraSidecarKinds.map { "oura-\($0).jsonl" }.compactMap { byName[$0] }
     }
 
     /// The on-disk path a crash report would live at, when a crash handler is wired. There is no producer

--- a/StrandTests/TestBundleAssemblerTests.swift
+++ b/StrandTests/TestBundleAssemblerTests.swift
@@ -46,6 +46,36 @@ final class TestBundleAssemblerTests: XCTestCase {
         XCTAssertEqual(raw.data.last, Data(oversized.utf8).last)
     }
 
+    func testCapSnapsTrimmedTailToLineBoundary() {
+        // A raw byte-count tail can (and in production did) land mid-record: a real export shipped
+        // oura-cva-ppg.jsonl/oura-real-steps.jsonl/oura-motion.jsonl each with a corrupted first line.
+        // Every trimmable name is newline-delimited JSONL, so the trimmed tail must always start at a
+        // clean line boundary.
+        let small = FileExport.BundleEntry(name: "report.txt", data: Data("small".utf8))
+        let lines = (1...2000).map { "{\"n\":\($0),\"pad\":\"\(String(repeating: "x", count: 50))\"}" }
+        let raw = FileExport.BundleEntry(name: "oura-raw.jsonl", data: Data(lines.joined(separator: "\n").utf8))
+        // Force a mid-file trim at a cap unlikely to land exactly on a newline.
+        let cap = raw.data.count / 2
+        let (capped, truncated) = TestBundleAssembler.capEntries([small, raw], capBytes: cap)
+        XCTAssertTrue(truncated)
+        let cappedRaw = capped.first { $0.name == "oura-raw.jsonl" }!
+        let text = String(data: cappedRaw.data, encoding: .utf8)!
+        XCTAssertFalse(text.isEmpty)
+        XCTAssertTrue(text.hasPrefix("{"), "trimmed tail must start at a clean line boundary, got: \(text.prefix(30))")
+        // Every kept line must still be valid JSON (no partial record survived).
+        for line in text.split(separator: "\n") {
+            XCTAssertNotNil(try? JSONSerialization.jsonObject(with: Data(line.utf8)),
+                            "corrupted line survived trimming: \(line.prefix(30))")
+        }
+    }
+
+    func testTrimToLineBoundaryHandlesNoNewline() {
+        // A single-line (or already-empty) entry has nothing to snap to - returned unchanged, never worse.
+        let noNewline = Data("no newline here".utf8)
+        XCTAssertEqual(TestBundleAssembler.trimToLineBoundary(noNewline), noNewline)
+        XCTAssertEqual(TestBundleAssembler.trimToLineBoundary(Data()), Data())
+    }
+
     func testCapLeavesUndersizedBundleUntouched() {
         let entries = [FileExport.BundleEntry(name: "report.txt", data: Data("tiny".utf8))]
         let (capped, truncated) = TestBundleAssembler.capEntries(entries, capBytes: 20 * 1024 * 1024)

--- a/StrandTests/TestBundleAssemblerTests.swift
+++ b/StrandTests/TestBundleAssemblerTests.swift
@@ -56,13 +56,21 @@ final class TestBundleAssemblerTests: XCTestCase {
     // MARK: - Oura diagnostics attachment (#Test-Centre Oura sidecars)
 
     func testNormalizedOuraEntryNameDropsRingId() {
-        // The three sidecars normalize to id-free names; the ring UUID is gone from the filename.
+        // All six sidecars normalize to id-free names; the ring UUID is gone from the filename.
         XCTAssertEqual(TestBundleAssembler.normalizedOuraEntryName(
             forFile: "oura-raw-5C4C0BF8-2DF6-1B3A-18D0-3DF0B3590148.jsonl"), "oura-raw.jsonl")
         XCTAssertEqual(TestBundleAssembler.normalizedOuraEntryName(
             forFile: "oura-ibihr-5C4C0BF8-2DF6-1B3A-18D0-3DF0B3590148.jsonl"), "oura-ibihr.jsonl")
         XCTAssertEqual(TestBundleAssembler.normalizedOuraEntryName(
             forFile: "oura-activity-oura-5C4C0BF8.jsonl"), "oura-activity.jsonl")
+        // #Test-Centre follow-up: cva-ppg/motion/real-steps shipped writers (Strand/BLE/Oura*Dump.swift)
+        // before the bundler knew their kind — regression coverage for that gap.
+        XCTAssertEqual(TestBundleAssembler.normalizedOuraEntryName(
+            forFile: "oura-cva-ppg-oura-2H3B2405003655.jsonl"), "oura-cva-ppg.jsonl")
+        XCTAssertEqual(TestBundleAssembler.normalizedOuraEntryName(
+            forFile: "oura-motion-oura-2H3B2405003655.jsonl"), "oura-motion.jsonl")
+        XCTAssertEqual(TestBundleAssembler.normalizedOuraEntryName(
+            forFile: "oura-real-steps-oura-2H3B2405003655.jsonl"), "oura-real-steps.jsonl")
         // Non-sidecar files are ignored.
         XCTAssertNil(TestBundleAssembler.normalizedOuraEntryName(forFile: "raw-capture.jsonl"))
         XCTAssertNil(TestBundleAssembler.normalizedOuraEntryName(forFile: "whoop.sqlite"))
@@ -72,8 +80,9 @@ final class TestBundleAssemblerTests: XCTestCase {
     func testNormalizedOuraNamesAreAllTrimmable() {
         // Every normalized sidecar name must be in the cap's trimmable set, else a big night's dump could
         // blow the 20 MB cap instead of being tail-trimmed.
-        for kind in ["raw", "ibihr", "activity"] {
+        for kind in TestBundleAssembler.ouraSidecarKinds {
             XCTAssertTrue(TestBundleAssembler.trimmableNames.contains("oura-\(kind).jsonl"))
+            XCTAssertTrue(TestBundleAssembler.ouraSidecarNames.contains("oura-\(kind).jsonl"))
         }
     }
 


### PR DESCRIPTION
## Two export-bundler bugs, one file

**1. Three Oura sidecars never made it into the bundle.** `TestBundleAssembler.normalizedOuraEntryName()`
hard-coded the Oura diagnostics kinds it recognises to the original three (`raw`/`ibihr`/`activity`).
The `cva-ppg`, `motion` and `real-steps` dump writers shipped later and have been writing real files
on-device the whole time — but the bundler didn't know their kind, so it silently dropped all three
from every Test Centre export. Confirmed against two real exports where the strap log shows the writers
firing and the files never appear in the zip.

Fix: collapse the four places that independently listed sidecar kinds down to one source of truth
(`ouraSidecarKinds`), so a future dump writer needs exactly one line added to be picked up by
`normalizedOuraEntryName` / `ouraDiagnosticEntries` / `trimmableNames` / `ouraSidecarNames` together,
instead of silently missing export.

**2. Oversized JSONL sidecars were trimmed to a raw byte count.** `capEntries` keeps the most-recent tail
of an oversized file by byte count — fine for a freeform text log, but a byte-count cut on a
newline-delimited JSONL file can land mid-record. Confirmed in production: a real overnight export
(2026-07-30/31) shipped `oura-cva-ppg.jsonl`, `oura-real-steps.jsonl` and `oura-motion.jsonl` each with a
corrupted first line, the first time their combined size crossed the 20 MB cap.

Fix: `trimToLineBoundary` — after the proportional byte-count trim, drop bytes up to and including
the first newline, so every kept line is a complete record. Every trimmable name is JSONL, so this is
safe across the board; a single very-long line with no newline is returned unchanged, never worse than
before.

## Verification

- `StrandTests` **1753/0** (1 pre-existing skip) on the rebased tip — app-target Swift, so verified via
  `xcodebuild … test`, not just `swift test`. `TestBundleAssemblerTests` 14/14, including the new
  `testCapSnapsTrimmedTailToLineBoundary` (every kept line parses as valid JSON after a forced mid-file
  trim) and a normalisation case for each newly-recognised sidecar kind.
- Apple-only, and deliberately so. Android *does* have `OuraMotionDump`/`OuraRealStepsDump` writers, but
  its `TestBundleAssembler.kt` exports **no** Oura sidecars at all today (only `raw-capture.jsonl`) — so
  the Android situation is a wider, pre-existing gap ("Oura sidecars are never exported"), not a twin of
  this bug ("three of six sidecars are dropped"). Worth its own issue; not smuggled into this PR.