### PR TITLE
today: put scan and connect on the Today header

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -40,7 +40,6 @@ import androidx.compose.material.icons.filled.Accessibility
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Air
 import androidx.compose.material.icons.filled.Autorenew
-import androidx.compose.material.icons.automirrored.filled.BatteryUnknown
 import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Check
@@ -50,16 +49,18 @@ import androidx.compose.material.icons.filled.Functions
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.MonitorWeight
-import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Thermostat
 import androidx.compose.material.icons.filled.Timeline
 import androidx.compose.material.icons.filled.TrackChanges
-import androidx.compose.material.icons.filled.WaterDrop
 import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.filled.WaterDrop
+import androidx.compose.material.icons.automirrored.filled.BatteryUnknown
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -267,6 +268,9 @@ private data class TodayLiveSnapshot(
      *  most once per connection, so it costs the snapshot nothing. */
     val historyReady: Boolean,
     val historySyncExperimental: Boolean,
+    /** Whether a scan is running, so the header chip can say so and refuse a second tap while it is
+     *  (#2169). Flips twice per scan rather than per tick, so it costs this snapshot nothing. */
+    val scanning: Boolean,
     /** #689/#815: the connect-time GET_DATA_RANGE backlog sample, when known. Set once per connection,
      *  so it adds no per-tick churn to this snapshot. */
     val pagesBehindAtConnect: Int?,
@@ -342,6 +346,10 @@ fun TodayScreen(
     // 72→73 bpm tick produces an EQUAL snapshot and the body is NOT recomposed; it only recomposes when
     // connection / sync / battery / streaming-presence actually change. The live bpm number is rendered
     // elsewhere (HeartRateTrendCard), which scopes its own collection. Appearance-preserving.
+    // #2169: the ONE gate every scan entry point goes through. `connect()` called directly silently
+    // does nothing on Android 12+ when the Bluetooth permission was denied or revoked (#1), so Today's
+    // two new affordances use the same wrapper Settings' Re-scan and Live's Connect already use.
+    val requestScan = rememberRequestScan { viewModel.connect() }
     val liveSnap by remember {
         derivedStateOf {
             val s = live
@@ -354,6 +362,7 @@ fun TodayScreen(
                 syncChunksThisSession = s.syncChunksThisSession,
                 historyReady = s.historyReady,
                 historySyncExperimental = s.historySyncExperimental,
+                scanning = s.scanning,
                 pagesBehindAtConnect = s.pagesBehindAtConnect,
                 batteryPct = s.batteryPct,
                 whoop5 = s.whoop5Detected,
@@ -1347,6 +1356,8 @@ fun TodayScreen(
                 lastSyncAt = liveSnap.lastSyncAt,
                 historySyncExperimental = liveSnap.historySyncExperimental,
                 pagesBehindAtConnect = liveSnap.pagesBehindAtConnect,
+                scanning = liveSnap.scanning,
+                onRescan = requestScan,
                 onPickDay = { offset -> selectedDayOffset = offset },
                 onQuickActions = onQuickActions,
                 onOpenSettings = onOpenSettings,
@@ -1371,7 +1382,9 @@ fun TodayScreen(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Spacer(Modifier.size(HeaderClusterControl))
+                // #2169: the balancing spacer becomes the control. Same size, so the wordmark stays
+                // centred and nothing else in the header gives up width for it.
+                RescanDisc(scanning = liveSnap.scanning, onClick = requestScan)
                 Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
                     LiquidWordmark()
                 }
@@ -2190,6 +2203,48 @@ private fun TodayCardDismissButton(onClick: () -> Unit, modifier: Modifier = Mod
     }
 }
 
+/**
+ * Scan and connect, on the LEADING edge of the wordmark row (#2169).
+ *
+ * That slot cost nothing to take. The row was a spacer, the wordmark centred in what was left, and the
+ * Customize disc; the spacer existed only to balance the disc so the wordmark sat centred. A control
+ * there replaces it, and the wordmark stays where it was.
+ *
+ * Deliberately NOT in the right-hand cluster, which is where this would otherwise belong. #2110
+ * measured that: a fifth control there leaves the 28sp day title about 117dp, and "Yesterday" needs
+ * about 139dp, so it would ellipsize a title that fits today.
+ *
+ * Greys out and stops taking taps while a scan is running, which is the same rule the Settings and Live
+ * buttons follow. No spinner: the sync chip two controls away is already the thing that reports state.
+ */
+@Composable
+private fun RescanDisc(scanning: Boolean, onClick: () -> Unit) {
+    val interaction = remember { MutableInteractionSource() }
+    Box(
+        modifier = Modifier
+            .size(HeaderClusterControl)
+            .liquidPress(interaction)
+            .clip(CircleShape)
+            // The same translucent-white disc its siblings use: part of the header, not a call to action.
+            .background(Color.White.copy(alpha = if (scanning) 0.08f else 0.16f))
+            .clickable(
+                interactionSource = interaction,
+                indication = null,
+                enabled = !scanning,
+                onClick = onClick,
+            )
+            .semantics { contentDescription = uiString(R.string.l10n_today_screen_scan_and_connect_40157030) },
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            Icons.Filled.Refresh,
+            contentDescription = null,
+            tint = Color.White.copy(alpha = if (scanning) 0.45f else 1f),
+            modifier = Modifier.size(16.dp),
+        )
+    }
+}
+
 /** Customize Today (#2110): section order and visibility, on the trailing edge of the wordmark row.
  *
  *  Icon-only at the shared header-control size. The glyph and the accessibility-label-instead-of-text
@@ -2366,6 +2421,9 @@ private fun LiquidTodayHeader(
     historySyncExperimental: Boolean = false,
     // #689/#815: the connect-time backlog sample, when known.
     pagesBehindAtConnect: Int? = null,
+    // #2169: whether a scan is already running, and how to ask for one.
+    scanning: Boolean = false,
+    onRescan: (() -> Unit)? = null,
     onPickDay: (Int) -> Unit,
     onQuickActions: () -> Unit,
     onOpenSettings: () -> Unit,
@@ -2464,6 +2522,7 @@ private fun LiquidTodayHeader(
                 backfilling = backfilling, chunks = syncChunksThisSession,
                 lastSyncAt = lastSyncAt, historySyncExperimental = historySyncExperimental,
                 pagesBehind = pagesBehindAtConnect,
+                scanning = scanning, onRescan = onRescan,
             )
             // (a) Profile avatar (the photo set in Settings, or the NOOP loop mark) → Settings. Mirrors iOS.
             Box(
@@ -2503,6 +2562,13 @@ private fun SyncStatusChip(
     lastSyncAt: Long?,
     historySyncExperimental: Boolean,
     pagesBehind: Int? = null,
+    // #2169: the chip is the one thing in the header that reports sync state and took no tap at all,
+    // so asking it for a sync is the gesture a reader tries first. Routed through the caller rather
+    // than calling connect() here, because the permission gate has to come first: on Android 12+ a
+    // direct connect() silently does nothing when the Bluetooth permission was denied or revoked (#1).
+    // Null leaves the chip exactly as it was, which is what the other callers of it want.
+    scanning: Boolean = false,
+    onRescan: (() -> Unit)? = null,
 ) {
     // The clock and the translated "now" word are resolved HERE, in the composable that already depends
     // on both, and handed down — so `SyncChipState.resolve` stays a genuinely pure decision that a plain
@@ -2516,6 +2582,10 @@ private fun SyncStatusChip(
         nowSec = System.currentTimeMillis() / 1000L,
         pagesBehind = pagesBehind,
     )
+    // Offered only when there is an action to run and no scan already running, the same rule the
+    // Settings and Live buttons follow. `Syncing` deliberately keeps its tap: a sync in flight is not
+    // a scan in flight, and asking to reconnect mid-backfill is a reasonable thing to want.
+    val tap = onRescan?.takeIf { !scanning }
     when (state) {
         is SyncChipState.Syncing -> {
             // Both counts are inflected, so "1 chunk" and "1 page" read correctly. Android <plurals>
@@ -2534,14 +2604,17 @@ private fun SyncStatusChip(
                     uiString(R.string.l10n_today_screen_sync_chip_syncing_desc_92daf60c, chunksText)
                 },
                 detail = pagesText,
+                onClick = tap,
             )
         }
         is SyncChipState.Synced -> ChipCapsule(
             Icons.Filled.Check, state.agoText, Palette.textSecondary,
-            uiString(R.string.l10n_today_screen_sync_chip_synced_desc_4d255944, state.agoText))
+            uiString(R.string.l10n_today_screen_sync_chip_synced_desc_4d255944, state.agoText),
+            onClick = tap)
         SyncChipState.ExperimentalLive -> ChipCapsule(
             Icons.Filled.Check, uiString(R.string.l10n_today_screen_sync_chip_live_98aadb37), Palette.textSecondary,
-            uiString(R.string.l10n_today_screen_sync_chip_experimental_desc_3de06a70))
+            uiString(R.string.l10n_today_screen_sync_chip_experimental_desc_3de06a70),
+            onClick = tap)
         SyncChipState.Hidden -> Unit
         // cold start — render nothing; the building-scores note covers it.
     }
@@ -2549,7 +2622,16 @@ private fun SyncStatusChip(
 
 /** The shared sync-chip capsule (icon + terse label). Twin of the iOS `SyncStatusChip.chip`. */
 @Composable
-private fun ChipCapsule(icon: ImageVector, text: String, tint: Color, desc: String, detail: String? = null) {
+private fun ChipCapsule(
+    icon: ImageVector,
+    text: String,
+    tint: Color,
+    desc: String,
+    detail: String? = null,
+    // #2169: a second way to the same action as the disc, on the one header element that already
+    // reports sync state and took no tap at all. Costs no width, and null leaves the pill inert.
+    onClick: (() -> Unit)? = null,
+) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp),
@@ -2559,6 +2641,20 @@ private fun ChipCapsule(icon: ImageVector, text: String, tint: Color, desc: Stri
             .height(HeaderClusterControl)
             .clip(RoundedCornerShape(50))
             .background(Palette.surfaceInset)
+            // After the clip, so the ripple stays inside the capsule.
+            // onClickLabel rather than a contentDescription: the icon already describes the STATE
+            // ("synced 3 minutes ago"), and overriding that would trade the information for the action.
+            // A click label names the action alongside it instead of in place of it.
+            .then(
+                if (onClick != null) {
+                    Modifier.clickable(
+                        onClickLabel = uiString(R.string.l10n_today_screen_scan_and_connect_40157030),
+                        onClick = onClick,
+                    )
+                } else {
+                    Modifier
+                }
+            )
             .padding(horizontal = 10.dp),
     ) {
         Icon(icon, contentDescription = desc, tint = tint, modifier = Modifier.size(14.dp))

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -2784,4 +2784,5 @@
     <string name="coach_consent_off">Aus: Der Coach antwortet allgemein und sendet keine deiner Werte.</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">Ein Heute-Bildschirm, den du selbst zusammenstellst, Stress auf dem Homescreen und Backups, die sich selbst prüfen</string>
     <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">Bewertet bis %1$s. Spätere Stunden brauchen mehr Herzfrequenz-Messwerte.</string>
+    <string name="l10n_today_screen_scan_and_connect_40157030">Suchen und verbinden</string>
 </resources>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -2771,4 +2771,5 @@
     <string name="coach_consent_off">Desactivado: el coach responde en general y no envía ninguna de tus métricas.</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">Una pantalla de Hoy que organizas tú, el estrés en la pantalla de inicio y copias de seguridad que se comprueban solas</string>
     <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">Puntuado hasta las %1$s. Las horas posteriores necesitan más muestras de frecuencia cardiaca.</string>
+    <string name="l10n_today_screen_scan_and_connect_40157030">Buscar y conectar</string>
 </resources>

--- a/android/app/src/main/res/values-fr/strings.xml
+++ b/android/app/src/main/res/values-fr/strings.xml
@@ -2770,4 +2770,5 @@
     <string name="coach_consent_off">Désactivé : le coach répond de façon générale et n\'envoie aucune de vos données.</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">Un écran Aujourd\'hui que vous composez vous-même, le stress sur l\'écran d\'accueil, et des sauvegardes qui se vérifient elles-mêmes</string>
     <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">Évalué jusqu\'à %1$s. Les heures suivantes nécessitent plus de mesures de fréquence cardiaque.</string>
+    <string name="l10n_today_screen_scan_and_connect_40157030">Rechercher et connecter</string>
 </resources>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -2779,4 +2779,5 @@
     <string name="coach_consent_off">Wyłączone: coach odpowiada ogólnie i nie wysyła żadnych Twoich danych.</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">Ekran Dzisiaj, który układasz sam, stres na ekranie głównym i kopie zapasowe, które same się sprawdzają</string>
     <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">Ocenione do %1$s. Późniejsze godziny wymagają więcej pomiarów tętna.</string>
+    <string name="l10n_today_screen_scan_and_connect_40157030">Skanuj i połącz</string>
 </resources>

--- a/android/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/app/src/main/res/values-pt-rPT/strings.xml
@@ -2763,4 +2763,5 @@
     <string name="coach_consent_off">Desligado: o coach responde de forma geral e não envia nenhuma das tuas métricas.</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">Um ecrã Hoje que organiza a seu gosto, o stress no ecrã principal e cópias de segurança que se verificam a si próprias</string>
     <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">Avaliado até às %1$s. As horas seguintes precisam de mais amostras de frequência cardíaca.</string>
+    <string name="l10n_today_screen_scan_and_connect_40157030">Procurar e ligar</string>
 </resources>

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -2658,4 +2658,5 @@
     <string name="coach_consent_off">Выключено: коуч отвечает в общем виде и не отправляет ваши показатели.</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">Экран «Сегодня», который вы составляете сами, стресс на главном экране и резервные копии, которые проверяют себя сами</string>
     <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">Оценено до %1$s. Для более поздних часов нужно больше измерений пульса.</string>
+    <string name="l10n_today_screen_scan_and_connect_40157030">Найти и подключить</string>
 </resources>

--- a/android/app/src/main/res/values-zh/strings.xml
+++ b/android/app/src/main/res/values-zh/strings.xml
@@ -2682,4 +2682,5 @@
     <string name="coach_consent_off">关闭：教练只作一般性回答，不发送你的任何数据。</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">可自行编排的「今天」页面、主屏幕上的压力曲线，以及会自我校验的备份</string>
     <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">已评分至 %1$s。较晚的时段需要更多心率采样。</string>
+    <string name="l10n_today_screen_scan_and_connect_40157030">扫描并连接</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2800,4 +2800,5 @@
     <string name="coach_consent_off">Off: the coach answers generally and sends none of your metrics.</string>
     <string name="l10n_app_changelog_a_today_screen_you_arrange_yourself_6194ccd0">A Today screen you arrange yourself, stress on the home screen, and backups that check themselves</string>
     <string name="l10n_stress_screen_scored_through_1_s_later_hours_fbb7d6c7">Scored through %1$s. Later hours need more heart-rate samples.</string>
+    <string name="l10n_today_screen_scan_and_connect_40157030">Scan and connect</string>
 </resources>


### PR DESCRIPTION
## What was missing

Requested by @paulinyrobert-del, who runs with background connection off and wanted a sync without leaving Today. There was no way to start a scan from Today at all. The quick-actions menu behind the `+` is four navigations (Live HR, Start workout, Log journal, Breathe) and does not connect anything; the header's other controls go to Settings, Devices and that sheet. There is no pull-to-refresh either, on Today or in the scaffold it uses.

Re-scan is in Settings and Scan & Connect is on Live, both of which the report describes accurately.

## The change

Two affordances, one action, and neither takes width from anything.

**A disc on the leading edge of the wordmark row.** That row was a spacer, the wordmark centred in what remained, and the Customize disc. The spacer was not decoration: #2110 put it there so it "mirrors the trailing control exactly", keeping the wordmark optically centred after the wordmark and control had previously overlapped. The new disc is the same `HeaderClusterControl` size as the one it mirrors, so that invariant holds exactly and the wordmark does not move.

Deliberately **not** in the right-hand cluster, which is where a control like this would otherwise belong. #2110 measured that too: a fifth control there leaves the 28sp day title about 117dp, and "Yesterday" needs about 139dp, so it would ellipsize a title that fits today.

**And the sync chip takes a tap.** It is the one header element that already reports sync state and had no tap at all, so asking the thing that says "3 minutes ago" for another sync is the gesture a reader tries first. It costs no width. The tap carries an `onClickLabel` rather than a `contentDescription`, so the action is named alongside the state the icon already describes instead of replacing it.

## The part that would have been a silent bug

Both routes go through `rememberRequestScan`, the same wrapper Settings' Re-scan and Live's Connect use, which requests the runtime Bluetooth permission before scanning. Calling `vm.connect()` directly silently does nothing on Android 12+ when that permission has been denied or revoked, which was #1. A third entry point had to go through the gate rather than around it, and a version that looked correct and did nothing would have been easy to ship.

The disc greys and refuses taps while a scan is running, matching the Settings and Live buttons. The chip keeps its tap during a sync, because a backfill in flight is not a scan in flight.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

Android compiles. i18n gate, doc lint and `lintVitalFullRelease -PstagingRelease` all clean. `SyncChipStateTest` and `BackupSyncTest`: **26 tests, 0 failures**, XML timestamp checked against the clock. The chip's state resolution is untouched, which is why those still pass unchanged.

The new label is in all eight `values*` files, the three non-focus locales ratcheting rather than tolerating a gap.

**This wants a device.** Two header controls and a permission prompt are not things a unit test here can show. What to look at: the wordmark should still sit centred, the disc should grey while searching, and tapping either affordance with the Bluetooth permission revoked should prompt rather than do nothing.

## Scope

Android only. The disc stays visible when a strap is already connected, which matches Settings' Re-scan rather than inventing a new rule for the same action.

## Related issues

#2169.

The report also mentions 12 of 14 nights with no HRV, described as expected. I queried that in review and was wrong: overnight HRV comes from the continuous beat-to-beat stream, which is gated on background connection, so sparse HRV with that off is the designed trade rather than a fault. Corrected on the issue, and nothing to chase there.


## Re-review

No change to the code this pass, but it found something next to it.

**The reporter's "green dot" is real, and I said it was not.** Today has no status indicator now, which is why I could not find one, but it had one until 7.0.0. `RecordingStatusChip` is still in `TodayScreen.kt` as a `private @Composable` with **no call site**, along with `recordingTitle` and `recordingDetail`, which nothing else uses. It was live at 6.0.2 as `RecordingStatusChip(state = recordingState, onConnect = onOpenSettings)`, and the redesign at 4da3cfb4a dropped the call and kept the definition.

Its doc describes the very tap this issue asks for, "Tapping a not-recording chip routes to connect", and the Swift side still models the colour: "green recording, amber last-synced, red not recording". `RecordingState` is still computed in `TodayScoring.kt` and still unit-tested, with an English parity contract asserted against Swift, for a view Android no longer draws.

Filed as #2179 rather than folded in here, because whether to restore it or delete the orphans is a judgement call and not this PR's question. If it does come back it can call the same action this PR adds, instead of routing to Settings and a scroll.

**Checked, no defect.** The wordmark row is inside a plain `item { Column { … } }` with no conditional, so the new disc always renders. There is no pull-to-refresh on Today or in its scaffold, so the claim that nothing on Today could start a scan holds. `rememberRequestScan` is called unconditionally at composition, as it must be to register its launcher, matching how Settings and Live use it.


## Third pass

No code change. One limitation found that is worth stating rather than leaving for someone to hit.

**A permanently-denied permission is still a silent tap, and Today is the worst place for that.** `rememberRequestScan` checks the permission and launches the request if it is missing; its launcher callback calls `onGranted` whatever the result, and the doc says a denial then "surfaces the explanatory status note rather than failing silently". On Android 12+, once a permission has been denied twice the system shows no dialog at all, so the launch returns immediately, `connect()` runs, `startScan()` throws, and the BLE layer swallows it. That is the original #1 symptom.

This is not introduced here: Settings' Re-scan and Live's Connect go through the same wrapper and behave the same way. What is different about Today is that it has nowhere to put the explanation. Searching `TodayScreen.kt` for a status-note surface finds none, and after #2179 it has no recording-status indicator either, so the two screens that already offer this action sit beside connection status and this one does not.

In the ordinary cases the feedback is fine. A granted permission scans and the sync chip two controls away changes state; a fresh denial happens in a dialog the user just dismissed. It is the permanently-denied case that lands mutely, and it lands mutely on all three entry points today.

Worth a follow-up rather than a fourth commit here, and worth deciding alongside #2179, since "Today has no connection status" is the same gap seen from the other side.
