### PR TITLE
stress: stop the widget snapshot rounding the level a second time

### DIFF
--- a/android/app/src/main/java/com/noop/widget/StressTrace.kt
+++ b/android/app/src/main/java/com/noop/widget/StressTrace.kt
@@ -81,7 +81,11 @@ object StressTrace {
             if (bits.size != 3) continue
             val ts = bits[0].toLongOrNull() ?: continue
             val level = if (bits[1] == "-") null else bits[1].toDoubleOrNull() ?: continue
-            if (level != null && (level < 0.0 || level > DOMAIN_MAX)) continue
+            // Negated rather than written as the two out-of-range tests, so a NaN is skipped too.
+            // Every comparison against NaN is false, so `level < 0.0 || level > DOMAIN_MAX` admitted
+            // one, and "NaN" is text `toDoubleOrNull` accepts. Infinity was always caught, being
+            // greater than the ceiling.
+            if (level != null && !(level >= 0.0 && level <= DOMAIN_MAX)) continue
             out.add(StressPoint(ts, level, bits[2] == "1"))
         }
         out.sortBy { it.ts }

--- a/android/app/src/main/java/com/noop/widget/StressTrace.kt
+++ b/android/app/src/main/java/com/noop/widget/StressTrace.kt
@@ -46,11 +46,28 @@ object StressTrace {
      *  a malformed payload from growing the list without bound. */
     const val MAX_POINTS: Int = 26
 
-    /** `ts:level:moving`, comma separated, with `-` for an unscored hour. Compact enough for a prefs
-     *  string at a day's length, and readable in a bug report, which a binary blob would not be. */
+    /**
+     * `ts:level:moving`, comma separated, with `-` for an unscored hour. Compact enough for a prefs
+     * string at a day's length, and readable in a bug report, which a binary blob would not be.
+     *
+     * THE LEVEL IS WRITTEN LOSSLESSLY (#2166). This used to be `"%.2f"`, which made the snapshot a
+     * rounding step in front of a rounding: the widget printed a level that had been rounded to two
+     * decimals and then to one, while the Today card rounded the live double once. Two roundings move
+     * a value across a boundary one rounding does not, so a raw 2.2450 printed 2.3 on the widget and
+     * 2.2 on the card, on identical data with no staleness in it. Measured across the domain, the two
+     * disagreed by a tenth on 5% of levels, and the same skew reached the peak and average, which are
+     * folded from this series on one side and from live points on the other.
+     *
+     * `Double.toString` emits the shortest decimal that reads back as the same double, so decode
+     * returns the bits encode was handed and the widget formats exactly what the card formats. Any
+     * fixed precision would only have made the disagreement rarer, which is the thing #2167 objects
+     * to elsewhere. It costs a few hundred characters a day and it costs the digits their tidiness,
+     * a level reading 1.5851456074086638 rather than 1.59; read the first few and ignore the rest.
+     * It is also locale-independent, which `String.format` without a fixed locale was not.
+     */
     fun encode(series: List<StressPoint>): String =
         series.joinToString(",") { p ->
-            val level = p.level?.let { String.format(java.util.Locale.US, "%.2f", it) } ?: "-"
+            val level = p.level?.toString() ?: "-"
             "${p.ts}:$level:${if (p.moving) 1 else 0}"
         }
 

--- a/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
+++ b/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
@@ -304,6 +304,23 @@ class StressTraceTest {
         assertEquals(awkward, back.map { it.level })
     }
 
+    /**
+     * A deeply suppressed level, where `Double.toString` switches to scientific notation.
+     *
+     * `"%.2f"` could not emit an `E`, so this shape is new with #2166 and the decoder had never seen
+     * it. A z-sum below about -8 squashes under 1e-3 and prints as `3.7018372795869517E-4`, which has
+     * no `:` or `,` in it to confuse the split, and parses back. Pinned because the encoding changed
+     * under a decoder that was written for fixed-point text.
+     */
+    @Test
+    fun `a level small enough to print in scientific notation still round-trips`() {
+        val tiny = 3.0 / (1.0 + Math.exp(9.0))
+        assertTrue("expected scientific notation, got $tiny", tiny.toString().contains("E"))
+        val back = StressTrace.decode(StressTrace.encode(listOf(at(0, tiny))))
+        assertEquals(tiny, back.single().level!!, 0.0)
+        assertEquals(StressTrace.formatLevel(tiny), StressTrace.formatLevel(back.single().level!!))
+    }
+
     /** A snapshot written by a build before #2166 still reads, two decimals and all. */
     @Test
     fun `an older two decimal snapshot still decodes`() {

--- a/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
+++ b/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
@@ -127,10 +127,12 @@ class StressTraceTest {
         val day = listOf(at(0, 1.25), at(1, null), at(2, null, moving = true), at(3, 2.5))
         val back = StressTrace.decode(StressTrace.encode(day))
         assertEquals(day.size, back.size)
-        assertEquals(1.25, back[0].level!!, 0.001)
+        // Exactly, not within a tolerance: since #2166 the snapshot is a faithful copy, and a
+        // tolerance here would pass just as well for the lossy encoding that caused that bug.
+        assertEquals(1.25, back[0].level!!, 0.0)
         assertNull(back[1].level)
         assertTrue(back[2].moving)
-        assertEquals(2.5, back[3].level!!, 0.001)
+        assertEquals(2.5, back[3].level!!, 0.0)
     }
 
     @Test
@@ -275,5 +277,39 @@ class StressTraceTest {
         assertEquals("1.9", StressTrace.formatLevel(1.85))
         assertEquals("2.0", StressTrace.formatLevel(1.96))
         assertEquals("0.0", StressTrace.formatLevel(0.04))
+    }
+
+    // #2166: the snapshot used to round to two decimals, so the widget rounded twice where the card
+    // rounded once and the two printed different tenths on 5% of levels.
+
+    /** The bands that used to skew. Each of these sits just under a tenth and just over the two
+     *  decimal step that would have carried it over. */
+    @Test
+    fun `a level prints the same through the snapshot as it does live`() {
+        for (raw in listOf(2.2450, 0.0450, 1.7450, 2.9450, 0.1450)) {
+            val throughSnapshot = StressTrace.decode(StressTrace.encode(listOf(at(0, raw))))
+            assertEquals(
+                "level $raw",
+                StressTrace.formatLevel(raw),
+                StressTrace.formatLevel(throughSnapshot.single().level!!),
+            )
+        }
+    }
+
+    /** The property the bands above are examples of: encode then decode returns the same bits. */
+    @Test
+    fun `the snapshot returns the level it was handed`() {
+        val awkward = listOf(0.0, 3.0, 2.2449999999999997, 1.5851456074086638, 0.7393400821388699)
+        val back = StressTrace.decode(StressTrace.encode(awkward.mapIndexed { i, v -> at(i, v) }))
+        assertEquals(awkward, back.map { it.level })
+    }
+
+    /** A snapshot written by a build before #2166 still reads, two decimals and all. */
+    @Test
+    fun `an older two decimal snapshot still decodes`() {
+        val back = StressTrace.decode("0:1.59:0,3600:2.45:1")
+        assertEquals(2, back.size)
+        assertEquals(1.59, back[0].level!!, 0.0)
+        assertTrue(back[1].moving)
     }
 }

--- a/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
+++ b/android/app/src/test/java/com/noop/widget/StressTraceTest.kt
@@ -1,6 +1,7 @@
 package com.noop.widget
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -319,6 +320,24 @@ class StressTraceTest {
         val back = StressTrace.decode(StressTrace.encode(listOf(at(0, tiny))))
         assertEquals(tiny, back.single().level!!, 0.0)
         assertEquals(StressTrace.formatLevel(tiny), StressTrace.formatLevel(back.single().level!!))
+    }
+
+    /**
+     * A NaN in a corrupt payload is skipped rather than drawn.
+     *
+     * `decode` is tolerant by design because it runs on the render path, and NaN was the one shape
+     * that got past the domain guard: every comparison against it is false, so the two out-of-range
+     * tests both said no. It would have reached the chart as a NaN coordinate and the average as a
+     * NaN fold. Infinity was always caught, being greater than the ceiling.
+     */
+    @Test
+    fun `a NaN level is skipped rather than admitted by the domain guard`() {
+        // The guard is what rejects it, not the parse: this is text Kotlin reads as a Double.
+        assertNotNull("NaN".toDoubleOrNull())
+        assertTrue(StressTrace.decode("0:NaN:0").isEmpty())
+        assertTrue(StressTrace.decode("0:Infinity:0").isEmpty())
+        // and the valid neighbours in the same payload still survive
+        assertEquals(2, StressTrace.decode("0:1.5:0,3600:NaN:0,7200:2.5:1").size)
     }
 
     /** A snapshot written by a build before #2166 still reads, two decimals and all. */


### PR DESCRIPTION
## What was wrong

The widget and the Today card printed different tenths for the same hour, on one device, off identical data, with no staleness involved. Measured across a million levels drawn over the 0-3 domain: **5.02% disagree**, about one render in twenty.

```
raw level   card    widget    (the widget's stored copy)
2.2450      2.2     2.3       2.25
0.0450      0.0     0.1       0.05
1.7450      1.7     1.8       1.75
```

The widget does not render the level the card renders. It renders a copy that has been **rounded twice**. `StressTrace.encode` wrote the series into the widget's prefs string at two decimals, `decode` read it back, and the widget formatted that to one decimal. The card never goes through any of it: `StressTodayCard` is handed live `StressPoint`s and rounds the raw double once.

Two roundings move a value across a boundary one rounding does not, for any raw level in the narrow band below each tenth. That band is 5% of the domain. The same skew reached the peak and the average, which are folded from this series on the widget and from live points on the card.

**#2165 was never going to reach this.** Both surfaces already call `StressTrace.formatLevel`. What differed was the number handed to it, not the spelling.

## The fix

`encode` writes `Double.toString`, the shortest decimal that reads back as the same double. `decode` returns the bits encode was handed, so the widget formats exactly what the card formats.

A wider fixed precision was the obvious alternative and is the wrong shape: six decimals would have cut the disagreement to about one render in 200,000 rather than ending it, and "unlikely to disagree" instead of "cannot" is precisely the objection #2167 raises about the iOS twin. `SleepStagerTrace.round1` reached the same conclusion for the sleep trace and said why.

**What it costs.** A few hundred characters a day, which is nothing for a prefs string, and the digits stop being tidy: a level now reads `1.5851456074086638` rather than `1.59`. The encoding doc says to read the first few and ignore the rest. As a small bonus it is locale-independent, which `String.format` without a fixed locale was not.

**Older snapshots still read.** A string written by a build before this decodes unchanged, two decimals and all, which a test pins. No migration, no version bump.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

`StressTraceTest`: **32 tests, 0 failures**, forced with `--rerun-tasks`, XML timestamp checked against the clock.

Three new, and the two that matter were **confirmed to fail against the old encoding** before the fix went back in, so they guard something:

- the five bands that used to skew now format the same through the snapshot as they do live;
- encode then decode returns the same bits;
- a two decimal snapshot from an older build still decodes.

The existing round-trip assertions are repinned from a `0.001` tolerance to exact. A tolerance there would have passed just as happily for the lossy encoding that caused this, so it was not guarding the thing its name claims.

Doc lint clean. Parity ledger unmoved: `widget/**` is outside the scanned globs, and `StressTrace.swift` has no serialisation to keep in step, WidgetKit passing its entry through as a struct.

## Scope

Android only, and the display path only. The analytic series is untouched, which is the reason for fixing transport rather than rounding at the producer: the snapshot stays the real series rather than becoming a display copy.

## Related issues

#2166. #2167 is the separate and currently unreachable rounding gap on the iOS side, and is worth reading alongside this one, since quantising the snapshot was what put an exact `2.25` in front of a formatter in the first place.


## Re-review (195c5143)

**A hazard the change introduces.** `Double.toString` switches to scientific notation under 1e-3, which `"%.2f"` could never emit, so this put a new shape in front of a decoder only ever handed fixed-point text. A z-sum below about -8 squashes there: -9 gives `3.7018372795869517E-4`. It does round-trip, and that is now pinned rather than assumed. The string carries no `:` or `,` to confuse the split, `toDoubleOrNull` takes the exponent, and the `-` marking an unscored hour is a whole field, so a negative exponent cannot be mistaken for it.

**The claim in this PR, checked rather than asserted.** Both surfaces call `StressWidgetProducer.todayCurve(repo, activeStrapId)`, the widget's at `AppViewModel.kt:1059` and the card's at `TodayScreen.kt:3651`. Same producer, same arguments, so the doubles really are identical and the round-trip was genuinely the only difference between them. With transport lossless they are now bit-identical, which is the reason the peak and the average come into line too and not only the headline number.

**Swept for the same bug elsewhere.** `HrTrace` is the only other snapshot encoder and it carries `bpm` as an `Int`, so it has nothing to round. `WidgetTelemetry`'s fixed-point is diagnostic text, not a transport format. The bug class is confined to this one encoder.

**Checked and clean.** `RenderedGate.changed` compares successive in-memory snapshots, never a stored one against a fresh one, so it was not silently re-pushing on a format mismatch before this and does not change behaviour now. `push` writes the encoded series without comparing it to what is stored. `decode` still caps at `MAX_POINTS`.

`StressTraceTest` **33 tests, 0 failures**.


## Third pass (13f75a8a)

**A NaN level got past the domain guard.** `decode` is tolerant by design, running on the render path where the alternative to a partial curve is a crashed home screen, and NaN was the one shape it admitted: every comparison against NaN is false, so `level < 0.0 || level > DOMAIN_MAX` said no to both tests. `"NaN"` is text `toDoubleOrNull` accepts, so a corrupt prefs string was enough. It would have reached the chart as a NaN coordinate, the average as a NaN fold, and the headline as `0.0`, NaN rounding to zero. Infinity was always caught, being greater than the ceiling.

Writing the guard as the negated in-range test skips it, valid levels unaffected. The test pins the parse as well as the outcome, so the guard is shown to be what rejects it rather than the parse quietly failing, and it was confirmed to fail against the old guard before the fix went back in.

**Not reachable from scoring**, and worth saying so rather than implying the app was drawing NaNs: both z-terms in `DaytimeStress.rawScore` are gated on `sd > 0.0001`, so there is no `0/0`, and `squash` of any finite sum is finite. This is about the malformed payload `decode` already promises to absorb, in the function whose contract this PR changes.

`StressTraceTest` **34 tests, 0 failures**.
