### PR TITLE
ci: do not let a failed release delete look like a tag that already exists

### DIFF
--- a/.github/workflows/fork-testing-build.yml
+++ b/.github/workflows/fork-testing-build.yml
@@ -72,6 +72,21 @@ jobs:
             echo "::error::$TAG still exists after a delete that reported success. Refusing to create over it."
             exit 1
           fi
+          # The TAG has to go as well, and its own failure is the quiet one. `create` ignores --target
+          # when the tag already exists, so a release gone but a tag left behind does not fail: it
+          # publishes today's assets against a tag still pointing at the previous build's commit, and
+          # nothing says so. The release title carries $SHA from the workflow, so it would read as
+          # today's build while `git checkout testing-latest` handed someone yesterday's source.
+          # Deleting the ref directly is the same thing --cleanup-tag meant to do, so try once more
+          # before giving up rather than failing a build over a leftover.
+          if gh api "repos/$GITHUB_REPOSITORY/git/refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "$TAG survived --cleanup-tag; deleting the ref directly."
+            gh api -X DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/$TAG" >/dev/null 2>&1 || true
+            if gh api "repos/$GITHUB_REPOSITORY/git/refs/tags/$TAG" >/dev/null 2>&1; then
+              echo "::error::The tag $TAG could not be removed. Creating now would publish this build against the previous build's commit, so stopping instead."
+              exit 1
+            fi
+          fi
           gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --prerelease --target "${{ github.sha }}" \
             --title "NOOP Staging — base ${VER} · ${DATE} · ${SHA}" \
             --notes "Rolling **latest** testing build — refreshed in place, so this tag is always the newest. NOOP main + ryanbr's open PRs + vetted community PRs, built with the **NOOP Staging** identity (installs **beside** the official app, separate data). Filenames carry the base app version (\`v${VER}\`).

--- a/.github/workflows/fork-testing-build.yml
+++ b/.github/workflows/fork-testing-build.yml
@@ -37,7 +37,41 @@ jobs:
           echo "ver=$VER" >> "$GITHUB_OUTPUT"
           # ROLLING release: recreate the single tag so stale (incl. old-version) assets never linger —
           # one stable URL, always the newest build, zero cleanup. (To KEEP a build, cut a one-off tag.)
-          gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes || true
+          #
+          # The delete USED to end in `|| true`, which could not tell "the tag is not there yet",
+          # which is the normal first-run case and fine, from "the delete failed", which makes the
+          # create below certain to fail (#2174). Build 499 hit a 500 from GitHub here, the create
+          # then stopped on "Release.tag_name already exists", and since meta gates all four build
+          # legs a blip in a metadata step threw away the Android, iOS and macOS builds behind it.
+          # The message a reader got described the symptom and pointed away from the cause.
+          delete_rolling_release() {
+            local out status attempt
+            for attempt in 1 2 3; do
+              out=$(gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes 2>&1) && status=0 || status=$?
+              [ "$status" -eq 0 ] && return 0
+              # Nothing there to delete is success, not failure: first build, or an earlier run that
+              # got as far as deleting. Anything else is worth another go, GitHub 5xx being transient.
+              case "$(printf '%s' "$out" | tr '[:upper:]' '[:lower:]')" in
+                *"not found"*|*404*) return 0 ;;
+              esac
+              echo "release delete attempt ${attempt} of 3 did not succeed: ${out}"
+              sleep $((attempt * 5))
+            done
+            return 1
+          }
+          delete_rolling_release || {
+            echo "::error::Could not delete $TAG after 3 attempts. Not creating over it, because that fails with a message about the tag existing rather than about this."
+            exit 1
+          }
+          # Assert rather than assume. A delete that reports success but leaves the release standing
+          # would otherwise be read by the create as a name clash, which is the confusion above.
+          # Known limit: a 5xx on this view reads the same as a clean 404, so a blip here lands back
+          # on the create's own error. That is where we were before, not somewhere worse, and failing
+          # the build on an inconclusive view would stop builds whose release really had gone.
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::$TAG still exists after a delete that reported success. Refusing to create over it."
+            exit 1
+          fi
           gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --prerelease --target "${{ github.sha }}" \
             --title "NOOP Staging — base ${VER} · ${DATE} · ${SHA}" \
             --notes "Rolling **latest** testing build — refreshed in place, so this tag is always the newest. NOOP main + ryanbr's open PRs + vetted community PRs, built with the **NOOP Staging** identity (installs **beside** the official app, separate data). Filenames carry the base app version (\`v${VER}\`).


### PR DESCRIPTION
## What was wrong

