### PR TITLE
stress: do not say Calibrating when the day has simply not started yet

### DIFF
--- a/android/app/src/main/java/com/noop/ui/StressScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/StressScreen.kt
@@ -700,12 +700,23 @@ internal fun StressTodayCard(points: List<StressPoint>, modifier: Modifier = Mod
             }
 
             if (stats == null) {
-                // The SAME "Calibrating" placeholder the pinned Today stress card already shows with no
-                // usable signal, so the two never disagree about what an unscored day looks like. Honest
-                // blank rather than a flat line at zero: only waking hours score, so this is every day's
-                // early morning as well as a day with too little signal.
+                // Two states, two answers, which is the distinction the WIDGET already draws and this card
+                // did not. Outside the 06:00-22:00 scored window nothing is coming until morning, and at
+                // 1am the local day has just rolled over with no waking hour in it at all: saying
+                // "Calibrating" there claims the app is working on something it will not touch for hours.
+                // Inside the window it is the honest word, the day simply not having produced a scorable
+                // hour yet. Both strings already exist and are translated, so this borrows rather than
+                // adds. Honest blank either way, never a flat line at zero.
+                val outsideScoredWindow =
+                    !DaytimeStress.isWakingHourOfDay(java.time.LocalTime.now().hour)
                 Text(
-                    uiString(R.string.l10n_today_screen_calibrating_37c2c9bd),
+                    uiString(
+                        if (outsideScoredWindow) {
+                            R.string.l10n_stress_glance_widget_resumes_in_the_morning_a640b49f
+                        } else {
+                            R.string.l10n_today_screen_calibrating_37c2c9bd
+                        }
+                    ),
                     style = NoopType.footnote,
                     color = textTertiary,
                 )

--- a/android/app/src/main/java/com/noop/ui/TodayScreen.kt
+++ b/android/app/src/main/java/com/noop/ui/TodayScreen.kt
@@ -106,8 +106,10 @@ import androidx.compose.ui.zIndex
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.withFrameNanos
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.PointerEventPass
@@ -174,6 +176,7 @@ import com.noop.data.DailyMetric
 import com.noop.protocol.Whoop5RR
 import com.noop.widget.StressPoint
 import com.noop.widget.StressWidgetProducer
+import com.noop.widget.WidgetSnapshotStore
 import com.noop.data.HrBucket
 import com.noop.data.SleepSession
 import com.noop.data.WhoopRepository
@@ -3822,6 +3825,24 @@ private fun HostedCardsSection(
     // card and the widget can never show different curves.
     val needsStressCurve = cards.contains(HostedCard.STRESS_TODAY)
     var stressCurve by remember { mutableStateOf<List<StressPoint>>(emptyList()) }
+    // SEEDED from the curve already on disk, so an app update does not show "Calibrating" for a day it
+    // has already scored. `stressCurve` starts empty on a cold process, and the card reads an empty
+    // curve as an unscored day, which is honest for a genuinely unscored one and wrong the moment the
+    // app is merely restarted. The first compute usually fills it, but not always in time: the strap id
+    // it needs comes from the source coordinator and is blank for a moment after launch, and a blank id
+    // makes the producer answer null, which by contract means "say nothing" and leaves the card empty
+    // until the next pass.
+    //
+    // The widget snapshot is the same curve, written by the last scoring pass and day-guarded on load,
+    // so it is either today's or nothing. Read once, off the main thread, and only while nothing better
+    // has arrived, so a compute that has already landed is never overwritten by a staler copy.
+    LaunchedEffect(Unit) {
+        if (stressCurve.isNotEmpty()) return@LaunchedEffect
+        val banked = withContext(Dispatchers.IO) {
+            runCatching { WidgetSnapshotStore.load(context).stressSeries }.getOrDefault(emptyList())
+        }
+        if (banked.isNotEmpty() && stressCurve.isEmpty()) stressCurve = banked
+    }
     // #2144: this used to score ONCE, when these keys last moved, and none of them tracks incoming
     // heart rate — `days` is the daily rows, not the intraday samples the curve is built from. So a
     // card left open held whatever it scored then, while the Stress screen scores when you open it,


### PR DESCRIPTION
## What was reported, and what it actually was

"Stress through the day" showed **Calibrating** right after an app update.

The update was not the cause, and the hour was. The timeline scores the waking window only, `06:00-22:00`, and past midnight the local day has just rolled over with no waking hour in it at all. Zero scorable hours means an empty curve, and the card reads an empty curve as an unscored day. It would have said the same thing at 1am with no update anywhere near it.

That leaves two separate problems, one of them the real complaint.

## 1. The card says the wrong word at night

The card had **one** empty state; the widget has **two**, and has since #571:

```kotlin
val outsideScoredWindow = !DaytimeStress.isWakingHourOfDay(hourNow)
val emptyReason = if (outsideScoredWindow) "Resumes in the morning" else "Calibrating"
```

Outside the window nothing is coming for hours. Inside it, the day simply has not produced a scorable hour yet. Saying "Calibrating" at 1am claims the app is working on something it will not touch until six.

The card now draws the same distinction, borrowing the widget's wording. Both strings already exist and are translated in all eight `values*` files, so this adds no copy, and the two surfaces finally answer the same question the same way.

## 2. An update in the daytime really can blank it

Separate from the above, and worth fixing while here. `stressCurve` starts empty on a cold process, and the first compute does not always fill it in time: the strap id it needs comes from the source coordinator and is blank for a moment after launch, and a blank id makes the producer return null, which by contract means "say nothing" and leaves the card empty until the next pass. An update lands squarely in that window.

The curve was never lost. The last scoring pass wrote it to the widget snapshot, which is day-guarded on load, so it is either today's or nothing. The card seeds from that, read once and off the main thread, and only while nothing better has arrived, so a compute that has already landed is never overwritten by a staler copy.

This would not have changed what was seen at 1am, since the snapshot is guarded to the same rolled-over day. It is the fix for the case the report sounded like.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## How it was tested

Compiles. i18n gate and doc lint clean. The widget suite is unchanged at **120 tests across seven classes, 0 failures**, which matters because the seed reads `WidgetSnapshotStore` and the wording borrows the widget's own strings.

**On device the interesting check is a daytime one**, since the night case is now a wording change anyone can read: update or force-stop the app mid-afternoon on a day with a scored curve, and the card should come back with the curve rather than a placeholder.

## Scope

Android. No behaviour change to scoring, the window, or the widget.

## Related issues

Reported directly against the testing build rather than as an issue.


## Re-review

**The claim this PR rests on, checked rather than assumed.** I said the local day rolls at midnight, which is what makes 1am unscorable. `stressLocalDayWindow` uses `day.atStartOfDay(zone)`, a plain calendar day, with no shifted boundary of the kind a sleep day often has. So at 1am the window holds about an hour, all of it outside `06:00-22:00`, and `StressTrace.stats` returns null the moment no point carries a level. The diagnosis holds.

**The hour is read at composition, so the word can go stale.** `LocalTime.now().hour` is not observable, so a card composed at 05:59 keeps saying "Resumes in the morning" until something else recomposes it. In practice the refresh loop from #2177 recomposes within fifteen minutes, and by six the curve usually has a point, which takes the branch out of play entirely. Left alone deliberately: the widget reads the clock the same way, and a ticker in the header to advance one word is a worse trade than a word that can be a few minutes late.

**A narrow caveat on the seed, worth writing down.** The widget snapshot does not record which strap wrote it. On a two-strap install, a cold start could therefore seed the other strap's curve for the second or two before the first compute replaces it. The exposure is small and self-correcting, and the alternative is the placeholder this PR exists to remove, but it is a real edge and the snapshot format is where it would be fixed if it ever matters.

**Considered and rejected: stopping an empty compute from clearing a seeded curve.** It would make the card steadier and it would be wrong. The producer documents an empty curve as a real answer about today, distinct from a null, precisely so a surface drops a stale line rather than keeping it. A card that refused to clear would outlive the data it was drawn from.
