### PR TITLE
parity tests: pass on macOS, and resolve expand_twin_map's root (#2143 follow-up)

### DIFF
--- a/Tools/parity_ledger.py
+++ b/Tools/parity_ledger.py
@@ -1645,6 +1645,9 @@ def build_compact_twin_map(root: Path) -> dict:
 
 def expand_twin_map(root: Path, twin_map: dict) -> tuple[dict, list[str]]:
     """Expand v3 from source and report every frozen-authority mismatch."""
+    # Resolve before taking the inventory, as build_twin_map and semantic_authority do: both
+    # receive this inventory and resolve their own root, so the spellings must already agree.
+    root = root.resolve()
     if twin_map.get("schema_version") != 3:
         return twin_map, []
     inventory = _inventory(root)

--- a/Tools/tests/test_parity_ledger.py
+++ b/Tools/tests/test_parity_ledger.py
@@ -114,6 +114,19 @@ class ParityLedgerTests(unittest.TestCase):
         result = parity_ledger.scan(self.root, compact)
         self.assertIn("twin-map-authority-drift", {item.rule for item in result.findings})
 
+    def test_expand_twin_map_accepts_a_symlinked_root(self) -> None:
+        # expand_twin_map built its inventory from the root as given while build_twin_map resolved it,
+        # so a root reached through a symlink (macOS /var -> /private/var) raised in relative_to. A
+        # symlinked root reproduces that on any OS, including the Linux runner.
+        self.write_clean_tree()
+        compact = parity_ledger.build_compact_twin_map(self.root)
+        with tempfile.TemporaryDirectory() as holder:
+            link = Path(holder) / "link"
+            link.symlink_to(self.root, target_is_directory=True)
+            expanded, drift = parity_ledger.expand_twin_map(link, compact)
+        self.assertEqual([], drift)
+        self.assertEqual(parity_ledger.build_twin_map(self.root), expanded)
+
     def test_compact_authority_drift_names_new_one_sided_declaration(self) -> None:
         self.write_clean_tree()
         subprocess.run(["git", "init", "-q"], cwd=self.root, check=True)
@@ -559,7 +572,9 @@ enum Engine {
         with mock.patch.object(parity_ledger, "_read", side_effect=recording_read):
             parity_ledger.scan(self.root, twin_map)
 
-        self.assertEqual(sorted([self.swift, self.kotlin]), sorted(reads))
+        # The ledger reads through resolved paths; compare resolved so a symlinked temp dir (macOS
+        # /var -> /private/var) does not fail a test about read counts.
+        self.assertEqual(sorted([self.swift.resolve(), self.kotlin.resolve()]), sorted(reads))
 
     def test_retargeted_claims_cannot_hide_behind_stale_file_and_constant_pairs(self) -> None:
         swift_one = self.swift.with_name("One.swift")
@@ -1166,10 +1181,10 @@ fun broken(value: Int) = "broken ${run { Trace.suffix(value) }
         real = parity_ledger.finding_identities_at_git_ref
         with mock.patch.object(parity_ledger, "finding_identities_at_git_ref", wraps=real) as scanned:
             self.assertEqual(0, self.run_cli(twin_map, baseline)[0])
-            scanned.assert_called_once_with(self.root, "origin/main")
+            scanned.assert_called_once_with(self.root.resolve(), "origin/main")
         with mock.patch.object(parity_ledger, "finding_identities_at_git_ref", wraps=real) as scanned:
             self.assertEqual(0, self.run_cli(twin_map, baseline, base=base_sha)[0])
-            scanned.assert_called_once_with(self.root, base_sha)
+            scanned.assert_called_once_with(self.root.resolve(), base_sha)
         code, output = self.run_cli(twin_map, baseline, base="missing/shallow-base")
         self.assertEqual(1, code)
         self.assertIn("cannot scan exact base", output)


### PR DESCRIPTION
Follow-up to #2158, as offered there. Independent of it: based on current `main`, different hunks, and it cherry-picks onto #2158 cleanly.

## First, a correction to #2158

#2158 says the parity suite has **3** pre-existing failures on macOS, "confirmed on unmodified `upstream/main`". That undercounts. On `main` I ran only those three tests by name, and the "3" came from the full suite run with #2158 applied. The full suite on unmodified `main` (`d6ad093b`) fails **five**:

| Suite on macOS | Tests | Failing |
|---|---|---|
| unmodified `main` | 105 | **5** |
| #2158 only | 106 | 3 |
| this PR only | 106 | 2 |
| **#2158 + this PR** | **107** | **0** |

So #2158 already fixed two more tests than it claimed, the two `test_compact_authority_drift_*` ones: both reach `_base_semantic_state` through the CLI. Its "no new failures" statement still holds. Every row above is a full `unittest discover -s tests -p "test_*.py"` run, and the last row is the two branches combined in a throwaway worktree, so all of it is measured.

## What this fixes: the other three

**`test_compact_map_expands_losslessly_and_detects_source_drift`: a real code defect.** `expand_twin_map` took its inventory from the root as given, then passed it to `build_twin_map` and `semantic_authority`, which both resolve their own root. It is the same shape as #2143, reached through a different function. This PR adds `root = root.resolve()` before the inventory, matching those two.

Checking every call that hands a pre-built inventory to `build_twin_map`:

| Caller | Inventory taken from | |
|---|---|---|
| `semantic_authority`, `scan` | root after `resolve()` | safe |
| `bootstrap_unpaired_debts` | `root.resolve()` | safe |
| `_base_semantic_state` | unresolved temp root | fixed in #2158 |
| `expand_twin_map` | unresolved root | **fixed here** |

In practice it mattered less than the table suggests. The CLI resolves `--root` itself before calling `expand_twin_map`, so nothing broke from the command line, only for callers passing an unresolved root, as the tests do. New test `test_expand_twin_map_accepts_a_symlinked_root` reaches the root through a symlink. It errors without the fix with the same `relative_to` trace (triggered by its own `link`, not macOS `/var`) and passes with it, so the Linux runner guards this too.

**The other two are test expectations, not code:**

- `test_scan_uses_one_immutable_source_snapshot_per_file` checks that each file is **read once**. The ledger reads through resolved paths on purpose, so the assertion now compares resolved paths. The read count it guards is unchanged.
- `test_improvement_base_selection_and_missing_ref_are_fail_closed` checks **which base ref** gets scanned. `main()` does `args.root.resolve()` on purpose, so the expected call now uses `self.root.resolve()`. The ref assertions are unchanged.

I did not change `setUp` to resolve the root globally. That would have made these pass by hiding exactly the unresolved-root path that exposed the `expand_twin_map` defect.

## Verification (macOS)

- New test: fails before the production fix, passes after (`unittest` exit code read directly, output unfiltered).
- Full suite on this branch: 106 run, 2 failing, both the `_base_semantic_state` path #2158 fixes.
- Full suite with #2158 cherry-picked on top: **107 run, OK, exit 0**.
- `python3 Tools/parity_ledger.py` on this branch: `OK no NEW parity ledger findings`.
- Not run on Linux locally. The two symlink tests (here and in #2158) are what carry that.