### PR TITLE
health: say when a Fitness Age is sitting on the end of its scale

### DIFF
--- a/Strand/Liquid/LiquidPrimitives.swift
+++ b/Strand/Liquid/LiquidPrimitives.swift
@@ -458,12 +458,16 @@ struct CountUpNumber: View, Animatable {
     /// byte-identical; the WHOOP 0–21 Effort scale passes 1 so the hero matches the app-wide one-decimal
     /// `effortDisplay` convention instead of rounding 12.6 → "13" (#45).
     var decimals: Int = 0
+    /// Rendered ahead of the number and never animated, for a value that is bounded rather than
+    /// measured: Fitness Age arrives clamped, so a reading at the edge of the scale shows "≤20" while
+    /// the count-up still runs (#2173). Empty by default, which leaves every existing caller identical.
+    var prefix: String = ""
     var animatableData: Double {
         get { value }
         set { value = newValue }
     }
     var body: some View {
-        Text(decimals > 0 ? String(format: "%.\(decimals)f", value) : "\(Int(value.rounded()))")
+        Text(prefix + (decimals > 0 ? String(format: "%.\(decimals)f", value) : "\(Int(value.rounded()))"))
             .font(font).monospacedDigit()
     }
 }

--- a/Strand/Liquid/LiquidTodayView.swift
+++ b/Strand/Liquid/LiquidTodayView.swift
@@ -945,7 +945,11 @@ struct LiquidTodayView: View {
                      value: stressText, tint: StrandPalette.accent, frac: fracOver(stress, 3))
         case .fitnessAge:
             cardLink(.metric("fitness_age"), title: card.title, sub: card.subtitle,
-                     value: unitText(fitnessAge, card.unit), tint: StrandPalette.chargeColor, frac: 0.5)
+                     // Bound symbol as on the Health hero (#2173), so a floored reading does not read
+                     // exact here and bounded there.
+                     value: fitnessAge.map { "\(fitnessAgeBoundSymbol($0))" + unitText($0, card.unit) }
+                         ?? unitText(fitnessAge, card.unit),
+                     tint: StrandPalette.chargeColor, frac: 0.5)
         case .vo2max:
             cardLink(.metric("vo2max_est"), title: card.title, sub: card.subtitle,
                      value: unitText(vo2max, card.unit), tint: StrandPalette.chargeColor, frac: 0.5)