The rolling testing release is deleted and recreated on every build, and the delete ended in `|| true`:

```bash
gh release delete "$TAG" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes || true
gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --prerelease --target "${{ github.sha }}" \
```

That swallows two very different things:

- **the tag is not there yet**, normal on a first run, and correctly ignored;
- **the delete failed**, which makes the `create` on the next line certain to fail.

Build 499 hit the second. GitHub returned a 500 on the delete, the create stopped on `Release.tag_name already exists`, and the job exited 1:

```
HTTP 500 (https://api.github.com/repos/ryanbr/noop/releases/387840121)
HTTP 422: Validation Failed (https://api.github.com/repos/ryanbr/noop/releases)
Release.tag_name already exists
```

The message a reader gets describes the symptom and points away from the cause: the tag exists **because the delete did not happen**. And because `meta` gates the four build legs, a blip in a metadata step threw away the Android, iOS and macOS builds behind it. A re-dispatch of the same commit went through untouched, which is the tell that nothing was wrong with the repo.

## The change

The delete retries three times with a short backoff, reads a 404 as the success it is, and stops the job with a message about **itself** if it never gets there. An assert before the create catches the other shape: a delete that reports success and leaves the release standing.

This is the hardening option from #2174 rather than the larger one, and I changed my mind about which to bring while writing it. Dropping the delete entirely and updating the release in place would remove the window rather than survive it, but `gh release edit --target` does not move a tag that already exists, so the rolling tag would need a forced ref update as well, plus explicit deletion of assets not in the new set to keep the stated property that stale old-version assets never linger. That is a behaviour change with several moving parts, against a failure that a retry handles. The option stays open and #2174 keeps the write-up.

## How it was tested

The step is not reachable from a test run without publishing a release, so the script was extracted from the workflow and exercised against a stubbed `gh`, under `bash -e` exactly as the step runs:

| stubbed behaviour | result |
|---|---|
| delete succeeds | exit 0, one call |
| release absent, 404 | exit 0, one call, read as success |
| 500 twice then success | exit 0, three calls, **this is build 499's case** |
| 500 every time | exit 1, error names the delete, not the tag |
| delete reports success, release survives | exit 1, caught by the assert |

`bash -n` clean, and the file still parses as YAML with all five jobs intact.

## One thing I got wrong on the way

I first rewrote `[ "$status" -eq 0 ] && return 0` as an `if`, on the theory that a trailing AND-list evaluating false is an exiting command under `errexit`. It is not: bash does not exit for `false && true`, so the original form was already safe and the reasoning was mistaken. Rather than keep a cosmetic change justified by something untrue, the line is back as it was. Worth saying because a comment asserting it would have been read as fact later.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / tooling

## Scope

One step in `.github/workflows/fork-testing-build.yml`. No app code, nothing to bump, and the next testing build exercises it for real.

## Related issues

#2174.


## Re-review (6e9f7cad)

**The assert covered the loud half and left the quiet one.** It checked the release was gone. `gh release create` ignores `--target` when the tag already exists, so a release deleted with its tag left behind does not fail at all: it publishes this build's assets against a tag still pointing at the **previous build's commit**, silently. The release title carries the workflow's own SHA, so it would read as today's build while `git checkout testing-latest` handed someone yesterday's source. That is worse than the error this PR started with, which at least stopped.

The tag is now checked too. Deleting the ref directly is what `--cleanup-tag` was trying to do, so a leftover gets one explicit attempt before the job gives up, rather than failing a build over something it can clear itself.

**What gh actually says, checked instead of assumed.** The stub had invented `HTTP 404: Not Found` for the nothing-to-delete case. The real wording is `release not found`, confirmed against this repo. The pattern matches both, so the behaviour was already right, but the test was agreeing with a string GitHub does not send. The stub now uses the real one.

**A flaw in the harness, not the workflow.** The first run of this table reported `deletes=0` everywhere while the exit codes were all correct. The counter path held a space and was read unquoted, so every count came back empty. Worth saying because the retry counts are the evidence for the case this PR exists to handle, and a table that reports zero calls proves nothing.

| stubbed behaviour | result |
|---|---|
| clean delete | exit 0, one delete |
| release absent, `release not found` | exit 0, one delete, read as success |
| 500 twice then success | exit 0, **three deletes**, build 499's case |
| 500 every time | exit 1, error names the delete |
| release survives the delete | exit 1, caught |
| tag survives, ref delete works | exit 0, cleared and carried on |
| tag survives, ref delete stuck | exit 1, error names the tag and what it would have caused |

YAML still parses with all five jobs, `bash -n` clean.
