### PR TITLE
parity_ledger: resolve the temp checkout root before deriving from it (#2143)

### DIFF
--- a/Tools/parity_ledger.py
+++ b/Tools/parity_ledger.py
@@ -1573,7 +1573,9 @@ def _base_semantic_state(
             stderr=subprocess.DEVNULL,
         )
         with tempfile.TemporaryDirectory() as directory:
-            base_root = Path(directory)
+            # Resolve before anything is derived from it: build_twin_map resolves its root, and an
+            # inventory taken from the unresolved spelling then fails relative_to (#2143, macOS).
+            base_root = Path(directory).resolve()
             with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as bundle:
                 bundle.extractall(base_root, filter="data")
             inventory = _inventory(base_root)
@@ -2576,7 +2578,8 @@ def finding_identities_at_git_ref(root: Path, ref: str) -> set[str]:
     except (FileNotFoundError, subprocess.CalledProcessError) as exc:
         raise ValueError(f"cannot scan exact base {ref!r}") from exc
     with tempfile.TemporaryDirectory() as directory:
-        base_root = Path(directory)
+        # Same resolution as _base_semantic_state, so both temp checkouts spell their root one way (#2143).
+        base_root = Path(directory).resolve()
         try:
             with tarfile.open(fileobj=io.BytesIO(archive), mode="r:") as bundle:
                 bundle.extractall(base_root, filter="data")

--- a/Tools/tests/test_parity_ledger.py
+++ b/Tools/tests/test_parity_ledger.py
@@ -96,6 +96,22 @@ class ParityLedgerTests(unittest.TestCase):
         )
         subprocess.run(["git", "branch", "origin/main", "HEAD"], cwd=self.root, check=True)
 
+    def test_base_semantic_state_survives_a_symlinked_temp_root(self) -> None:
+        # #2143: on macOS the temp dir is /var/folders/..., a symlink to /private/var/.... The base
+        # checkout built its inventory from the unresolved root, then build_twin_map resolved the
+        # root, so relative_to saw two spellings of one directory and raised. Pointing tempfile at a
+        # symlink reproduces that on any OS, including the Linux runner.
+        self.write_clean_tree()
+        self.mark_current_tree_as_origin_main()
+        with tempfile.TemporaryDirectory() as holder:
+            real = Path(holder) / "real"
+            real.mkdir()
+            link = Path(holder) / "link"
+            link.symlink_to(real, target_is_directory=True)
+            with mock.patch.object(tempfile, "tempdir", str(link)):
+                state = parity_ledger._base_semantic_state(self.root)
+        self.assertIsNotNone(state)
+
     def test_clean_synthetic_tree_has_no_findings(self) -> None:
         self.write_clean_tree()
         twin_map = parity_ledger.build_twin_map(self.root)


### PR DESCRIPTION
Closes #2143. The fix is the one the issue names, `base_root = Path(directory).resolve()` at both temp-checkout sites, plus a regression test that reproduces the crash on any OS. Verifying it on macOS turned up two corrections to the diagnosis and three pre-existing test failures, all below.

## The mechanism is the other way round, and only one site crashes

The issue describes the inner paths as resolved and the root as unresolved. The crash is the reverse: the **root** is resolved and the **path** is not.

```
ValueError: '/var/folders/.../tmp1fc4d_9p/Packages/OuraProtocol/Sources/OuraProtocol/ActivityEstimate.swift'
  is not in the subpath of '/private/var/folders/.../tmp1fc4d_9p'
```

What happens in `_base_semantic_state`:

1. `base_root = Path(directory)` is `/var/...`, unresolved.
2. `_inventory(base_root)` builds the file list from that spelling.
3. `build_twin_map(base_root, inventory)` does `root = root.resolve()` first, then receives the pre-built `/var/...` inventory.
4. `parse_twin_references` → `_relative(root, path)` compares the two spellings and raises.

The named fix is still right, because resolving `base_root` before step 2 makes the inventory and the root agree.

**`finding_identities_at_git_ref` does not crash**, called directly on the same machine against the same ref. It passes only `base_root` into `build_compact_twin_map` and `scan`, each deriving its own paths, so no pre-built inventory crosses a resolve. It gets the same one-line change anyway so the two temp checkouts spell their root one way, but that half is consistency, not a fix for an observed failure.

## Why it survived: the crash is conditional

Neither site runs on an ordinary invocation. `_base_semantic_state` runs only on authority drift; `finding_identities_at_git_ref` only with `--base` and a baseline decrease. On today's clean `main`, `python3 Tools/parity_ledger.py`, `--base upstream/main` and `--base upstream/main~5` all complete with `OK` on macOS, and `--refresh-derived` stops at `migration required` before it gets there. The crash I first reported came from a branch that had authority drift at the time.

So I reproduced it by calling `_base_semantic_state(ROOT)` directly, which forces the checkout regardless of drift:

| | `_base_semantic_state` | `finding_identities_at_git_ref` |
|---|---|---|
| before | `ValueError` (above) | returns a set |
| after | returns a tuple | returns a set |

## Regression test: reproduces on Linux too

`test_base_semantic_state_survives_a_symlinked_temp_root` points `tempfile.tempdir` at a **symlinked** directory. That creates the macOS condition on any OS, so the runner that could not see this bug now fails without the fix. Before the fix it errors with the same trace, and the paths show the test's own symlink doing it (`.../link/...` vs `.../real/...`), not macOS `/var`:

```
ValueError: '.../tmp7c8jag_k/link/tmpe_z2os5u/Packages/.../Engine.swift'
  is not in the subpath of '/private/var/.../tmp7c8jag_k/real/tmpe_z2os5u'
FAILED (errors=1)
```

After the fix it passes.

## Three test failures on macOS that are NOT from this change

The full parity suite on macOS, `cd Tools && python3 -m unittest discover -s tests -p "test_*.py"`, runs 106 tests with 3 failing:

- `test_compact_map_expands_losslessly_and_detects_source_drift` (ERROR)
- `test_improvement_base_selection_and_missing_ref_are_fail_closed` (FAIL)
- `test_scan_uses_one_immutable_source_snapshot_per_file` (FAIL)

To confirm they predate this change rather than assume it, I ran them in a separate worktree on unmodified `upstream/main` (`d6ad093b`). All three fail there identically. The failure set with the fix applied is the same three, so this change adds zero failures and one passing test. They pass on the Linux runner.

All three are the same `/var` vs `/private/var` family, and one is worth a look beyond the tests. The ERROR comes from **`expand_twin_map`**, which calls `build_twin_map(root, inventory)` with an inventory taken from the root it was given, the same shape as the bug fixed here. The real CLI root is `Path(__file__).resolve()`, so it does not bite in normal use, but any unresolved root reaching it would. The two FAILs are test-side: assertions compare the unresolved `setUp` root against paths the ledger has resolved.

I left all three alone to keep this to #2143. Happy to take them as a follow-up if you want the suite green on macOS.

## Verification

- New test: fails before the fix, passes after (`unittest` exit codes read directly, output not filtered).
- Full parity suite on macOS: 106 run, failures identical to pristine `upstream/main`, no new ones.
- `python3 Tools/parity_ledger.py` on macOS after the fix: `OK no NEW parity ledger findings`.
- Not run on Linux locally. The symlink test is the part meant to carry that.