### PR TITLE
fix(oura): let the #2097 anchor check judge a 10 s gap, not only 30 s

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraHistoryDrain.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraHistoryDrain.swift
@@ -29,9 +29,15 @@ public struct OuraHistoryDrain: Sendable, Equatable {
     /// power-cycle pause is measured in minutes (13m41s observed on one dead-battery reboot) — nowhere
     /// close to this margin, so it stays generous without risking a false "continuous" read.
     public static let anchorContinuityMaxPauseSeconds: Double = 20
-    /// Minimum wall-clock gap `anchorsAreContinuous` will judge; below this a few seconds of receipt-
-    /// latency noise would dominate the rate measurement, so the check declines rather than guessing.
-    public static let anchorContinuityMinGapSeconds: Double = 30
+    /// Minimum wall-clock gap `anchorsAreContinuous` will judge; below this the check declines rather
+    /// than guessing. 10 s, not the original 30: the test above is an ABSOLUTE margin
+    /// (`anchorContinuityMaxPauseSeconds`, 20 s), not a rate, so a few seconds of receipt-latency noise
+    /// inside a 10 s gap still leaves most of that margin — and a genuine power-cycle pause is minutes,
+    /// which cannot hide inside a short gap either (it shows up as the wall gap itself). The 30 s floor
+    /// declined on a real 27 s reconnect (2026-09-12, 268 ticks / 27 s = 9.93/s, ring clock plainly
+    /// continuous) and the old full re-pull fired — a fast relaunch-and-reconnect is the cheapest way
+    /// to produce a stale replay, so it is the case the floor must not exclude (#2097).
+    public static let anchorContinuityMinGapSeconds: Double = 10
 
     private var minBytesLeftSeen: UInt32 = .max
     private var stallCount = 0

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraHistoryDrainTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraHistoryDrainTests.swift
@@ -161,9 +161,21 @@ final class OuraHistoryDrainTests: XCTestCase {
 
     func testAnchorsAreContinuousDeclinesOnTooShortAGap() {
         let previous = (ringTicks: UInt32(1_000_000), unixSeconds: Int64(0))
-        let current = (ringTicks: UInt32(1_000_100), unixSeconds: Int64(10)) // below the 30s minimum
+        let current = (ringTicks: UInt32(1_000_050), unixSeconds: Int64(5)) // below the 10s minimum
         XCTAssertFalse(OuraHistoryDrain.anchorsAreContinuous(previous: previous, current: current),
                        "too short a gap to judge - declines rather than guessing")
+    }
+
+    func testAnchorsAreContinuousOnTheReal20260912FastReconnect() {
+        // 2026-09-12 19:38:56 -> 19:39:23: an app relaunch (Xcode install), state restoration resumed
+        // the still-connected ring, and the next connect came 27s later with a stale replay. Ring
+        // ticks 43358625 -> 43358893 = 268 ticks over 27s wall (9.93/s): plainly continuous, but the
+        // original 30s floor declined and the old full re-pull from 2026-07-24 fired. Must judge, and
+        // must say continuous.
+        let previous = (ringTicks: UInt32(43_358_625), unixSeconds: Int64(0))
+        let current = (ringTicks: UInt32(43_358_893), unixSeconds: Int64(27))
+        XCTAssertTrue(OuraHistoryDrain.anchorsAreContinuous(previous: previous, current: current),
+                      "a 27s gap with a continuous ring clock is judgeable and continuous")
     }
 
     func testAnchorsAreContinuousDeclinesWhenTicksWentBackward() {

--- a/android/app/src/main/java/com/noop/oura/OuraHistoryDrain.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraHistoryDrain.kt
@@ -168,10 +168,15 @@ class OuraHistoryDrain {
          */
         const val ANCHOR_CONTINUITY_MAX_PAUSE_SECONDS = 20.0
 
-        /** Minimum wall-clock gap [anchorsAreContinuous] will judge; below this a few seconds of
-         *  receipt-latency noise would dominate the rate measurement, so it declines rather than
-         *  guessing. */
-        const val ANCHOR_CONTINUITY_MIN_GAP_SECONDS = 30.0
+        /** Minimum wall-clock gap [anchorsAreContinuous] will judge; below this it declines rather
+         *  than guessing. 10 s, not the original 30: the test is an ABSOLUTE margin
+         *  ([ANCHOR_CONTINUITY_MAX_PAUSE_SECONDS], 20 s), not a rate, so a few seconds of receipt-latency
+         *  noise inside a 10 s gap still leaves most of that margin — and a genuine power-cycle pause is
+         *  minutes, which cannot hide inside a short gap either. The 30 s floor declined on a real 27 s
+         *  reconnect (2026-09-12, 268 ticks / 27 s = 9.93/s, ring clock plainly continuous) and the old
+         *  full re-pull fired — a fast relaunch-and-reconnect is the cheapest way to produce a stale
+         *  replay, so it is the case the floor must not exclude (#2097). Swift twin. */
+        const val ANCHOR_CONTINUITY_MIN_GAP_SECONDS = 10.0
 
         /**
          * Whether two `0x13 SyncTime` anchors observed across a connect-to-connect gap are consistent

--- a/android/app/src/test/java/com/noop/oura/OuraHistoryDrainTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraHistoryDrainTest.kt
@@ -197,7 +197,22 @@ class OuraHistoryDrainTest {
             "too short a gap to judge - declines rather than guessing",
             OuraHistoryDrain.anchorsAreContinuous(
                 previousRingTicks = 1_000_000L, previousUnixSeconds = 0L,
-                currentRingTicks = 1_000_100L, currentUnixSeconds = 10L, // below the 30s minimum
+                currentRingTicks = 1_000_050L, currentUnixSeconds = 5L, // below the 10s minimum
+            ),
+        )
+    }
+
+    @Test
+    fun testAnchorsAreContinuousOnTheReal20260912FastReconnect() {
+        // 2026-09-12 19:38:56 -> 19:39:23: an app relaunch, state restoration resumed the still-connected
+        // ring, and the next connect came 27s later with a stale replay. Ring ticks 43358625 -> 43358893
+        // = 268 ticks over 27s wall (9.93/s): plainly continuous, but the original 30s floor declined and
+        // the old full re-pull fired. Must judge, and must say continuous. Swift twin.
+        assertTrue(
+            "a 27s gap with a continuous ring clock is judgeable and continuous",
+            OuraHistoryDrain.anchorsAreContinuous(
+                previousRingTicks = 43_358_625L, previousUnixSeconds = 0L,
+                currentRingTicks = 43_358_893L, currentUnixSeconds = 27L,
             ),
         )
     }


### PR DESCRIPTION
## What happened

First hardware run of #2100's fix on a stale replay (`integration/oura-full@83c4435e`, Gen 3,
2026-09-12): it declined to judge, and the old full re-pull from 2026-07-24 fired.

```
[19:38:56] Oura: UTC anchor from SyncTime response (0x13) at connect - device rt 43358625 …
[19:39:23] Oura: UTC anchor from SyncTime response (0x13) at connect - device rt 43358893 …
[19:39:45] Oura: history caught up (bytes_left 0) but the ring served data older than cursor 43358436 - clock reset/seek ignored; next connect does a full pull
[19:39:45] Oura: ring reboot detected - starting the honest full re-pull; next drain pass in 5 s (1/6)
```

The two anchors were **268 ticks over 27 s** — 9.93 ticks/s, the ring's clock plainly continuous,
19.8 s inside the 20 s pause margin. But 27 s < `anchorContinuityMinGapSeconds` (30), so
`anchorsAreContinuous` returned its safe-default `false` and the cursor reset to 0. Full detail on
#2097 ([comment](https://github.com/ryanbr/noop/issues/2097#issuecomment-5648419469)).

## Why the floor is too high

It was justified as protecting a *rate* measurement from a few seconds of receipt-latency noise. The
check isn't a rate — it's an absolute margin, `wallDelta − ringSeconds ≤ 20 s`. A few seconds of noise
inside a 10 s gap still leaves most of that margin; a genuine power-cycle pause is minutes (13m41s on
the one on record) and cannot hide inside a short gap — it shows up as the wall gap itself; and ticks
going backwards already declines on its own. Meanwhile a fast relaunch-and-reconnect (here: an Xcode
reinstall, state restoration resuming the still-connected ring, next connect 27 s later) is the
cheapest way to produce a stale replay — exactly the case the floor excluded.

## The change

`anchorContinuityMinGapSeconds` 30 → **10**, Swift + Kotlin twin. `anchorContinuityMaxPauseSeconds`
stays 20. The existing too-short test moves from a 10 s gap to 5 s (10 s now judges), and the
27 s / 268-tick capture is added as `testAnchorsAreContinuousOnTheReal20260912FastReconnect` beside
the 5436 s handoff case.

## Verification

- The new test **fails against 30 and passes against 10 on both platforms** (flipped the constant
  back and forth to confirm it discriminates).
- Swift `OuraProtocol`: `swift test` **235/0**; `OuraHistoryDrainTests` 28/28.
- Android: `OuraHistoryDrainTest` **27/27** (forced re-run, not a cached result).
- macOS `Strand`: `BUILD SUCCEEDED` (package consumed by the app; API unchanged). `doc_comment_lint` OK.
- Hardware: the 27 s case is a real capture, but the change itself has not yet run on a strap. It is
  on `integration/oura-full` now; the next fast reconnect will say whether the "not a reboot (#2097)"
  line fires where the old floor declined.

## Not in this PR

The Oura-app handoff that #2097 actually describes is still un-exercised on the merged fix — this
occurrence was a relaunch, not a second client. That capture is still owed and will be reported on the
issue.

Relates to #2097, follows #2100.