### PR TITLE
fix(oura): only persist the SpO2 raw channel, drop dc_raw from spo2Sample

### DIFF
--- a/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
+++ b/Packages/WhoopStore/Sources/WhoopStore/OuraStreamMapping.swift
@@ -50,10 +50,12 @@ public enum OuraStreamMapping {
     ///   - `.hr`         (0x55 live-HR push)            → `hr:[HRSample]`
     ///   - `.ibi`        (0x44/0x60 IBI)                → `rr:[RRInterval]`
     ///   - `.hrv`        (0x5D HRV tag, u8 hr/rmssd pairs) → `events:[WhoopEvent(kind: OURA_HRV)]` (one row per 5-min bucket)
-    ///   - `.spo2`       (0x6F/0x70/0x77)              → `spo2:[SpO2Sample]`, carrying the decoder's own
+    ///   - `.spo2`       (0x6F/0x70 ONLY)              → `spo2:[SpO2Sample]`, carrying the decoder's own
     ///     `unit` tag. NOT all one quantity: 0x6F/0x70 are firmware-computed PERCENTAGES (tagged `"raw"`,
     ///     a legacy channel label — see `OuraDecoders.decodeSpO2PerSample`), while 0x77 is a genuine raw
-    ///     DC channel tagged `"dc_raw"`. Both land in `SpO2Sample.red`; neither is written to `spo2Pct`.
+    ///     DC channel tagged `"dc_raw"` on a wholly different scale. **0x77 is decoded but NOT persisted**
+    ///     — it is filtered at the guard below, because blending two scales into one `red` column corrupts
+    ///     any consumer that averages the stream without a unit filter. Nothing is written to `spo2Pct`.
     ///   - `.temp`       (0x46/0x75)                    → `skinTemp:[SkinTempSample(raw_adc)]`
     ///   - `.sleepPhase` (0x4E/0x5A 2-bit codes)        → `events:[WhoopEvent(kind: OURA_SLEEP_PHASE)]`
     ///   - `.battery`                                   → `battery:[BatterySample]`
@@ -124,11 +126,21 @@ public enum OuraStreamMapping {
                 ]))
 
             case .spo2(let v):
-                // Oura reports a single SpO2 channel; `SpO2Sample` is the WHOOP-shaped two-channel raw row,
-                // so we record the decoded value on `red` and leave `ir` at 0 (no second channel). `unit`
-                // carries the decoder's own scale tag ("raw"/"dc_raw") so downstream never assumes a %.
+                // Only persist the 0x6F/0x70 channel (`unit == "raw"`): a real overnight capture
+                // (2026-07-30/31, 22516 samples) clusters tightly at 95-105, matching a genuine %SpO2
+                // reading. The 0x77 DC channel (`unit == "dc_raw"`) is a wildly different-scale raw
+                // PPG/perfusion signal (-9K to +11.7M in the same capture) - not SpO2 at all, so blending
+                // it into `red` corrupts any consumer that averages the stream with no unit filter
+                // (`AnalyticsEngine.nightlySpo2RawMeans` still does; the ceiling-mean path only survives
+                // because it range-gates at 50...110). Still decoded, still reachable from
+                // `oura-raw.jsonl`; just never durably persisted. `SpO2Sample` is the WHOOP-shaped
+                // two-channel raw row, so we record the decoded value on `red` and leave `ir` at 0.
+                guard v.unit == "raw" else { continue }
+
+                // `unit` still travels onto the row (always "raw" past the guard) so downstream never
+                // assumes a %.
                 //
-                // Each sample gets its OWN second. `spo2Sample` is keyed (deviceId, ts), so the 13 samples
+                // Each surviving sample gets its OWN second. `spo2Sample` is keyed (deviceId, ts), so the 13 samples
                 // of one 0x6F record written at the record's single `ts` collided and only the first
                 // survived — 92% of an overnight silently discarded, and unrecoverable because the ring
                 // trims its banked history once the offload is acked (#1070). The samples are one per

--- a/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
+++ b/Packages/WhoopStore/Tests/WhoopStoreTests/OuraStreamMappingTests.swift
@@ -129,11 +129,21 @@ final class OuraStreamMappingTests: XCTestCase {
             .spo2(OuraSpO2(ringTimestamp: 100, value: 970, unit: "raw")),
             .spo2(OuraSpO2(ringTimestamp: 101, value: 12345, unit: "dc_raw")),
         ], at: ts)
-        XCTAssertEqual(s.spo2.map { $0.red }, [970, 12345])
-        XCTAssertEqual(s.spo2.map { $0.ir }, [0, 0])
-        XCTAssertEqual(s.spo2.map { $0.unit }, ["raw", "dc_raw"])
+        // Only the "raw" 0x6F/0x7B channel persists: a real capture shows it clustering at 95-105
+        // (genuine %SpO2), while "dc_raw" (0x77) is a wildly different-scale raw PPG/perfusion signal
+        // (-9K to +11.7M) that would corrupt a blind mean over `red` if it were mixed in.
+        XCTAssertEqual(s.spo2.map { $0.red }, [970])
+        XCTAssertEqual(s.spo2.map { $0.ir }, [0])
+        XCTAssertEqual(s.spo2.map { $0.unit }, ["raw"])
         // Single-sample records (count == 1) keep the record's own second, exactly as before #1070.
