### PR TITLE
ble: tell a retired probe reader to turn the switch ON, and stop under-reporting retirement

### DIFF
--- a/android/app/src/main/java/com/noop/ble/StalledLinkDiagnostics.kt
+++ b/android/app/src/main/java/com/noop/ble/StalledLinkDiagnostics.kt
@@ -126,9 +126,14 @@ internal fun backfillDeferredLine(
         // says where the toggle is rather than promising an answer.
         val probe = when {
             unbondedProbeOptedIn -> ""  // the probe is on — its own lines say what it found
-            unbondedProbeRetired -> " The \"Try history sync without pairing\" experiment has retired for" +
-                " this strap — turn it off and on in Test Centre to retry (#1804 fixed a false negative" +
-                " that could have latched it)."
+            // Reaching this branch PROVES the switch is off: the opted-in case above short-circuits to
+            // an empty hint. So "turn it off and on", which reads as advice to someone whose switch is
+            // on, is the one thing every reader of this sentence cannot do. Turning it ON is the whole
+            // action, and it is the off-to-ON edge `unbondedProbeBudgetRearms` looks for (#2135).
+            unbondedProbeRetired -> " The \"Try history sync without pairing\" experiment has retired" +
+                " for this strap and its switch is off, so turning it ON in Test Centre is what re-arms" +
+                " it (#1804 fixed a false negative that could have latched it, and #2135 made the" +
+                " re-arm clear that latch too)."
             else -> " The \"Try history sync without pairing\" experiment in Test Centre can test whether" +
                 " the offload works without a bond — its stage 3 is SET_CLOCK, the thing this gate" +
                 " blocks (#1635, #1802)."

--- a/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
+++ b/android/app/src/main/java/com/noop/ble/UnbondedOffloadProbe.kt
@@ -140,7 +140,12 @@ internal fun unbondedProbeSkippedLine(
 internal fun unbondedProbeRetired(
     previouslyRefused: Boolean,
     silentLinksSoFar: Int,
-    inconclusiveLinksSoFar: Int = 0,
+    /** No default: it had one, and BOTH consumers in WhoopBleClient silently took it, so a strap
+     *  retired only by the inconclusive budget (#1804's case, where every link is a local teardown)
+     *  reported NOT retired. The handshake stayed suppressed for a probe that would never run, which is
+     *  the exact harm `unbondedProbeSupersedesHandshake.probeRetired` exists to prevent. Required, so
+     *  the next consumer cannot omit it in silence. */
+    inconclusiveLinksSoFar: Int,
 ): Boolean =
     previouslyRefused
         || !unbondedProbeStillWorthAsking(silentLinksSoFar)

--- a/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopBleClient.kt
@@ -9463,6 +9463,7 @@ class WhoopBleClient(
                         probeRetired = unbondedProbeRetired(
                             previouslyRefused = unbondedOffloadPreviouslyRefused(g.device.address),
                             silentLinksSoFar = unbondedProbeSilentLinks,
+                            inconclusiveLinksSoFar = unbondedProbeInconclusiveLinks,
                         ),
                     )
                 ) {
@@ -10018,6 +10019,7 @@ class WhoopBleClient(
                 unbondedProbeRetired = unbondedProbeRetired(
                     previouslyRefused = unbondedOffloadPreviouslyRefused(lastDeviceAddress),
                     silentLinksSoFar = unbondedProbeSilentLinks,
+                    inconclusiveLinksSoFar = unbondedProbeInconclusiveLinks,
                 ),
             ))
             return

--- a/android/app/src/test/java/com/noop/ble/StalledLinkDiagnosticsTest.kt
+++ b/android/app/src/test/java/com/noop/ble/StalledLinkDiagnosticsTest.kt
@@ -187,8 +187,13 @@ class StalledLinkDiagnosticsTest {
     }
 
     /**
-     * When the probe has retired (latched refusal or spent silence budget), the hint says so and
-     * points at the off/on retry — #1804 fixed a false negative that could have latched it.
+     * When the probe has retired (latched refusal or spent silence budget), the hint says so and names
+     * the ONE action that exists: turning the switch on.
+     *
+     * Reaching that branch proves the switch is off, because the opted-in case short-circuits to an
+     * empty hint, so the old "turn it off and on" was advice only an opted-IN reader could follow and
+     * no reader of this sentence ever is. A field log showed the probe skipped for "the experiment is
+     * off" on the same link this line called retired.
      */
     @Test
     fun `the probe hint names the retry path when retired`() {
@@ -197,7 +202,8 @@ class StalledLinkDiagnosticsTest {
             unbondedProbeOptedIn = false, unbondedProbeRetired = true,
         )
         assertTrue(line, line.contains("retired"))
-        assertTrue(line, line.contains("turn it off and on"))
+        assertTrue(line, line.contains("turning it ON"))
+        assertFalse(line, line.contains("turn it off and on"))
         assertTrue(line, line.contains("#1804"))
     }
 

--- a/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
@@ -492,17 +492,21 @@ class UnbondedOffloadProbeTest {
     /** A latched refusal is the strap's verdict — it retires the probe, so the handshake must resume. */
     @Test
     fun `a latched refusal retires the probe`() {
-        assertTrue(unbondedProbeRetired(previouslyRefused = true, silentLinksSoFar = 0))
+        assertTrue(unbondedProbeRetired(previouslyRefused = true, silentLinksSoFar = 0,
+            inconclusiveLinksSoFar = 0))
     }
 
     /** Silence spends a budget rather than latching, so the probe stays live while it has one. */
     @Test
     fun `silence retires the probe only once its budget is spent`() {
-        assertFalse(unbondedProbeRetired(previouslyRefused = false, silentLinksSoFar = 0))
+        assertFalse(unbondedProbeRetired(previouslyRefused = false, silentLinksSoFar = 0,
+            inconclusiveLinksSoFar = 0))
         assertFalse(unbondedProbeRetired(
-            previouslyRefused = false, silentLinksSoFar = UNBONDED_PROBE_MAX_SILENT_LINKS - 1))
+            previouslyRefused = false, silentLinksSoFar = UNBONDED_PROBE_MAX_SILENT_LINKS - 1,
+            inconclusiveLinksSoFar = 0))
         assertTrue(unbondedProbeRetired(
-            previouslyRefused = false, silentLinksSoFar = UNBONDED_PROBE_MAX_SILENT_LINKS))
+            previouslyRefused = false, silentLinksSoFar = UNBONDED_PROBE_MAX_SILENT_LINKS,
+            inconclusiveLinksSoFar = 0))
     }
 
     /**
@@ -514,7 +518,7 @@ class UnbondedOffloadProbeTest {
     fun `the skip and the probe retire on exactly the same conditions`() {
         for (refused in listOf(false, true)) {
             for (silent in 0..UNBONDED_PROBE_MAX_SILENT_LINKS + 1) {
-                val retired = unbondedProbeRetired(refused, silent)
+                val retired = unbondedProbeRetired(refused, silent, inconclusiveLinksSoFar = 0)
                 val probeWouldRun = shouldProbeUnbondedOffload(
                     isWhoop5 = true, optedIn = true, bonded = false, helloWrittenThisLink = false,
                     alreadyProbedThisLink = false, previouslyRefused = refused, silentLinksSoFar = silent)
@@ -719,6 +723,38 @@ class UnbondedOffloadProbeTest {
         assertTrue(
             "a refusal latch the re-arm cannot sweep is a retirement with no way out",
             key!!.startsWith(UNBONDED_OFFLOAD_REFUSED_KEY_PREFIX),
+        )
+    }
+
+    /**
+     * #1804's budget must reach every consumer, not only the gate.
+     *
+     * `unbondedProbeRetired` used to default `inconclusiveLinksSoFar` to 0, and BOTH consumers in
+     * WhoopBleClient silently took that default while the gate passed the real count. So a strap retired
+     * only by the inconclusive budget, which is exactly the strap #1804 was written for since every one
+     * of its links is a local teardown, reported NOT retired: the handshake stayed suppressed for a probe
+     * that would never run, the harm `unbondedProbeSupersedesHandshake.probeRetired` exists to prevent.
+     *
+     * The parameter is required now, so a consumer cannot omit it in silence. This pins the behaviour the
+     * omission hid.
+     */
+    @Test
+    fun `a spent inconclusive budget retires the probe on its own`() {
+        assertTrue(
+            "every link torn down locally is a retirement, whatever silence and refusal say",
+            unbondedProbeRetired(
+                previouslyRefused = false,
+                silentLinksSoFar = 0,
+                inconclusiveLinksSoFar = UNBONDED_PROBE_MAX_INCONCLUSIVE_LINKS,
+            ),
+        )
+        assertFalse(
+            "one short of the cap is still worth asking",
+            unbondedProbeRetired(
+                previouslyRefused = false,
+                silentLinksSoFar = 0,
+                inconclusiveLinksSoFar = UNBONDED_PROBE_MAX_INCONCLUSIVE_LINKS - 1,
+            ),
         )
     }
 }

