### PR TITLE
health: trust Android baselines per signal

### DIFF
--- a/android/app/src/main/java/com/noop/analytics/V5HealthSignals.kt
+++ b/android/app/src/main/java/com/noop/analytics/V5HealthSignals.kt
@@ -41,7 +41,7 @@ object V5HealthSignals {
          * already raised. Nullable so an absent illness pass leaves it null. (Augment-only, Option A.)
          */
         val illnessDistance: IllnessDistance.Result?,
-        /** True once there are enough trusted nights for any of these to be more than "learning". */
+        /** True once an HRV or resting-HR baseline can honestly gate an illness heads-up. */
         val baselineTrusted: Boolean,
     )
 
@@ -60,7 +60,18 @@ object V5HealthSignals {
         activityBins: List<CircadianEngine.ActivityBin> = emptyList(),
         daysObserved: Int = 0,
     ): Snapshot {
-        val baselineTrusted = days.count { hasAnyVital(it) } >= MIN_BASELINE_NIGHTS
+        // #2131: trust belongs to a SIGNAL, not to a row. Counting rows with any vital let fourteen
+        // unrelated or mixed measurements lend confidence to an HRV/RHR illness claim even though no
+        // one baseline had fourteen observations. Use the same trailing window zAgainst uses for the
+        // newest night and mirror iOS's illness gate: a trusted RHR OR HRV baseline may raise. Keep the
+        // cycle classifier's existing availability gate separate so this illness fix cannot change it.
+        val cycleBaselineUsable = days.count { hasAnyVital(it) } >= MIN_BASELINE_NIGHTS
+        val baselineWindow = days.dropLast(1).takeLast(BASELINE_WINDOW).filter { hasAnyVital(it) }
+        val rhrBaselineTrusted =
+            baselineWindow.count { it.restingHr != null } >= MIN_BASELINE_NIGHTS
+        val hrvBaselineTrusted =
+            baselineWindow.count { it.avgHrv != null } >= MIN_BASELINE_NIGHTS
+        val baselineTrusted = rhrBaselineTrusted || hrvBaselineTrusted
 
         // ── Per-night z-scores against each signal's trailing rolling baseline ──
         val nights = ArrayList<CyclePhaseEngine.Night>(days.size)
@@ -78,7 +89,11 @@ object V5HealthSignals {
 
         // ── Cycle awareness (opt-in) ──
         val cycle = if (cycleOptedIn) {
-            CyclePhaseEngine.classify(nights, baselineUsable = baselineTrusted, loggedPeriodStarts = loggedPeriodStarts)
+            CyclePhaseEngine.classify(
+                nights,
+                baselineUsable = cycleBaselineUsable,
+                loggedPeriodStarts = loggedPeriodStarts,
+            )
         } else {
             CyclePhaseEngine.Result(
                 phase = CyclePhaseEngine.Phase.LEARNING,
@@ -151,7 +166,7 @@ object V5HealthSignals {
      *  twin's `guard bins.count >= 6` in AppModel.computeCircadianPhase. */
     internal const val MIN_CIRCADIAN_BINS = 6
 
-    /** A day is "usable" for the baseline if it carries at least one of the four illness/cycle vitals. */
+    /** Whether a row can contribute to any signal's baseline; empty rows do not enter trust counts. */
     private fun hasAnyVital(d: DailyMetric): Boolean =
         d.restingHr != null || d.avgHrv != null || d.skinTempDevC != null || d.respRateBpm != null
 

--- a/android/app/src/test/java/com/noop/analytics/V5HealthSignalsTest.kt
+++ b/android/app/src/test/java/com/noop/analytics/V5HealthSignalsTest.kt
@@ -1,0 +1,66 @@
+package com.noop.analytics
+
+import com.noop.data.DailyMetric
+import java.time.LocalDate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class V5HealthSignalsTest {
+
+    private fun day(
+        offset: Long,
+        restingHr: Int? = null,
+        hrv: Double? = null,
+        skinTemp: Double? = null,
+        respiration: Double? = null,
+    ) = DailyMetric(
+        deviceId = "my-whoop-noop",
+        day = LocalDate.of(2026, 1, 1).plusDays(offset).toString(),
+        restingHr = restingHr,
+        avgHrv = hrv,
+        skinTempDevC = skinTemp,
+        respRateBpm = respiration,
+    )
+
+    @Test
+    fun `different vital rows cannot combine into a trusted illness baseline`() {
+        val history = (0L until 14L).map { offset ->
+            if (offset % 2L == 0L) day(offset, restingHr = 55)
+            else day(offset, hrv = 50.0)
+        }
+        val snapshot = V5HealthSignals.evaluate(
+            days = history + day(14, skinTemp = 0.6, respiration = 18.0),
+            cycleOptedIn = false,
+        )
+
+        assertFalse(snapshot.baselineTrusted)
+        assertEquals(IllnessSignalEngine.Level.QUIET, snapshot.illness.level)
+        assertEquals("Still learning your baseline - keeping an eye out.", snapshot.illness.copy)
+    }
+
+    @Test
+    fun `fourteen nights for one illness signal are trusted`() {
+        val history = (0L until 14L).map { offset ->
+            day(offset, restingHr = 54 + (offset % 3L).toInt())
+        }
+        val snapshot = V5HealthSignals.evaluate(
+            days = history + day(14, restingHr = 64),
+            cycleOptedIn = false,
+        )
+
+        assertTrue(snapshot.baselineTrusted)
+    }
+
+    @Test
+    fun `temperature trust remains local to the cycle engine`() {
+        val days = (0L until 56L).map { offset -> day(offset, skinTemp = 0.2) }
+        val snapshot = V5HealthSignals.evaluate(days = days, cycleOptedIn = true)
+
+        assertFalse(snapshot.baselineTrusted)
+        assertEquals(IllnessSignalEngine.Level.QUIET, snapshot.illness.level)
+        assertNotEquals(CyclePhaseEngine.Phase.LEARNING, snapshot.cycle.phase)
+    }
+}


### PR DESCRIPTION
Fixes #2131

Summary:
- derive Android illness baseline trust from per-signal resting-HR or HRV history in the same trailing window used by the latest z-score
- keep the cycle classifier’s existing availability gate independent
- cover mixed histories, the 14-night positive boundary, and temperature-only cycle history

Tests:
- ./gradlew :app:assembleFullDebug :app:testFullDebugUnitTest
- python3 Tools/parity_ledger.py --base upstream/main
- python3 Tools/doc_comment_lint.py
- python3 Tools/i18n_audit.py --ci upstream/main