### PR TITLE
stress: give the marker tile's reading the width the chip was holding

### DIFF
--- a/Strand/Screens/StressView.swift
+++ b/Strand/Screens/StressView.swift
@@ -515,7 +515,15 @@ struct StressView: View {
     private func markerTile(label: LocalizedStringKey, value: String, delta: Double?, accent: Color, higherIsStress: Bool) -> some View {
         let deltaText: String?
         let deltaColor: Color
-        if let delta, abs(delta) >= 0.5 {
+        // NO CHIP for a missing delta, rather than a claim we cannot make (#2145). It is nil when
+        // today has no reading or there is no 30-day baseline to stand one against, and both fell
+        // through to the at-baseline chip: a tile with no reading read "— at baseline", and a
+        // first-week tile put a reading exactly on a baseline that did not exist yet. StatTile draws
+        // the pill only for a non-nil delta, so nil is already the way to say nothing here.
+        if delta == nil {
+            deltaText = nil
+            deltaColor = StrandPalette.textTertiary
+        } else if let delta, abs(delta) >= 0.5 {
             let up = delta > 0
             let isStressful = (up == higherIsStress)
             deltaText = String(localized: "\(up ? "+" : "−")\(Int(abs(delta).rounded())) vs base")

--- a/android/app/src/main/java/com/noop/ui/Components.kt
+++ b/android/app/src/main/java/com/noop/ui/Components.kt
@@ -528,6 +528,12 @@ fun StatTile(
     // intrinsic size. Used by narrow two-column tiles where a wide chip (e.g. "1234 kcal" or
     // "+10 vs base") would otherwise starve the reading column and clip its value. The default
     // keeps callers that have enough width exactly as they were.
+    //
+    // NO CALLER PASSES TRUE ANY MORE, and reach for a shorter chip before reaching for this (#2145).
+    // It splits the row evenly, which starves BOTH sides once the chip is wide: the value is weighted
+    // with fill = true, so it is held to exactly its share however little the chip turns out to need.
+    // The stress marker tiles clipped their reading AND their chip this way. The workouts feed went
+    // full width, the stress tiles shortened the chip; both then wanted the natural-width path.
     compactDelta: Boolean = false,
 ) {
     // Each tile borrows its accent as a faint card wash, so a metric reads as part of its

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -1199,9 +1199,16 @@ private fun MarkerTile(
     higherIsStress: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val deltaText: String
+    val deltaText: String?
     val deltaColor: Color
-    if (delta != null && kotlin.math.abs(delta) >= 0.5) {
+    if (delta == null) {
+        // NO CHIP, rather than a claim we cannot make. The delta is null when today has no reading or
+        // there is no 30-day baseline to stand it against, and both of those used to render the
+        // at-baseline chip: a tile with no reading read "— at baseline", and a first-week tile said a
+        // reading sat exactly on a baseline that did not exist yet. StatTile draws no chip for null.
+        deltaText = null
+        deltaColor = Palette.textTertiary
+    } else if (kotlin.math.abs(delta) >= 0.5) {
         val up = delta > 0
         val isStressful = (up == higherIsStress)
         // The magnitude alone, signed. TrendChip reads the sign to pick its ▲/▼, and the section
@@ -1210,8 +1217,10 @@ private fun MarkerTile(
         deltaText = "${if (up) "+" else "−"}${kotlin.math.abs(delta).roundToInt()}"
         deltaColor = if (isStressful) Palette.statusWarning else Palette.statusPositive
     } else {
-        // "at baseline" for the same reason: the header supplies "baseline", the chip supplies the
+        // "at baseline" shortens the same way: the header supplies "baseline", the chip supplies the
         // distance from it, which is none. No glyph, TrendChip showing one only for a signed value.
+        // Reached only with a real delta now, so it says "measured, and it is zero" rather than
+        // standing in for "nothing to measure".
         deltaText = "±0"
         deltaColor = Palette.textTertiary
     }

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -1204,10 +1204,15 @@ private fun MarkerTile(
     if (delta != null && kotlin.math.abs(delta) >= 0.5) {
         val up = delta > 0
         val isStressful = (up == higherIsStress)
-        deltaText = "${if (up) "+" else "−"}${kotlin.math.abs(delta).roundToInt()} vs base"
+        // The magnitude alone, signed. TrendChip reads the sign to pick its ▲/▼, and the section
+        // header two lines up already says "vs 30-day baseline", so spelling "vs base" again inside
+        // the chip spent width on a word the reader has just been given (#2145).
+        deltaText = "${if (up) "+" else "−"}${kotlin.math.abs(delta).roundToInt()}"
         deltaColor = if (isStressful) Palette.statusWarning else Palette.statusPositive
     } else {
-        deltaText = "at baseline"
+        // "at baseline" for the same reason: the header supplies "baseline", the chip supplies the
+        // distance from it, which is none. No glyph, TrendChip showing one only for a signed value.
+        deltaText = "±0"
         deltaColor = Palette.textTertiary
     }
     StatTile(
@@ -1217,10 +1222,15 @@ private fun MarkerTile(
         accent = accent,
         delta = deltaText,
         deltaColor = deltaColor,
-        // #492 item 5: on narrow two-column cards the intrinsic-width "vs base" chip used to consume
-        // nearly the whole row and leave the reading as "4…" / "73…". Share the row evenly so the real
-        // physiological value stays intact; the explanatory chip is the element allowed to ellipsize.
-        compactDelta = true,
+        // NO compactDelta, deliberately (#2145). #492 item 5 added it because the intrinsic-width
+        // "vs base" chip ate the row and left the reading as "4…", and an even split then starved
+        // BOTH sides on a two-up tile: "53 bpm" and "+7 vs base" each want more than half, so the
+        // field saw "53 …" beside "▲ +7 vs …". An even split cannot be the answer, because a weighted
+        // child with fill = true is held to exactly its share, so the value stays at half however
+        // little the chip needs. The chip is now the sign and at most three digits at 12sp, so it
+        // measures under 45dp including its pill padding, and the weighted value takes everything
+        // else. The old chip wanted about 90dp of a row that has about 140dp to give, which is what
+        // made it starve the reading in the first place.
     )
 }
 


### PR DESCRIPTION
## What was wrong

Reported by @bartmuskala with a screenshot that placed it exactly. On the Stress screen the `RESTING HR` tile read `53 …` beside a chip reading `▲ +7 vs …`, and `HRV` read `31 …` beside `▼ −29 v…`. Both halves of the row cut, neither winning.

The two tiles on the same rows that carry **no** delta chip, `STRESS` and `CALM TIME`, render in full at the same width. That places it in the row that holds a value beside a chip rather than in the tile or the screen.

## Why

`MarkerTile` asked for `compactDelta`, which splits that row evenly. On a two-up tile there is about 140dp to give, and `+7 vs base` alone wants about 90dp of it, so neither side fits in its half.

The even split was itself the previous repair. Before #492 item 5 the chip took its natural width and left the reading as `4…`, so the row was set to share instead. Sharing starves both sides rather than one, because **a weighted child with `fill = true` is held to exactly its share**: the value sits at half however little the chip turns out to need. There was no width at which both strings fit, so the row could only pick which one to cut.

## The change

The chip carries the signed magnitude and nothing else. The section header directly above these tiles already reads `vs 30-day baseline`, so `vs base` was being bought at the reading's expense to repeat something the reader had just been given. At 12sp with at most three digits the chip measures under 45dp including its pill padding, which leaves the value the rest of the row at full size. The even split then goes, and the natural-width path comes back.

`at baseline` becomes `±0` for the same reason. `TrendChip` shows no glyph for it, having one only for a signed value.

No caller passes `compactDelta` any more. Its documentation now says so, and says to reach for a shorter chip before reaching for it, since the workouts feed had already left it behind by going full width.

## A second bug, not fixed here

The value is drawn by `AutoSizeValue`, whose stated job is to shrink to 0.6x **rather than** truncate, added for this exact symptom in #319/#332. `53 bpm` at 0.6x would have fitted the half it was given. It truncated instead, so that safety net is not firing, and it sits under every `StatTile` in the app rather than only these two.

This PR does not depend on it: the reading now fits at full size with no shrink required. I have not chased the cause, because it wants a device to confirm and I cannot run Compose here. Filed separately as #2171.

## Localisation

`vs base` and `at baseline` were English literals on Android while the Apple twin passes both through `String(localized:)`. The change takes both out of the UI without needing a new string, since a signed number needs no translation.

`Tools/i18n_audit.py` never saw them: its count is **234 before and after**. That is the known blind spot for literals assigned outside a composable call, so the audit passing was not evidence they were fine.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

`compileFullDebugKotlin` clean, doc lint clean, `i18n_audit.py` unchanged at 234.

**This is a layout change and wants eyes on a device**, which is the honest state of it: there is no unit test that measures a Compose row, and the screenshot that reports it came from a phone I do not have. What to look at on the Stress screen: `RESTING HR` and `HRV` should read `53 bpm` and `31 ms` in full, with a short chip beside each, and should stay intact at larger font scales, where the old split failed first.

## One trade-off worth stating

A screen reader used to hear `+7 vs base` and now hears `+7`. The tile label and the section header still carry the context, but the chip alone is terser than it was. Restoring it properly means a description string localised across the eight `values*` files rather than a literal, which is more churn than the two words are worth in this PR. Happy to add it if you would rather have it.

## Related issues

#2145. #2171 is the shrink helper, which is the wider of the two.


## Re-review (85cb48df)

**The tile claimed a fact it did not have.** `rhrDelta` is null when today has no reading or there is no 30-day baseline to stand it against:

```kotlin
val rhrDelta = if (rhrT != null && meanRHR != null) rhrT - meanRHR else null
```

Both of those fell through to the at-baseline chip, so a tile with nothing in it put that chip beside the empty-value dash, and a first-week tile put a reading exactly on a baseline that did not exist yet. Shortening the chip to `±0` sharpened the false claim rather than causing it, which is what made it visible on a second read.

A null delta now draws no chip at all, which both `StatTile`s already support: the Kotlin one renders the pill inside `if (delta != null)`, the Swift one inside `if let delta`. The at-baseline branch is reached only with a real delta now, so it says "measured, and it is zero" rather than standing in for "nothing to measure".

**The Swift twin had the identical flaw**, so both are corrected together rather than leaving one side claiming it. This widens the PR past the Android layout it started as, deliberately: it is one defect in one tile with two implementations. iOS keeps its wording, not being the surface that clips, so the shortened chip stays Android only.

The first pass missed it because the reported screenshot came from a strap with a month of history behind it, where the delta is always present. The empty and first-week states are the ones nobody photographs.

**Checked:** parity ledger unmoved, `Strand/**` being outside the scanned globs. Kotlin compiles, doc lint clean. The Swift change is app-target, which does not build on this machine, so it rests on the macOS leg of CI. Adding a Swift file also moves this PR onto the larger check roster.
