### PR TITLE
fix(oura): stop announcing a ring reboot the #2097 judge has just rejected

### DIFF
--- a/Packages/OuraProtocol/Sources/OuraProtocol/OuraHistoryDrain.swift
+++ b/Packages/OuraProtocol/Sources/OuraProtocol/OuraHistoryDrain.swift
@@ -92,7 +92,22 @@ public struct OuraHistoryDrain: Sendable, Equatable {
     public mutating func noteStoredRingTime(_ rt: UInt32, resumeCursorAtFetchStart: UInt32) {
         guard rt <= Self.maxPlausibleResumeTicks else { return }
         if rt > maxStoredRingTime { maxStoredRingTime = rt }
-        if resumeCursorAtFetchStart > 0, rt < resumeCursorAtFetchStart { sawPreResumeData = true }
+        if Self.predatesResume(ringTime: rt, resumeCursorAtFetchStart: resumeCursorAtFetchStart) { sawPreResumeData = true }
+    }
+
+    /// Whether a record stamped `ringTime` was served from BEFORE where this fetch resumed — the one
+    /// comparison behind `sawPreResumeData`, exposed so a caller can apply it to a whole hypnogram burst.
+    /// A cursor of 0 is a full pull with no floor, so nothing predates it.
+    ///
+    /// WHY A BURST NEEDS THIS (2026-09-13, Gen 3, Oura-app handoff): "discarding the stale replay" in the
+    /// #2097 judge keeps the CURSOR, but every replayed record has already been ingested by then.
+    /// Time-series rows dedupe on their primary keys; the hypnogram assembler does not — it received the
+    /// last two sleep-phase records of two nights, re-served from the second client's position without
+    /// their 0x49 windows, and end-anchored each pair at its write time into a 52-minute session whose
+    /// codes were not the night's tail at all. A burst whose write moment predates the resume cursor was
+    /// already banked from its own drain; the persist refuses it instead of handing it to the dedup.
+    public static func predatesResume(ringTime: UInt32, resumeCursorAtFetchStart: UInt32) -> Bool {
+        resumeCursorAtFetchStart > 0 && ringTime < resumeCursorAtFetchStart
     }
 
     /// Record ANY history record's ring-time toward the in-session continuation cursor (anchored or not),

--- a/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraHistoryDrainTests.swift
+++ b/Packages/OuraProtocol/Tests/OuraProtocolTests/OuraHistoryDrainTests.swift
@@ -260,4 +260,46 @@ final class OuraHistoryDrainTests: XCTestCase {
         XCTAssertEqual(d.maxStoredRingTime, 2_900_000)
         XCTAssertEqual(d.maxSeenRingTime, 3_000_000, "stored notes don't inflate the seen max")
     }
+
+    /// `predatesResume` is the ONE comparison behind `sawPreResumeData`, applied to whole hypnogram
+    /// bursts by the app layer (a re-served night's tail must not become a phantom session — 2026-09-13).
+    /// The expected column is the standalone-compiled Swift twin's stdout, verbatim, over the same cases the
+    /// Kotlin test carries, so both platforms are pinned to the same table rather than to each other.
+    func testPredatesResumeOracleTable() {
+        let cases: [(UInt32, UInt32)] = [
+            (42_867_280, 43_895_637), (43_731_586, 43_895_637), (43_895_636, 43_895_637), (43_895_637, 43_895_637),
+            (43_895_638, 43_895_637), (43_897_237, 43_895_637), (0, 43_895_637), (1, 43_895_637),
+            (42_867_280, 0), (0, 0), (UInt32.max, 0), (UInt32.max, UInt32.max), (UInt32.max - 1, UInt32.max),
+            (5, 1), (1, 5), (0, 1),
+        ]
+        let got = cases.map { "\($0.0),\($0.1),\(OuraHistoryDrain.predatesResume(ringTime: $0.0, resumeCursorAtFetchStart: $0.1))" }
+            .joined(separator: "\n")
+        XCTAssertEqual(got, """
+42867280,43895637,true
+43731586,43895637,true
+43895636,43895637,true
+43895637,43895637,false
+43895638,43895637,false
+43897237,43895637,false
+0,43895637,true
+1,43895637,true
+42867280,0,false
+0,0,false
+4294967295,0,false
+4294967295,4294967295,false
+4294967294,4294967295,true
+5,1,false
+1,5,true
+0,1,true
+""")
+    }
+
+    func testPredatesResumeIsWhatFlagsPreResumeData() {
+        var d = OuraHistoryDrain()
+        d.noteStoredRingTime(43_731_586, resumeCursorAtFetchStart: 43_895_637)
+        XCTAssertTrue(d.sawPreResumeData, "the drain flag and the burst gate must agree on the same sample")
+        var e = OuraHistoryDrain()
+        e.noteStoredRingTime(43_897_237, resumeCursorAtFetchStart: 43_895_637)
+        XCTAssertFalse(e.sawPreResumeData)
+    }
 }

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -941,6 +941,20 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// available). Logs the reconstructed window + stage minutes so a capture is self-evident.
     private func persistHypnogramBurst(_ burst: OuraHypnogramBurst) {
         guard let driver, burst.totalCodes > 0 else { return }
+        // STALE-REPLAY GATE (2026-09-13, Oura-app handoff on a Gen 3): a second BLE client on the same
+        // phone makes the ring re-serve from ITS position, and the #2097 judge rightly keeps our cursor —
+        // but by then every replayed record has been ingested. Time-series rows dedupe on their keys; a
+        // burst does not: the last two sleep-phase records of a night came back without their 0x49 window
+        // and were end-anchored at their write time into a 52-minute `[no-0x49-onset]` session whose codes
+        // were not the night's tail. A burst written BEFORE where this fetch resumed was already banked
+        // from its own drain, so it is refused here rather than handed to the persist closure's dedup
+        // (which only catches a fragment that happens to sit inside a stored row, and only with onset
+        // keying on). A genuine reboot is unaffected: its judge resets the cursor to 0 and the chained
+        // full pull re-serves the same records with no floor.
+        if OuraHistoryDrain.predatesResume(ringTime: burst.lastRingTimestamp, resumeCursorAtFetchStart: resumeCursorAtFetchStart) {
+            log("Oura: hypnogram burst (\(burst.totalCodes) codes, written at rt \(burst.lastRingTimestamp)) predates the resume cursor \(resumeCursorAtFetchStart) - a re-serve from a second BLE client's position (#2097), already banked from its own drain; not persisted")
+            return
+        }
         // HOLD-UNTIL-ANCHOR (same discipline as pendingAnchorEvents): the burst end IS the night's whole
         // time axis, so guessing it from wall-clock would persist real stage codes at fabricated times.
         // An unanchored burst is parked and re-tried when the 0x42 anchor lands; if the session ends

--- a/Strand/BLE/OuraLiveSource.swift
+++ b/Strand/BLE/OuraLiveSource.swift
@@ -788,8 +788,13 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         if let burst = hypnogramAssembler.flush() {
             persistHypnogramBurst(burst)
         }
-        let rebootFullPullPending = drain.sawPreResumeData
-        commitResumeCursor(drainCompleted: completed)
+        // Ask the cursor commit whether it actually reset for a reboot rather than reading
+        // `drain.sawPreResumeData` directly: that flag is also raised by a stale replay from a second BLE
+        // client's serve position, which the #2097 judge inside `commitResumeCursor` rejects as "not a
+        // reboot" and answers by keeping the cursor. Snapshotting the flag here (as this did until
+        // 2026-09-13) had the scheduler print "ring reboot detected - starting the honest full re-pull"
+        // two lines after "not a reboot (#2097)" and burn a chained pass that only re-read the kept cursor.
+        let rebootFullPullPending = commitResumeCursor(drainCompleted: completed)
         logActivityEstimateSummary()
         advance(.historyCursorAdvanced(cursor: historyCursor, moreData: false))
         if rebootFullPullPending || resumeBacklog {
@@ -864,7 +869,10 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// `OuraHistoryDrain.anchorsAreContinuous`), in which case the stale replay is treated like ordinary
     /// stale data instead (dropped; cursor follows the same forward-only-if-resolving rule as any other
     /// drain) rather than forcing a full re-pull of the ring's entire history.
-    private func commitResumeCursor(drainCompleted: Bool) {
+    ///
+    /// Returns `true` only when the cursor WAS reset to 0 for a reboot — the one outcome that leaves a
+    /// full re-pull pending for `finishDrain` to chain. A stale replay the judge rejected returns `false`.
+    private func commitResumeCursor(drainCompleted: Bool) -> Bool {
         let how = drainCompleted ? "caught up (bytes_left 0)" : "stopped early"
         let resolves = drain.maxStoredRingTime > 0
             && (driver?.unixSeconds(forRingTimestamp: drain.maxStoredRingTime) != nil)
@@ -875,7 +883,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
             log("Oura: history \(how) but the ring served data older than cursor \(resumeCursorAtFetchStart) - clock reset/seek ignored; next connect does a full pull")
             historyCursor = 0
             OuraHistoryCursorStore.save(0, deviceId: deviceId)
-            return
+            return true
         }
         if drain.sawPreResumeData {
             log("Oura: history \(how) but the ring served data older than cursor \(resumeCursorAtFetchStart) - the ring's own SyncTime clock never paused across the gap, so this is a second BLE client's serve position, not a reboot (#2097); discarding the stale replay instead of a full re-pull")
@@ -889,6 +897,7 @@ public final class OuraLiveSource: NSObject, ObservableObject {
         } else {
             log("Oura: history \(how) (resume cursor unchanged \(historyCursor) [\(describeCursor(historyCursor))])")
         }
+        return false
     }
 
     /// Whether this drain's `sawPreResumeData` flag should be trusted as a genuine ring reboot, or
@@ -1586,7 +1595,6 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// Returns false (and writes nothing) if the link is not ready, so the caller can say so rather than
     /// silently appearing to have written. The value bytes are logged verbatim: this is a write to the
     /// ring's own config, and a strap log that does not say exactly what went out is useless afterwards.
-    @discardableResult
     func writeUserInfo(field: OuraUserInfoField, value: [UInt8]) -> Bool {
         guard peripheral != nil, writeCharacteristic != nil else {
             log("Oura: 0x20 user-info write SKIPPED - no connected ring / write characteristic")
@@ -1613,7 +1621,6 @@ public final class OuraLiveSource: NSObject, ObservableObject {
     /// also sends is guaranteed to log a fresh line — the connect-time SpO2/real_steps auto-probe (or an
     /// earlier manual call) may have already consumed `logFeatureStatus`'s once-per-connection dedup for
     /// this exact feature id.
-    @discardableResult
     func writeFeatureMode(feature: UInt8, mode: UInt8) -> Bool {
         guard peripheral != nil, writeCharacteristic != nil else {
             log("Oura: feature-mode write SKIPPED - no connected ring / write characteristic")
@@ -2972,7 +2979,6 @@ public enum OuraKeyStore {
 
     /// Store (or replace) the 16-byte install key for `deviceId`. A wrong-length key is rejected (no
     /// partial key is ever stored, so a later read can't return a malformed key).
-    @discardableResult
     public static func save(_ key: Data, deviceId: String) -> Bool {
         guard key.count == keyLength else { return false }
         SecItemDelete(baseQuery(deviceId: deviceId) as CFDictionary)

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -790,6 +790,21 @@ class OuraLiveSource(
     private fun persistHypnogramBurst(burst: OuraHypnogramBurst) {
         val d = driver ?: return
         if (burst.totalCodes <= 0) return
+        // STALE-REPLAY GATE (2026-09-13, Oura-app handoff on a Gen 3): a second BLE client on the same
+        // phone makes the ring re-serve from ITS position, and the #2097 judge rightly keeps our cursor —
+        // but by then every replayed record has been ingested. Time-series rows dedupe on their keys; a
+        // burst does not: the last two sleep-phase records of a night came back without their 0x49 window
+        // and were end-anchored at their write time into a 52-minute `[no-0x49-onset]` session whose codes
+        // were not the night's tail. A burst written BEFORE where this fetch resumed was already banked
+        // from its own drain, so it is refused here rather than handed to the persist path's dedup. A
+        // genuine reboot is unaffected: its judge resets the cursor to 0 and the chained full pull
+        // re-serves the same records with no floor. Twin of the Swift gate.
+        if (OuraHistoryDrain.predatesResume(burst.lastRingTimestamp, resumeCursorAtFetchStart)) {
+            log("Oura: hypnogram burst (${burst.totalCodes} codes, written at rt ${burst.lastRingTimestamp})" +
+                " predates the resume cursor $resumeCursorAtFetchStart - a re-serve from a second BLE client's" +
+                " position (#2097), already banked from its own drain; not persisted")
+            return
+        }
         val writeEnd = d.unixSeconds(forRingTimestamp = burst.lastRingTimestamp)
         if (writeEnd == null) {
             pendingUnanchoredBursts.add(burst)

--- a/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
+++ b/android/app/src/main/java/com/noop/ble/OuraLiveSource.kt
@@ -694,8 +694,13 @@ class OuraLiveSource(
         pendingContinuation = false
         handler.removeCallbacks(batchQuietRunnable)
         hypnogramAssembler.flush()?.let { persistHypnogramBurst(it) }
-        val rebootFullPullPending = drain.sawPreResumeData
-        commitResumeCursor(completed)
+        // Ask the cursor commit whether it actually reset for a reboot rather than reading
+        // `drain.sawPreResumeData` directly: that flag is also raised by a stale replay from a second BLE
+        // client's serve position, which the #2097 judge inside `commitResumeCursor` rejects as "not a
+        // reboot" and answers by keeping the cursor. Snapshotting the flag here (as this did until
+        // 2026-09-13) had the scheduler print "ring reboot detected - starting the honest full re-pull"
+        // two lines after "not a reboot (#2097)" and burn a chained pass that only re-read the kept cursor.
+        val rebootFullPullPending = commitResumeCursor(completed)
         advance(OuraTransition.HistoryCursorAdvanced(cursor = historyCursor, moreData = false))
         if (rebootFullPullPending || resumeBacklog) {
             if (chainedDrainPasses >= MAX_CHAINED_DRAIN_PASSES) {
@@ -724,8 +729,11 @@ class OuraLiveSource(
      * [OuraHistoryDrain.anchorsAreContinuous]), in which case the stale replay is treated like ordinary
      * stale data instead (dropped; cursor follows the same forward-only-if-resolving rule as any other
      * drain) rather than forcing a full re-pull of the ring's entire history.
+     *
+     * Returns `true` only when the cursor WAS reset to 0 for a reboot — the one outcome that leaves a
+     * full re-pull pending for [finishDrain] to chain. A stale replay the judge rejected returns `false`.
      */
-    private fun commitResumeCursor(drainCompleted: Boolean) {
+    private fun commitResumeCursor(drainCompleted: Boolean): Boolean {
         val how = if (drainCompleted) "caught up (bytes_left 0)" else "stopped early"
         val resolves = drain.maxStoredRingTime > 0 &&
             driver?.unixSeconds(forRingTimestamp = drain.maxStoredRingTime) != null
@@ -736,7 +744,7 @@ class OuraLiveSource(
                 " - clock reset/seek ignored; next connect does a full pull")
             historyCursor = 0
             OuraHistoryCursorStore.save(appContext, deviceId, 0)
-            return
+            return true
         }
         if (drain.sawPreResumeData) {
             log("Oura: history $how but the ring served data older than cursor $resumeCursorAtFetchStart" +
@@ -754,6 +762,7 @@ class OuraLiveSource(
         } else {
             log("Oura: history $how (resume cursor unchanged $historyCursor)")
         }
+        return false
     }
 
     /**

--- a/android/app/src/main/java/com/noop/oura/OuraHistoryDrain.kt
+++ b/android/app/src/main/java/com/noop/oura/OuraHistoryDrain.kt
@@ -84,7 +84,7 @@ class OuraHistoryDrain {
     fun noteStoredRingTime(rt: Long, resumeCursorAtFetchStart: Long) {
         if (rt > MAX_PLAUSIBLE_RESUME_TICKS) return
         if (rt > maxStoredRingTime) maxStoredRingTime = rt
-        if (resumeCursorAtFetchStart > 0 && rt < resumeCursorAtFetchStart) sawPreResumeData = true
+        if (predatesResume(rt, resumeCursorAtFetchStart)) sawPreResumeData = true
     }
 
     /**
@@ -132,6 +132,23 @@ class OuraHistoryDrain {
     }
 
     companion object {
+        /**
+         * Whether a record stamped [ringTime] was served from BEFORE where this fetch resumed — the one
+         * comparison behind [sawPreResumeData], exposed so a caller can apply it to a whole hypnogram
+         * burst. A cursor of 0 is a full pull with no floor, so nothing predates it.
+         *
+         * WHY A BURST NEEDS THIS (2026-09-13, Gen 3, Oura-app handoff): "discarding the stale replay"
+         * in the #2097 judge keeps the CURSOR, but every replayed record has already been ingested by
+         * then. Time-series rows dedupe on their primary keys; the hypnogram assembler does not — it
+         * received the last two sleep-phase records of two nights, re-served from the second client's
+         * position without their 0x49 windows, and end-anchored each pair at its write time into a
+         * 52-minute session whose codes were not the night's tail at all. A burst whose write moment
+         * predates the resume cursor was already banked from its own drain; the persist refuses it
+         * instead of handing it to the dedup. Twin of Swift `OuraHistoryDrain.predatesResume`.
+         */
+        fun predatesResume(ringTime: Long, resumeCursorAtFetchStart: Long): Boolean =
+            resumeCursorAtFetchStart > 0 && ringTime < resumeCursorAtFetchStart
+
         /**
          * A ring-time above this is corrupt (~1.6 years of ticks) and must not set the resume cursor,
          * or the next session would seek into nonsense. Bounds the cursor at the source.

--- a/android/app/src/test/java/com/noop/oura/OuraHistoryDrainTest.kt
+++ b/android/app/src/test/java/com/noop/oura/OuraHistoryDrainTest.kt
@@ -317,4 +317,53 @@ class OuraHistoryDrainTest {
         // Stall floor reset: a fresh flat sequence starts counting from scratch.
         assertTrue(d.onSummary(bytesLeft = 1000, moreData = true, elapsedSeconds = 1.0))
     }
+
+    /**
+     * `predatesResume` is the ONE comparison behind `sawPreResumeData`, applied to whole hypnogram bursts
+     * by the app layer (a re-served night's tail must not become a phantom session — 2026-09-13). The
+     * expected block is the standalone-compiled SWIFT twin's stdout, verbatim
+     * (`swiftc -O twin.swift main.swift -o t && ./t`), over the same cases — the Kotlin side is pinned to
+     * the Swift oracle, not read side by side with it.
+     */
+    @Test
+    fun predatesResumeMatchesTheSwiftOracleTable() {
+        val cases = listOf(
+            42_867_280L to 43_895_637L, 43_731_586L to 43_895_637L, 43_895_636L to 43_895_637L, 43_895_637L to 43_895_637L,
+            43_895_638L to 43_895_637L, 43_897_237L to 43_895_637L, 0L to 43_895_637L, 1L to 43_895_637L,
+            42_867_280L to 0L, 0L to 0L, 4_294_967_295L to 0L, 4_294_967_295L to 4_294_967_295L, 4_294_967_294L to 4_294_967_295L,
+            5L to 1L, 1L to 5L, 0L to 1L,
+        )
+        val got = cases.joinToString("\n") { (rt, cur) -> "$rt,$cur,${OuraHistoryDrain.predatesResume(rt, cur)}" }
+        assertEquals(
+            """
+            42867280,43895637,true
+            43731586,43895637,true
+            43895636,43895637,true
+            43895637,43895637,false
+            43895638,43895637,false
+            43897237,43895637,false
+            0,43895637,true
+            1,43895637,true
+            42867280,0,false
+            0,0,false
+            4294967295,0,false
+            4294967295,4294967295,false
+            4294967294,4294967295,true
+            5,1,false
+            1,5,true
+            0,1,true
+            """.trimIndent(),
+            got,
+        )
+    }
+
+    @Test
+    fun predatesResumeIsWhatFlagsPreResumeData() {
+        val d = OuraHistoryDrain()
+        d.noteStoredRingTime(43_731_586L, resumeCursorAtFetchStart = 43_895_637L)
+        assertTrue("the drain flag and the burst gate must agree on the same sample", d.sawPreResumeData)
+        val e = OuraHistoryDrain()
+        e.noteStoredRingTime(43_897_237L, resumeCursorAtFetchStart = 43_895_637L)
+        assertFalse(e.sawPreResumeData)
+    }
 }


### PR DESCRIPTION
## What was wrong

Two things showed up in the same 2026-09-13 10:37 Gen 3 log — the first Oura-app handoff exercised on
#2100 + #2155. Both apps share one iPhone's CoreBluetooth link, so the ring's replies to the Oura app
land in NOOP's notify stream, and the ring served data from before NOOP's resume cursor.

**1. The reboot line contradicted the verdict two lines above it.** `finishDrain` snapshotted
`drain.sawPreResumeData` *before* `commitResumeCursor` ran. That flag is raised by a stale replay from
a second client's serve position just as much as by a real ring reboot; the #2097 judge inside
`commitResumeCursor` tells the two apart and keeps the cursor for a replay — but its verdict never
reached the chained-pass scheduler:

```
[10:37:27] Oura: history caught up (bytes_left 0) but the ring served data older than cursor 43895637 - … not a reboot (#2097); discarding the stale replay instead of a full re-pull
[10:37:27] Oura: history caught up (bytes_left 0) - resume cursor advanced to 43897237 [2026-09-13 10:36:39]
[10:37:27] Oura: ring reboot detected - starting the honest full re-pull; next drain pass in 5 s (1/6)
…
[10:37:32] Oura: fetching history from cursor 43897237 (2026-09-13 10:36:39) [cursor-fix]
[10:37:33] Oura: history caught up (bytes_left 0) (resume cursor unchanged 43897237 …)
```

The cursor was kept and the chained pass re-read it — no data was wrong — but the line asserts the
opposite of the decision, and one of the six allowed chained passes was spent on nothing. The same log
is otherwise the first positive hardware confirmation of #2100 + #2155: cursor 43895637 → 43896636 →
43897237 → 43897837, forward only, never 0, across the handoff.

**2. "Discarding the stale replay" was cursor-only; the replayed records had already been ingested.**
Time-series rows dedupe on their keys. A hypnogram burst does not. The assembler received the last two
sleep-phase records of two nights, re-served from the Oura app's position *without* their 0x49 windows,
and end-anchored each pair at its write time into a 104-code, 52-minute `[no-0x49-onset]` session
(`[2026-09-12 06:24:50 → 07:16:50]`, `[2026-09-13 08:11:07 → 09:03:07]`) whose codes were not the
night's tail. Onset keying suppressed one and banked the other over its own earlier copy; with the
shipped default (keying off) both land as naps.

## Change

- `commitResumeCursor` now returns whether it actually reset the cursor for a reboot, and `finishDrain`
  chains the full re-pull off that return, not off the raw flag. It is true on exactly one path (the
  clock-reset branch that zeroes the cursor); false after the judge rejects a replay and after an
  ordinary advance.
- `persistHypnogramBurst` refuses a burst whose write moment predates where the fetch resumed, before
  anchoring, with a log line naming the cursor. The rule is the comparison `sawPreResumeData` already
  uses, lifted into `OuraHistoryDrain.predatesResume` so the drain flag and the burst gate cannot drift
  apart. It keys on the burst's *last* ring timestamp, so a burst that straddles the resume point still
  persists. A cursor of 0 (full pull) has no floor, so a genuine reboot's chained re-pull is unaffected —
  the two changes do not fight.
- Same shape on both platforms: `OuraLiveSource.kt` had the identical snapshot, `OuraHistoryDrain.kt`
  gets the same `predatesResume`.
- Third commit restores three `@discardableResult` attributes (`writeUserInfo`, `writeFeatureMode`,
  `OuraKeyStore.save`) the first commit dropped by accident; the file's attribute set matches main again.

## Verification

- `OuraProtocol` `swift test` 237/0, with an oracle table for `predatesResume`; the Kotlin test carries
  the standalone-compiled Swift twin's stdout verbatim over the same 16 cases (`OuraHistoryDrainTest`
  29/0), plus a test pinning the drain flag and the burst gate to the same sample.
- macOS `Strand` **BUILD SUCCEEDED** (app-target Swift; CI does not compile it), no unused-result warning
  in `OuraLiveSource` / `AddDeviceWizard`. Android `compileFullDebugKotlin` clean. `doc_comment_lint` OK.
- The pure decision core's reboot path is unchanged; its existing tests still pass unmodified.
- Not hardware-validated yet: the next Oura-app handoff on the flashed tip is the check. The two
  `ring reboot detected` lines must be absent while `not a reboot (#2097)` and the kept cursor remain, and
  `predates the resume cursor … not persisted` must appear where the two
  `sleep session persisted … [no-0x49-onset]` lines used to.