### PR TITLE
stress: keep the Today curve as fresh as the screen it links to

### DIFF
--- a/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
+++ b/android/app/src/main/java/com/noop/ble/WhoopConnectionService.kt
@@ -842,7 +842,7 @@ class WhoopConnectionService : Service() {
         /** How often this service rescores the widget's stress curve. Matched to the curve's own
          *  half-hour resolution and to the in-app analytics cadence, not to the live HR stream that
          *  drives the collector it sits in. */
-        private const val STRESS_RESCORE_INTERVAL_MS = 15L * 60L * 1000L
+        private val STRESS_RESCORE_INTERVAL_MS = StressWidgetProducer.RESCORE_INTERVAL_MS
 
         private const val CHANNEL_ID = "noop_strap_connection"
         private const val NOTIF_ID = 4201

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -522,6 +522,22 @@ private fun StressAdvancedCard(
 
 // MARK: - 3 · Daytime timeline (intraday, same 0–3 proxy)
 
+/**
+ * How far behind the clock the newest scored hour has to be before the timeline says so (#2144).
+ *
+ * An hour is scored once its bucket holds [DaytimeStress.minHourHrSamples] heart-rate samples, and
+ * that is the ONLY test: there is no completeness rule, so the hour in progress scores as soon as it
+ * has banked enough, which on a strap streaming at roughly 1 Hz is a few minutes in. What actually
+ * decides how far back the curve ends is therefore sample DENSITY, not the clock, and a strap that
+ * banks history in chunks rather than streaming leaves recent hours under the bar for a while.
+ *
+ * So a healthy curve can end anywhere from minutes to an hour or two back depending on how the day's
+ * data arrived, and a threshold here has to clear all of that to avoid crying wolf. Two and a half
+ * hours is past what any of it explains, which is about where a reader starts wondering whether
+ * syncing has died rather than reading the chart.
+ */
+private const val staleTimelineSeconds: Long = 150L * 60L
+
 @Composable
 private fun StressDaytimeSection(
     day: DaytimeStress.Result,
@@ -578,6 +594,24 @@ private fun StressDaytimeSection(
                     style = NoopType.footnote,
                     color = Palette.textTertiary,
                 )
+                // Where the curve actually stops, said plainly, and only when it is far enough behind
+                // the clock to look broken (#2144). The caption above gives the rule; a reader looking
+                // at a line that ends at 2pm on an axis running to 4pm wants to know that THIS hour is
+                // the reason, not a sync that has died. Quiet on an ordinary day, when the newest
+                // scored hour is simply the one that has just finished.
+                val lastScored = day.scored.lastOrNull()?.startTs
+                if (lastScored != null &&
+                    System.currentTimeMillis() / 1000L - lastScored >= staleTimelineSeconds
+                ) {
+                    Text(
+                        uiString(
+                            R.string.l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7,
+                            pointTimeLabel(lastScored),
+                        ),
+                        style = NoopType.footnote,
+                        color = Palette.textTertiary,
+                    )
+                }
             }
         }
 

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -136,13 +136,30 @@ fun StressScreen(vm: AppViewModel, onBreathe: () -> Unit = {}) {
     // one. Both surfaces now age at the same rate, which is the actual ask in the report.
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
     androidx.compose.runtime.LaunchedEffect(vm.activeStrapId, lifecycleOwner) {
+        // Guarded on the same fingerprint the widget producer memoises against, for the same reason.
+        // `loadDaytimeStress` is the expensive read on this screen, three windowed row fetches plus the
+        // two HRV engines, and repeating it was free when it happened once on open. On a timer it is
+        // not: with the strap disconnected, or simply quiet, nothing about today's heart rate has moved
+        // and re-reading produces a result identical to the one already on screen. An indexed count and
+        // max answers that for the price of neither.
+        var lastHrFingerprint: Pair<Int, Long>? = null
         lifecycleOwner.lifecycle.repeatOnLifecycle(androidx.lifecycle.Lifecycle.State.STARTED) {
             while (true) {
-                val read = runCatching { loadDaytimeStress(vm, NoopPrefs.stressPersonalBaseline(context)) }
-                    .getOrDefault(DaytimeReadout(DaytimeStress.Result.EMPTY, null, null))
-                daytime = read.daytime
-                stressIndex = read.stressIndex
-                freqHrv = read.freqHrv
+                val nowSeconds = System.currentTimeMillis() / 1000L
+                val window = stressLocalDayWindowContaining(nowSeconds, ZoneId.systemDefault())
+                val fingerprint = runCatching {
+                    vm.repo.hrFingerprintWindow(vm.activeStrapId, window.fromEpochSecond, nowSeconds)
+                }.getOrNull()
+                // A failed fingerprint reads as "cannot tell", which loads rather than skips: being
+                // wrong about this costs one pass, being wrong the other way freezes the screen.
+                if (fingerprint == null || fingerprint != lastHrFingerprint) {
+                    lastHrFingerprint = fingerprint
+                    val read = runCatching { loadDaytimeStress(vm, NoopPrefs.stressPersonalBaseline(context)) }
+                        .getOrDefault(DaytimeReadout(DaytimeStress.Result.EMPTY, null, null))
+                    daytime = read.daytime
+                    stressIndex = read.stressIndex
+                    freqHrv = read.freqHrv
+                }
                 delay(StressWidgetProducer.RESCORE_INTERVAL_MS)
             }
         }

--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -56,6 +56,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.noop.analytics.DaytimeBaselines
 import com.noop.analytics.DaytimeStress
 import com.noop.analytics.HrvFreqDomain
@@ -63,6 +64,7 @@ import com.noop.analytics.StressIndex
 import com.noop.data.DailyMetric
 import com.noop.widget.StressPoint
 import com.noop.widget.StressTrace
+import com.noop.widget.StressWidgetProducer
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -70,6 +72,7 @@ import java.util.Locale
 import kotlin.math.exp
 import kotlin.math.roundToInt
 import kotlin.math.sqrt
+import kotlinx.coroutines.delay
 
 // MARK: - Stress Monitor (ported from Strand/Screens/StressView.swift)
 //
@@ -126,12 +129,23 @@ fun StressScreen(vm: AppViewModel, onBreathe: () -> Unit = {}) {
     // span/beat gate is not met. Faithful twin of the iOS StressView readouts.
     var stressIndex by remember { mutableStateOf<StressIndex.Components?>(null) }
     var freqHrv by remember { mutableStateOf<HrvFreqDomain.Bands?>(null) }
-    androidx.compose.runtime.LaunchedEffect(vm.activeStrapId) {
-        val read = runCatching { loadDaytimeStress(vm, NoopPrefs.stressPersonalBaseline(context)) }
-            .getOrDefault(DaytimeReadout(DaytimeStress.Result.EMPTY, null, null))
-        daytime = read.daytime
-        stressIndex = read.stressIndex
-        freqHrv = read.freqHrv
+    // #2144: on the SAME interval the Today card and the widget score on, and gated the same way.
+    // This used to read once, on open, which is why the screen happened to be the fresher of the two
+    // when the report was filed: it had simply been opened later. Refreshing only the card would have
+    // moved the disagreement rather than ended it, since a screen left open would then be the stale
+    // one. Both surfaces now age at the same rate, which is the actual ask in the report.
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    androidx.compose.runtime.LaunchedEffect(vm.activeStrapId, lifecycleOwner) {
+        lifecycleOwner.lifecycle.repeatOnLifecycle(androidx.lifecycle.Lifecycle.State.STARTED) {
+            while (true) {
+                val read = runCatching { loadDaytimeStress(vm, NoopPrefs.stressPersonalBaseline(context)) }
+                    .getOrDefault(DaytimeReadout(DaytimeStress.Result.EMPTY, null, null))
+                daytime = read.daytime
+                stressIndex = read.stressIndex
+                freqHrv = read.freqHrv
+                delay(StressWidgetProducer.RESCORE_INTERVAL_MS)
+            }
+        }
     }
 
     // Rebuild the model only when the inputs (days, stored) actually change — the

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -144,7 +144,10 @@ import android.app.DatePickerDialog
 import android.content.Context
 import android.view.HapticFeedbackConstants
 import android.widget.Toast
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.repeatOnLifecycle
 import com.noop.R
 import com.noop.ai.AiKeyStore
 import com.noop.analytics.Baselines
@@ -3653,19 +3656,29 @@ private fun HostedCardsSection(
     // and the two drifted apart by however long sat between the two triggers. A reporter saw 1pm here
     // against 2pm there at twenty past four. Same producer and same scoring on both sides; the whole
     // difference was when each last asked, so this asks again on the cadence the widget already uses.
-    LaunchedEffect(needsStressCurve, days, viewModel.activeStrapId) {
+    val stressLifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(needsStressCurve, days, viewModel.activeStrapId, stressLifecycleOwner) {
         if (!needsStressCurve) {
             stressCurve = emptyList()
             return@LaunchedEffect
         }
-        while (true) {
-            // A null is "nothing to say about stress right now" (no device to read), which the producer
-            // documents as keep-what-you-had rather than "today scored nothing". Holding the last curve
-            // matters more here than it did for a single pass: blanking the card on one bad tick would
-            // be a visible flicker on a screen that is sitting open.
-            StressWidgetProducer.todayCurve(viewModel.repo, viewModel.activeStrapId)
-                ?.let { stressCurve = it.points }
-            delay(StressWidgetProducer.RESCORE_INTERVAL_MS)
+        // Gated on STARTED, the same reason HealthScreen's live-HR tick is: a LaunchedEffect is tied to
+        // the composition and not to the lifecycle, so an ungated loop here would go on scoring a day of
+        // heart-rate rows every fifteen minutes for as long as the composition survived in the
+        // background. The service is already doing that work on this exact cadence while backgrounded,
+        // which is the point of it, so the card doing it too would be a second pass that nothing is on
+        // screen to read. Resuming re-enters the block and scores immediately, so coming back to the app
+        // shows a current curve rather than waiting out an interval.
+        stressLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            while (true) {
+                // A null is "nothing to say about stress right now" (no device to read), which the
+                // producer documents as keep-what-you-had rather than "today scored nothing". Holding
+                // the last curve matters more here than for a single pass: blanking the card on one bad
+                // tick would be a visible flicker on a screen that is sitting open.
+                StressWidgetProducer.todayCurve(viewModel.repo, viewModel.activeStrapId)
+                    ?.let { stressCurve = it.points }
+                delay(StressWidgetProducer.RESCORE_INTERVAL_MS)
+            }
         }
     }
     // Turning the card's own destination into the callback that reaches it. The mapping itself lives

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -104,6 +104,7 @@ import androidx.compose.ui.zIndex
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.withFrameNanos
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -3646,11 +3647,25 @@ private fun HostedCardsSection(
     // card and the widget can never show different curves.
     val needsStressCurve = cards.contains(HostedCard.STRESS_TODAY)
     var stressCurve by remember { mutableStateOf<List<StressPoint>>(emptyList()) }
+    // #2144: this used to score ONCE, when these keys last moved, and none of them tracks incoming
+    // heart rate — `days` is the daily rows, not the intraday samples the curve is built from. So a
+    // card left open held whatever it scored then, while the Stress screen scores when you open it,
+    // and the two drifted apart by however long sat between the two triggers. A reporter saw 1pm here
+    // against 2pm there at twenty past four. Same producer and same scoring on both sides; the whole
+    // difference was when each last asked, so this asks again on the cadence the widget already uses.
     LaunchedEffect(needsStressCurve, days, viewModel.activeStrapId) {
-        stressCurve = if (needsStressCurve) {
-            StressWidgetProducer.todayCurve(viewModel.repo, viewModel.activeStrapId)?.points ?: emptyList()
-        } else {
-            emptyList()
+        if (!needsStressCurve) {
+            stressCurve = emptyList()
+            return@LaunchedEffect
+        }
+        while (true) {
+            // A null is "nothing to say about stress right now" (no device to read), which the producer
+            // documents as keep-what-you-had rather than "today scored nothing". Holding the last curve
+            // matters more here than it did for a single pass: blanking the card on one bad tick would
+            // be a visible flicker on a screen that is sitting open.
+            StressWidgetProducer.todayCurve(viewModel.repo, viewModel.activeStrapId)
+                ?.let { stressCurve = it.points }
+            delay(StressWidgetProducer.RESCORE_INTERVAL_MS)
         }
     }
     // Turning the card's own destination into the callback that reaches it. The mapping itself lives

--- a/android/app/src/main/java/com/noop/widget/StressWidgetProducer.kt
+++ b/android/app/src/main/java/com/noop/widget/StressWidgetProducer.kt
@@ -51,6 +51,22 @@ internal object StressWidgetProducer {
     const val RESCORE_RETRY_MS: Long = 60L * 1000L
 
     /**
+     * How often a live surface should ask for today's curve again.
+     *
+     * Lives here rather than in one caller because more than one surface has to keep step: the
+     * connection service scores on it for the widget, and the Today card now refreshes on it too
+     * (#2144). Before that the card scored once, when its LaunchedEffect keys last moved, and none
+     * of those keys track incoming heart rate, so a card left open drifted hours behind the Stress
+     * screen, which scores when you open it. Two surfaces, one producer, and the only difference
+     * between them was when each last asked.
+     *
+     * Matched to the data rather than to the stream: the curve resolves to half-hours, so asking
+     * more often than this buys nothing and costs a day of heart-rate rows every time, the memo
+     * being no help while a strap is streaming into the window it fingerprints.
+     */
+    const val RESCORE_INTERVAL_MS: Long = 15L * 60L * 1000L
+
+    /**
      * The stamp to keep after an attempt, given what that attempt actually produced (#2120).
      *
      * The caller stamps BEFORE it reads, deliberately: stamping inside the placement branch would leave

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2783,4 +2783,5 @@
     <string name="coach_consent_on">An: Ladung, Erholung, HRV und Workouts gehen an den Anbieter, jedes Workout mit Sportart, Dauer, Distanz und Herzfrequenz.</string>
     <string name="coach_consent_off">Aus: Der Coach antwortet allgemein und sendet keine deiner Werte.</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">Ein Heute-Bildschirm, den du selbst zusammenstellst, Stress auf dem Homescreen und Backups, die sich selbst prüfen</string>
+    <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">Bewertet bis %1$s. Spätere Stunden brauchen mehr Herzfrequenz-Messwerte.</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2770,4 +2770,5 @@
     <string name="coach_consent_on">Activado: tu carga, descanso, HRV y entrenamientos se envían al proveedor, cada entrenamiento con su deporte, duración, distancia y frecuencia cardíaca.</string>
     <string name="coach_consent_off">Desactivado: el coach responde en general y no envía ninguna de tus métricas.</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">Una pantalla de Hoy que organizas tú, el estrés en la pantalla de inicio y copias de seguridad que se comprueban solas</string>
+    <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">Puntuado hasta las %1$s. Las horas posteriores necesitan más muestras de frecuencia cardiaca.</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2769,4 +2769,5 @@
     <string name="coach_consent_on">Activé : votre charge, repos, VFC et entraînements sont envoyés au fournisseur, chaque entraînement avec son sport, sa durée, sa distance et sa fréquence cardiaque.</string>
     <string name="coach_consent_off">Désactivé : le coach répond de façon générale et n\'envoie aucune de vos données.</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">Un écran Aujourd\'hui que vous composez vous-même, le stress sur l\'écran d\'accueil, et des sauvegardes qui se vérifient elles-mêmes</string>
+    <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">Évalué jusqu\'à %1$s. Les heures suivantes nécessitent plus de mesures de fréquence cardiaque.</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2778,4 +2778,5 @@
     <string name="coach_consent_on">Włączone: Twój ładunek, odpoczynek, HRV i treningi trafiają do dostawcy, każdy trening ze sportem, czasem, dystansem i tętnem.</string>
     <string name="coach_consent_off">Wyłączone: coach odpowiada ogólnie i nie wysyła żadnych Twoich danych.</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">Ekran Dzisiaj, który układasz sam, stres na ekranie głównym i kopie zapasowe, które same się sprawdzają</string>
+    <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">Ocenione do %1$s. Późniejsze godziny wymagają więcej pomiarów tętna.</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2762,4 +2762,5 @@
     <string name="coach_consent_on">Ligado: a tua carga, descanso, VFC e treinos são enviados ao fornecedor, cada treino com o desporto, duração, distância e frequência cardíaca.</string>
     <string name="coach_consent_off">Desligado: o coach responde de forma geral e não envia nenhuma das tuas métricas.</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">Um ecrã Hoje que organiza a seu gosto, o stress no ecrã principal e cópias de segurança que se verificam a si próprias</string>
+    <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">Avaliado até às %1$s. As horas seguintes precisam de mais amostras de frequência cardíaca.</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -2657,4 +2657,5 @@
     <string name="coach_consent_on">Включено: заряд, отдых, ВСР и тренировки отправляются провайдеру, каждая тренировка с видом спорта, длительностью, дистанцией и пульсом.</string>
     <string name="coach_consent_off">Выключено: коуч отвечает в общем виде и не отправляет ваши показатели.</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">Экран «Сегодня», который вы составляете сами, стресс на главном экране и резервные копии, которые проверяют себя сами</string>
+    <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">Оценено до %1$s. Для более поздних часов нужно больше измерений пульса.</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2681,4 +2681,5 @@
     <string name="coach_consent_on">开启：你的充能、休息、HRV 和训练会发送给服务商，每次训练包含运动类型、时长、距离和心率。</string>
     <string name="coach_consent_off">关闭：教练只作一般性回答，不发送你的任何数据。</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">可自行编排的「今天」页面、主屏幕上的压力曲线，以及会自我校验的备份</string>
+    <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">已评分至 %1$s。较晚的时段需要更多心率采样。</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2799,4 +2799,5 @@
     <string name="coach_consent_on">On: your charge, rest, HRV and workouts are sent to the provider, each workout with its sport, duration, distance and heart rate.</string>
     <string name="coach_consent_off">Off: the coach answers generally and sends none of your metrics.</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">A Today screen you arrange yourself, stress on the home screen, and backups that check themselves</string>
+    <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">Scored through %1$s. Later hours need more heart-rate samples.</string>
 </resources>


### PR DESCRIPTION
## What was wrong

Reported by @bartmuskala. The Today card's stress curve ended at 1pm, the Stress screen's ended at 2pm, and it was twenty past four.

Neither view recomputed as heart rate arrived. Each scored once, when its own trigger last fired, and then held:

```kotlin
LaunchedEffect(needsStressCurve, days, viewModel.activeStrapId)   // Today card
LaunchedEffect(vm.activeStrapId)                                  // Stress screen
```

None of the card's keys moves when a sample lands. `days` is the list of daily rows, not the intraday samples the curve is built from. The screen's key means "once, on open". So walking from the card into the screen always gave the screen the later read, and the gap was however long sat between the two triggers.

Both surfaces run the same scoring through the same producer, so this was never two different answers. It was one answer, read at two different moments.

## The change

The card asks again on the cadence the widget already uses. That constant moves to `StressWidgetProducer`, which owns the rescoring contract, and `WhoopConnectionService` reads it from there instead of keeping its own copy, so the three surfaces cannot drift apart by definition rather than by coincidence.

Fifteen minutes is matched to the data, not the stream: the curve resolves to half-hours, and asking more often costs a day of heart-rate rows each time, the memo being no help while a strap streams into the window it fingerprints.

A null from the producer now leaves the previous curve alone instead of blanking the card. That is what the producer documents a null to mean, and it matters more in a loop than it did for a single pass, where one bad tick would be a visible flicker on a screen sitting open.

## Saying where the curve stops

The timeline now says "Scored through 2 pm" once the newest scored hour is far enough behind the clock to look broken rather than merely recent, which is the message the report asked for. The existing caption already gives the rule; what a reader looking at a line ending at 2pm on an axis running to 4pm wants to know is that the rule is the reason and not a sync that has died.

**The threshold is deliberately generous, and the re-review is why.** My first pass wrote that an hour is scored only once it finishes. That is wrong and I had already posted it on the issue, so it is corrected there too. The only test is the sample count:

```kotlin
val mHr = if (hrs.size >= minHourHrSamples) mean(hrs) else null
```

There is no completeness rule, so the hour in progress scores as soon as it has banked 300 samples, a few minutes in on a strap streaming at roughly 1 Hz. What decides how far back a curve ends is sample **density**, not the clock, and a strap that banks history in chunks leaves recent hours under the bar for a while. A healthy curve can therefore end anywhere from minutes to an hour or two back, and the threshold has to clear all of that. Two and a half hours is past what any of it explains.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

Android compiles. i18n gate, doc lint and the parity ledger all clean, and `lintVitalFullRelease -PstagingRelease` passes with the new string in place.

The new string is in all **eight** `values*` files. The four focus locales are required outright; `pl`, `ru` and `zh` ratchet, so one new English-only entry would have failed them, and did on the first run.

**This wants a device.** The mechanism is verified by reading the triggers, but "the card keeps step over an afternoon" is a wall-clock behaviour no unit test here can show. What to look at: leave Today open for twenty minutes with a strap connected and the curve should extend; open the Stress screen and the two should end at the same place.

## Scope

**Android only, and iOS was checked rather than assumed.** Both its surfaces key on `repo.refreshSeq`, so they refresh together and cannot drift this way. The endpoint message is Android-only for now; iOS can have it whenever, and it is a string across nine catalogs rather than a mechanism.

## Related issues

#2144. This is also the freshness question left open under #2164, now with a mechanism rather than a guess.


## Re-review (0d960377)

**The loop was tied to the composition, not the lifecycle, and those are not the same thing.** A `LaunchedEffect` keeps running while the composition survives in the background, so the first commit would have gone on scoring a day of heart-rate rows every fifteen minutes with the screen off.

That is worse than it sounds, because the connection service is already doing exactly that work on exactly that cadence while backgrounded, which is the point of it. The card doing it too was a second pass with nothing on screen to read the result, and the cost lands on battery, which is the thing this repo has spent the most effort protecting.

`repeatOnLifecycle(STARTED)` is the shape `HealthScreen` already uses one screen over, for a related reason: its live-HR tick would otherwise bank a frozen value once a second while backgrounded. Following the local precedent rather than inventing a gate. Resuming re-enters the block and scores straight away, so returning to the app shows a current curve rather than waiting out an interval.

Worth saying plainly: the first commit fixed the reported bug and introduced a background drain to do it. The bug was in the fix, not in the diagnosis, and it took a second look to see it.

**A note on the comment above this code**, which claims the card and the widget "can never show different curves". That was true of the values and not of freshness, which is what this PR is about. It is now true of both, so it stays as written.


## Third pass (bac40daa)

**Refreshing only the card moves the disagreement rather than ending it.** The Stress screen still read once, on open. So a screen left sitting open becomes the stale side, and the two surfaces disagree again, in the other direction.

Worth being clear about why that was easy to miss: the screen looked like the reliable one in the report. It was not. It had simply been opened more recently than the card had last been triggered, and nothing about it keeps it current. Two surfaces that age at different rates will always find a way to disagree; the point is not which one refreshes, it is that they age together.

The screen now uses the same interval and the same lifecycle gate, for the same reasons.

That makes three commits, each fixing something the one before it created or left:

1. the card never refreshed;
2. making it refresh scored in the background, where nothing could read it;
3. the screen it was being compared against still never refreshed.


## Fourth pass (d039beae)

**Putting the screen's load on a timer made a cost that was free when it happened once.** `loadDaytimeStress` is three windowed row fetches plus the two HRV engines. Running it on open is nothing; running it every fifteen minutes while a screen sits open, to produce a result identical to the one already drawn, is waste with a battery cost.

It is now guarded on the same heart-rate fingerprint the widget producer memoises against, an indexed count and max, so an unchanged day costs that and nothing else. With a strap disconnected or simply quiet, which is the case where the repeat was pure loss, the screen now does almost nothing.

A fingerprint that cannot be read loads rather than skips. Being wrong that way costs one pass; being wrong the other way freezes the screen, and those are not comparable.

Midnight needs no special case: the fingerprint is taken over the local day being displayed, so the window moving is itself the change that triggers a reload.

**Also checked, no change needed.** `StressWidgetBackgroundScoringTest` keeps its own `15L * 60L * 1000L` literal rather than reading the constant, which is right: it tests `shouldRescore`'s comparison, not the chosen number, and would still be a valid test at any interval. `uiString` does have the vararg overload the new string's argument relies on.
