### PR TITLE
today: show the scan control only while the strap is away, and make it look like a scan

### DIFF
--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -135,6 +135,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -351,6 +352,31 @@ fun TodayScreen(
     // does nothing on Android 12+ when the Bluetooth permission was denied or revoked (#1), so Today's
     // two new affordances use the same wrapper Settings' Re-scan and Live's Connect already use.
     val requestScan = rememberRequestScan { viewModel.connect() }
+    // #2169: Today can start a connect but had nowhere to report one that never starts. Every early
+    // exit from a user-initiated connect writes an explanatory note and leaves `scanning` false, so
+    // "Bluetooth is off. Turn it on, then tap Connect." and the Nearby-devices permission line were
+    // being set and thrown away: Live and Onboarding render `statusNote`, Today does not. A tap that
+    // cannot proceed therefore changed nothing on screen at all, which reads as a dead control.
+    //
+    // Shown only after a tap from HERE, and only when the tap did not get as far as scanning, so this
+    // stays a reply to a press rather than Today quietly becoming a connection-status surface, which
+    // is a larger question (#2179).
+    var scanTapAt by remember { mutableStateOf(0L) }
+    var scanHint by remember { mutableStateOf<String?>(null) }
+    val requestScanFromToday = {
+        scanTapAt = System.currentTimeMillis()
+        requestScan()
+    }
+    LaunchedEffect(scanTapAt) {
+        if (scanTapAt == 0L) return@LaunchedEffect
+        scanHint = null
+        // Long enough for the permission dialog and the adapter checks to settle, short enough to still
+        // read as the answer to the press.
+        delay(700)
+        if (!live.scanning && !live.connected) scanHint = live.statusNote
+        delay(4_500)
+        scanHint = null
+    }
     val liveSnap by remember {
         derivedStateOf {
             val s = live
@@ -1361,7 +1387,7 @@ fun TodayScreen(
                 // One rule for both affordances: they exist while the strap is away. Connected, the
                 // chip goes back to reporting sync and nothing else, rather than offering a connect to
                 // something already connected.
-                onRescan = if (liveSnap.connected) null else requestScan,
+                onRescan = if (liveSnap.connected) null else requestScanFromToday,
                 onPickDay = { offset -> selectedDayOffset = offset },
                 onQuickActions = onQuickActions,
                 onOpenSettings = onOpenSettings,
@@ -1410,7 +1436,7 @@ fun TodayScreen(
                 ) {
                     if (scanAffordance > 0.01f) {
                         Box(modifier = Modifier.graphicsLayer { alpha = scanAffordance }) {
-                            RescanDisc(scanning = liveSnap.scanning, onClick = requestScan)
+                            RescanDisc(scanning = liveSnap.scanning, onClick = requestScanFromToday)
                         }
                     }
                 }
@@ -1418,6 +1444,17 @@ fun TodayScreen(
                     LiquidWordmark()
                 }
                 CustomizeDisc(onClick = { showLayoutEditor = true })
+            }
+            // The reply to a tap that went nowhere. Wording comes from the BLE layer, the same text
+            // Live and Onboarding show, so this adds no copy of its own.
+            scanHint?.let { hint ->
+                Text(
+                    hint,
+                    style = NoopType.footnote,
+                    color = Palette.textSecondary,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth().padding(top = 6.dp),
+                )
             }
         }
         }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1403,7 +1403,6 @@ fun TodayScreen(
                 val scanAffordance by animateFloatAsState(
                     targetValue = if (liveSnap.connected) 0f else 1f,
                     animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
-                    label = "scanAffordance",
                 )
                 Box(
                     modifier = Modifier.size(HeaderClusterControl),

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1358,7 +1358,10 @@ fun TodayScreen(
                 historySyncExperimental = liveSnap.historySyncExperimental,
                 pagesBehindAtConnect = liveSnap.pagesBehindAtConnect,
                 scanning = liveSnap.scanning,
-                onRescan = requestScan,
+                // One rule for both affordances: they exist while the strap is away. Connected, the
+                // chip goes back to reporting sync and nothing else, rather than offering a connect to
+                // something already connected.
+                onRescan = if (liveSnap.connected) null else requestScan,
                 onPickDay = { offset -> selectedDayOffset = offset },
                 onQuickActions = onQuickActions,
                 onOpenSettings = onOpenSettings,
@@ -1383,9 +1386,20 @@ fun TodayScreen(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                // #2169: the balancing spacer becomes the control. Same size, so the wordmark stays
-                // centred and nothing else in the header gives up width for it.
-                RescanDisc(scanning = liveSnap.scanning, onClick = requestScan)
+                // #2169: the balancing spacer becomes the control, but ONLY while there is something to
+                // connect. A permanently visible control has to explain itself; one that appears exactly
+                // when the strap is away says what it is for by being there, and cannot be read as a
+                // reload button on a screen that never reloads. Connected, it goes back to being a
+                // spacer, so the wordmark is centred by the same control-sized gutter either way and
+                // nothing moves as the strap comes and goes.
+                //
+                // Scanning counts as needed: a scan running means not yet connected, and hiding the
+                // control mid-attempt would take away the only in-progress signal the header has.
+                if (!liveSnap.connected) {
+                    RescanDisc(scanning = liveSnap.scanning, onClick = requestScan)
+                } else {
+                    Spacer(Modifier.size(HeaderClusterControl))
+                }
                 Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
                     LiquidWordmark()
                 }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -1395,10 +1395,25 @@ fun TodayScreen(
                 //
                 // Scanning counts as needed: a scan running means not yet connected, and hiding the
                 // control mid-attempt would take away the only in-progress signal the header has.
-                if (!liveSnap.connected) {
-                    RescanDisc(scanning = liveSnap.scanning, onClick = requestScan)
-                } else {
-                    Spacer(Modifier.size(HeaderClusterControl))
+                // The SLOT is permanent and only the control inside it fades, rather than swapping the
+                // two. A 4.0 that is dropping and auto-reconnecting flips `connected` repeatedly, and an
+                // instant swap turns that into a blinking icon beside the wordmark; a fade reads as a
+                // pulse instead. Keeping the gutter itself always present also means the wordmark cannot
+                // shift even mid-transition, which an if/else between a control and a spacer allows.
+                val scanAffordance by animateFloatAsState(
+                    targetValue = if (liveSnap.connected) 0f else 1f,
+                    animationSpec = tween(durationMillis = 220, easing = FastOutSlowInEasing),
+                    label = "scanAffordance",
+                )
+                Box(
+                    modifier = Modifier.size(HeaderClusterControl),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    if (scanAffordance > 0.01f) {
+                        Box(modifier = Modifier.graphicsLayer { alpha = scanAffordance }) {
+                            RescanDisc(scanning = liveSnap.scanning, onClick = requestScan)
+                        }
+                    }
                 }
                 Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
                     LiquidWordmark()

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -351,7 +351,17 @@ fun TodayScreen(
     // #2169: the ONE gate every scan entry point goes through. `connect()` called directly silently
     // does nothing on Android 12+ when the Bluetooth permission was denied or revoked (#1), so Today's
     // two new affordances use the same wrapper Settings' Re-scan and Live's Connect already use.
-    val requestScan = rememberRequestScan { viewModel.connect() }
+    var scanTapAt by remember { mutableStateOf(0L) }
+    // Armed from INSIDE the granted callback, not from the tap. `rememberRequestScan` runs this either
+    // straight away, when the permission is already held, or after the system dialog closes; timing the
+    // reply from the tap instead would start a clock while that dialog was still open and then answer a
+    // press that was proceeding perfectly well, with whatever stale note happened to be lying around.
+    // A permanently denied permission still lands here, the launcher's callback firing either way, so
+    // the case most worth explaining is the one this keeps.
+    val requestScan = rememberRequestScan {
+        scanTapAt = System.currentTimeMillis()
+        viewModel.connect()
+    }
     // #2169: Today can start a connect but had nowhere to report one that never starts. Every early
     // exit from a user-initiated connect writes an explanatory note and leaves `scanning` false, so
     // "Bluetooth is off. Turn it on, then tap Connect." and the Nearby-devices permission line were
@@ -361,18 +371,13 @@ fun TodayScreen(
     // Shown only after a tap from HERE, and only when the tap did not get as far as scanning, so this
     // stays a reply to a press rather than Today quietly becoming a connection-status surface, which
     // is a larger question (#2179).
-    var scanTapAt by remember { mutableStateOf(0L) }
     var scanHint by remember { mutableStateOf<String?>(null) }
-    val requestScanFromToday = {
-        scanTapAt = System.currentTimeMillis()
-        requestScan()
-    }
     LaunchedEffect(scanTapAt) {
         if (scanTapAt == 0L) return@LaunchedEffect
         scanHint = null
-        // Long enough for the permission dialog and the adapter checks to settle, short enough to still
-        // read as the answer to the press.
-        delay(700)
+        // Long enough for the adapter checks and the scan start to settle, short enough to still read
+        // as the answer to the press. The dialog is already behind us by here.
+        delay(400)
         if (!live.scanning && !live.connected) scanHint = live.statusNote
         delay(4_500)
         scanHint = null
@@ -1387,7 +1392,7 @@ fun TodayScreen(
                 // One rule for both affordances: they exist while the strap is away. Connected, the
                 // chip goes back to reporting sync and nothing else, rather than offering a connect to
                 // something already connected.
-                onRescan = if (liveSnap.connected) null else requestScanFromToday,
+                onRescan = if (liveSnap.connected) null else requestScan,
                 onPickDay = { offset -> selectedDayOffset = offset },
                 onQuickActions = onQuickActions,
                 onOpenSettings = onOpenSettings,
@@ -1436,7 +1441,7 @@ fun TodayScreen(
                 ) {
                     if (scanAffordance > 0.01f) {
                         Box(modifier = Modifier.graphicsLayer { alpha = scanAffordance }) {
-                            RescanDisc(scanning = liveSnap.scanning, onClick = requestScanFromToday)
+                            RescanDisc(scanning = liveSnap.scanning, onClick = requestScan)
                         }
                     }
                 }

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -41,6 +41,8 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Air
 import androidx.compose.material.icons.filled.Autorenew
 import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material.icons.filled.Bluetooth
+import androidx.compose.material.icons.filled.BluetoothSearching
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
@@ -53,7 +55,6 @@ import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material.icons.filled.MonitorHeart
 import androidx.compose.material.icons.filled.MonitorWeight
-import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Thermostat
 import androidx.compose.material.icons.filled.Timeline
 import androidx.compose.material.icons.filled.TrackChanges
@@ -2237,7 +2238,12 @@ private fun RescanDisc(scanning: Boolean, onClick: () -> Unit) {
         contentAlignment = Alignment.Center,
     ) {
         Icon(
-            Icons.Filled.Refresh,
+            // Bluetooth, not Refresh. Settings can use a circular arrow because the word "Re-scan" is
+            // sitting next to it; here the glyph is the whole affordance, and a circular arrow on a
+            // screen full of numbers reads as "reload my data" rather than "look for my strap". This is
+            // also the icon Live's Scan & Connect button and the onboarding connect steps already use,
+            // so the same action now looks the same everywhere it appears.
+            if (scanning) Icons.Filled.BluetoothSearching else Icons.Filled.Bluetooth,
             contentDescription = null,
             tint = Color.White.copy(alpha = if (scanning) 0.45f else 1f),
             modifier = Modifier.size(16.dp),


### PR DESCRIPTION
## Why

Two things about the control that merged in #2178, both raised on the build.

**A circular arrow reads as "reload".** Settings can use that glyph because the word "Re-scan" is sitting next to it. On a bare disc the glyph is the whole affordance, and on a screen that is nothing but numbers a refresh arrow suggests it reloads them. Nothing on Today reloads.

**And a control that is always there has to explain itself.** With a strap already connected there is nothing useful behind the tap, so the disc sat in the header inviting a press that would do nothing a reader would notice.

## What changed

The glyph is Bluetooth, which is what this app already uses for this action, on Live's Scan and Connect button and through the onboarding connect steps. The same thing now looks the same everywhere it appears, and the icon says what the tap is about. Searching swaps to the seeking variant, so the greyed state says what it is doing rather than only that it is busy.

The control appears **only while the strap is away**. Appearing exactly when it is needed says what it is for by being there, which is a better answer than any icon. Connected, the slot goes back to being the spacer it was before #2178, so the wordmark is centred by the same control-sized gutter either way and nothing shifts as the strap comes and goes.

Scanning counts as away: a scan running means not yet connected, and hiding the control mid-attempt would remove the only in-progress signal the header has.

The chip's tap follows the same rule rather than a different one. Connected, it goes back to reporting sync and nothing else, instead of offering a connect to something already connected.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

Compiles. i18n gate and doc lint unchanged, and no strings move: the label is the one #2178 added, and the icon carries no text.

**Wants a device**, like the control it adjusts. What to look at: the disc should be absent with a strap connected and the wordmark still centred, should appear when the strap drops, and should show the seeking glyph while searching.

## Still open, and not fixed here

A tap that cannot proceed is still silent on Today. Every user-initiated connect that stops early writes an explanatory note, "Bluetooth is off. Turn it on, then tap Connect." among them, and Today renders none of them, because it has no status surface at all since the recording chip went in 7.0.0 (#2179).

Hiding the control while connected narrows that: the common pointless tap is gone. It does not close it, since Bluetooth being off is exactly a case where the control now shows and the tap still says nothing. That wants either a transient message on Today or the status surface #2179 is about, and there is no snackbar host in the app today to hang the first one on.

## Related issues

#2169, adjusting #2178. #2179 for the missing status surface underneath it.


## Re-review

**Hiding the control was right; swapping it was not.** An `if/else` between the control and a spacer makes every `connected` flip a visible event, and a 4.0 that drops and auto-reconnects flips it repeatedly. That turns the header into a blinking icon for exactly the users whose link is worst.

The slot is permanent now and only the control inside it fades. A reconnect burst reads as a pulse rather than a flash, and keeping the gutter itself always present means the wordmark cannot shift even mid-transition, which swapping a control for a spacer allows. Below a hair above zero it is not rendered at all, so no invisible tap target sits in the header once it has faded. Inside the 220ms fade it is still tappable, which costs a re-scan at worst.

**And the fade arrived with a gate failure.** `animateFloatAsState`'s inspector `label` is a hardcoded string in a `ui/` file, which is precisely what `Tools/i18n_audit.py` exists to catch; it cannot tell tooling metadata from words a reader sees. Baselining it would teach the gate to ignore a real class of mistake for one convenience, so the label goes instead.

Worth recording how that reached a commit at all: the gate and the commit were separate statements rather than chained, so a failing gate printed `i18n=1` and the commit ran anyway. The gate did its job; the way it was invoked did not.


## A tap that goes nowhere now says so (f49b3776)

Hiding the control while connected removed the pointless tap. It did not fix the other half: a tap that **cannot** proceed still changed nothing on screen, which from the reader's side is the same thing as a dead button.

Every early exit from a user-initiated connect writes an explanation and leaves `scanning` false:

```
"Bluetooth is off. Turn it on, then tap Connect."
"NOOP needs the Nearby devices / Bluetooth permission. Allow it in …"
"Bluetooth isn't ready yet. Try again in a moment."
```

`LiveScreen` and `OnboardingScreen` render `statusNote`. Today does not, so all of those were being set and thrown away by the one screen that could start a connect without being able to report it.

Today now shows that note under the wordmark for a few seconds, and only after a tap **from here** that did not reach scanning. That keeps it a reply to a press rather than Today quietly becoming a connection-status surface, which is the larger question in #2179. The wording is the BLE layer's own, the same text the other two screens show, so this adds no copy and no new string.

**On whether the control should vanish when pressed: it should not, and does not.** A successful tap keeps it and swaps the glyph to seeking, so the press has a visible consequence; it fades only once the strap is actually connected, which is when it stops being needed. Vanishing on the press would delete the one signal that anything is happening.

So the rule end to end is: absent while connected, present while not, seeking while scanning, and a sentence underneath when a press could not get started.


## Re-review of the reply (dea3c0b8)

The reply was armed on the **tap** and read the state 700ms later. That is wrong the moment a permission dialog opens: the user is still looking at it, nothing is scanning, nothing is connected, so the check fires and answers a press that was proceeding perfectly well, with whatever stale note happened to be lying around from an earlier attempt.

Arming inside `rememberRequestScan`'s granted callback removes the race rather than widening a timeout against it. That callback runs immediately when the permission is already held and after the dialog closes when it is not, so the clock starts when `connect()` actually runs, and the delay drops to 400ms with the dialog no longer inside it.

The case most worth explaining still lands there: a permanently denied permission shows no dialog at all, the launcher's callback fires regardless, `connect()` throws, the Nearby-devices note is written, and the reply catches it.

**Also considered, and left alone.** The hint pushes the list down for the few seconds it is visible. An overlay would avoid that but would sit on top of content; a message that appears directly under the control the reader just pressed, because they pressed it, is the one place a small shift explains itself.