--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -786,11 +786,13 @@ private struct FitnessAgeSection: View {
         // "At least N" is the same number said truthfully, and where there is no safe distance to give
         // (a chronological age at or inside the bound) the line states the bound on its own.
         if bound == "≤" {
-            if younger && years > 0 { return String(localized: "At least \(years) years younger than your age") }
+            if younger && years == 1 { return String(localized: "At least 1 year younger than your age") }
+            if younger && years > 1 { return String(localized: "At least \(years) years younger than your age") }
             return String(localized: "\(Int(FitnessAgeEngine.minAge)) or younger")
         }
         if bound == "≥" {
-            if !younger && years > 0 { return String(localized: "At least \(years) years older than your age") }
+            if !younger && years == 1 { return String(localized: "At least 1 year older than your age") }
+            if !younger && years > 1 { return String(localized: "At least \(years) years older than your age") }
             return String(localized: "\(Int(FitnessAgeEngine.maxAge)) or older")
         }
         if years == 0 { return String(localized: "About the same as your age") }

--- a/Strand/Screens/HealthView.swift
+++ b/Strand/Screens/HealthView.swift
@@ -780,7 +780,19 @@ private struct FitnessAgeSection: View {
 
     /// The younger/older-than-your-age subtitle as whole-phrase variants per count and direction, so
     /// translators see complete sentences (never a stitched plural or direction fragment).
-    private func ageDeltaLine(years: Int, younger: Bool) -> String {
+    private func ageDeltaLine(years: Int, younger: Bool, bound: String = "") -> String {
+        // A bounded reading can only be stated as a direction, never as a distance: the true age is at
+        // or beyond the bound, so a plain "N years younger" would present a floor as a measurement.
+        // "At least N" is the same number said truthfully, and where there is no safe distance to give
+        // (a chronological age at or inside the bound) the line states the bound on its own.
+        if bound == "≤" {
+            if younger && years > 0 { return String(localized: "At least \(years) years younger than your age") }
+            return String(localized: "\(Int(FitnessAgeEngine.minAge)) or younger")
+        }
+        if bound == "≥" {
+            if !younger && years > 0 { return String(localized: "At least \(years) years older than your age") }
+            return String(localized: "\(Int(FitnessAgeEngine.maxAge)) or older")
+        }
         if years == 0 { return String(localized: "About the same as your age") }
         switch (younger, years == 1) {
         case (true, true):   return String(localized: "1 year younger than your age")
@@ -818,6 +830,7 @@ private struct FitnessAgeSection: View {
 
     private func heroCard(age: Double) -> some View {
         let shown = Int(age.rounded())
+        let bound = fitnessAgeBoundSymbol(age)
         let delta = Double(profile.age) - age        // +ve = fitness age younger than chronological
         let years = Int(abs(delta).rounded())
         let younger = delta >= 0
@@ -833,14 +846,14 @@ private struct FitnessAgeSection: View {
                         LiquidVessel(value: fitnessAgeFraction(age), tint: StrandPalette.chargeColor,
                                      animated: true, tapPassesThrough: true)
                             .frame(width: 96, height: 96)
-                        CountUpNumber(value: Double(shown), font: StrandFont.rounded(30))
+                        CountUpNumber(value: Double(shown), font: StrandFont.rounded(30), prefix: bound)
                             .foregroundStyle(.white)
                             .shadow(color: .black.opacity(0.5), radius: 6, y: 1)
                             .allowsHitTesting(false)
                     }
                     VStack(alignment: .leading, spacing: NoopMetrics.space1) {
                         Text("Fitness Age").strandOverline()
-                        Text(ageDeltaLine(years: years, younger: younger))
+                        Text(ageDeltaLine(years: years, younger: younger, bound: bound))
                             .font(StrandFont.subhead)
                             .foregroundStyle(younger ? StrandPalette.statusPositive : StrandPalette.statusWarning)
                     }
@@ -868,7 +881,8 @@ private struct FitnessAgeSection: View {
             }
             .buttonStyle(LiquidPressStyle())
             .accessibilityElement(children: .ignore)
-            .accessibilityLabel("Fitness Age \(shown), \(ageDeltaLine(years: years, younger: younger)). Tap to see the trend.")
+            // The spoken label carries the bound too, so a screen reader is not told a floored reading is exact.
+            .accessibilityLabel("Fitness Age \(bound)\(shown), \(ageDeltaLine(years: years, younger: younger, bound: bound)). Tap to see the trend.")
 
             Text("± \(Int(FitnessAgeEngine.displayBandYears)) yr · a fitness comparison, not a biological age")
                 .font(StrandFont.footnote)
@@ -1569,3 +1583,21 @@ struct VitalityDemoScreen: View {
     }
 }
 #endif
+
+/// The symbol a stored Fitness Age needs when it is sitting on a reporting bound (#2173).
+///
+/// `FitnessAgeEngine` clamps to [minAge, maxAge], so every model output below 20 is stored as
+/// exactly 20.0 and every output above 80 as exactly 80.0. A reader cannot tell either from a
+/// genuine 20 or 80, and the number looks as exact as every other number on the screen, which is
+/// what makes a floored reading read like a sync or scoring fault rather than the end of the scale.
+///
+/// Decided from the value rather than carried out of the engine, matching the Kotlin twin. The
+/// clamp returns the bound constant itself, so equality is exact and needs no tolerance, and
+/// deciding here covers the weekly rows already banked, which no flag added today could reach.
+/// A reading that is genuinely 20.0 is therefore also called "20 or younger", which is true of it.
+/// Saying "<20" would need the unclamped value, and that is gone before anything is stored.
+func fitnessAgeBoundSymbol(_ value: Double) -> String {
+    if value <= FitnessAgeEngine.minAge { return "≤" }
+    if value >= FitnessAgeEngine.maxAge { return "≥" }
+    return ""
+}

--- a/Strand/Screens/TodayView.swift
+++ b/Strand/Screens/TodayView.swift
@@ -2817,7 +2817,8 @@ struct TodayView: View {
             // copy and the owner's reply on #706.
             return stressToday.map { "\(Int($0.rounded()))" } ?? Self.calibratingPlaceholder
         case .fitnessAge:
-            return withUnit(fitnessAgeToday.map { "\(Int($0.rounded()))" } ?? "—")
+            // Bound symbol as on the Health hero (#2173).
+            return withUnit(fitnessAgeToday.map { "\(fitnessAgeBoundSymbol($0))\(Int($0.rounded()))" } ?? "—")
         case .vo2max:
             return vo2maxToday.map { "\(Int($0.rounded()))" } ?? "—"
         case .vitality:

--- a/Tools/i18n_audit_baseline.json
+++ b/Tools/i18n_audit_baseline.json
@@ -122,14 +122,6 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
-      "Off: the coach answers generally and sends none of your metrics."
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
-      "On: your recovery, sleep, HRV and workouts are shared with the provider for tailored coaching."
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/CoachScreen.kt",
       "Only if your server requires one"
     ],
     [
@@ -450,10 +442,6 @@
     ],
     [
       "android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt",
-      "%d:%02d"
-    ],
-    [
-      "android/app/src/main/java/com/noop/ui/LiveWorkoutScreen.kt",
       "Below Zone 1"
     ],
     [
@@ -725,10 +713,6 @@
       "Unread. ${item.title}. ${item.message}"
     ],
     [
-      "android/app/src/main/java/com/noop/ui/WorkoutStart.kt",
-      "%d:%02d"
-    ],
-    [
       "android/app/src/main/java/com/noop/ui/WorkoutsScreen.kt",
       "${WorkoutEditing.displaySport(row.sport)}, ${dateLabel(row.startTs)}"
     ],
@@ -936,6 +920,10 @@
     ],
     [
       "Strand/Screens/HealthView.swift",
+      "Fitness Age \\(bound)\\(shown), \\(ageDeltaLine(years: years, younger: younger, bound: bound)). Tap to see the trend."
+    ],
+    [
+      "Strand/Screens/HealthView.swift",
       "Refresh Fitness Age now"
     ],
     [
@@ -1021,10 +1009,6 @@
     [
       "Strand/Screens/SettingsView.swift",
       "Date of birth, age \\(profile.age) years"
-    ],
-    [
-      "Strand/Screens/SettingsView.swift",
-      "NOOP estimates your steps from your WHOOP's motion, calibrated to your phone's step count. It's an estimate, not a step counter — a WHOOP 5.0 / MG streams motion (not a step count) only with deep data on."
     ],
     [
       "Strand/Screens/SettingsView.swift",

--- a/android/app/src/main/java/com/noop/ui/HealthScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/HealthScreen.kt
@@ -939,6 +939,27 @@ private fun HealthHeroVessel(
     }
 }
 
+/**
+ * The symbol a stored Fitness Age needs when it is sitting on a reporting bound (#2173).
+ *
+ * `FitnessAgeEngine` clamps to [minAge, maxAge], so every model output below 20 is stored as exactly
+ * 20.0 and every output above 80 as exactly 80.0. A reader cannot tell those from a genuine 20 or 80,
+ * and the number looks as exact as any other, which is what makes a floored reading read like a sync
+ * or scoring fault rather than the edge of the scale.
+ *
+ * Decided from the value rather than carried out of the engine deliberately. The clamp returns the
+ * bound constant itself, so equality is exact and needs no tolerance, and deciding here covers the
+ * weekly rows already persisted, which no flag added today could reach. The cost is that a reading
+ * that is genuinely 20.0 is also called "20 or younger", which is true of it, so nothing is claimed
+ * that is not known. Saying "<20" would need the unclamped value, and that is gone by the time
+ * anything is stored.
+ */
+internal fun fitnessAgeBoundSymbol(value: Double): String = when {
+    value <= FitnessAgeEngine.minAge -> "≤"
+    value >= FitnessAgeEngine.maxAge -> "≥"
+    else -> ""
+}
+
 /** The hero tile: a big Fitness Age number on the gold Charge world, the younger/older read-out, an
  *  optional VO₂max chip, the honest ± band caption, and a "How accurate is this?" toggle. */
 @Composable
@@ -951,10 +972,21 @@ private fun FitnessAgeHero(
     checklistOpen: Boolean,
 ) {
     val shown = fitnessAge.roundToInt()
+    val boundSymbol = fitnessAgeBoundSymbol(fitnessAge)
     // Delta vs the user's actual age: younger when the fitness age is below it. abs() drives the words.
     val deltaYears = (chronoAge - fitnessAge).roundToInt()
     val younger = fitnessAge < chronoAge
+    // A bounded reading can only be stated as a direction, never as a distance (#2173). The true age
+    // is somewhere at or beyond the bound, so "N years younger" would be a floor presented as a
+    // measurement; "at least N" is the same number said truthfully. Below the floor with a chronological
+    // age at or under it there is no safe distance to state at all, so the card states the bound alone.
     val deltaWord = when {
+        boundSymbol == "≤" && deltaYears > 0 ->
+            "At least $deltaYears ${yearWord(deltaYears)} younger than your age"
+        boundSymbol == "≤" -> "${FitnessAgeEngine.minAge.roundToInt()} or younger"
+        boundSymbol == "≥" && deltaYears < 0 ->
+            "At least ${kotlin.math.abs(deltaYears)} ${yearWord(deltaYears)} older than your age"
+        boundSymbol == "≥" -> "${FitnessAgeEngine.maxAge.roundToInt()} or older"
         deltaYears == 0 -> "About your age"
         younger -> "$deltaYears ${yearWord(deltaYears)} younger than your age"
         else -> "${kotlin.math.abs(deltaYears)} ${yearWord(deltaYears)} older than your age"
@@ -984,6 +1016,9 @@ private fun FitnessAgeHero(
                         value = shown.toDouble(),
                         tint = Palette.chargeColor,
                         diameter = 96.dp,
+                        // The vessel already takes a formatter, so a bounded reading needs no change
+                        // to the component: the count-up still runs, it just arrives at "≤20".
+                        format = { "$boundSymbol${it.roundToInt()}" },
                     )
                     Text(
                         text = deltaWord,

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -4128,7 +4128,9 @@ private fun dashboardCardValue(
             // state instead, matching the owner's reply on #706 and the StressScreen empty/calibrating copy.
             stress?.let { it.roundToInt().toString() } ?: STRESS_CALIBRATING
         DashboardCard.FITNESS_AGE ->
-            withUnit(fitnessAge?.let { it.roundToInt().toString() } ?: NO_DATA)
+            // Carries the bound symbol the Health hero uses (#2173), so a floored reading does not read
+            // as an exact one here and as a bounded one there.
+            withUnit(fitnessAge?.let { "${fitnessAgeBoundSymbol(it)}${it.roundToInt()}" } ?: NO_DATA)
         DashboardCard.VO2MAX ->
             vo2max?.let { it.roundToInt().toString() } ?: NO_DATA
         DashboardCard.VITALITY ->


### PR DESCRIPTION
## What was wrong

Raised by @Fr1tz77. `FitnessAgeEngine` clamps its result to `[20, 80]`, on both platforms:

```swift
return min(maxAge, max(minAge, fa))          // FitnessAgeEngine.swift:72
```
```kotlin
return fa.coerceIn(minAge, maxAge)           // FitnessAgeEngine.kt:60
```

So every model output below 20 banks as exactly `20.0`, and the card showed that like any other reading. A floored result looked exact, and because it stops moving while everything around it keeps updating, it reads as a sync or scoring fault rather than as the end of the scale.

**The age-difference line was the worse half, and the report did not raise it.** `deltaYears` is built as `age - fa` from the clamped value, so it inherits the bound. A 45-year-old whose model output is 15 was told "25 years younger than your age" when the model said 30. That is a trimmed number presented as a measurement, and a reader has no way to see it.

**The upper bound had the identical defect** and was not raised either. It is done here rather than left to be reported next.

## The change

A value sitting on a bound reads `≤20` or `≥80`, on the Health hero and on both Today tiles, so the number stops claiming a precision the model did not give.

A bounded reading can only be stated as a **direction**, never as a distance, so the difference line says "At least 25 years younger than your age". Where there is no safe distance to give, it states the bound alone. Two cases make that concrete, and they are the point of the whole change:

| stored | chronological age | line |
|---|---|---|
| 20.0 | 45 | At least 25 years younger than your age |
| 20.0 | 18 | 20 or younger |
| 80.0 | 85 | 80 or older |

The 18-year-old does **not** get "2 years older", because below the floor the true value is unknown and could be either side of them. Same in the other direction at 85.

## Why it is decided from the value, not carried out of the engine

The card does not read a `FitnessAgeResult`. It reads a weekly value banked in the `fitness_age` metric series, `faPts.last?.value` on iOS and the same series on Android, so a flag added to the engine today would not reach the screen at all and would not reach a single row already stored.

The clamp returns the bound constant itself, so `value <= minAge` is exact and needs no tolerance. The cost, stated plainly: a reading that is genuinely `20.0` is also called "20 or younger". That is true of it, so nothing is claimed that is not known. Saying `<20` would need the unclamped value, and that is discarded one line after it exists.

This also leaves the engines, the model and its supported range untouched, which is what the report asked for.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

Android compiles. The Swift is app-target and does not build on this machine, so it rests on the macOS and iOS legs of CI.

Both platforms' branch logic was walked through **fifteen readings** and agrees on every one: each bound, either side of it, both singulars, and a chronological age inside each bound. That check is what caught the bug in the second commit, where the iOS bounded line said "At least 1 **years** younger" because it hardcoded the plural the unbounded branch four lines below it splits on.

Parity ledger unmoved and doc lint clean. The i18n gate passes; the baseline went **287 to 283**, since this rewrites a literal already tracked there and clears five entries that had gone stale.

## What is deliberately not here

The trend chart still plots a bounded point as a plain point at 20. Marking bounded points on a series is a presentation question of its own rather than a wording one, and it is not what makes the headline misleading.

Whether 20 is the right floor for the Nes/HUNT model is a modelling decision and stays open. Saying so when a reading lands on it does not wait for it.

The iOS spoken label carries the bound, so a screen reader is not told a floored reading is exact. The Android delta copy remains an English literal, as it was before this: localising it is a separate piece of work and this change neither adds to that debt nor pretends it is absent.

## Related issues

#2173. #2071 reshapes which age numbers exist; this is about telling the truth regarding the one already shown, and survives whatever that lands on.


## Re-review

No defect this pass. What was checked, since the Swift here cannot be compiled on the machine it was written on and "it looks right" is not a test:

**The unverifiable call signatures, read rather than assumed.** `unitText(_ v: Double?, _ unit: String, decimals: Int = 0)` takes an optional, so passing a non-optional `Double` from inside `map` promotes and the nil branch still returns the no-value dash exactly as before. `CountUpNumber`'s new `prefix` is declared after `decimals`, both defaulted, so `CountUpNumber(value:font:prefix:)` matches the memberwise order with `decimals` omitted. `animatableData` is computed and stays out of that init, so the count-up still animates on `value` alone. `fitnessAgeBoundSymbol` is a single top-level declaration with three call sites and no name it could collide with.

**One more surface, deliberately left alone.** `CompareScreen` lists `fitness_age` as a generic comparable metric and renders it through the shared zero-decimal formatter. It is the same category as the trend chart already excluded above: a series view rather than the headline, where a bound symbol on plotted values would disagree with the axis they sit on. Naming it so the exclusion is complete rather than accidental.

**The spoken path on both platforms.** Android hides the hero number from screen readers already, `Modifier.clearAndSetSemantics {}` inside the vessel, so the difference line is what is read, and that line now carries the bound. iOS puts the bound in its label and in the same line. Neither platform can now tell a screen reader that a floored reading is exact.

**Left as it is on purpose.** The iOS tile builds its value as `"\(fitnessAgeBoundSymbol($0))" + unitText($0, card.unit)`, where the interpolation around an already-`String` result is redundant. It is verified correct against the signature above, and tidying unverifiable code for looks is how a typo reaches CI instead of a compiler.
