### PR TITLE
fix(oura): fetch ring history every 5 min, not 15 — the periodic fetch is the real data cadence

### DIFF
--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -675,10 +675,22 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// One-shot delay before a self-chained drain pass (see `finishDrain`). Invalidated on teardown.
     private var chainedDrainTimer: Timer?
     /// Periodic re-fetch while connected, so an overnight-connected session (or one left open after a nap)
-    /// picks up freshly-banked sleep data without needing a reconnect. Mirrors BLEManager's ~15 min
-    /// periodic WHOOP history-offload floor.
+    /// picks up freshly-banked sleep data without needing a reconnect.
+    ///
+    /// MEASURED 2026-08-10 (capture `…-260810-1556`, 2h31m at 96.6% connected): this interval is not just a
+    /// backstop, it is the ACTUAL DATA CADENCE. Between fetches the ring delivered **nothing at all** —
+    /// seven arrival gaps of 893-928 s inside live sessions, clustering exactly on the old 900 s value,
+    /// while the app was awake (59-60 live-HR re-arms per gap), the link was up and the ring was worn. Only
+    /// **2.1%** of `0x80` "live HR" arrived within 15 s of its own second; the median record was **385 s**
+    /// old on arrival. So a user watching live HR was watching a 6-minute-old burst.
+    ///
+    /// 900 -> 300 s halves-and-then-some the worst-case staleness at a marginal cost: while live HR is on
+    /// the app already writes `dhr_enable`+`dhr_subscribe` every 15 s (462 commands/h measured), against
+    /// which the whole history-fetch machinery was 21 commands/h. The payload is unchanged either way — the
+    /// same records arrive, in smaller chunks — and `fetchHistoryIfIdle` is a no-op unless the driver is
+    /// idle-streaming, so a fetch never overlaps a drain.
     private var historyFetchTimer: Timer?
-    private let historyFetchInterval: TimeInterval = 900
+    private let historyFetchInterval: TimeInterval = 300
 
     /// Kick a history-fetch pass at the current cursor, but ONLY when the driver is idle-streaming (never
     /// overlaps a fetch already in flight - the driver's own phase is the guard, so this is safe to call

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -465,12 +465,22 @@ class OuraLiveSource(
 
     /**
      * Periodic re-fetch while connected, so an overnight-connected session (or one left open after a nap)
-     * picks up freshly-banked sleep data without needing a reconnect. Mirrors the WHOOP ~15 min periodic
-     * history-offload floor. Held as a NAMED runnable so [stop]/disconnect can remove it from the handler,
-     * matching [reengageRunnable] / [reconnectRunnable].
+     * picks up freshly-banked sleep data without needing a reconnect. Held as a NAMED runnable so
+     * [stop]/disconnect can remove it from the handler, matching [reengageRunnable] / [reconnectRunnable].
      */
     private var historyFetchScheduled = false
-    private val historyFetchIntervalMs = 900_000L
+    /**
+     * MEASURED 2026-08-10 (capture `…-260810-1556`, 2h31m at 96.6% connected): this interval is not just a
+     * backstop, it is the ACTUAL DATA CADENCE. Between fetches the ring delivered nothing at all — seven
+     * arrival gaps of 893-928 s inside live sessions, clustering exactly on the old 900 s value, while the
+     * app was awake (59-60 live-HR re-arms per gap), the link was up and the ring was worn. Only 2.1% of
+     * `0x80` "live HR" arrived within 15 s of its own second; the median record was 385 s old on arrival.
+     *
+     * 900 -> 300 s at a marginal cost: while live HR is on the app already writes dhr_enable+dhr_subscribe
+     * every 15 s (462 commands/h measured) against 21 commands/h for the whole history-fetch machinery.
+     * Payload is unchanged — the same records, in smaller chunks. Swift twin: `historyFetchInterval`.
+     */
+    private val historyFetchIntervalMs = 300_000L
     private val historyFetchRunnable = object : Runnable {
         override fun run() {
             fetchHistoryIfIdle()


### PR DESCRIPTION
## The problem

On this ring, the "live" notify subscription is nominally active but delivers almost nothing between
history fetches — the periodic fetch is where the data actually arrives. So `historyFetchInterval`
isn't a backstop, it's the cadence at which anything reaches the app.

Measured on capture `noop-master-iOS-v9.3.1-260810-1556` (2 h 31 m, 96.6 % connected, app awake):

* **Seven arrival gaps of 893–928 s** inside live sessions, clustering exactly on the old 900 s
  interval. Nothing of **any** tag arrived between history fetches.
* The app was awake through every one — 59–60 live-HR re-arms per gap against ~60 expected at 15 s —
  and each window *opens* with `receiving live data - first HR NN bpm` / `ring WORN - live HR
  streaming`. So this isn't #1215 (app terminated) or #1286 (app suspended); it's a healthy link
  delivering nothing.
* Only **2.1 %** of the 1,546 `0x80` "live HR" records arrived within 15 s of their own second. Median
  lag **385 s**, p90 1,024 s. What the Live screen showed as live HR was typically a 6-minute-old
  burst.

## The change

`historyFetchInterval` 900 → 300 s, both platforms (`Strand/BLE/OuraLiveSource.swift`,
`android/…/ble/OuraLiveSource.kt`). One constant each, plus the measured rationale as a doc comment so
it isn't "tidied" back to 15 min.

**Benefit:** worst-case staleness for anything not scored live — banked HR, sleep phases, skin temp,
`0x6A` breath rows — drops from ~15 min to ~5 min. On two overnight runs (2026-08-11, 08-12,
`integration/oura-full`) arrival gaps went **893–928 s → 298–299 s**. Same records, smaller chunks,
three times sooner.

**Cost:** negligible by construction. The whole history-fetch machinery was 21 commands/h at 900 s, so
~63/h at 300 s — against the 462 commands/h the live-HR re-arm already spends (`dhr_enable` +
`dhr_subscribe` every 15 s). The payload is unchanged (the same records arrive, just in smaller
chunks), and `fetchHistoryIfIdle` is a no-op unless the driver is idle-streaming, so a fetch never
overlaps a drain. **No battery regression observed** over the month `integration/oura-full` has run at
300 s — but no controlled A/B was done, so this PR claims no battery *effect* in either direction.


## Verification

* macOS `Strand`: `BUILD SUCCEEDED` + `StrandTests` **1751/0** (1 pre-existing skip) — app-target
  Swift, so via `xcodebuild … test`, since no default CI compiles it. No new tests: a constant change
  with no branch to cover.
* Android: `compileFullDebugKotlin` clean.
* Hardware: the gap reduction is validated on two overnight runs (above).

Relates to #1213.