-        XCTAssertEqual(s.spo2.map { $0.ts }, [ts, ts])
+        XCTAssertEqual(s.spo2.map { $0.ts }, [ts])
+    }
+
+    func testSpO2DcRawChannelIsDroppedNotPersisted() {
+        let s = OuraStreamMapping.streams(from: [
+            .spo2(OuraSpO2(ringTimestamp: 100, value: 11_709_098, unit: "dc_raw")),
+        ], at: ts)
+        XCTAssertTrue(s.spo2.isEmpty)
     }
 
     // #1070: `spo2Sample` is keyed (deviceId, ts). A 0x6F record's 13 per-second samples used to be

--- a/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
+++ b/android/app/src/main/java/com/noop/data/OuraStreamMapping.kt
@@ -113,6 +113,13 @@ object OuraStreamMapping {
                 }
 
                 is OuraEvent.Spo2 -> {
+                    // Only persist the 0x6F/0x70 channel (unit == "raw"): a real overnight capture
+                    // (2026-07-30/31, 22516 samples) clusters tightly at 95-105, matching a genuine %SpO2
+                    // reading. The 0x77 DC channel (unit == "dc_raw") is a wildly different-scale raw
+                    // PPG/perfusion signal (-9K to +11.7M in the same capture) - not SpO2 at all, so
+                    // blending it into `red` would corrupt any consumer that averages the stream with no
+                    // unit filter. Mirrors the Swift OuraStreamMapping twin.
+                    if (ev.value.unit != "raw") continue
                     // The ring exposes ONE combined SpO2 reading (not separate red/ir channels): its
                     // raw value goes in `red`; `ir` stays 0 (an unread channel, never a fabricated
                     // second reading). `unit` carries the decoder's own scale tag so downstream never

--- a/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
+++ b/android/app/src/test/java/com/noop/data/OuraStreamMappingTest.kt
@@ -244,6 +244,18 @@ class OuraStreamMappingTest {
     }
 
     @Test
+    fun spo2DcRawChannelIsDroppedNotPersisted() {
+        // The 0x77 DC channel (unit "dc_raw") is a wildly different-scale raw PPG/perfusion signal
+        // (-9K to +11.7M in a real capture) - not SpO2 at all, so it must never reach the durable
+        // stream where a blind mean over `red` would be corrupted. Mirrors the Swift twin.
+        val s = OuraStreamMapping.streams(
+            listOf(OuraEvent.Spo2(OuraSpO2(ringTimestamp = 1, value = 11_709_098, unit = "dc_raw"))),
+            anchor,
+        )
+        assertTrue(s.spo2.isEmpty())
+    }
+
+    @Test
     fun tempPersistsAsHundredthsOfDegree() {
         val s = OuraStreamMapping.streams(
             listOf(OuraEvent.Temp(OuraTemp(ringTimestamp = 4, celsius = 33.27))),


### PR DESCRIPTION
## The problem

`OuraStreamMapping` appends **both** SpO2 decoder outputs into the same durable `spo2Sample.red`
column under different `unit` tags — `"raw"` for `0x6F`/`0x70`, `"dc_raw"` for `0x77` — without
filtering. A real overnight capture (2026-07-30/31, 22,516 `"raw"` + 43,317 `"dc_raw"` samples) shows
why that's wrong: `"raw"` clusters tightly at 95–105, a genuine %SpO2 reading; `"dc_raw"` ranges from
−9,072 to +11,709,098 — a completely different-scale raw PPG/perfusion signal, not SpO2 at all.

Two scales in one column corrupt any consumer that averages `red` without a unit filter:
- `AnalyticsEngine.nightlySpo2RawMeans` — still called in the daily pipeline — does exactly that today.
- The newer ceiling-mean path only survives because it range-gates at `50...110`
  (`spo2SingleChannelPlausible`), i.e. every consumer has to remember to defend itself.

And independently of consumers: it writes roughly two junk rows for every real one into a durable
table, for a channel nobody scores.

## The fix

Filter the `.spo2` mapping case to `unit == "raw"` only, on both platforms. `0x77` is still decoded
(Tier-A, unchanged) and still present in the `oura-raw.jsonl` capture for research — it just never
reaches the durable stream. Fixing it at persist time stops the pollution at the source and removes
the dependency on every present and future consumer applying its own range gate.

## Scope

`OuraStreamMapping` is package-level (`Packages/WhoopStore`) with a byte-identical Kotlin twin
(`android/…/data/OuraStreamMapping.kt`) per the parity contract; both changed in this commit. No
migration: existing `dc_raw` rows already stored are left in place (the range gate downstream already
ignores them); this only stops writing new ones.

## Verification

- Swift `WhoopStore`: `swift test` **547/0**; `OuraStreamMappingTests` 26/26 — new
  `testSpO2DcRawChannelIsDroppedNotPersisted`, and `testSpO2MapsToSpO2StreamPreservingUnit` updated to
  expect only the `raw` sample.
- macOS `Strand`: `BUILD SUCCEEDED` (the package is app-consumed; API unchanged).
- Android: `compileFullDebugKotlin` clean; `OuraStreamMappingTest` green, incl. the Kotlin twin of the
  new test.