--- a/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
+++ b/android/app/src/test/java/com/noop/ble/UnbondedOffloadProbeTest.kt
@@ -513,19 +513,31 @@ class UnbondedOffloadProbeTest {
      * The two gates must agree by construction, not by both being edited together. Whenever the probe
      * declines for a RETIREMENT reason, the skip must decline too — otherwise the strap is stranded with a
      * suppressed handshake and nothing using the link it creates.
+     *
+     * All THREE retirement grounds are swept. The inconclusive axis was held at 0 here while the ground
+     * itself was live, so this pinned the agreement on two thirds of the rule, and stranding is precisely
+     * what the omission of that axis caused in `WhoopBleClient`. To be accurate about what this test can
+     * and cannot do: a pure-function sweep cannot see a CALL SITE that forgets an argument, which is why
+     * `unbondedProbeRetired` no longer offers a default for it. This pins that the two rules agree once
+     * they are both given it.
      */
     @Test
     fun `the skip and the probe retire on exactly the same conditions`() {
         for (refused in listOf(false, true)) {
             for (silent in 0..UNBONDED_PROBE_MAX_SILENT_LINKS + 1) {
-                val retired = unbondedProbeRetired(refused, silent, inconclusiveLinksSoFar = 0)
-                val probeWouldRun = shouldProbeUnbondedOffload(
-                    isWhoop5 = true, optedIn = true, bonded = false, helloWrittenThisLink = false,
-                    alreadyProbedThisLink = false, previouslyRefused = refused, silentLinksSoFar = silent)
-                val skips = unbondedProbeSupersedesHandshake(
-                    optedIn = true, isWhoop5 = true, appLevelBonded = false, userInitiated = false,
-                    probeRetired = retired)
-                assertEquals("refused=$refused silent=$silent", probeWouldRun, skips)
+                for (inconclusive in 0..UNBONDED_PROBE_MAX_INCONCLUSIVE_LINKS + 1) {
+                    val retired = unbondedProbeRetired(refused, silent, inconclusive)
+                    val probeWouldRun = shouldProbeUnbondedOffload(
+                        isWhoop5 = true, optedIn = true, bonded = false, helloWrittenThisLink = false,
+                        alreadyProbedThisLink = false, previouslyRefused = refused,
+                        silentLinksSoFar = silent, inconclusiveLinksSoFar = inconclusive)
+                    val skips = unbondedProbeSupersedesHandshake(
+                        optedIn = true, isWhoop5 = true, appLevelBonded = false, userInitiated = false,
+                        probeRetired = retired)
+                    assertEquals(
+                        "refused=$refused silent=$silent inconclusive=$inconclusive",
+                        probeWouldRun, skips)
+                }
             }
         }
     }


### PR DESCRIPTION
## What was wrong

Reaching the retired branch of the backfill hint **proves the switch is off**, because the opted-in case above it short-circuits to an empty hint:

```kotlin
unbondedProbeOptedIn -> ""                    // on: its own lines say what it found
unbondedProbeRetired -> "...turn it off and on in Test Centre to retry..."
else                 -> "...can test whether the offload works without a bond..."
```

So "turn it off and on", which reads as advice to someone whose switch is on, is the one thing every reader of that sentence cannot do.

## Caught in a field log

The same link carried both, twenty minutes apart:

```
09:46:25  [connection] unbonded probe skipped, the unbonded-offload experiment is off
10:39:58  Backfill: deferred ... The experiment has retired for this strap,
                     turn it off and on in Test Centre to retry
```

Two diagnostics disagreeing about the reader's state, and the wrong one carrying the instruction. It cost real time: I read that line and told the maintainer to toggle a switch that was already off, which is why the probe had still not run a day later.

## The change

Turning it **ON** is the whole action, and it is the off-to-ON edge `unbondedProbeBudgetRearms` looks for. Since #2135 that edge clears the refusal latch as well, so the sentence can now promise something it could not before.

Rendered:

> The "Try history sync without pairing" experiment has retired for this strap and its switch is off, so turning it ON in Test Centre is what re-arms it (...).

## Deliberately only this one site

`unbondedProbeGaveUpLine` says "turn the experiment off and on" too, and it is **correct**: it prints at the moment of retirement, while the probe is running and the switch is on, so off then on is exactly the edge that reader needs.

The two differ because the reader's state differs, which is worth knowing before someone makes them agree. The doc comments in `UnbondedOffloadProbe` and `HelloSuppression` describing the re-arm as "off and on" are accurate as mechanism notes and are left alone.

## And the bug the re-review found underneath it

`unbondedProbeRetired` retires on any of three grounds: a latched refusal, a spent silence budget, or a spent **inconclusive** budget. The gate passes all three. Both consumers in `WhoopBleClient` passed two and took the default of `0` for the third:

```kotlin
probeRetired = unbondedProbeRetired(
    previouslyRefused = ...,
    silentLinksSoFar = ...,          // and nothing else
)
```

So a strap retired only by the inconclusive budget reported **not retired**. That strap is the one #1804 was written for, where every link is a local teardown.

At the supersedes call the consequence is not cosmetic: `probeRetired` reads false, `unbondedProbeSupersedesHandshake` keeps returning true, and the CLIENT_HELLO stays suppressed **forever** for a probe that will never run. Its own parameter doc says exactly why that must not happen:

> The probe has stopped asking, so skipping the hello now buys nothing and costs the strap its bond and its offload.

The count was a property on the class the whole time, two lines from each call. Nothing blocked it but the default.

**The default is gone.** A required parameter would have failed both sites at compile time, which is the same lesson as the nullable prefs default removed in #2136: an optional argument whose omission changes behaviour is a trap rather than a convenience. Six test call sites become explicit about the axis they test, which reads better anyway.

This is why the wording fix and the behaviour fix ship together: the sentence promises a retirement the consumers were under-reporting.

## Type of change

- [x] Bug fix (one in copy, one in behaviour)
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

`StalledLinkDiagnosticsTest` **32** and `UnbondedOffloadProbeTest` **52**, 0 failures, forced with `--rerun-tasks`, XML timestamps checked against the clock.

One new case pins what the omission hid: a spent inconclusive budget retires the probe on its own, and one short of the cap does not.

The test that pinned the old wording is repinned to the new instruction and now also asserts the old phrase is **absent**, since the failure mode here is a sentence that still parses and still mentions the right toggle while misinstructing.

The composed line was rendered from source and checked for the join defects concatenated copy invites: no double spaces, no missing separators.

## Scope

Android only, no Swift twin of this diagnostic. No declarations added, so nothing for the parity ledger to carry.

## Related issues

#2135 (the re-arm that now clears the latch), #1635 (why a 5/MG reaches this state at all), #1804 (the false negative that could latch it).